### PR TITLE
ci: pull the lane's box image once, with retries, instead of per test

### DIFF
--- a/.github/workflows/incus-create.yml
+++ b/.github/workflows/incus-create.yml
@@ -68,6 +68,9 @@ jobs:
       # switch itself is unit-tested in internal/testsupport/incusenv, so a
       # lane that stopped exercising Incus cannot report green by not running.
       CONTAINARIUM_REQUIRE_INCUS: '1'
+      # Every Go test creates from the copy pulled once above, rather than
+      # re-fetching from the public mirror on each create (#1375).
+      CONTAINARIUM_LANE_IMAGE: lane-box
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -140,6 +143,34 @@ jobs:
           # than assume, since a missing range fails at instance start.
           grep -q '^root:' /etc/subuid || echo 'root:1000000:1000000000' | sudo tee -a /etc/subuid
           grep -q '^root:' /etc/subgid || echo 'root:1000000:1000000000' | sudo tee -a /etc/subgid
+
+      # Pull the box image ONCE, with retries, into the runner's local store.
+      #
+      # Every test used to fetch images:ubuntu/24.04 from
+      # images.linuxcontainers.org at run time — five or more fetches per run
+      # against a third-party mirror. When it hiccuped, every PR touching this
+      # lane failed at once with "The requested image couldn't be found",
+      # which reads as a code failure: two unrelated PRs were investigated for
+      # it in one afternoon (#1375).
+      #
+      # One fetch, retried, and a failure here names the mirror at the step
+      # that talks to it rather than surfacing inside a product test.
+      - name: Pre-pull the box image
+        run: |
+          set -euo pipefail
+          pulled=""
+          for attempt in 1 2 3 4 5; do
+            if sudo incus image copy images:ubuntu/24.04 local: --alias lane-box >/dev/null 2>&1; then
+              pulled=yes; break
+            fi
+            echo "image pull attempt $attempt failed; retrying in 15s"
+            sleep 15
+          done
+          if [ -z "$pulled" ]; then
+            echo "::error::could not pull images:ubuntu/24.04 from images.linuxcontainers.org after 5 attempts — the mirror is unavailable, not the code under test"
+            exit 1
+          fi
+          sudo incus image list
 
       # Assert the environment before trusting any result from it. The Go
       # helper does the same check and fails on it (CONTAINARIUM_REQUIRE_INCUS
@@ -252,7 +283,7 @@ jobs:
 
           TENANT="lane$$"
           /tmp/containarium --server "$SERVER" create "$TENANT" \
-            --no-ssh-key --podman=false --disk 5GB --encrypted
+            --no-ssh-key --podman=false --disk 5GB --encrypted --image lane-box
 
           # The claim, checked on the host: the instance sits under the
           # TENANT's encryptionroot, not the pool default.
@@ -318,7 +349,7 @@ jobs:
           fi
 
           if /tmp/containarium --server "$SERVER" create "nokeys$$" \
-               --no-ssh-key --podman=false --disk 5GB --encrypted > /tmp/refusal.log 2>&1; then
+               --no-ssh-key --podman=false --disk 5GB --encrypted --image lane-box > /tmp/refusal.log 2>&1; then
             echo "::error::an encrypted create SUCCEEDED on a daemon with no key custody — the closed default regressed"
             exit 1
           fi

