### PR TITLE
feat(zfs): tenant offboarding — destroy the pool, then the dataset

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -4971,6 +4971,39 @@
         ]
       }
     },
+    "/v1/tenants/{tenant}/storage": {
+      "delete": {
+        "summary": "Destroy a departing tenant's encrypted storage",
+        "description": "Deletes the tenant's Incus storage pool and then the encrypted dataset it was sourced at. Refused while the tenant still has containers. Irreversible — the dataset is the tenant's encryptionroot, so this destroys the only key path to their data. Admin only.",
+        "operationId": "ContainerService_DeleteTenantStorage",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/DeleteTenantStorageResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "tenant",
+            "description": "The tenant being offboarded.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "Container Operations"
+        ]
+      }
+    },
     "/v1/tenants/{username}/compose/disable": {
       "post": {
         "summary": "Disable stops the autostart unit. Does NOT stop the running\ncontainers — use the compose CLI for that.",
@@ -8088,6 +8121,24 @@
           "type": "string"
         }
       }
+    },
+    "DeleteTenantStorageResponse": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string",
+          "description": "Human-readable summary."
+        },
+        "storagePool": {
+          "type": "string",
+          "description": "The Incus storage pool that was deleted."
+        },
+        "dataset": {
+          "type": "string",
+          "description": "The ZFS dataset that was destroyed — the tenant's encryptionroot, and\nwith it the only thing that could decrypt their data."
+        }
+      },
+      "description": "DeleteTenantStorageResponse records what was destroyed, so an operator has\na statement of what this removed rather than only that it succeeded."
     },
     "DeleteVolumeResponse": {
       "type": "object",

--- a/internal/server/encrypted_create.go
+++ b/internal/server/encrypted_create.go
@@ -114,6 +114,7 @@ func (s *ContainerServer) SetEncryptionStorage(tenantRoot string, client *incus.
 		incusStoragePools{
 			createPool: client.CreateZFSPool,
 			poolSource: client.StoragePoolSource,
+			deletePool: client.DeleteStoragePool,
 		},
 	)
 }

--- a/internal/server/encryption_hooks.go
+++ b/internal/server/encryption_hooks.go
@@ -64,6 +64,9 @@ type storagePoolAPI interface {
 	CreateZFSPool(name, source string) error
 	// StoragePoolSource reports where a pool points, and whether it exists.
 	StoragePoolSource(name string) (source string, exists bool, err error)
+	// DeleteStoragePool removes a pool. Absent is success, so a teardown
+	// interrupted halfway can be re-run (#1343).
+	DeleteStoragePool(name string) error
 }
 
 // encryptionHooks carries the collaborators the lifecycle hooks need.
@@ -492,6 +495,7 @@ func (s incusEncryptionState) SetPool(containerName, pool string) error {
 type incusStoragePools struct {
 	createPool func(name, source string) error
 	poolSource func(name string) (source string, exists bool, err error)
+	deletePool func(name string) error
 }
 
 func (p incusStoragePools) CreateZFSPool(name, source string) error {
@@ -500,6 +504,10 @@ func (p incusStoragePools) CreateZFSPool(name, source string) error {
 
 func (p incusStoragePools) StoragePoolSource(name string) (string, bool, error) {
 	return p.poolSource(name)
+}
+
+func (p incusStoragePools) DeleteStoragePool(name string) error {
+	return p.deletePool(name)
 }
 
 // ListEncrypted returns the containers carrying a key ref, so a rotation can

--- a/internal/server/encryption_hooks_integration_test.go
+++ b/internal/server/encryption_hooks_integration_test.go
@@ -67,6 +67,11 @@ func (m *memPools) CreateZFSPool(name, source string) error {
 	return nil
 }
 
+func (m *memPools) DeleteStoragePool(name string) error {
+	delete(m.sources, name)
+	return nil
+}
+
 func (m *memPools) StoragePoolSource(name string) (string, bool, error) {
 	src, ok := m.sources[name]
 	return src, ok, nil

--- a/internal/server/encryption_hooks_test.go
+++ b/internal/server/encryption_hooks_test.go
@@ -115,8 +115,11 @@ func (f *fakeRefStore) ListEncrypted() ([]string, error) {
 type fakePools struct {
 	sources   map[string]string
 	created   []string
+	deleted   []string
+	onDelete  func()
 	createErr error
 	sourceErr error
+	deleteErr error
 }
 
 func newFakePools() *fakePools { return &fakePools{sources: map[string]string{}} }
@@ -127,6 +130,22 @@ func (f *fakePools) CreateZFSPool(name, source string) error {
 	}
 	f.created = append(f.created, name)
 	f.sources[name] = source
+	return nil
+}
+
+func (f *fakePools) DeleteStoragePool(name string) error {
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
+	// onDelete lets a test observe what had ALREADY happened at the moment
+	// the pool was deleted. A flag set here unconditionally would record
+	// nothing about order — it would be true whichever way round the calls
+	// ran, which is a check that cannot fail.
+	if f.onDelete != nil {
+		f.onDelete()
+	}
+	f.deleted = append(f.deleted, name)
+	delete(f.sources, name)
 	return nil
 }
 

--- a/internal/server/tenant_offboarding.go
+++ b/internal/server/tenant_offboarding.go
@@ -1,0 +1,123 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/footprintai/containarium/internal/auth"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// Tenant offboarding (#1343).
+//
+// Per-tenant encryption creates two durable resources — an Incus storage pool
+// and the encrypted dataset it is sourced at — and until now nothing removed
+// them. A tenant who left kept both forever, the dataset holding their
+// key-encrypted data indefinitely.
+//
+// The ORDER is the whole issue. Destroying the dataset first leaves an Incus
+// pool pointing at nothing, and EnsureStorage/reviewExistingStorage walk every
+// pool at daemon start — so a mis-ordered teardown breaks startup for every
+// tenant on the host, not only the departing one.
+
+// DeleteTenantStorage destroys a departing tenant's encrypted storage.
+//
+// Irreversible: the dataset is the tenant's encryptionroot, so destroying it
+// destroys the only key path to their data. Admin only, like every other
+// operation on tenant key custody.
+func (s *ContainerServer) DeleteTenantStorage(ctx context.Context, req *pb.DeleteTenantStorageRequest) (*pb.DeleteTenantStorageResponse, error) {
+	if req.GetTenant() == "" {
+		return nil, status.Error(codes.InvalidArgument, "tenant is required")
+	}
+	if err := auth.RequireRole(ctx, auth.RoleAdmin); err != nil {
+		return nil, err
+	}
+
+	pool := tenantPoolName(req.GetTenant())
+	dataset, err := tenantDataset(s.encryption.tenantRootOrEmpty(), req.GetTenant())
+	if err != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "resolve the tenant's dataset: %v", err)
+	}
+
+	if err := s.encryption.DestroyTenantStorage(ctx, req.GetTenant()); err != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "%v", err)
+	}
+
+	return &pb.DeleteTenantStorageResponse{
+		Message: fmt.Sprintf(
+			"destroyed tenant %s's encrypted storage: pool %s and dataset %s. Their data is "+
+				"unrecoverable — the dataset was the only thing that could decrypt it",
+			req.GetTenant(), pool, dataset),
+		StoragePool: pool,
+		Dataset:     dataset,
+	}, nil
+}
+
+// tenantRootOrEmpty reports the configured tenant dataset root, or "" when
+// encryption is not wired. Lets a caller build the same names the hooks use
+// without duplicating the nil-receiver dance.
+func (h *encryptionHooks) tenantRootOrEmpty() string {
+	if h == nil {
+		return ""
+	}
+	return h.tenantRoot
+}
+
+// DestroyTenantStorage removes a tenant's Incus pool and then their encrypted
+// dataset, refusing while any of their containers still exist.
+//
+// Re-runnable: a pool that is already gone is not an error, so a teardown
+// interrupted halfway can be finished rather than leaving an operator stuck
+// between two half-removed resources.
+func (h *encryptionHooks) DestroyTenantStorage(ctx context.Context, tenant string) error {
+	if !h.enabled() {
+		return fmt.Errorf("encryption is not configured on this daemon, so there is no tenant storage to destroy")
+	}
+	dataset, err := tenantDataset(h.tenantRoot, tenant)
+	if err != nil {
+		return err
+	}
+	pool := tenantPoolName(tenant)
+
+	// Refuse while anything still lives under the tenant's encryptionroot.
+	// Deleting the pool from under a live box destroys its storage, and the
+	// containers are the reason the pool exists at all.
+	//
+	// The question goes to ZFS, not to the daemon's records: storage is what
+	// is about to be destroyed, so storage is what gets asked. A container
+	// whose record was lost would otherwise read as "no containers" and its
+	// data would be destroyed with the pool.
+	occupied, err := h.zfs.HasChildren(ctx, dataset)
+	if err != nil {
+		return fmt.Errorf("cannot determine whether tenant %s still has container storage, so "+
+			"refusing to destroy theirs: %w", tenant, err)
+	}
+	if occupied {
+		return fmt.Errorf(
+			"tenant %s still has container datasets under %s; delete their containers first. "+
+				"Removing the pool underneath a live container destroys its storage",
+			tenant, dataset)
+	}
+
+	// Pool first. The pool REFERENCES the dataset; destroying the dataset
+	// first leaves the pool dangling, and the daemon reads every pool at
+	// startup — which would break startup for every tenant on this host.
+	if err := h.pools.DeleteStoragePool(pool); err != nil {
+		return fmt.Errorf("could not delete storage pool %s, so tenant %s's dataset was left "+
+			"untouched: %w", pool, tenant, err)
+	}
+
+	if err := h.zfs.Destroy(ctx, dataset); err != nil {
+		return fmt.Errorf(
+			"storage pool %s was deleted but its dataset %s could not be destroyed (%w). Nothing "+
+				"references that dataset now and it still holds tenant %s's encrypted data — it "+
+				"needs manual removal", pool, dataset, err, tenant)
+	}
+
+	log.Printf("[encryption] offboarded tenant %s: pool %s deleted, dataset %s destroyed", tenant, pool, dataset)
+	return nil
+}

