### PR TITLE
fix(sentinel): stop TestTunnelIntegration touching testing.T from server goroutines

### DIFF
--- a/internal/sentinel/tunnel_callback_guard_test.go
+++ b/internal/sentinel/tunnel_callback_guard_test.go
@@ -1,0 +1,83 @@
+package sentinel
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// The tunnel server's OnConnect/OnDisconnect callbacks run on goroutines that
+// OUTLIVE the test function, so they must never touch *testing.T (#1374).
+//
+// A t.Logf in one of them raced tRunner's write marking the test complete,
+// and — because it fired only when a session happened to close after the test
+// returned — presented as an intermittent failure in PRs that touched nothing
+// nearby. Two unrelated PRs were investigated for it before the cause was
+// found.
+//
+// Re-adding a t.Logf there would be an easy and natural thing to do while
+// debugging, and the resulting flake would take days to attribute again. So
+// the constraint is enforced rather than described.
+//
+// This asserts over the parsed AST rather than by running the test: the race
+// is a scheduling accident that a passing run cannot rule out. What CAN be
+// checked deterministically is that the callbacks do not reference the test
+// at all, which is what makes the race impossible.
+func TestTunnelCallbacksDoNotTouchTheTestingT(t *testing.T) {
+	const file = "tunnel_integration_test.go"
+
+	fset := token.NewFileSet()
+	parsed, err := parser.ParseFile(fset, file, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", file, err)
+	}
+
+	checked := 0
+	ast.Inspect(parsed, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok || len(assign.Lhs) != 1 || len(assign.Rhs) != 1 {
+			return true
+		}
+		sel, ok := assign.Lhs[0].(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if sel.Sel.Name != "OnConnect" && sel.Sel.Name != "OnDisconnect" {
+			return true
+		}
+		lit, ok := assign.Rhs[0].(*ast.FuncLit)
+		if !ok {
+			return true
+		}
+		checked++
+
+		ast.Inspect(lit.Body, func(inner ast.Node) bool {
+			call, ok := inner.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			callee, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			recv, ok := callee.X.(*ast.Ident)
+			if !ok || recv.Name != "t" {
+				return true
+			}
+			t.Errorf("%s calls t.%s — that callback runs on a server goroutine which outlives "+
+				"the test, so touching the testing.T races the runner marking the test done "+
+				"(#1374). Send to a channel instead, or drop the line.",
+				sel.Sel.Name, callee.Sel.Name)
+			return false
+		})
+		return true
+	})
+
+	// A guard that matched nothing would pass forever. Require that it
+	// actually found the callbacks it exists to police.
+	if checked < 2 {
+		t.Errorf("inspected %d callback(s), want both OnConnect and OnDisconnect — they were "+
+			"renamed or restructured, and this guard silently stopped checking anything", checked)
+	}
+}

--- a/internal/sentinel/tunnel_integration_test.go
+++ b/internal/sentinel/tunnel_integration_test.go
@@ -93,15 +93,33 @@ func TestTunnelIntegration(t *testing.T) {
 	registry := NewTunnelRegistry()
 	tunnelServer := NewTunnelServer("", policyAny(token), registry)
 
+	// These callbacks run on the tunnel server's own goroutines, which
+	// OUTLIVE this function: a session closing after the test returns still
+	// invokes OnDisconnect. So they must not touch `t` at all.
+	//
+	// They used to log through t.Logf, and the data race that produced was
+	// real — the read of the test's state raced tRunner's write marking the
+	// test complete (#1374). Calling t.Log after a test returns is
+	// documented misuse; here it also fired only sometimes, depending on
+	// when the session happened to close, so it presented as a flake in
+	// unrelated PRs.
+	//
+	// The sends are non-blocking for the same reason. A buffered-1 channel
+	// accepts the first event; a second would block the server's goroutine
+	// forever, and nothing reads disconnectCh at all.
 	connectCh := make(chan *TunnelSpot, 1)
 	disconnectCh := make(chan string, 1)
 	tunnelServer.OnConnect = func(spot *TunnelSpot) {
-		t.Logf("[integration] spot connected: %s at %s", spot.ID, spot.LocalIP)
-		connectCh <- spot
+		select {
+		case connectCh <- spot:
+		default:
+		}
 	}
 	tunnelServer.OnDisconnect = func(spot *TunnelSpot) {
-		t.Logf("[integration] spot disconnected: %s", spot.ID)
-		disconnectCh <- spot.ID
+		select {
+		case disconnectCh <- spot.ID:
+		default:
+		}
 	}
 
 	go func() { _ = tunnelServer.Serve(ctx, connMux.TunnelListener()) }()


### PR DESCRIPTION
Closes #1374. Found while investigating a red check on #1370 — a PR that touches nothing in `internal/sentinel`.

## The race

`OnConnect`/`OnDisconnect` run on the tunnel server's own goroutines, which **outlive the test function**: a session closing after the test returns still invokes `OnDisconnect`. Both logged through `t.Logf`, and the read of the test's state raced `tRunner`'s write marking the test complete.

```
WARNING: DATA RACE
Read at ... by goroutine 549:
  testing.(*common).Logf()
  sentinel.TestTunnelIntegration.func11()   tunnel_integration_test.go:103
  sentinel.(*TunnelServer).monitorSession() tunnel_server.go:365
Previous write at ... by goroutine 535:
  testing.tRunner.func1()                   <- the test function returning
```

Because it fires only when a session happens to close late, it presented as an **intermittent failure in unrelated PRs**. #1370 was investigated for it before the cause was found.

## A second problem in the same three lines

`disconnectCh` is buffered-1 and **nothing ever reads it**. A second disconnect would have blocked a server goroutine for the remaining life of the test binary. Both sends are now non-blocking.

## Why there is an AST guard

A passing run cannot prove a scheduling race is gone — the package passed 4/4 under `-race` *before* this fix as well as after. What can be checked deterministically is that the callbacks do not reference `t` **at all**, which is what makes the race impossible.

So `TestTunnelCallbacksDoNotTouchTheTestingT` parses the file and fails if either callback calls anything on `t`. Verified by putting the `t.Logf` back:

```
--- FAIL: TestTunnelCallbacksDoNotTouchTheTestingT
    OnDisconnect calls t.Logf — that callback runs on a server goroutine which outlives the
    test, so touching the testing.T races the runner marking the test done (#1374).
```

It also fails if it stops finding both callbacks, because a guard that matched nothing would pass forever — the same failure mode this repo already guards against in `dual_server_wiring_test.go`, which is where the AST approach is borrowed from.

Re-adding a `t.Logf` there while debugging is a natural thing to do, and the resulting flake would take days to attribute again. That is what the guard is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)