--- a/internal/server/encrypted_create_integration_test.go
+++ b/internal/server/encrypted_create_integration_test.go
@@ -88,7 +88,7 @@ func createEncrypted(t *testing.T, s *ContainerServer, tenant string) string {
 
 	if _, err := s.CreateContainer(ctx, &pb.CreateContainerRequest{
 		Username:  tenant,
-		Image:     "images:ubuntu/24.04",
+		Image:     incusenv.BoxImage(),
 		OsType:    pb.OSType_OS_TYPE_UBUNTU_2404,
 		Encrypted: true,
 		Resources: &pb.ResourceLimits{Disk: "5GB"},
@@ -253,7 +253,7 @@ func TestIntegrationIncus_UnencryptedCreateIsUnchanged(t *testing.T) {
 
 	if _, err := s.CreateContainer(rpcCtx, &pb.CreateContainerRequest{
 		Username:  tenant,
-		Image:     "images:ubuntu/24.04",
+		Image:     incusenv.BoxImage(),
 		OsType:    pb.OSType_OS_TYPE_UBUNTU_2404,
 		Resources: &pb.ResourceLimits{Disk: "5GB"},
 		// Encrypted deliberately unset.

--- a/internal/testsupport/incusenv/disposition.go
+++ b/internal/testsupport/incusenv/disposition.go
@@ -15,7 +15,10 @@
 // anywhere. The code that touches a real Incus lives behind the `incus` tag.
 package incusenv
 
-import "strings"
+import (
+	"os"
+	"strings"
+)
 
 // RequireEnv is the environment variable that turns "no usable Incus here"
 // from a skip into a failure. Set it in any lane whose job is to prove the
@@ -56,4 +59,21 @@ func DispositionFor(value string) Disposition {
 	default:
 		return Skip
 	}
+}
+
+// BoxImage is the image the lane's tests create containers from.
+//
+// Overridable so CI can point every test at an image already pulled into the
+// runner's local store. Without that, each test fetches
+// `images:ubuntu/24.04` from images.linuxcontainers.org at run time — five or
+// more fetches per run against a third-party mirror, and when that mirror
+// hiccups every PR touching the lane fails at once with "The requested image
+// couldn't be found", which reads as a code failure (#1375).
+//
+// Defaults to the public alias so a developer's laptop needs no setup.
+func BoxImage() string {
+	if img := os.Getenv("CONTAINARIUM_LANE_IMAGE"); img != "" {
+		return img
+	}
+	return "images:ubuntu/24.04"
 }

--- a/internal/testsupport/incusenv/disposition_test.go
+++ b/internal/testsupport/incusenv/disposition_test.go
@@ -42,3 +42,25 @@ func TestDispositionFor(t *testing.T) {
 		})
 	}
 }
+
+// BoxImage decides where every lane test fetches its image from, so it gets a
+// test that runs in the ordinary suite — the lane itself cannot check its own
+// default, and getting this wrong sends five image fetches per run back to a
+// third-party mirror (#1375).
+func TestBoxImage(t *testing.T) {
+	t.Run("defaults to the public alias", func(t *testing.T) {
+		t.Setenv("CONTAINARIUM_LANE_IMAGE", "")
+		if got := BoxImage(); got != "images:ubuntu/24.04" {
+			t.Errorf("BoxImage() = %q, want the public alias — a developer's laptop has no "+
+				"pre-pulled copy and must still work with no setup", got)
+		}
+	})
+
+	t.Run("honours the override", func(t *testing.T) {
+		t.Setenv("CONTAINARIUM_LANE_IMAGE", "lane-box")
+		if got := BoxImage(); got != "lane-box" {
+			t.Errorf("BoxImage() = %q, want the override — without it CI re-fetches from the "+
+				"public mirror on every create, which is what #1375 was filed for", got)
+		}
+	})
+}

--- a/pkg/core/box/lxc/create_integration_test.go
+++ b/pkg/core/box/lxc/create_integration_test.go
@@ -77,7 +77,7 @@ func TestIntegrationIncus_CreateThroughTheDaemonsOwnPath(t *testing.T) {
 
 	st, err := backend.Create(ctx, box.BoxSpec{
 		Ref:       box.BoxRef{Tenant: name},
-		Image:     "images:ubuntu/24.04",
+		Image:     incusenv.BoxImage(),
 		OSType:    pb.OSType_OS_TYPE_UBUNTU_2404,
 		AutoStart: true,
 		// No SSH keys on purpose: seeding them creates a jump-server

--- a/pkg/core/box/lxc/encrypted_create_integration_test.go
+++ b/pkg/core/box/lxc/encrypted_create_integration_test.go
@@ -81,7 +81,7 @@ func TestIntegrationIncus_ContainerDatasetNamesTheRealDataset(t *testing.T) {
 
 	if _, err := New(container.NewWithBackend(client)).Create(ctx, box.BoxSpec{
 		Ref:       box.BoxRef{Tenant: name},
-		Image:     "images:ubuntu/24.04",
+		Image:     incusenv.BoxImage(),
 		OSType:    pb.OSType_OS_TYPE_UBUNTU_2404,
 		AutoStart: true,
 	}); err != nil {
@@ -158,7 +158,7 @@ func TestIntegrationIncus_InstanceOnAPreExistingEncryptedDataset(t *testing.T) {
 	// Now the daemon's own create, onto a dataset that already exists.
 	_, createErr := New(container.NewWithBackend(client)).Create(ctx, box.BoxSpec{
 		Ref:       box.BoxRef{Tenant: name},
-		Image:     "images:ubuntu/24.04",
+		Image:     incusenv.BoxImage(),
 		OSType:    pb.OSType_OS_TYPE_UBUNTU_2404,
 		AutoStart: true,
 	})
@@ -239,7 +239,7 @@ func TestIntegrationIncus_InstanceInheritsEncryptionFromThePoolRoot(t *testing.T
 
 	st, err := New(container.NewWithBackend(client)).Create(ctx, box.BoxSpec{
 		Ref:       box.BoxRef{Tenant: name},
-		Image:     "images:ubuntu/24.04",
+		Image:     incusenv.BoxImage(),
 		OSType:    pb.OSType_OS_TYPE_UBUNTU_2404,
 		AutoStart: true,
 		Resources: box.ResourceLimits{Disk: "5GB"},

--- a/pkg/core/incus/tenant_pool_integration_test.go
+++ b/pkg/core/incus/tenant_pool_integration_test.go
@@ -70,7 +70,7 @@ func TestIntegrationIncus_PoolSourcedAtAnEncryptedDataset(t *testing.T) {
 	// mechanism (#1335).
 	if err := client.CreateContainer(incus.ContainerConfig{
 		Name:  fmt.Sprintf("pooltest%d", os.Getpid()),
-		Image: "images:ubuntu/24.04",
+		Image: incusenv.BoxImage(),
 		Disk:  &incus.DiskDevice{Path: "/", Pool: pool, Size: "3GB"},
 	}); err != nil {
 		t.Fatalf("Incus would not build an instance in a pool sourced at an encrypted dataset: %v\n"+


### PR DESCRIPTION
Closes #1375. Removes the run-time dependency on a third-party mirror that produced two false reds in one afternoon.

## The problem

Every test on the Incus lane fetched `images:ubuntu/24.04` from **images.linuxcontainers.org** at create time — five or more fetches per run. When the mirror hiccuped, every PR touching the lane's paths failed simultaneously with:

```
Failed getting remote image info: Failed getting image: The requested image couldn't be found
```

That reads as a code failure. **#1372 and #1373 were both investigated for it**, and #1372 touches no Incus code at all — the giveaway that the cause was external. Both re-ran green with no change.

## The fix

- **One pull, retried five times**, into a local alias before any test runs. A mirror that is genuinely unavailable now fails *the step that talks to it*, with a message saying so, instead of surfacing inside a product test three minutes later.
- **`incusenv.BoxImage()`** is the single place the image is chosen. `CONTAINARIUM_LANE_IMAGE` points CI at the local copy; the default keeps a developer's laptop working with no setup.
- The daemon-flag steps pass `--image lane-box` for the same reason.

Seven hardcoded references across four lane files now go through one function.

## Why BoxImage is tested in the ordinary unit suite

It sits in the **untagged** half of `incusenv`, so `TestBoxImage` runs without Incus. The lane cannot meaningfully check its own default: if the override stopped being honoured, the only symptom would be the mirror traffic quietly returning — invisible until the day it fails again. Both directions are asserted (default, and override).

## Note for the reviewer

While writing this, one of my workflow edits silently matched nothing — the `CONTAINARIUM_LANE_IMAGE` env var was never added on the first pass, which would have left the Go tests still hitting the mirror while the YAML *looked* right. Caught by grepping for the variable rather than trusting the edit. Worth knowing because the failure mode is invisible: the lane would still pass, just slowly and fragilely, exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)