--- a/internal/server/tenant_offboarding_test.go
+++ b/internal/server/tenant_offboarding_test.go
@@ -1,0 +1,190 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/pkg/core/zfskey"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// Tenant offboarding (#1343).
+//
+// Per-tenant encryption creates two durable resources — an Incus storage pool
+// and the encrypted dataset it is sourced at — and nothing removed them. A
+// tenant who leaves kept both forever, the dataset holding their
+// key-encrypted data indefinitely.
+//
+// The ORDER is the whole issue. Destroying the dataset first leaves an Incus
+// pool pointing at nothing, and `EnsureStorage`/`reviewExistingStorage` walk
+// every pool at daemon start — so a mis-ordered teardown breaks startup for
+// every tenant on the host, not just the departing one.
+
+func offboardHooks(t *testing.T, z *zfsFake, containers map[string]zfskey.KeyRef) (*encryptionHooks, *fakePools, *fakeRefStore) {
+	t.Helper()
+	// The shared fake defaults `zfs list` to failing, which means "dataset
+	// absent" for Exists. Offboarding asks the same verb a different
+	// question — "does this root have children?" — so the tests here supply
+	// a real listing instead.
+	delete(z.errs, "list")
+	pools := newFakePools()
+	pools.sources["containarium-tenant-alice"] = "tank/tenants/alice"
+	placed := map[string]string{}
+	for name := range containers {
+		placed[name] = "containarium-tenant-alice"
+	}
+	refs := &fakeRefStore{refs: containers, pools: placed}
+	return testHooksWith(t, z, &fakeKeyProvider{key: aKey(t)}, refs, pools), pools, refs
+}
+
+// The guard: a tenant with containers still on their pool is not offboarded.
+// Deleting the pool underneath a live container destroys its storage.
+func TestDestroyTenantStorage_RefusesWhileContainersRemain(t *testing.T) {
+	z := newZFSFake()
+	// ZFS reports a container dataset still living under the tenant root.
+	z.stdout["list"] = "tank/tenants/alice\ntank/tenants/alice/containers/alice-container"
+	h, pools, _ := offboardHooks(t, z, map[string]zfskey.KeyRef{})
+
+	err := h.DestroyTenantStorage(context.Background(), "alice")
+	if err == nil {
+		t.Fatal("offboarded a tenant that still has containers — their storage would be deleted " +
+			"out from under a live box")
+	}
+	if !strings.Contains(err.Error(), "tank/tenants/alice") {
+		t.Errorf("the error does not name what is still there, so an operator cannot act: %v", err)
+	}
+	if len(pools.deleted) != 0 {
+		t.Errorf("the pool was deleted anyway: %v", pools.deleted)
+	}
+	if z.ran("destroy") {
+		t.Errorf("the dataset was destroyed anyway; calls=%v", z.calls)
+	}
+}
+
+// The order: pool first, dataset second.
+func TestDestroyTenantStorage_DeletesThePoolBeforeTheDataset(t *testing.T) {
+	z := newZFSFake()
+	z.stdout["list"] = "tank/tenants/alice" // empty: only the root itself
+	h, pools, _ := offboardHooks(t, z, map[string]zfskey.KeyRef{})
+
+	// Observe what had already happened when the pool was deleted. This is
+	// the ordering assertion; a flag the fake sets unconditionally would be
+	// true either way round and prove nothing.
+	datasetGoneFirst := false
+	pools.onDelete = func() { datasetGoneFirst = z.ran("destroy") }
+
+	if err := h.DestroyTenantStorage(context.Background(), "alice"); err != nil {
+		t.Fatalf("DestroyTenantStorage: %v", err)
+	}
+
+	if len(pools.deleted) != 1 || pools.deleted[0] != "containarium-tenant-alice" {
+		t.Fatalf("deleted pools = %v, want the tenant's", pools.deleted)
+	}
+	if !z.ran("destroy") || !z.ran("tank/tenants/alice") {
+		t.Fatalf("the tenant dataset was not destroyed; calls=%v", z.calls)
+	}
+	if datasetGoneFirst {
+		t.Error("the dataset was destroyed BEFORE the pool was deleted — the pool would then " +
+			"point at nothing, and EnsureStorage walks every pool at daemon start, so the next " +
+			"restart breaks for every tenant on this host")
+	}
+}
+
+// If the dataset survives a successful pool delete, the operator has to be
+// told exactly what is left: the pool is gone, so nothing will ever reference
+// that dataset again, and it holds the tenant's encrypted data.
+func TestDestroyTenantStorage_SaysWhatIsLeftWhenTheDatasetSurvives(t *testing.T) {
+	z := newZFSFake()
+	z.stdout["list"] = "tank/tenants/alice"
+	z.errs["destroy"] = errors.New("dataset is busy")
+	h, pools, _ := offboardHooks(t, z, map[string]zfskey.KeyRef{})
+
+	err := h.DestroyTenantStorage(context.Background(), "alice")
+	if err == nil {
+		t.Fatal("a surviving dataset was reported as a clean offboarding")
+	}
+	if len(pools.deleted) != 1 {
+		t.Errorf("the pool delete did not happen: %v", pools.deleted)
+	}
+	for _, want := range []string{"tank/tenants/alice", "manual"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the error does not mention %q, so the leftover is invisible: %v", want, err)
+		}
+	}
+}
+
+// A pool that is already gone must not stop the dataset being cleaned up —
+// offboarding has to be re-runnable after a partial failure.
+func TestDestroyTenantStorage_IsRerunnableAfterAPartialTeardown(t *testing.T) {
+	z := newZFSFake()
+	z.stdout["list"] = "tank/tenants/alice"
+	h, pools, _ := offboardHooks(t, z, map[string]zfskey.KeyRef{})
+	delete(pools.sources, "containarium-tenant-alice") // the pool went first time
+
+	if err := h.DestroyTenantStorage(context.Background(), "alice"); err != nil {
+		t.Fatalf("a re-run after a partial teardown failed: %v — an operator cannot finish what "+
+			"they started", err)
+	}
+	if !z.ran("destroy") {
+		t.Errorf("the leftover dataset was not cleaned up; calls=%v", z.calls)
+	}
+}
+
+func TestDestroyTenantStorage_RequiresEncryptionToBeConfigured(t *testing.T) {
+	var h *encryptionHooks
+	if err := h.DestroyTenantStorage(context.Background(), "alice"); err == nil {
+		t.Fatal("a daemon with no encryption claimed to have offboarded a tenant")
+	}
+}
+
+// --- the RPC ------------------------------------------------------------
+
+func TestDeleteTenantStorage_RequiresAdmin(t *testing.T) {
+	z := newZFSFake()
+	z.stdout["list"] = "tank/tenants/alice"
+	h, _, _ := offboardHooks(t, z, map[string]zfskey.KeyRef{})
+	s := &ContainerServer{encryption: h}
+
+	_, err := s.DeleteTenantStorage(
+		tenantWithScopes("alice", auth.ScopeContainersWrite),
+		&pb.DeleteTenantStorageRequest{Tenant: "alice"})
+	if err == nil {
+		t.Fatal("a non-admin destroyed a tenant's encrypted storage")
+	}
+	if got := status.Code(err); got != codes.PermissionDenied {
+		t.Errorf("code = %v, want PermissionDenied", got)
+	}
+}
+
+func TestDeleteTenantStorage_ReportsWhatItRemoved(t *testing.T) {
+	z := newZFSFake()
+	z.stdout["list"] = "tank/tenants/alice"
+	h, _, _ := offboardHooks(t, z, map[string]zfskey.KeyRef{})
+	s := &ContainerServer{encryption: h}
+
+	resp, err := s.DeleteTenantStorage(adminCtx(), &pb.DeleteTenantStorageRequest{Tenant: "alice"})
+	if err != nil {
+		t.Fatalf("DeleteTenantStorage: %v", err)
+	}
+	if resp.StoragePool == "" || resp.Dataset == "" {
+		t.Errorf("the response does not name what was destroyed (pool=%q dataset=%q) — an "+
+			"operator has no record of what this removed", resp.StoragePool, resp.Dataset)
+	}
+}
+
+func TestDeleteTenantStorage_RejectsAnEmptyTenant(t *testing.T) {
+	z := newZFSFake()
+	z.stdout["list"] = "tank/tenants/alice"
+	h, _, _ := offboardHooks(t, z, map[string]zfskey.KeyRef{})
+	s := &ContainerServer{encryption: h}
+
+	if _, err := s.DeleteTenantStorage(adminCtx(), &pb.DeleteTenantStorageRequest{}); err == nil {
+		t.Fatal("an empty tenant was accepted — tenantDataset would name the root itself")
+	}
+}

--- a/pkg/core/zfscrypt/zfscrypt.go
+++ b/pkg/core/zfscrypt/zfscrypt.go
@@ -356,6 +356,37 @@ func (m *Manager) EnsureParent(ctx context.Context, dataset string) error {
 	return nil
 }
 
+// HasChildren reports whether a dataset has any descendants.
+//
+// The offboarding guard (#1343): a tenant's encryptionroot with children
+// still holds container datasets, and deleting its pool would destroy them.
+//
+// Asked of ZFS rather than of the daemon's own records deliberately. A record
+// can be lost — a config key cleared, a store restored from an older backup —
+// and an enumeration of records would then report "no containers" for a
+// tenant whose data is still there. Storage is the thing being destroyed, so
+// storage is what gets asked.
+func (m *Manager) HasChildren(ctx context.Context, dataset string) (bool, error) {
+	if err := validateDataset(dataset); err != nil {
+		return false, err
+	}
+	stdout, stderr, err := m.run.Run(ctx, nil, "list", "-H", "-o", "name", "-r", dataset)
+	if err != nil {
+		return false, fmt.Errorf("list children of %s: %w: %s", dataset, err, strings.TrimSpace(stderr))
+	}
+	for _, line := range strings.Split(strings.TrimSpace(stdout), "\n") {
+		name := strings.TrimSpace(line)
+		// The recursive listing includes the dataset itself, and a sibling
+		// like <dataset>2 shares its prefix — only a "/" separated descendant
+		// counts, or a tenant could never be offboarded while a
+		// similarly-named one exists.
+		if name != "" && strings.HasPrefix(name, dataset+"/") {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // Destroy removes a dataset. Used to clean up a half-built container so
 // a failed encrypted create leaves no partial state behind.
 func (m *Manager) Destroy(ctx context.Context, dataset string) error {

--- a/pkg/core/zfscrypt/zfscrypt_test.go
+++ b/pkg/core/zfscrypt/zfscrypt_test.go
@@ -460,3 +460,71 @@ func TestChangeKey(t *testing.T) {
 		}
 	})
 }
+
+// HasChildren backs the offboarding guard (#1343): a tenant encryptionroot
+// with child datasets still holds containers.
+//
+// Asked of ZFS rather than of the daemon's own records on purpose. A record
+// can be lost — a config key cleared, a store restored from an older backup —
+// and the enumeration would then report "no containers" for a tenant whose
+// data is still there, which is the one mistake this guard cannot afford.
+func TestHasChildren(t *testing.T) {
+	t.Run("children present", func(t *testing.T) {
+		r := newFakeRunner()
+		r.stdout["list"] = "tank/tenants/alice\ntank/tenants/alice/containers\ntank/tenants/alice/containers/alice-container"
+		m := NewManager(r)
+
+		has, err := m.HasChildren(context.Background(), "tank/tenants/alice")
+		if err != nil {
+			t.Fatalf("HasChildren: %v", err)
+		}
+		if !has {
+			t.Error("reported no children for a dataset that has them — offboarding would destroy " +
+				"a tenant's live container storage")
+		}
+	})
+
+	t.Run("the dataset itself is not a child of itself", func(t *testing.T) {
+		r := newFakeRunner()
+		r.stdout["list"] = "tank/tenants/alice"
+		m := NewManager(r)
+
+		has, err := m.HasChildren(context.Background(), "tank/tenants/alice")
+		if err != nil {
+			t.Fatalf("HasChildren: %v", err)
+		}
+		if has {
+			t.Error("an empty tenant root reported children — its own name is in the recursive " +
+				"listing and must not count, or a tenant could never be offboarded")
+		}
+	})
+
+	// A prefix match would call tank/tenants/alice2 a child of
+	// tank/tenants/alice, and refuse to offboard alice forever.
+	t.Run("a sibling with a shared prefix is not a child", func(t *testing.T) {
+		r := newFakeRunner()
+		r.stdout["list"] = "tank/tenants/alice\ntank/tenants/alice2\ntank/tenants/alice2/containers"
+		m := NewManager(r)
+
+		has, err := m.HasChildren(context.Background(), "tank/tenants/alice")
+		if err != nil {
+			t.Fatalf("HasChildren: %v", err)
+		}
+		if has {
+			t.Error("a sibling sharing a name prefix was counted as a child — alice could never " +
+				"be offboarded while alice2 exists")
+		}
+	})
+
+	t.Run("surfaces the zfs error", func(t *testing.T) {
+		r := newFakeRunner()
+		r.errs["list"] = errors.New("exit status 1")
+		r.stderr["list"] = "cannot open 'tank/tenants/alice': dataset does not exist"
+		m := NewManager(r)
+
+		if _, err := m.HasChildren(context.Background(), "tank/tenants/alice"); err == nil {
+			t.Fatal("an unreadable dataset was reported as having no children — offboarding " +
+				"would proceed on a guess")
+		}
+	})
+}

--- a/pkg/pb/containarium/v1/container.pb.go
+++ b/pkg/pb/containarium/v1/container.pb.go
@@ -4931,6 +4931,123 @@ func (x *AdoptMigratedContainerRequest) GetZfsPool() string {
 	return ""
 }
 
+// DeleteTenantStorageRequest tears down a departing tenant's encrypted
+// storage (#1343): the Incus storage pool, and the encrypted dataset it is
+// sourced at.
+//
+// Refused while the tenant still has containers — deleting the pool from
+// under a live box destroys its storage.
+type DeleteTenantStorageRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The tenant being offboarded.
+	Tenant        string `protobuf:"bytes,1,opt,name=tenant,proto3" json:"tenant,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteTenantStorageRequest) Reset() {
+	*x = DeleteTenantStorageRequest{}
+	mi := &file_containarium_v1_container_proto_msgTypes[60]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteTenantStorageRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteTenantStorageRequest) ProtoMessage() {}
+
+func (x *DeleteTenantStorageRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_container_proto_msgTypes[60]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteTenantStorageRequest.ProtoReflect.Descriptor instead.
+func (*DeleteTenantStorageRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{60}
+}
+
+func (x *DeleteTenantStorageRequest) GetTenant() string {
+	if x != nil {
+		return x.Tenant
+	}
+	return ""
+}
+
+// DeleteTenantStorageResponse records what was destroyed, so an operator has
+// a statement of what this removed rather than only that it succeeded.
+type DeleteTenantStorageResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Human-readable summary.
+	Message string `protobuf:"bytes,1,opt,name=message,proto3" json:"message,omitempty"`
+	// The Incus storage pool that was deleted.
+	StoragePool string `protobuf:"bytes,2,opt,name=storage_pool,json=storagePool,proto3" json:"storage_pool,omitempty"`
+	// The ZFS dataset that was destroyed — the tenant's encryptionroot, and
+	// with it the only thing that could decrypt their data.
+	Dataset       string `protobuf:"bytes,3,opt,name=dataset,proto3" json:"dataset,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteTenantStorageResponse) Reset() {
+	*x = DeleteTenantStorageResponse{}
+	mi := &file_containarium_v1_container_proto_msgTypes[61]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteTenantStorageResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteTenantStorageResponse) ProtoMessage() {}
+
+func (x *DeleteTenantStorageResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_container_proto_msgTypes[61]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteTenantStorageResponse.ProtoReflect.Descriptor instead.
+func (*DeleteTenantStorageResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{61}
+}
+
+func (x *DeleteTenantStorageResponse) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+func (x *DeleteTenantStorageResponse) GetStoragePool() string {
+	if x != nil {
+		return x.StoragePool
+	}
+	return ""
+}
+
+func (x *DeleteTenantStorageResponse) GetDataset() string {
+	if x != nil {
+		return x.Dataset
+	}
+	return ""
+}
+
 // RewrapContainerRequest rotates the key protecting a container's data
 // (#1204), driven by the control plane during a maintenance window.
 //
@@ -4957,7 +5074,7 @@ type RewrapContainerRequest struct {
 
 func (x *RewrapContainerRequest) Reset() {
 	*x = RewrapContainerRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[60]
+	mi := &file_containarium_v1_container_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4969,7 +5086,7 @@ func (x *RewrapContainerRequest) String() string {
 func (*RewrapContainerRequest) ProtoMessage() {}
 
 func (x *RewrapContainerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[60]
+	mi := &file_containarium_v1_container_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4982,7 +5099,7 @@ func (x *RewrapContainerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RewrapContainerRequest.ProtoReflect.Descriptor instead.
 func (*RewrapContainerRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{60}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *RewrapContainerRequest) GetUsername() string {
@@ -5016,7 +5133,7 @@ type RewrapContainerResponse struct {
 
 func (x *RewrapContainerResponse) Reset() {
 	*x = RewrapContainerResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[61]
+	mi := &file_containarium_v1_container_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5028,7 +5145,7 @@ func (x *RewrapContainerResponse) String() string {
 func (*RewrapContainerResponse) ProtoMessage() {}
 
 func (x *RewrapContainerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[61]
+	mi := &file_containarium_v1_container_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5041,7 +5158,7 @@ func (x *RewrapContainerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RewrapContainerResponse.ProtoReflect.Descriptor instead.
 func (*RewrapContainerResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{61}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *RewrapContainerResponse) GetMessage() string {
@@ -5090,7 +5207,7 @@ type PrepareEncryptedMigrationRequest struct {
 
 func (x *PrepareEncryptedMigrationRequest) Reset() {
 	*x = PrepareEncryptedMigrationRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[62]
+	mi := &file_containarium_v1_container_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5102,7 +5219,7 @@ func (x *PrepareEncryptedMigrationRequest) String() string {
 func (*PrepareEncryptedMigrationRequest) ProtoMessage() {}
 
 func (x *PrepareEncryptedMigrationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[62]
+	mi := &file_containarium_v1_container_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5115,7 +5232,7 @@ func (x *PrepareEncryptedMigrationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PrepareEncryptedMigrationRequest.ProtoReflect.Descriptor instead.
 func (*PrepareEncryptedMigrationRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{62}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *PrepareEncryptedMigrationRequest) GetUsername() string {
@@ -5161,7 +5278,7 @@ type PrepareEncryptedMigrationResponse struct {
 
 func (x *PrepareEncryptedMigrationResponse) Reset() {
 	*x = PrepareEncryptedMigrationResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[63]
+	mi := &file_containarium_v1_container_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5173,7 +5290,7 @@ func (x *PrepareEncryptedMigrationResponse) String() string {
 func (*PrepareEncryptedMigrationResponse) ProtoMessage() {}
 
 func (x *PrepareEncryptedMigrationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[63]
+	mi := &file_containarium_v1_container_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5186,7 +5303,7 @@ func (x *PrepareEncryptedMigrationResponse) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use PrepareEncryptedMigrationResponse.ProtoReflect.Descriptor instead.
 func (*PrepareEncryptedMigrationResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{63}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *PrepareEncryptedMigrationResponse) GetCanResolve() bool {
@@ -5225,7 +5342,7 @@ type AdoptMigratedContainerResponse struct {
 
 func (x *AdoptMigratedContainerResponse) Reset() {
 	*x = AdoptMigratedContainerResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[64]
+	mi := &file_containarium_v1_container_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5237,7 +5354,7 @@ func (x *AdoptMigratedContainerResponse) String() string {
 func (*AdoptMigratedContainerResponse) ProtoMessage() {}
 
 func (x *AdoptMigratedContainerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[64]
+	mi := &file_containarium_v1_container_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5250,7 +5367,7 @@ func (x *AdoptMigratedContainerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdoptMigratedContainerResponse.ProtoReflect.Descriptor instead.
 func (*AdoptMigratedContainerResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{64}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *AdoptMigratedContainerResponse) GetMessage() string {
@@ -5624,7 +5741,13 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\busername\x18\x01 \x01(\tR\busername\x12#\n" +
 	"\rsource_routes\x18\x02 \x03(\tR\fsourceRoutes\x12\x1e\n" +
 	"\vzfs_key_ref\x18\x03 \x01(\tR\tzfsKeyRef\x12\x19\n" +
-	"\bzfs_pool\x18\x04 \x01(\tR\azfsPool\"T\n" +
+	"\bzfs_pool\x18\x04 \x01(\tR\azfsPool\"4\n" +
+	"\x1aDeleteTenantStorageRequest\x12\x16\n" +
+	"\x06tenant\x18\x01 \x01(\tR\x06tenant\"t\n" +
+	"\x1bDeleteTenantStorageResponse\x12\x18\n" +
+	"\amessage\x18\x01 \x01(\tR\amessage\x12!\n" +
+	"\fstorage_pool\x18\x02 \x01(\tR\vstoragePool\x12\x18\n" +
+	"\adataset\x18\x03 \x01(\tR\adataset\"T\n" +
 	"\x16RewrapContainerRequest\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\x12\x1e\n" +
 	"\vnew_key_ref\x18\x02 \x01(\tR\tnewKeyRef\"\x84\x01\n" +
@@ -5696,7 +5819,7 @@ func file_containarium_v1_container_proto_rawDescGZIP() []byte {
 }
 
 var file_containarium_v1_container_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
-var file_containarium_v1_container_proto_msgTypes = make([]protoimpl.MessageInfo, 71)
+var file_containarium_v1_container_proto_msgTypes = make([]protoimpl.MessageInfo, 73)
 var file_containarium_v1_container_proto_goTypes = []any{
 	(OSType)(0),                               // 0: containarium.v1.OSType
 	(AccessType)(0),                           // 1: containarium.v1.AccessType
@@ -5765,48 +5888,50 @@ var file_containarium_v1_container_proto_goTypes = []any{
 	(*MoveContainerRequest)(nil),              // 64: containarium.v1.MoveContainerRequest
 	(*MoveContainerResponse)(nil),             // 65: containarium.v1.MoveContainerResponse
 	(*AdoptMigratedContainerRequest)(nil),     // 66: containarium.v1.AdoptMigratedContainerRequest
-	(*RewrapContainerRequest)(nil),            // 67: containarium.v1.RewrapContainerRequest
-	(*RewrapContainerResponse)(nil),           // 68: containarium.v1.RewrapContainerResponse
-	(*PrepareEncryptedMigrationRequest)(nil),  // 69: containarium.v1.PrepareEncryptedMigrationRequest
-	(*PrepareEncryptedMigrationResponse)(nil), // 70: containarium.v1.PrepareEncryptedMigrationResponse
-	(*AdoptMigratedContainerResponse)(nil),    // 71: containarium.v1.AdoptMigratedContainerResponse
-	nil,                                       // 72: containarium.v1.Container.LabelsEntry
-	nil,                                       // 73: containarium.v1.CreateContainerRequest.LabelsEntry
-	nil,                                       // 74: containarium.v1.CreateContainerRequest.StackParametersEntry
-	nil,                                       // 75: containarium.v1.ListContainersRequest.LabelFilterEntry
-	nil,                                       // 76: containarium.v1.SetContainerAttributionRequest.LabelsEntry
-	nil,                                       // 77: containarium.v1.SetContainerAttributionResponse.LabelsEntry
-	(*timestamppb.Timestamp)(nil),             // 78: google.protobuf.Timestamp
-	(*descriptorpb.EnumValueOptions)(nil),     // 79: google.protobuf.EnumValueOptions
+	(*DeleteTenantStorageRequest)(nil),        // 67: containarium.v1.DeleteTenantStorageRequest
+	(*DeleteTenantStorageResponse)(nil),       // 68: containarium.v1.DeleteTenantStorageResponse
+	(*RewrapContainerRequest)(nil),            // 69: containarium.v1.RewrapContainerRequest
+	(*RewrapContainerResponse)(nil),           // 70: containarium.v1.RewrapContainerResponse
+	(*PrepareEncryptedMigrationRequest)(nil),  // 71: containarium.v1.PrepareEncryptedMigrationRequest
+	(*PrepareEncryptedMigrationResponse)(nil), // 72: containarium.v1.PrepareEncryptedMigrationResponse
+	(*AdoptMigratedContainerResponse)(nil),    // 73: containarium.v1.AdoptMigratedContainerResponse
+	nil,                                       // 74: containarium.v1.Container.LabelsEntry
+	nil,                                       // 75: containarium.v1.CreateContainerRequest.LabelsEntry
+	nil,                                       // 76: containarium.v1.CreateContainerRequest.StackParametersEntry
+	nil,                                       // 77: containarium.v1.ListContainersRequest.LabelFilterEntry
+	nil,                                       // 78: containarium.v1.SetContainerAttributionRequest.LabelsEntry
+	nil,                                       // 79: containarium.v1.SetContainerAttributionResponse.LabelsEntry
+	(*timestamppb.Timestamp)(nil),             // 80: google.protobuf.Timestamp
+	(*descriptorpb.EnumValueOptions)(nil),     // 81: google.protobuf.EnumValueOptions
 }
 var file_containarium_v1_container_proto_depIdxs = []int32{
 	2,  // 0: containarium.v1.Container.state:type_name -> containarium.v1.ContainerState
 	7,  // 1: containarium.v1.Container.resources:type_name -> containarium.v1.ResourceLimits
 	8,  // 2: containarium.v1.Container.network:type_name -> containarium.v1.NetworkInfo
-	72, // 3: containarium.v1.Container.labels:type_name -> containarium.v1.Container.LabelsEntry
+	74, // 3: containarium.v1.Container.labels:type_name -> containarium.v1.Container.LabelsEntry
 	0,  // 4: containarium.v1.Container.os_type:type_name -> containarium.v1.OSType
 	1,  // 5: containarium.v1.Container.access_type:type_name -> containarium.v1.AccessType
-	78, // 6: containarium.v1.Container.ttl_expires_at:type_name -> google.protobuf.Timestamp
-	78, // 7: containarium.v1.Container.stopped_at:type_name -> google.protobuf.Timestamp
+	80, // 6: containarium.v1.Container.ttl_expires_at:type_name -> google.protobuf.Timestamp
+	80, // 7: containarium.v1.Container.stopped_at:type_name -> google.protobuf.Timestamp
 	3,  // 8: containarium.v1.Container.delete_policy:type_name -> containarium.v1.DeletePolicy
 	4,  // 9: containarium.v1.Container.encryption_state:type_name -> containarium.v1.EncryptionState
 	7,  // 10: containarium.v1.CreateContainerRequest.resources:type_name -> containarium.v1.ResourceLimits
-	73, // 11: containarium.v1.CreateContainerRequest.labels:type_name -> containarium.v1.CreateContainerRequest.LabelsEntry
+	75, // 11: containarium.v1.CreateContainerRequest.labels:type_name -> containarium.v1.CreateContainerRequest.LabelsEntry
 	0,  // 12: containarium.v1.CreateContainerRequest.os_type:type_name -> containarium.v1.OSType
-	74, // 13: containarium.v1.CreateContainerRequest.stack_parameters:type_name -> containarium.v1.CreateContainerRequest.StackParametersEntry
+	76, // 13: containarium.v1.CreateContainerRequest.stack_parameters:type_name -> containarium.v1.CreateContainerRequest.StackParametersEntry
 	9,  // 14: containarium.v1.CreateContainerResponse.container:type_name -> containarium.v1.Container
 	2,  // 15: containarium.v1.ListContainersRequest.state:type_name -> containarium.v1.ContainerState
-	75, // 16: containarium.v1.ListContainersRequest.label_filter:type_name -> containarium.v1.ListContainersRequest.LabelFilterEntry
+	77, // 16: containarium.v1.ListContainersRequest.label_filter:type_name -> containarium.v1.ListContainersRequest.LabelFilterEntry
 	9,  // 17: containarium.v1.ListContainersResponse.containers:type_name -> containarium.v1.Container
 	9,  // 18: containarium.v1.GetContainerResponse.container:type_name -> containarium.v1.Container
 	10, // 19: containarium.v1.GetContainerResponse.metrics:type_name -> containarium.v1.ContainerMetrics
 	9,  // 20: containarium.v1.StartContainerResponse.container:type_name -> containarium.v1.Container
 	9,  // 21: containarium.v1.StopContainerResponse.container:type_name -> containarium.v1.Container
-	78, // 22: containarium.v1.SetContainerTTLResponse.ttl_expires_at:type_name -> google.protobuf.Timestamp
+	80, // 22: containarium.v1.SetContainerTTLResponse.ttl_expires_at:type_name -> google.protobuf.Timestamp
 	3,  // 23: containarium.v1.SetContainerDeletePolicyRequest.delete_policy:type_name -> containarium.v1.DeletePolicy
 	3,  // 24: containarium.v1.SetContainerDeletePolicyResponse.delete_policy:type_name -> containarium.v1.DeletePolicy
-	76, // 25: containarium.v1.SetContainerAttributionRequest.labels:type_name -> containarium.v1.SetContainerAttributionRequest.LabelsEntry
-	77, // 26: containarium.v1.SetContainerAttributionResponse.labels:type_name -> containarium.v1.SetContainerAttributionResponse.LabelsEntry
+	78, // 25: containarium.v1.SetContainerAttributionRequest.labels:type_name -> containarium.v1.SetContainerAttributionRequest.LabelsEntry
+	79, // 26: containarium.v1.SetContainerAttributionResponse.labels:type_name -> containarium.v1.SetContainerAttributionResponse.LabelsEntry
 	10, // 27: containarium.v1.GetMetricsResponse.metrics:type_name -> containarium.v1.ContainerMetrics
 	9,  // 28: containarium.v1.ResizeContainerResponse.container:type_name -> containarium.v1.Container
 	43, // 29: containarium.v1.AddCollaboratorResponse.collaborator:type_name -> containarium.v1.Collaborator
@@ -5820,9 +5945,9 @@ var file_containarium_v1_container_proto_depIdxs = []int32{
 	5,  // 37: containarium.v1.SetMetricsExportResponse.provider:type_name -> containarium.v1.CloudMetricsProvider
 	6,  // 38: containarium.v1.SetMetricsExportResponse.groups:type_name -> containarium.v1.CloudMetricsGroup
 	5,  // 39: containarium.v1.GetMetricsExportResponse.provider:type_name -> containarium.v1.CloudMetricsProvider
-	78, // 40: containarium.v1.GetMetricsExportResponse.last_success_at:type_name -> google.protobuf.Timestamp
+	80, // 40: containarium.v1.GetMetricsExportResponse.last_success_at:type_name -> google.protobuf.Timestamp
 	6,  // 41: containarium.v1.GetMetricsExportResponse.groups:type_name -> containarium.v1.CloudMetricsGroup
-	79, // 42: containarium.v1.state_name:extendee -> google.protobuf.EnumValueOptions
+	81, // 42: containarium.v1.state_name:extendee -> google.protobuf.EnumValueOptions
 	43, // [43:43] is the sub-list for method output_type
 	43, // [43:43] is the sub-list for method input_type
 	43, // [43:43] is the sub-list for extension type_name
@@ -5841,7 +5966,7 @@ func file_containarium_v1_container_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_v1_container_proto_rawDesc), len(file_containarium_v1_container_proto_rawDesc)),
 			NumEnums:      7,
-			NumMessages:   71,
+			NumMessages:   73,
 			NumExtensions: 1,
 			NumServices:   0,
 		},

--- a/pkg/pb/containarium/v1/service.pb.go
+++ b/pkg/pb/containarium/v1/service.pb.go
@@ -26,7 +26,7 @@ var File_containarium_v1_service_proto protoreflect.FileDescriptor
 
 const file_containarium_v1_service_proto_rawDesc = "" +
 	"\n" +
-	"\x1dcontainarium/v1/service.proto\x12\x0fcontainarium.v1\x1a\x1fcontainarium/v1/container.proto\x1a\x1ccontainarium/v1/config.proto\x1a\x19containarium/v1/app.proto\x1a\x1dcontainarium/v1/network.proto\x1a\x1bcontainarium/v1/alert.proto\x1a\x1dcontainarium/v1/secrets.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto2\xf0\x9a\x01\n" +
+	"\x1dcontainarium/v1/service.proto\x12\x0fcontainarium.v1\x1a\x1fcontainarium/v1/container.proto\x1a\x1ccontainarium/v1/config.proto\x1a\x19containarium/v1/app.proto\x1a\x1dcontainarium/v1/network.proto\x1a\x1bcontainarium/v1/alert.proto\x1a\x1dcontainarium/v1/secrets.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto2ڞ\x01\n" +
 	"\x10ContainerService\x12\xae\x02\n" +
 	"\x0fCreateContainer\x12'.containarium.v1.CreateContainerRequest\x1a(.containarium.v1.CreateContainerResponse\"\xc7\x01\x92A\xaa\x01\n" +
 	"\n" +
@@ -50,7 +50,9 @@ const file_containarium_v1_service_proto_rawDesc = "" +
 	"\x0fResizeContainer\x12'.containarium.v1.ResizeContainerRequest\x1a(.containarium.v1.ResizeContainerResponse\"\xdc\x01\x92A\xad\x01\n" +
 	"\x14Container Operations\x12\x1aResize container resources\x1ayDynamically adjusts CPU, memory, and disk resources without container restart. Disk can only be increased, not decreased.\x82\xd3\xe4\x93\x02%:\x01*\x1a /v1/containers/{username}/resize\x12\xc8\x03\n" +
 	"\rMoveContainer\x12%.containarium.v1.MoveContainerRequest\x1a&.containarium.v1.MoveContainerResponse\"\xe7\x02\x92A\xba\x02\n" +
-	"\x14Container Operations\x12 Migrate container to peer daemon\x1a\xff\x01Pre-copy snapshot-based migration to a peer daemon. Sub-second downtime on ZFS/btrfs storage with low write rate; up to minutes on dir-pool or active workloads. Caller must have incus remotes configured both directions between the source and target hosts.\x82\xd3\xe4\x93\x02#:\x01*\"\x1e/v1/containers/{username}/move\x12\xc5\x03\n" +
+	"\x14Container Operations\x12 Migrate container to peer daemon\x1a\xff\x01Pre-copy snapshot-based migration to a peer daemon. Sub-second downtime on ZFS/btrfs storage with low write rate; up to minutes on dir-pool or active workloads. Caller must have incus remotes configured both directions between the source and target hosts.\x82\xd3\xe4\x93\x02#:\x01*\"\x1e/v1/containers/{username}/move\x12\xe7\x03\n" +
+	"\x13DeleteTenantStorage\x12+.containarium.v1.DeleteTenantStorageRequest\x1a,.containarium.v1.DeleteTenantStorageResponse\"\xf4\x02\x92A\xcc\x02\n" +
+	"\x14Container Operations\x12.Destroy a departing tenant's encrypted storage\x1a\x83\x02Deletes the tenant's Incus storage pool and then the encrypted dataset it was sourced at. Refused while the tenant still has containers. Irreversible — the dataset is the tenant's encryptionroot, so this destroys the only key path to their data. Admin only.\x82\xd3\xe4\x93\x02\x1e*\x1c/v1/tenants/{tenant}/storage\x12\xc5\x03\n" +
 	"\x0fRewrapContainer\x12'.containarium.v1.RewrapContainerRequest\x1a(.containarium.v1.RewrapContainerResponse\"\xde\x02\x92A\xaf\x02\n" +
 	"\x14Container Operations\x12 Rotate a tenant's encryption key\x1a\xf4\x01Rewraps the tenant's ZFS encryptionroot onto new key material supplied as a key reference. Only the wrapping key changes, so the cost is independent of dataset size. Affects every container the tenant owns, which the response lists. Admin only.\x82\xd3\xe4\x93\x02%:\x01*\" /v1/containers/{username}/rewrap\x12\xf9\x04\n" +
 	"\x19PrepareEncryptedMigration\x121.containarium.v1.PrepareEncryptedMigrationRequest\x1a2.containarium.v1.PrepareEncryptedMigrationResponse\"\xf4\x03\x92A\xb0\x03\n" +
@@ -174,109 +176,111 @@ var file_containarium_v1_service_proto_goTypes = []any{
 	(*StopContainerRequest)(nil),              // 6: containarium.v1.StopContainerRequest
 	(*ResizeContainerRequest)(nil),            // 7: containarium.v1.ResizeContainerRequest
 	(*MoveContainerRequest)(nil),              // 8: containarium.v1.MoveContainerRequest
-	(*RewrapContainerRequest)(nil),            // 9: containarium.v1.RewrapContainerRequest
-	(*PrepareEncryptedMigrationRequest)(nil),  // 10: containarium.v1.PrepareEncryptedMigrationRequest
-	(*AdoptMigratedContainerRequest)(nil),     // 11: containarium.v1.AdoptMigratedContainerRequest
-	(*ToggleMonitoringRequest)(nil),           // 12: containarium.v1.ToggleMonitoringRequest
-	(*ToggleAutoSleepRequest)(nil),            // 13: containarium.v1.ToggleAutoSleepRequest
-	(*SetContainerTTLRequest)(nil),            // 14: containarium.v1.SetContainerTTLRequest
-	(*SetContainerDeletePolicyRequest)(nil),   // 15: containarium.v1.SetContainerDeletePolicyRequest
-	(*SetContainerAttributionRequest)(nil),    // 16: containarium.v1.SetContainerAttributionRequest
-	(*AddSSHKeyRequest)(nil),                  // 17: containarium.v1.AddSSHKeyRequest
-	(*RemoveSSHKeyRequest)(nil),               // 18: containarium.v1.RemoveSSHKeyRequest
-	(*AddCollaboratorRequest)(nil),            // 19: containarium.v1.AddCollaboratorRequest
-	(*RemoveCollaboratorRequest)(nil),         // 20: containarium.v1.RemoveCollaboratorRequest
-	(*ListCollaboratorsRequest)(nil),          // 21: containarium.v1.ListCollaboratorsRequest
-	(*GetMetricsRequest)(nil),                 // 22: containarium.v1.GetMetricsRequest
-	(*CleanupDiskRequest)(nil),                // 23: containarium.v1.CleanupDiskRequest
-	(*InstallStackRequest)(nil),               // 24: containarium.v1.InstallStackRequest
-	(*ListStacksRequest)(nil),                 // 25: containarium.v1.ListStacksRequest
-	(*GetSystemInfoRequest)(nil),              // 26: containarium.v1.GetSystemInfoRequest
-	(*ListBackendsRequest)(nil),               // 27: containarium.v1.ListBackendsRequest
-	(*AdvertiseCapacityRequest)(nil),          // 28: containarium.v1.AdvertiseCapacityRequest
-	(*WithdrawCapacityRequest)(nil),           // 29: containarium.v1.WithdrawCapacityRequest
-	(*GetCapacityHeadroomRequest)(nil),        // 30: containarium.v1.GetCapacityHeadroomRequest
-	(*ProfileBackendRequest)(nil),             // 31: containarium.v1.ProfileBackendRequest
-	(*GetCapabilityProfileRequest)(nil),       // 32: containarium.v1.GetCapabilityProfileRequest
-	(*GetSelfMeasurementRequest)(nil),         // 33: containarium.v1.GetSelfMeasurementRequest
-	(*GetLatestReleaseRequest)(nil),           // 34: containarium.v1.GetLatestReleaseRequest
-	(*ValidateGPURequest)(nil),                // 35: containarium.v1.ValidateGPURequest
-	(*TriggerUpgradeRequest)(nil),             // 36: containarium.v1.TriggerUpgradeRequest
-	(*GetUpgradeStatusRequest)(nil),           // 37: containarium.v1.GetUpgradeStatusRequest
-	(*GetMonitoringInfoRequest)(nil),          // 38: containarium.v1.GetMonitoringInfoRequest
-	(*SetMetricsExportRequest)(nil),           // 39: containarium.v1.SetMetricsExportRequest
-	(*GetMetricsExportRequest)(nil),           // 40: containarium.v1.GetMetricsExportRequest
-	(*CreateAlertRuleRequest)(nil),            // 41: containarium.v1.CreateAlertRuleRequest
-	(*ListAlertRulesRequest)(nil),             // 42: containarium.v1.ListAlertRulesRequest
-	(*GetAlertRuleRequest)(nil),               // 43: containarium.v1.GetAlertRuleRequest
-	(*UpdateAlertRuleRequest)(nil),            // 44: containarium.v1.UpdateAlertRuleRequest
-	(*DeleteAlertRuleRequest)(nil),            // 45: containarium.v1.DeleteAlertRuleRequest
-	(*GetAlertingInfoRequest)(nil),            // 46: containarium.v1.GetAlertingInfoRequest
-	(*ListDefaultAlertRulesRequest)(nil),      // 47: containarium.v1.ListDefaultAlertRulesRequest
-	(*UpdateAlertingConfigRequest)(nil),       // 48: containarium.v1.UpdateAlertingConfigRequest
-	(*TestWebhookRequest)(nil),                // 49: containarium.v1.TestWebhookRequest
-	(*ListWebhookDeliveriesRequest)(nil),      // 50: containarium.v1.ListWebhookDeliveriesRequest
-	(*SetSecretRequest)(nil),                  // 51: containarium.v1.SetSecretRequest
-	(*GetSecretRequest)(nil),                  // 52: containarium.v1.GetSecretRequest
-	(*ListSecretsRequest)(nil),                // 53: containarium.v1.ListSecretsRequest
-	(*DeleteSecretRequest)(nil),               // 54: containarium.v1.DeleteSecretRequest
-	(*RefreshSecretsRequest)(nil),             // 55: containarium.v1.RefreshSecretsRequest
-	(*CreateContainerResponse)(nil),           // 56: containarium.v1.CreateContainerResponse
-	(*ListContainersResponse)(nil),            // 57: containarium.v1.ListContainersResponse
-	(*GetContainerResponse)(nil),              // 58: containarium.v1.GetContainerResponse
-	(*DebugContainerResponse)(nil),            // 59: containarium.v1.DebugContainerResponse
-	(*DeleteContainerResponse)(nil),           // 60: containarium.v1.DeleteContainerResponse
-	(*StartContainerResponse)(nil),            // 61: containarium.v1.StartContainerResponse
-	(*StopContainerResponse)(nil),             // 62: containarium.v1.StopContainerResponse
-	(*ResizeContainerResponse)(nil),           // 63: containarium.v1.ResizeContainerResponse
-	(*MoveContainerResponse)(nil),             // 64: containarium.v1.MoveContainerResponse
-	(*RewrapContainerResponse)(nil),           // 65: containarium.v1.RewrapContainerResponse
-	(*PrepareEncryptedMigrationResponse)(nil), // 66: containarium.v1.PrepareEncryptedMigrationResponse
-	(*AdoptMigratedContainerResponse)(nil),    // 67: containarium.v1.AdoptMigratedContainerResponse
-	(*ToggleMonitoringResponse)(nil),          // 68: containarium.v1.ToggleMonitoringResponse
-	(*ToggleAutoSleepResponse)(nil),           // 69: containarium.v1.ToggleAutoSleepResponse
-	(*SetContainerTTLResponse)(nil),           // 70: containarium.v1.SetContainerTTLResponse
-	(*SetContainerDeletePolicyResponse)(nil),  // 71: containarium.v1.SetContainerDeletePolicyResponse
-	(*SetContainerAttributionResponse)(nil),   // 72: containarium.v1.SetContainerAttributionResponse
-	(*AddSSHKeyResponse)(nil),                 // 73: containarium.v1.AddSSHKeyResponse
-	(*RemoveSSHKeyResponse)(nil),              // 74: containarium.v1.RemoveSSHKeyResponse
-	(*AddCollaboratorResponse)(nil),           // 75: containarium.v1.AddCollaboratorResponse
-	(*RemoveCollaboratorResponse)(nil),        // 76: containarium.v1.RemoveCollaboratorResponse
-	(*ListCollaboratorsResponse)(nil),         // 77: containarium.v1.ListCollaboratorsResponse
-	(*GetMetricsResponse)(nil),                // 78: containarium.v1.GetMetricsResponse
-	(*CleanupDiskResponse)(nil),               // 79: containarium.v1.CleanupDiskResponse
-	(*InstallStackResponse)(nil),              // 80: containarium.v1.InstallStackResponse
-	(*ListStacksResponse)(nil),                // 81: containarium.v1.ListStacksResponse
-	(*GetSystemInfoResponse)(nil),             // 82: containarium.v1.GetSystemInfoResponse
-	(*ListBackendsResponse)(nil),              // 83: containarium.v1.ListBackendsResponse
-	(*AdvertiseCapacityResponse)(nil),         // 84: containarium.v1.AdvertiseCapacityResponse
-	(*WithdrawCapacityResponse)(nil),          // 85: containarium.v1.WithdrawCapacityResponse
-	(*GetCapacityHeadroomResponse)(nil),       // 86: containarium.v1.GetCapacityHeadroomResponse
-	(*ProfileBackendResponse)(nil),            // 87: containarium.v1.ProfileBackendResponse
-	(*GetCapabilityProfileResponse)(nil),      // 88: containarium.v1.GetCapabilityProfileResponse
-	(*GetSelfMeasurementResponse)(nil),        // 89: containarium.v1.GetSelfMeasurementResponse
-	(*GetLatestReleaseResponse)(nil),          // 90: containarium.v1.GetLatestReleaseResponse
-	(*ValidateGPUResponse)(nil),               // 91: containarium.v1.ValidateGPUResponse
-	(*TriggerUpgradeResponse)(nil),            // 92: containarium.v1.TriggerUpgradeResponse
-	(*GetUpgradeStatusResponse)(nil),          // 93: containarium.v1.GetUpgradeStatusResponse
-	(*GetMonitoringInfoResponse)(nil),         // 94: containarium.v1.GetMonitoringInfoResponse
-	(*SetMetricsExportResponse)(nil),          // 95: containarium.v1.SetMetricsExportResponse
-	(*GetMetricsExportResponse)(nil),          // 96: containarium.v1.GetMetricsExportResponse
-	(*CreateAlertRuleResponse)(nil),           // 97: containarium.v1.CreateAlertRuleResponse
-	(*ListAlertRulesResponse)(nil),            // 98: containarium.v1.ListAlertRulesResponse
-	(*GetAlertRuleResponse)(nil),              // 99: containarium.v1.GetAlertRuleResponse
-	(*UpdateAlertRuleResponse)(nil),           // 100: containarium.v1.UpdateAlertRuleResponse
-	(*DeleteAlertRuleResponse)(nil),           // 101: containarium.v1.DeleteAlertRuleResponse
-	(*GetAlertingInfoResponse)(nil),           // 102: containarium.v1.GetAlertingInfoResponse
-	(*ListDefaultAlertRulesResponse)(nil),     // 103: containarium.v1.ListDefaultAlertRulesResponse
-	(*UpdateAlertingConfigResponse)(nil),      // 104: containarium.v1.UpdateAlertingConfigResponse
-	(*TestWebhookResponse)(nil),               // 105: containarium.v1.TestWebhookResponse
-	(*ListWebhookDeliveriesResponse)(nil),     // 106: containarium.v1.ListWebhookDeliveriesResponse
-	(*SetSecretResponse)(nil),                 // 107: containarium.v1.SetSecretResponse
-	(*GetSecretResponse)(nil),                 // 108: containarium.v1.GetSecretResponse
-	(*ListSecretsResponse)(nil),               // 109: containarium.v1.ListSecretsResponse
-	(*DeleteSecretResponse)(nil),              // 110: containarium.v1.DeleteSecretResponse
-	(*RefreshSecretsResponse)(nil),            // 111: containarium.v1.RefreshSecretsResponse
+	(*DeleteTenantStorageRequest)(nil),        // 9: containarium.v1.DeleteTenantStorageRequest
+	(*RewrapContainerRequest)(nil),            // 10: containarium.v1.RewrapContainerRequest
+	(*PrepareEncryptedMigrationRequest)(nil),  // 11: containarium.v1.PrepareEncryptedMigrationRequest
+	(*AdoptMigratedContainerRequest)(nil),     // 12: containarium.v1.AdoptMigratedContainerRequest
+	(*ToggleMonitoringRequest)(nil),           // 13: containarium.v1.ToggleMonitoringRequest
+	(*ToggleAutoSleepRequest)(nil),            // 14: containarium.v1.ToggleAutoSleepRequest
+	(*SetContainerTTLRequest)(nil),            // 15: containarium.v1.SetContainerTTLRequest
+	(*SetContainerDeletePolicyRequest)(nil),   // 16: containarium.v1.SetContainerDeletePolicyRequest
+	(*SetContainerAttributionRequest)(nil),    // 17: containarium.v1.SetContainerAttributionRequest
+	(*AddSSHKeyRequest)(nil),                  // 18: containarium.v1.AddSSHKeyRequest
+	(*RemoveSSHKeyRequest)(nil),               // 19: containarium.v1.RemoveSSHKeyRequest
+	(*AddCollaboratorRequest)(nil),            // 20: containarium.v1.AddCollaboratorRequest
+	(*RemoveCollaboratorRequest)(nil),         // 21: containarium.v1.RemoveCollaboratorRequest
+	(*ListCollaboratorsRequest)(nil),          // 22: containarium.v1.ListCollaboratorsRequest
+	(*GetMetricsRequest)(nil),                 // 23: containarium.v1.GetMetricsRequest
+	(*CleanupDiskRequest)(nil),                // 24: containarium.v1.CleanupDiskRequest
+	(*InstallStackRequest)(nil),               // 25: containarium.v1.InstallStackRequest
+	(*ListStacksRequest)(nil),                 // 26: containarium.v1.ListStacksRequest
+	(*GetSystemInfoRequest)(nil),              // 27: containarium.v1.GetSystemInfoRequest
+	(*ListBackendsRequest)(nil),               // 28: containarium.v1.ListBackendsRequest
+	(*AdvertiseCapacityRequest)(nil),          // 29: containarium.v1.AdvertiseCapacityRequest
+	(*WithdrawCapacityRequest)(nil),           // 30: containarium.v1.WithdrawCapacityRequest
+	(*GetCapacityHeadroomRequest)(nil),        // 31: containarium.v1.GetCapacityHeadroomRequest
+	(*ProfileBackendRequest)(nil),             // 32: containarium.v1.ProfileBackendRequest
+	(*GetCapabilityProfileRequest)(nil),       // 33: containarium.v1.GetCapabilityProfileRequest
+	(*GetSelfMeasurementRequest)(nil),         // 34: containarium.v1.GetSelfMeasurementRequest
+	(*GetLatestReleaseRequest)(nil),           // 35: containarium.v1.GetLatestReleaseRequest
+	(*ValidateGPURequest)(nil),                // 36: containarium.v1.ValidateGPURequest
+	(*TriggerUpgradeRequest)(nil),             // 37: containarium.v1.TriggerUpgradeRequest
+	(*GetUpgradeStatusRequest)(nil),           // 38: containarium.v1.GetUpgradeStatusRequest
+	(*GetMonitoringInfoRequest)(nil),          // 39: containarium.v1.GetMonitoringInfoRequest
+	(*SetMetricsExportRequest)(nil),           // 40: containarium.v1.SetMetricsExportRequest
+	(*GetMetricsExportRequest)(nil),           // 41: containarium.v1.GetMetricsExportRequest
+	(*CreateAlertRuleRequest)(nil),            // 42: containarium.v1.CreateAlertRuleRequest
+	(*ListAlertRulesRequest)(nil),             // 43: containarium.v1.ListAlertRulesRequest
+	(*GetAlertRuleRequest)(nil),               // 44: containarium.v1.GetAlertRuleRequest
+	(*UpdateAlertRuleRequest)(nil),            // 45: containarium.v1.UpdateAlertRuleRequest
+	(*DeleteAlertRuleRequest)(nil),            // 46: containarium.v1.DeleteAlertRuleRequest
+	(*GetAlertingInfoRequest)(nil),            // 47: containarium.v1.GetAlertingInfoRequest
+	(*ListDefaultAlertRulesRequest)(nil),      // 48: containarium.v1.ListDefaultAlertRulesRequest
+	(*UpdateAlertingConfigRequest)(nil),       // 49: containarium.v1.UpdateAlertingConfigRequest
+	(*TestWebhookRequest)(nil),                // 50: containarium.v1.TestWebhookRequest
+	(*ListWebhookDeliveriesRequest)(nil),      // 51: containarium.v1.ListWebhookDeliveriesRequest
+	(*SetSecretRequest)(nil),                  // 52: containarium.v1.SetSecretRequest
+	(*GetSecretRequest)(nil),                  // 53: containarium.v1.GetSecretRequest
+	(*ListSecretsRequest)(nil),                // 54: containarium.v1.ListSecretsRequest
+	(*DeleteSecretRequest)(nil),               // 55: containarium.v1.DeleteSecretRequest
+	(*RefreshSecretsRequest)(nil),             // 56: containarium.v1.RefreshSecretsRequest
+	(*CreateContainerResponse)(nil),           // 57: containarium.v1.CreateContainerResponse
+	(*ListContainersResponse)(nil),            // 58: containarium.v1.ListContainersResponse
+	(*GetContainerResponse)(nil),              // 59: containarium.v1.GetContainerResponse
+	(*DebugContainerResponse)(nil),            // 60: containarium.v1.DebugContainerResponse
+	(*DeleteContainerResponse)(nil),           // 61: containarium.v1.DeleteContainerResponse
+	(*StartContainerResponse)(nil),            // 62: containarium.v1.StartContainerResponse
+	(*StopContainerResponse)(nil),             // 63: containarium.v1.StopContainerResponse
+	(*ResizeContainerResponse)(nil),           // 64: containarium.v1.ResizeContainerResponse
+	(*MoveContainerResponse)(nil),             // 65: containarium.v1.MoveContainerResponse
+	(*DeleteTenantStorageResponse)(nil),       // 66: containarium.v1.DeleteTenantStorageResponse
+	(*RewrapContainerResponse)(nil),           // 67: containarium.v1.RewrapContainerResponse
+	(*PrepareEncryptedMigrationResponse)(nil), // 68: containarium.v1.PrepareEncryptedMigrationResponse
+	(*AdoptMigratedContainerResponse)(nil),    // 69: containarium.v1.AdoptMigratedContainerResponse
+	(*ToggleMonitoringResponse)(nil),          // 70: containarium.v1.ToggleMonitoringResponse
+	(*ToggleAutoSleepResponse)(nil),           // 71: containarium.v1.ToggleAutoSleepResponse
+	(*SetContainerTTLResponse)(nil),           // 72: containarium.v1.SetContainerTTLResponse
+	(*SetContainerDeletePolicyResponse)(nil),  // 73: containarium.v1.SetContainerDeletePolicyResponse
+	(*SetContainerAttributionResponse)(nil),   // 74: containarium.v1.SetContainerAttributionResponse
+	(*AddSSHKeyResponse)(nil),                 // 75: containarium.v1.AddSSHKeyResponse
+	(*RemoveSSHKeyResponse)(nil),              // 76: containarium.v1.RemoveSSHKeyResponse
+	(*AddCollaboratorResponse)(nil),           // 77: containarium.v1.AddCollaboratorResponse
+	(*RemoveCollaboratorResponse)(nil),        // 78: containarium.v1.RemoveCollaboratorResponse
+	(*ListCollaboratorsResponse)(nil),         // 79: containarium.v1.ListCollaboratorsResponse
+	(*GetMetricsResponse)(nil),                // 80: containarium.v1.GetMetricsResponse
+	(*CleanupDiskResponse)(nil),               // 81: containarium.v1.CleanupDiskResponse
+	(*InstallStackResponse)(nil),              // 82: containarium.v1.InstallStackResponse
+	(*ListStacksResponse)(nil),                // 83: containarium.v1.ListStacksResponse
+	(*GetSystemInfoResponse)(nil),             // 84: containarium.v1.GetSystemInfoResponse
+	(*ListBackendsResponse)(nil),              // 85: containarium.v1.ListBackendsResponse
+	(*AdvertiseCapacityResponse)(nil),         // 86: containarium.v1.AdvertiseCapacityResponse
+	(*WithdrawCapacityResponse)(nil),          // 87: containarium.v1.WithdrawCapacityResponse
+	(*GetCapacityHeadroomResponse)(nil),       // 88: containarium.v1.GetCapacityHeadroomResponse
+	(*ProfileBackendResponse)(nil),            // 89: containarium.v1.ProfileBackendResponse
+	(*GetCapabilityProfileResponse)(nil),      // 90: containarium.v1.GetCapabilityProfileResponse
+	(*GetSelfMeasurementResponse)(nil),        // 91: containarium.v1.GetSelfMeasurementResponse
+	(*GetLatestReleaseResponse)(nil),          // 92: containarium.v1.GetLatestReleaseResponse
+	(*ValidateGPUResponse)(nil),               // 93: containarium.v1.ValidateGPUResponse
+	(*TriggerUpgradeResponse)(nil),            // 94: containarium.v1.TriggerUpgradeResponse
+	(*GetUpgradeStatusResponse)(nil),          // 95: containarium.v1.GetUpgradeStatusResponse
+	(*GetMonitoringInfoResponse)(nil),         // 96: containarium.v1.GetMonitoringInfoResponse
+	(*SetMetricsExportResponse)(nil),          // 97: containarium.v1.SetMetricsExportResponse
+	(*GetMetricsExportResponse)(nil),          // 98: containarium.v1.GetMetricsExportResponse
+	(*CreateAlertRuleResponse)(nil),           // 99: containarium.v1.CreateAlertRuleResponse
+	(*ListAlertRulesResponse)(nil),            // 100: containarium.v1.ListAlertRulesResponse
+	(*GetAlertRuleResponse)(nil),              // 101: containarium.v1.GetAlertRuleResponse
+	(*UpdateAlertRuleResponse)(nil),           // 102: containarium.v1.UpdateAlertRuleResponse
+	(*DeleteAlertRuleResponse)(nil),           // 103: containarium.v1.DeleteAlertRuleResponse
+	(*GetAlertingInfoResponse)(nil),           // 104: containarium.v1.GetAlertingInfoResponse
+	(*ListDefaultAlertRulesResponse)(nil),     // 105: containarium.v1.ListDefaultAlertRulesResponse
+	(*UpdateAlertingConfigResponse)(nil),      // 106: containarium.v1.UpdateAlertingConfigResponse
+	(*TestWebhookResponse)(nil),               // 107: containarium.v1.TestWebhookResponse
+	(*ListWebhookDeliveriesResponse)(nil),     // 108: containarium.v1.ListWebhookDeliveriesResponse
+	(*SetSecretResponse)(nil),                 // 109: containarium.v1.SetSecretResponse
+	(*GetSecretResponse)(nil),                 // 110: containarium.v1.GetSecretResponse
+	(*ListSecretsResponse)(nil),               // 111: containarium.v1.ListSecretsResponse
+	(*DeleteSecretResponse)(nil),              // 112: containarium.v1.DeleteSecretResponse
+	(*RefreshSecretsResponse)(nil),            // 113: containarium.v1.RefreshSecretsResponse
 }
 var file_containarium_v1_service_proto_depIdxs = []int32{
 	0,   // 0: containarium.v1.ContainerService.CreateContainer:input_type -> containarium.v1.CreateContainerRequest
@@ -288,111 +292,113 @@ var file_containarium_v1_service_proto_depIdxs = []int32{
 	6,   // 6: containarium.v1.ContainerService.StopContainer:input_type -> containarium.v1.StopContainerRequest
 	7,   // 7: containarium.v1.ContainerService.ResizeContainer:input_type -> containarium.v1.ResizeContainerRequest
 	8,   // 8: containarium.v1.ContainerService.MoveContainer:input_type -> containarium.v1.MoveContainerRequest
-	9,   // 9: containarium.v1.ContainerService.RewrapContainer:input_type -> containarium.v1.RewrapContainerRequest
-	10,  // 10: containarium.v1.ContainerService.PrepareEncryptedMigration:input_type -> containarium.v1.PrepareEncryptedMigrationRequest
-	11,  // 11: containarium.v1.ContainerService.AdoptMigratedContainer:input_type -> containarium.v1.AdoptMigratedContainerRequest
-	12,  // 12: containarium.v1.ContainerService.ToggleMonitoring:input_type -> containarium.v1.ToggleMonitoringRequest
-	13,  // 13: containarium.v1.ContainerService.ToggleAutoSleep:input_type -> containarium.v1.ToggleAutoSleepRequest
-	14,  // 14: containarium.v1.ContainerService.SetContainerTTL:input_type -> containarium.v1.SetContainerTTLRequest
-	15,  // 15: containarium.v1.ContainerService.SetContainerDeletePolicy:input_type -> containarium.v1.SetContainerDeletePolicyRequest
-	16,  // 16: containarium.v1.ContainerService.SetContainerAttribution:input_type -> containarium.v1.SetContainerAttributionRequest
-	17,  // 17: containarium.v1.ContainerService.AddSSHKey:input_type -> containarium.v1.AddSSHKeyRequest
-	18,  // 18: containarium.v1.ContainerService.RemoveSSHKey:input_type -> containarium.v1.RemoveSSHKeyRequest
-	19,  // 19: containarium.v1.ContainerService.AddCollaborator:input_type -> containarium.v1.AddCollaboratorRequest
-	20,  // 20: containarium.v1.ContainerService.RemoveCollaborator:input_type -> containarium.v1.RemoveCollaboratorRequest
-	21,  // 21: containarium.v1.ContainerService.ListCollaborators:input_type -> containarium.v1.ListCollaboratorsRequest
-	22,  // 22: containarium.v1.ContainerService.GetMetrics:input_type -> containarium.v1.GetMetricsRequest
-	23,  // 23: containarium.v1.ContainerService.CleanupDisk:input_type -> containarium.v1.CleanupDiskRequest
-	24,  // 24: containarium.v1.ContainerService.InstallStack:input_type -> containarium.v1.InstallStackRequest
-	25,  // 25: containarium.v1.ContainerService.ListStacks:input_type -> containarium.v1.ListStacksRequest
-	26,  // 26: containarium.v1.ContainerService.GetSystemInfo:input_type -> containarium.v1.GetSystemInfoRequest
-	27,  // 27: containarium.v1.ContainerService.ListBackends:input_type -> containarium.v1.ListBackendsRequest
-	28,  // 28: containarium.v1.ContainerService.AdvertiseCapacity:input_type -> containarium.v1.AdvertiseCapacityRequest
-	29,  // 29: containarium.v1.ContainerService.WithdrawCapacity:input_type -> containarium.v1.WithdrawCapacityRequest
-	30,  // 30: containarium.v1.ContainerService.GetCapacityHeadroom:input_type -> containarium.v1.GetCapacityHeadroomRequest
-	31,  // 31: containarium.v1.ContainerService.ProfileBackend:input_type -> containarium.v1.ProfileBackendRequest
-	32,  // 32: containarium.v1.ContainerService.GetCapabilityProfile:input_type -> containarium.v1.GetCapabilityProfileRequest
-	33,  // 33: containarium.v1.ContainerService.GetSelfMeasurement:input_type -> containarium.v1.GetSelfMeasurementRequest
-	34,  // 34: containarium.v1.ContainerService.GetLatestRelease:input_type -> containarium.v1.GetLatestReleaseRequest
-	35,  // 35: containarium.v1.ContainerService.ValidateGPU:input_type -> containarium.v1.ValidateGPURequest
-	36,  // 36: containarium.v1.ContainerService.TriggerUpgrade:input_type -> containarium.v1.TriggerUpgradeRequest
-	37,  // 37: containarium.v1.ContainerService.GetUpgradeStatus:input_type -> containarium.v1.GetUpgradeStatusRequest
-	38,  // 38: containarium.v1.ContainerService.GetMonitoringInfo:input_type -> containarium.v1.GetMonitoringInfoRequest
-	39,  // 39: containarium.v1.ContainerService.SetMetricsExport:input_type -> containarium.v1.SetMetricsExportRequest
-	40,  // 40: containarium.v1.ContainerService.GetMetricsExport:input_type -> containarium.v1.GetMetricsExportRequest
-	41,  // 41: containarium.v1.ContainerService.CreateAlertRule:input_type -> containarium.v1.CreateAlertRuleRequest
-	42,  // 42: containarium.v1.ContainerService.ListAlertRules:input_type -> containarium.v1.ListAlertRulesRequest
-	43,  // 43: containarium.v1.ContainerService.GetAlertRule:input_type -> containarium.v1.GetAlertRuleRequest
-	44,  // 44: containarium.v1.ContainerService.UpdateAlertRule:input_type -> containarium.v1.UpdateAlertRuleRequest
-	45,  // 45: containarium.v1.ContainerService.DeleteAlertRule:input_type -> containarium.v1.DeleteAlertRuleRequest
-	46,  // 46: containarium.v1.ContainerService.GetAlertingInfo:input_type -> containarium.v1.GetAlertingInfoRequest
-	47,  // 47: containarium.v1.ContainerService.ListDefaultAlertRules:input_type -> containarium.v1.ListDefaultAlertRulesRequest
-	48,  // 48: containarium.v1.ContainerService.UpdateAlertingConfig:input_type -> containarium.v1.UpdateAlertingConfigRequest
-	49,  // 49: containarium.v1.ContainerService.TestWebhook:input_type -> containarium.v1.TestWebhookRequest
-	50,  // 50: containarium.v1.ContainerService.ListWebhookDeliveries:input_type -> containarium.v1.ListWebhookDeliveriesRequest
-	51,  // 51: containarium.v1.ContainerService.SetSecret:input_type -> containarium.v1.SetSecretRequest
-	52,  // 52: containarium.v1.ContainerService.GetSecret:input_type -> containarium.v1.GetSecretRequest
-	53,  // 53: containarium.v1.ContainerService.ListSecrets:input_type -> containarium.v1.ListSecretsRequest
-	54,  // 54: containarium.v1.ContainerService.DeleteSecret:input_type -> containarium.v1.DeleteSecretRequest
-	55,  // 55: containarium.v1.ContainerService.RefreshSecrets:input_type -> containarium.v1.RefreshSecretsRequest
-	56,  // 56: containarium.v1.ContainerService.CreateContainer:output_type -> containarium.v1.CreateContainerResponse
-	57,  // 57: containarium.v1.ContainerService.ListContainers:output_type -> containarium.v1.ListContainersResponse
-	58,  // 58: containarium.v1.ContainerService.GetContainer:output_type -> containarium.v1.GetContainerResponse
-	59,  // 59: containarium.v1.ContainerService.DebugContainer:output_type -> containarium.v1.DebugContainerResponse
-	60,  // 60: containarium.v1.ContainerService.DeleteContainer:output_type -> containarium.v1.DeleteContainerResponse
-	61,  // 61: containarium.v1.ContainerService.StartContainer:output_type -> containarium.v1.StartContainerResponse
-	62,  // 62: containarium.v1.ContainerService.StopContainer:output_type -> containarium.v1.StopContainerResponse
-	63,  // 63: containarium.v1.ContainerService.ResizeContainer:output_type -> containarium.v1.ResizeContainerResponse
-	64,  // 64: containarium.v1.ContainerService.MoveContainer:output_type -> containarium.v1.MoveContainerResponse
-	65,  // 65: containarium.v1.ContainerService.RewrapContainer:output_type -> containarium.v1.RewrapContainerResponse
-	66,  // 66: containarium.v1.ContainerService.PrepareEncryptedMigration:output_type -> containarium.v1.PrepareEncryptedMigrationResponse
-	67,  // 67: containarium.v1.ContainerService.AdoptMigratedContainer:output_type -> containarium.v1.AdoptMigratedContainerResponse
-	68,  // 68: containarium.v1.ContainerService.ToggleMonitoring:output_type -> containarium.v1.ToggleMonitoringResponse
-	69,  // 69: containarium.v1.ContainerService.ToggleAutoSleep:output_type -> containarium.v1.ToggleAutoSleepResponse
-	70,  // 70: containarium.v1.ContainerService.SetContainerTTL:output_type -> containarium.v1.SetContainerTTLResponse
-	71,  // 71: containarium.v1.ContainerService.SetContainerDeletePolicy:output_type -> containarium.v1.SetContainerDeletePolicyResponse
-	72,  // 72: containarium.v1.ContainerService.SetContainerAttribution:output_type -> containarium.v1.SetContainerAttributionResponse
-	73,  // 73: containarium.v1.ContainerService.AddSSHKey:output_type -> containarium.v1.AddSSHKeyResponse
-	74,  // 74: containarium.v1.ContainerService.RemoveSSHKey:output_type -> containarium.v1.RemoveSSHKeyResponse
-	75,  // 75: containarium.v1.ContainerService.AddCollaborator:output_type -> containarium.v1.AddCollaboratorResponse
-	76,  // 76: containarium.v1.ContainerService.RemoveCollaborator:output_type -> containarium.v1.RemoveCollaboratorResponse
-	77,  // 77: containarium.v1.ContainerService.ListCollaborators:output_type -> containarium.v1.ListCollaboratorsResponse
-	78,  // 78: containarium.v1.ContainerService.GetMetrics:output_type -> containarium.v1.GetMetricsResponse
-	79,  // 79: containarium.v1.ContainerService.CleanupDisk:output_type -> containarium.v1.CleanupDiskResponse
-	80,  // 80: containarium.v1.ContainerService.InstallStack:output_type -> containarium.v1.InstallStackResponse
-	81,  // 81: containarium.v1.ContainerService.ListStacks:output_type -> containarium.v1.ListStacksResponse
-	82,  // 82: containarium.v1.ContainerService.GetSystemInfo:output_type -> containarium.v1.GetSystemInfoResponse
-	83,  // 83: containarium.v1.ContainerService.ListBackends:output_type -> containarium.v1.ListBackendsResponse
-	84,  // 84: containarium.v1.ContainerService.AdvertiseCapacity:output_type -> containarium.v1.AdvertiseCapacityResponse
-	85,  // 85: containarium.v1.ContainerService.WithdrawCapacity:output_type -> containarium.v1.WithdrawCapacityResponse
-	86,  // 86: containarium.v1.ContainerService.GetCapacityHeadroom:output_type -> containarium.v1.GetCapacityHeadroomResponse
-	87,  // 87: containarium.v1.ContainerService.ProfileBackend:output_type -> containarium.v1.ProfileBackendResponse
-	88,  // 88: containarium.v1.ContainerService.GetCapabilityProfile:output_type -> containarium.v1.GetCapabilityProfileResponse
-	89,  // 89: containarium.v1.ContainerService.GetSelfMeasurement:output_type -> containarium.v1.GetSelfMeasurementResponse
-	90,  // 90: containarium.v1.ContainerService.GetLatestRelease:output_type -> containarium.v1.GetLatestReleaseResponse
-	91,  // 91: containarium.v1.ContainerService.ValidateGPU:output_type -> containarium.v1.ValidateGPUResponse
-	92,  // 92: containarium.v1.ContainerService.TriggerUpgrade:output_type -> containarium.v1.TriggerUpgradeResponse
-	93,  // 93: containarium.v1.ContainerService.GetUpgradeStatus:output_type -> containarium.v1.GetUpgradeStatusResponse
-	94,  // 94: containarium.v1.ContainerService.GetMonitoringInfo:output_type -> containarium.v1.GetMonitoringInfoResponse
-	95,  // 95: containarium.v1.ContainerService.SetMetricsExport:output_type -> containarium.v1.SetMetricsExportResponse
-	96,  // 96: containarium.v1.ContainerService.GetMetricsExport:output_type -> containarium.v1.GetMetricsExportResponse
-	97,  // 97: containarium.v1.ContainerService.CreateAlertRule:output_type -> containarium.v1.CreateAlertRuleResponse
-	98,  // 98: containarium.v1.ContainerService.ListAlertRules:output_type -> containarium.v1.ListAlertRulesResponse
-	99,  // 99: containarium.v1.ContainerService.GetAlertRule:output_type -> containarium.v1.GetAlertRuleResponse
-	100, // 100: containarium.v1.ContainerService.UpdateAlertRule:output_type -> containarium.v1.UpdateAlertRuleResponse
-	101, // 101: containarium.v1.ContainerService.DeleteAlertRule:output_type -> containarium.v1.DeleteAlertRuleResponse
-	102, // 102: containarium.v1.ContainerService.GetAlertingInfo:output_type -> containarium.v1.GetAlertingInfoResponse
-	103, // 103: containarium.v1.ContainerService.ListDefaultAlertRules:output_type -> containarium.v1.ListDefaultAlertRulesResponse
-	104, // 104: containarium.v1.ContainerService.UpdateAlertingConfig:output_type -> containarium.v1.UpdateAlertingConfigResponse
-	105, // 105: containarium.v1.ContainerService.TestWebhook:output_type -> containarium.v1.TestWebhookResponse
-	106, // 106: containarium.v1.ContainerService.ListWebhookDeliveries:output_type -> containarium.v1.ListWebhookDeliveriesResponse
-	107, // 107: containarium.v1.ContainerService.SetSecret:output_type -> containarium.v1.SetSecretResponse
-	108, // 108: containarium.v1.ContainerService.GetSecret:output_type -> containarium.v1.GetSecretResponse
-	109, // 109: containarium.v1.ContainerService.ListSecrets:output_type -> containarium.v1.ListSecretsResponse
-	110, // 110: containarium.v1.ContainerService.DeleteSecret:output_type -> containarium.v1.DeleteSecretResponse
-	111, // 111: containarium.v1.ContainerService.RefreshSecrets:output_type -> containarium.v1.RefreshSecretsResponse
-	56,  // [56:112] is the sub-list for method output_type
-	0,   // [0:56] is the sub-list for method input_type
+	9,   // 9: containarium.v1.ContainerService.DeleteTenantStorage:input_type -> containarium.v1.DeleteTenantStorageRequest
+	10,  // 10: containarium.v1.ContainerService.RewrapContainer:input_type -> containarium.v1.RewrapContainerRequest
+	11,  // 11: containarium.v1.ContainerService.PrepareEncryptedMigration:input_type -> containarium.v1.PrepareEncryptedMigrationRequest
+	12,  // 12: containarium.v1.ContainerService.AdoptMigratedContainer:input_type -> containarium.v1.AdoptMigratedContainerRequest
+	13,  // 13: containarium.v1.ContainerService.ToggleMonitoring:input_type -> containarium.v1.ToggleMonitoringRequest
+	14,  // 14: containarium.v1.ContainerService.ToggleAutoSleep:input_type -> containarium.v1.ToggleAutoSleepRequest
+	15,  // 15: containarium.v1.ContainerService.SetContainerTTL:input_type -> containarium.v1.SetContainerTTLRequest
+	16,  // 16: containarium.v1.ContainerService.SetContainerDeletePolicy:input_type -> containarium.v1.SetContainerDeletePolicyRequest
+	17,  // 17: containarium.v1.ContainerService.SetContainerAttribution:input_type -> containarium.v1.SetContainerAttributionRequest
+	18,  // 18: containarium.v1.ContainerService.AddSSHKey:input_type -> containarium.v1.AddSSHKeyRequest
+	19,  // 19: containarium.v1.ContainerService.RemoveSSHKey:input_type -> containarium.v1.RemoveSSHKeyRequest
+	20,  // 20: containarium.v1.ContainerService.AddCollaborator:input_type -> containarium.v1.AddCollaboratorRequest
+	21,  // 21: containarium.v1.ContainerService.RemoveCollaborator:input_type -> containarium.v1.RemoveCollaboratorRequest
+	22,  // 22: containarium.v1.ContainerService.ListCollaborators:input_type -> containarium.v1.ListCollaboratorsRequest
+	23,  // 23: containarium.v1.ContainerService.GetMetrics:input_type -> containarium.v1.GetMetricsRequest
+	24,  // 24: containarium.v1.ContainerService.CleanupDisk:input_type -> containarium.v1.CleanupDiskRequest
+	25,  // 25: containarium.v1.ContainerService.InstallStack:input_type -> containarium.v1.InstallStackRequest
+	26,  // 26: containarium.v1.ContainerService.ListStacks:input_type -> containarium.v1.ListStacksRequest
+	27,  // 27: containarium.v1.ContainerService.GetSystemInfo:input_type -> containarium.v1.GetSystemInfoRequest
+	28,  // 28: containarium.v1.ContainerService.ListBackends:input_type -> containarium.v1.ListBackendsRequest
+	29,  // 29: containarium.v1.ContainerService.AdvertiseCapacity:input_type -> containarium.v1.AdvertiseCapacityRequest
+	30,  // 30: containarium.v1.ContainerService.WithdrawCapacity:input_type -> containarium.v1.WithdrawCapacityRequest
+	31,  // 31: containarium.v1.ContainerService.GetCapacityHeadroom:input_type -> containarium.v1.GetCapacityHeadroomRequest
+	32,  // 32: containarium.v1.ContainerService.ProfileBackend:input_type -> containarium.v1.ProfileBackendRequest
+	33,  // 33: containarium.v1.ContainerService.GetCapabilityProfile:input_type -> containarium.v1.GetCapabilityProfileRequest
+	34,  // 34: containarium.v1.ContainerService.GetSelfMeasurement:input_type -> containarium.v1.GetSelfMeasurementRequest
+	35,  // 35: containarium.v1.ContainerService.GetLatestRelease:input_type -> containarium.v1.GetLatestReleaseRequest
+	36,  // 36: containarium.v1.ContainerService.ValidateGPU:input_type -> containarium.v1.ValidateGPURequest
+	37,  // 37: containarium.v1.ContainerService.TriggerUpgrade:input_type -> containarium.v1.TriggerUpgradeRequest
+	38,  // 38: containarium.v1.ContainerService.GetUpgradeStatus:input_type -> containarium.v1.GetUpgradeStatusRequest
+	39,  // 39: containarium.v1.ContainerService.GetMonitoringInfo:input_type -> containarium.v1.GetMonitoringInfoRequest
+	40,  // 40: containarium.v1.ContainerService.SetMetricsExport:input_type -> containarium.v1.SetMetricsExportRequest
+	41,  // 41: containarium.v1.ContainerService.GetMetricsExport:input_type -> containarium.v1.GetMetricsExportRequest
+	42,  // 42: containarium.v1.ContainerService.CreateAlertRule:input_type -> containarium.v1.CreateAlertRuleRequest
+	43,  // 43: containarium.v1.ContainerService.ListAlertRules:input_type -> containarium.v1.ListAlertRulesRequest
+	44,  // 44: containarium.v1.ContainerService.GetAlertRule:input_type -> containarium.v1.GetAlertRuleRequest
+	45,  // 45: containarium.v1.ContainerService.UpdateAlertRule:input_type -> containarium.v1.UpdateAlertRuleRequest
+	46,  // 46: containarium.v1.ContainerService.DeleteAlertRule:input_type -> containarium.v1.DeleteAlertRuleRequest
+	47,  // 47: containarium.v1.ContainerService.GetAlertingInfo:input_type -> containarium.v1.GetAlertingInfoRequest
+	48,  // 48: containarium.v1.ContainerService.ListDefaultAlertRules:input_type -> containarium.v1.ListDefaultAlertRulesRequest
+	49,  // 49: containarium.v1.ContainerService.UpdateAlertingConfig:input_type -> containarium.v1.UpdateAlertingConfigRequest
+	50,  // 50: containarium.v1.ContainerService.TestWebhook:input_type -> containarium.v1.TestWebhookRequest
+	51,  // 51: containarium.v1.ContainerService.ListWebhookDeliveries:input_type -> containarium.v1.ListWebhookDeliveriesRequest
+	52,  // 52: containarium.v1.ContainerService.SetSecret:input_type -> containarium.v1.SetSecretRequest
+	53,  // 53: containarium.v1.ContainerService.GetSecret:input_type -> containarium.v1.GetSecretRequest
+	54,  // 54: containarium.v1.ContainerService.ListSecrets:input_type -> containarium.v1.ListSecretsRequest
+	55,  // 55: containarium.v1.ContainerService.DeleteSecret:input_type -> containarium.v1.DeleteSecretRequest
+	56,  // 56: containarium.v1.ContainerService.RefreshSecrets:input_type -> containarium.v1.RefreshSecretsRequest
+	57,  // 57: containarium.v1.ContainerService.CreateContainer:output_type -> containarium.v1.CreateContainerResponse
+	58,  // 58: containarium.v1.ContainerService.ListContainers:output_type -> containarium.v1.ListContainersResponse
+	59,  // 59: containarium.v1.ContainerService.GetContainer:output_type -> containarium.v1.GetContainerResponse
+	60,  // 60: containarium.v1.ContainerService.DebugContainer:output_type -> containarium.v1.DebugContainerResponse
+	61,  // 61: containarium.v1.ContainerService.DeleteContainer:output_type -> containarium.v1.DeleteContainerResponse
+	62,  // 62: containarium.v1.ContainerService.StartContainer:output_type -> containarium.v1.StartContainerResponse
+	63,  // 63: containarium.v1.ContainerService.StopContainer:output_type -> containarium.v1.StopContainerResponse
+	64,  // 64: containarium.v1.ContainerService.ResizeContainer:output_type -> containarium.v1.ResizeContainerResponse
+	65,  // 65: containarium.v1.ContainerService.MoveContainer:output_type -> containarium.v1.MoveContainerResponse
+	66,  // 66: containarium.v1.ContainerService.DeleteTenantStorage:output_type -> containarium.v1.DeleteTenantStorageResponse
+	67,  // 67: containarium.v1.ContainerService.RewrapContainer:output_type -> containarium.v1.RewrapContainerResponse
+	68,  // 68: containarium.v1.ContainerService.PrepareEncryptedMigration:output_type -> containarium.v1.PrepareEncryptedMigrationResponse
+	69,  // 69: containarium.v1.ContainerService.AdoptMigratedContainer:output_type -> containarium.v1.AdoptMigratedContainerResponse
+	70,  // 70: containarium.v1.ContainerService.ToggleMonitoring:output_type -> containarium.v1.ToggleMonitoringResponse
+	71,  // 71: containarium.v1.ContainerService.ToggleAutoSleep:output_type -> containarium.v1.ToggleAutoSleepResponse
+	72,  // 72: containarium.v1.ContainerService.SetContainerTTL:output_type -> containarium.v1.SetContainerTTLResponse
+	73,  // 73: containarium.v1.ContainerService.SetContainerDeletePolicy:output_type -> containarium.v1.SetContainerDeletePolicyResponse
+	74,  // 74: containarium.v1.ContainerService.SetContainerAttribution:output_type -> containarium.v1.SetContainerAttributionResponse
+	75,  // 75: containarium.v1.ContainerService.AddSSHKey:output_type -> containarium.v1.AddSSHKeyResponse
+	76,  // 76: containarium.v1.ContainerService.RemoveSSHKey:output_type -> containarium.v1.RemoveSSHKeyResponse
+	77,  // 77: containarium.v1.ContainerService.AddCollaborator:output_type -> containarium.v1.AddCollaboratorResponse
+	78,  // 78: containarium.v1.ContainerService.RemoveCollaborator:output_type -> containarium.v1.RemoveCollaboratorResponse
+	79,  // 79: containarium.v1.ContainerService.ListCollaborators:output_type -> containarium.v1.ListCollaboratorsResponse
+	80,  // 80: containarium.v1.ContainerService.GetMetrics:output_type -> containarium.v1.GetMetricsResponse
+	81,  // 81: containarium.v1.ContainerService.CleanupDisk:output_type -> containarium.v1.CleanupDiskResponse
+	82,  // 82: containarium.v1.ContainerService.InstallStack:output_type -> containarium.v1.InstallStackResponse
+	83,  // 83: containarium.v1.ContainerService.ListStacks:output_type -> containarium.v1.ListStacksResponse
+	84,  // 84: containarium.v1.ContainerService.GetSystemInfo:output_type -> containarium.v1.GetSystemInfoResponse
+	85,  // 85: containarium.v1.ContainerService.ListBackends:output_type -> containarium.v1.ListBackendsResponse
+	86,  // 86: containarium.v1.ContainerService.AdvertiseCapacity:output_type -> containarium.v1.AdvertiseCapacityResponse
+	87,  // 87: containarium.v1.ContainerService.WithdrawCapacity:output_type -> containarium.v1.WithdrawCapacityResponse
+	88,  // 88: containarium.v1.ContainerService.GetCapacityHeadroom:output_type -> containarium.v1.GetCapacityHeadroomResponse
+	89,  // 89: containarium.v1.ContainerService.ProfileBackend:output_type -> containarium.v1.ProfileBackendResponse
+	90,  // 90: containarium.v1.ContainerService.GetCapabilityProfile:output_type -> containarium.v1.GetCapabilityProfileResponse
+	91,  // 91: containarium.v1.ContainerService.GetSelfMeasurement:output_type -> containarium.v1.GetSelfMeasurementResponse
+	92,  // 92: containarium.v1.ContainerService.GetLatestRelease:output_type -> containarium.v1.GetLatestReleaseResponse
+	93,  // 93: containarium.v1.ContainerService.ValidateGPU:output_type -> containarium.v1.ValidateGPUResponse
+	94,  // 94: containarium.v1.ContainerService.TriggerUpgrade:output_type -> containarium.v1.TriggerUpgradeResponse
+	95,  // 95: containarium.v1.ContainerService.GetUpgradeStatus:output_type -> containarium.v1.GetUpgradeStatusResponse
+	96,  // 96: containarium.v1.ContainerService.GetMonitoringInfo:output_type -> containarium.v1.GetMonitoringInfoResponse
+	97,  // 97: containarium.v1.ContainerService.SetMetricsExport:output_type -> containarium.v1.SetMetricsExportResponse
+	98,  // 98: containarium.v1.ContainerService.GetMetricsExport:output_type -> containarium.v1.GetMetricsExportResponse
+	99,  // 99: containarium.v1.ContainerService.CreateAlertRule:output_type -> containarium.v1.CreateAlertRuleResponse
+	100, // 100: containarium.v1.ContainerService.ListAlertRules:output_type -> containarium.v1.ListAlertRulesResponse
+	101, // 101: containarium.v1.ContainerService.GetAlertRule:output_type -> containarium.v1.GetAlertRuleResponse
+	102, // 102: containarium.v1.ContainerService.UpdateAlertRule:output_type -> containarium.v1.UpdateAlertRuleResponse
+	103, // 103: containarium.v1.ContainerService.DeleteAlertRule:output_type -> containarium.v1.DeleteAlertRuleResponse
+	104, // 104: containarium.v1.ContainerService.GetAlertingInfo:output_type -> containarium.v1.GetAlertingInfoResponse
+	105, // 105: containarium.v1.ContainerService.ListDefaultAlertRules:output_type -> containarium.v1.ListDefaultAlertRulesResponse
+	106, // 106: containarium.v1.ContainerService.UpdateAlertingConfig:output_type -> containarium.v1.UpdateAlertingConfigResponse
+	107, // 107: containarium.v1.ContainerService.TestWebhook:output_type -> containarium.v1.TestWebhookResponse
+	108, // 108: containarium.v1.ContainerService.ListWebhookDeliveries:output_type -> containarium.v1.ListWebhookDeliveriesResponse
+	109, // 109: containarium.v1.ContainerService.SetSecret:output_type -> containarium.v1.SetSecretResponse
+	110, // 110: containarium.v1.ContainerService.GetSecret:output_type -> containarium.v1.GetSecretResponse
+	111, // 111: containarium.v1.ContainerService.ListSecrets:output_type -> containarium.v1.ListSecretsResponse
+	112, // 112: containarium.v1.ContainerService.DeleteSecret:output_type -> containarium.v1.DeleteSecretResponse
+	113, // 113: containarium.v1.ContainerService.RefreshSecrets:output_type -> containarium.v1.RefreshSecretsResponse
+	57,  // [57:114] is the sub-list for method output_type
+	0,   // [0:57] is the sub-list for method input_type
 	0,   // [0:0] is the sub-list for extension type_name
 	0,   // [0:0] is the sub-list for extension extendee
 	0,   // [0:0] is the sub-list for field type_name

--- a/pkg/pb/containarium/v1/service.pb.gw.go
+++ b/pkg/pb/containarium/v1/service.pb.gw.go
@@ -408,6 +408,45 @@ func local_request_ContainerService_MoveContainer_0(ctx context.Context, marshal
 	return msg, metadata, err
 }
 
+func request_ContainerService_DeleteTenantStorage_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq DeleteTenantStorageRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	val, ok := pathParams["tenant"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "tenant")
+	}
+	protoReq.Tenant, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "tenant", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.DeleteTenantStorage(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ContainerService_DeleteTenantStorage_0(ctx context.Context, marshaler runtime.Marshaler, server ContainerServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq DeleteTenantStorageRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	val, ok := pathParams["tenant"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "tenant")
+	}
+	protoReq.Tenant, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "tenant", err)
+	}
+	msg, err := server.DeleteTenantStorage(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_ContainerService_RewrapContainer_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq RewrapContainerRequest
@@ -2306,6 +2345,26 @@ func RegisterContainerServiceHandlerServer(ctx context.Context, mux *runtime.Ser
 		}
 		forward_ContainerService_MoveContainer_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodDelete, pattern_ContainerService_DeleteTenantStorage_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.ContainerService/DeleteTenantStorage", runtime.WithHTTPPathPattern("/v1/tenants/{tenant}/storage"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ContainerService_DeleteTenantStorage_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_DeleteTenantStorage_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_ContainerService_RewrapContainer_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -3459,6 +3518,23 @@ func RegisterContainerServiceHandlerClient(ctx context.Context, mux *runtime.Ser
 		}
 		forward_ContainerService_MoveContainer_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodDelete, pattern_ContainerService_DeleteTenantStorage_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.ContainerService/DeleteTenantStorage", runtime.WithHTTPPathPattern("/v1/tenants/{tenant}/storage"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ContainerService_DeleteTenantStorage_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_DeleteTenantStorage_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_ContainerService_RewrapContainer_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -4288,6 +4364,7 @@ var (
 	pattern_ContainerService_StopContainer_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "stop"}, ""))
 	pattern_ContainerService_ResizeContainer_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "resize"}, ""))
 	pattern_ContainerService_MoveContainer_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "move"}, ""))
+	pattern_ContainerService_DeleteTenantStorage_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "tenants", "tenant", "storage"}, ""))
 	pattern_ContainerService_RewrapContainer_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "rewrap"}, ""))
 	pattern_ContainerService_PrepareEncryptedMigration_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "prepare-encrypted-migration"}, ""))
 	pattern_ContainerService_AdoptMigratedContainer_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "adopt"}, ""))
@@ -4348,6 +4425,7 @@ var (
 	forward_ContainerService_StopContainer_0             = runtime.ForwardResponseMessage
 	forward_ContainerService_ResizeContainer_0           = runtime.ForwardResponseMessage
 	forward_ContainerService_MoveContainer_0             = runtime.ForwardResponseMessage
+	forward_ContainerService_DeleteTenantStorage_0       = runtime.ForwardResponseMessage
 	forward_ContainerService_RewrapContainer_0           = runtime.ForwardResponseMessage
 	forward_ContainerService_PrepareEncryptedMigration_0 = runtime.ForwardResponseMessage
 	forward_ContainerService_AdoptMigratedContainer_0    = runtime.ForwardResponseMessage

--- a/pkg/pb/containarium/v1/service_grpc.pb.go
+++ b/pkg/pb/containarium/v1/service_grpc.pb.go
@@ -28,6 +28,7 @@ const (
 	ContainerService_StopContainer_FullMethodName             = "/containarium.v1.ContainerService/StopContainer"
 	ContainerService_ResizeContainer_FullMethodName           = "/containarium.v1.ContainerService/ResizeContainer"
 	ContainerService_MoveContainer_FullMethodName             = "/containarium.v1.ContainerService/MoveContainer"
+	ContainerService_DeleteTenantStorage_FullMethodName       = "/containarium.v1.ContainerService/DeleteTenantStorage"
 	ContainerService_RewrapContainer_FullMethodName           = "/containarium.v1.ContainerService/RewrapContainer"
 	ContainerService_PrepareEncryptedMigration_FullMethodName = "/containarium.v1.ContainerService/PrepareEncryptedMigration"
 	ContainerService_AdoptMigratedContainer_FullMethodName    = "/containarium.v1.ContainerService/AdoptMigratedContainer"
@@ -109,6 +110,18 @@ type ContainerServiceClient interface {
 	// for active workloads on dir-pool. Prereq: incus remotes
 	// configured both ways between the source and target VMs.
 	MoveContainer(ctx context.Context, in *MoveContainerRequest, opts ...grpc.CallOption) (*MoveContainerResponse, error)
+	// DeleteTenantStorage tears down a departing tenant's encrypted storage
+	// (#1343) — the Incus storage pool, then the encrypted dataset it is
+	// sourced at, in that order.
+	//
+	// The order is not cosmetic: destroying the dataset first leaves a pool
+	// pointing at nothing, and the daemon walks every pool at startup, so a
+	// mis-ordered teardown breaks startup for every tenant on the host.
+	//
+	// Refused while the tenant still has containers. DESTRUCTIVE and
+	// irreversible: the dataset is the tenant's encryptionroot, so destroying
+	// it destroys the only thing that could decrypt their data. Admin only.
+	DeleteTenantStorage(ctx context.Context, in *DeleteTenantStorageRequest, opts ...grpc.CallOption) (*DeleteTenantStorageResponse, error)
 	// RewrapContainer rotates the key protecting a container's data onto
 	// new key material, without rewriting the data (#1204).
 	//
@@ -429,6 +442,16 @@ func (c *containerServiceClient) MoveContainer(ctx context.Context, in *MoveCont
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(MoveContainerResponse)
 	err := c.cc.Invoke(ctx, ContainerService_MoveContainer_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *containerServiceClient) DeleteTenantStorage(ctx context.Context, in *DeleteTenantStorageRequest, opts ...grpc.CallOption) (*DeleteTenantStorageResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DeleteTenantStorageResponse)
+	err := c.cc.Invoke(ctx, ContainerService_DeleteTenantStorage_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -937,6 +960,18 @@ type ContainerServiceServer interface {
 	// for active workloads on dir-pool. Prereq: incus remotes
 	// configured both ways between the source and target VMs.
 	MoveContainer(context.Context, *MoveContainerRequest) (*MoveContainerResponse, error)
+	// DeleteTenantStorage tears down a departing tenant's encrypted storage
+	// (#1343) — the Incus storage pool, then the encrypted dataset it is
+	// sourced at, in that order.
+	//
+	// The order is not cosmetic: destroying the dataset first leaves a pool
+	// pointing at nothing, and the daemon walks every pool at startup, so a
+	// mis-ordered teardown breaks startup for every tenant on the host.
+	//
+	// Refused while the tenant still has containers. DESTRUCTIVE and
+	// irreversible: the dataset is the tenant's encryptionroot, so destroying
+	// it destroys the only thing that could decrypt their data. Admin only.
+	DeleteTenantStorage(context.Context, *DeleteTenantStorageRequest) (*DeleteTenantStorageResponse, error)
 	// RewrapContainer rotates the key protecting a container's data onto
 	// new key material, without rewriting the data (#1204).
 	//
@@ -1199,6 +1234,9 @@ func (UnimplementedContainerServiceServer) ResizeContainer(context.Context, *Res
 }
 func (UnimplementedContainerServiceServer) MoveContainer(context.Context, *MoveContainerRequest) (*MoveContainerResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method MoveContainer not implemented")
+}
+func (UnimplementedContainerServiceServer) DeleteTenantStorage(context.Context, *DeleteTenantStorageRequest) (*DeleteTenantStorageResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method DeleteTenantStorage not implemented")
 }
 func (UnimplementedContainerServiceServer) RewrapContainer(context.Context, *RewrapContainerRequest) (*RewrapContainerResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RewrapContainer not implemented")
@@ -1520,6 +1558,24 @@ func _ContainerService_MoveContainer_Handler(srv interface{}, ctx context.Contex
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(ContainerServiceServer).MoveContainer(ctx, req.(*MoveContainerRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ContainerService_DeleteTenantStorage_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteTenantStorageRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ContainerServiceServer).DeleteTenantStorage(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ContainerService_DeleteTenantStorage_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ContainerServiceServer).DeleteTenantStorage(ctx, req.(*DeleteTenantStorageRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -2412,6 +2468,10 @@ var ContainerService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "MoveContainer",
 			Handler:    _ContainerService_MoveContainer_Handler,
+		},
+		{
+			MethodName: "DeleteTenantStorage",
+			Handler:    _ContainerService_DeleteTenantStorage_Handler,
 		},
 		{
 			MethodName: "RewrapContainer",

--- a/proto/containarium/v1/container.proto
+++ b/proto/containarium/v1/container.proto
@@ -1250,6 +1250,31 @@ message AdoptMigratedContainerRequest {
   string zfs_pool = 4;
 }
 
+// DeleteTenantStorageRequest tears down a departing tenant's encrypted
+// storage (#1343): the Incus storage pool, and the encrypted dataset it is
+// sourced at.
+//
+// Refused while the tenant still has containers — deleting the pool from
+// under a live box destroys its storage.
+message DeleteTenantStorageRequest {
+  // The tenant being offboarded.
+  string tenant = 1;
+}
+
+// DeleteTenantStorageResponse records what was destroyed, so an operator has
+// a statement of what this removed rather than only that it succeeded.
+message DeleteTenantStorageResponse {
+  // Human-readable summary.
+  string message = 1;
+
+  // The Incus storage pool that was deleted.
+  string storage_pool = 2;
+
+  // The ZFS dataset that was destroyed — the tenant's encryptionroot, and
+  // with it the only thing that could decrypt their data.
+  string dataset = 3;
+}
+
 // RewrapContainerRequest rotates the key protecting a container's data
 // (#1204), driven by the control plane during a maintenance window.
 //

--- a/proto/containarium/v1/service.proto
+++ b/proto/containarium/v1/service.proto
@@ -173,6 +173,28 @@ service ContainerService {
     };
   }
 
+  // DeleteTenantStorage tears down a departing tenant's encrypted storage
+  // (#1343) — the Incus storage pool, then the encrypted dataset it is
+  // sourced at, in that order.
+  //
+  // The order is not cosmetic: destroying the dataset first leaves a pool
+  // pointing at nothing, and the daemon walks every pool at startup, so a
+  // mis-ordered teardown breaks startup for every tenant on the host.
+  //
+  // Refused while the tenant still has containers. DESTRUCTIVE and
+  // irreversible: the dataset is the tenant's encryptionroot, so destroying
+  // it destroys the only thing that could decrypt their data. Admin only.
+  rpc DeleteTenantStorage(DeleteTenantStorageRequest) returns (DeleteTenantStorageResponse) {
+    option (google.api.http) = {
+      delete: "/v1/tenants/{tenant}/storage"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Destroy a departing tenant's encrypted storage";
+      description: "Deletes the tenant's Incus storage pool and then the encrypted dataset it was sourced at. Refused while the tenant still has containers. Irreversible — the dataset is the tenant's encryptionroot, so this destroys the only key path to their data. Admin only.";
+      tags: "Container Operations";
+    };
+  }
+
   // RewrapContainer rotates the key protecting a container's data onto
   // new key material, without rewriting the data (#1204).
   //


### PR DESCRIPTION
Closes #1343. Completes the per-tenant encryption feature: it created two durable resources and had no removal path.

## Why the order is the whole issue

The Incus pool **references** the dataset, and the daemon walks every pool at startup (`EnsureStorage` → `reviewExistingStorage`). Destroy the dataset first and you leave a pool pointing at nothing — which breaks startup **for every tenant on the host**, not only the departing one.

So: pool first, dataset second. Asserted by observing what had *already* happened at the moment the pool was deleted.

## The guard asks ZFS, not the daemon's records

Offboarding is refused while anything still lives under the tenant's encryptionroot — and that question goes to `zfs list -r`, not to an enumeration of container records.

Storage is what is about to be destroyed, so storage is what gets asked. A container whose record was lost — a config key cleared, a store restored from an older backup — would read as "no containers" under a records-based check, and its data would be destroyed along with the pool. The ZFS check sees what is actually there.

`zfscrypt.HasChildren` backs it, with the prefix trap covered: `tank/tenants/alice2` is **not** a child of `tank/tenants/alice`, or alice could never be offboarded while alice2 exists.

## Failure handling

| Situation | Behaviour |
| --- | --- |
| Containers remain | Refused; nothing touched |
| Pool already gone (partial teardown) | Not an error — the dataset is still cleaned up, so an operator can finish what they started |
| Pool deleted, dataset survives | Error naming the leftover and that it needs **manual** removal: nothing references it now, and it still holds the tenant's data |

## Test evidence

CI run linked in a follow-up comment. 8 server tests + 4 on `zfscrypt.HasChildren`.

**Two vacuous assertions were caught by mutation testing during this work, and both are worth noting** because a passing test hid each:

1. My first ordering check used a flag the fake set **unconditionally** when the pool was deleted — true whichever way round the calls ran. Inverting the production order did **not** fail it. It now observes state at the moment of deletion:

```
--- FAIL: TestDestroyTenantStorage_DeletesThePoolBeforeTheDataset
    the dataset was destroyed BEFORE the pool was deleted — the pool would then point at
    nothing, and EnsureStorage walks every pool at daemon start, so the next restart breaks
    for every tenant on this host
```

2. An earlier mutation attempt appeared to prove a test weak when it had actually broken the build; the compile error was filtered out by my own grep. Both times the lesson is the same — a mutation that does not compile, or that the fake cannot observe, proves nothing and looks exactly like a weak test.

## Reviewer notes

- Proto-first: `DeleteTenantStorage` RPC + messages, then `make proto`. `DELETE /v1/tenants/{tenant}/storage`.
- Admin only, like every other operation on tenant key custody.
- The response names the pool and dataset destroyed — an operator needs a record of what this removed, not just that it succeeded.
- `DeleteStoragePool` joins the hooks' `storagePoolAPI`; the concrete method has existed since #1338 and was unused until now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)