### PR TITLE
feat(container): snapshot lifecycle RPCs and CLI (#1160a)

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -2636,6 +2636,115 @@
         ]
       }
     },
+    "/v1/containers/{username}/snapshots": {
+      "get": {
+        "summary": "List a container's snapshots",
+        "description": "Lists the container's ZFS snapshots, each with the bytes it uniquely holds (what deleting it would free) and the bytes it references in total.",
+        "operationId": "ContainerService_ListContainerSnapshots",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListContainerSnapshotsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "Container Operations"
+        ]
+      },
+      "post": {
+        "summary": "Snapshot a container",
+        "description": "Takes a point-in-time ZFS snapshot of the container's dataset. Instant and space-efficient: it shares blocks with the live dataset until they diverge. Works while the container runs, and while its encryption key is unloaded.",
+        "operationId": "ContainerService_CreateContainerSnapshot",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/CreateContainerSnapshotResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "username",
+            "description": "The container to snapshot.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CreateContainerSnapshotBody"
+            }
+          }
+        ],
+        "tags": [
+          "Container Operations"
+        ]
+      }
+    },
+    "/v1/containers/{username}/snapshots/{name}": {
+      "delete": {
+        "summary": "Delete a container snapshot",
+        "description": "Removes the snapshot and reports the bytes reclaimed. Works while the container's encryption key is unloaded.",
+        "operationId": "ContainerService_DeleteContainerSnapshot",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/DeleteContainerSnapshotResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "Container Operations"
+        ]
+      }
+    },
     "/v1/containers/{username}/ssh-keys": {
       "post": {
         "summary": "Add SSH key",
@@ -7600,6 +7709,26 @@
       },
       "title": "ContainerMetrics contains runtime metrics for a container"
     },
+    "ContainerSnapshot": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Snapshot name, unique per container."
+        },
+        "usedBytes": {
+          "type": "string",
+          "format": "int64",
+          "description": "Bytes uniquely held by this snapshot — space that would be freed by\ndeleting it. Surfaced because a forgotten snapshot silently pins disk,\nand nothing else in the API would say so."
+        },
+        "referencedBytes": {
+          "type": "string",
+          "format": "int64",
+          "description": "Bytes the snapshot references in total, including data it shares with\nthe live dataset. Much larger than used_bytes for a fresh snapshot, and\nnot the number that matters for reclaiming space."
+        }
+      },
+      "description": "ContainerSnapshot is a point-in-time ZFS snapshot of a container's\ndataset (#1160)."
+    },
     "ContainerState": {
       "type": "string",
       "enum": [
@@ -7854,6 +7983,27 @@
       },
       "title": "CreateContainerResponse is the response from creating a container"
     },
+    "CreateContainerSnapshotBody": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Snapshot name. Must be unique for this container."
+        }
+      },
+      "description": "CreateContainerSnapshotRequest snapshots a container's dataset.\n\nSucceeds even when the container's encryption key is unloaded: ZFS allows\nit, and blocking on key-custody reachability would let a transient outage\nsuppress the backup window (encryption design, resolved decision #3)."
+    },
+    "CreateContainerSnapshotResponse": {
+      "type": "object",
+      "properties": {
+        "snapshot": {
+          "$ref": "#/definitions/ContainerSnapshot"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    },
     "CreateVolumeRequest": {
       "type": "object",
       "properties": {
@@ -8080,6 +8230,19 @@
         }
       },
       "title": "DeleteContainerResponse is the response from deleting a container"
+    },
+    "DeleteContainerSnapshotResponse": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string"
+        },
+        "freedBytes": {
+          "type": "string",
+          "format": "int64",
+          "description": "Bytes reclaimed — what the snapshot uniquely held."
+        }
+      }
     },
     "DeleteNetworkPolicyResponse": {
       "type": "object"
@@ -9578,6 +9741,18 @@
         }
       },
       "title": "ListCollaboratorsResponse is the response from listing collaborators"
+    },
+    "ListContainerSnapshotsResponse": {
+      "type": "object",
+      "properties": {
+        "snapshots": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/ContainerSnapshot"
+          }
+        }
+      }
     },
     "ListContainersResponse": {
       "type": "object",

--- a/internal/client/grpc.go
+++ b/internal/client/grpc.go
@@ -1187,3 +1187,41 @@ func (c *GRPCClient) StopEgressProxy(containerName string) error {
 	}
 	return nil
 }
+
+// --- container snapshots (#1160) ----------------------------------------
+
+// CreateContainerSnapshot snapshots a container's dataset via gRPC.
+func (c *GRPCClient) CreateContainerSnapshot(req *pb.CreateContainerSnapshotRequest) (*pb.CreateContainerSnapshotResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	resp, err := c.client.CreateContainerSnapshot(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create snapshot: %w", err)
+	}
+	return resp, nil
+}
+
+// ListContainerSnapshots lists a container's snapshots via gRPC.
+func (c *GRPCClient) ListContainerSnapshots(req *pb.ListContainerSnapshotsRequest) (*pb.ListContainerSnapshotsResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	resp, err := c.client.ListContainerSnapshots(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list snapshots: %w", err)
+	}
+	return resp, nil
+}
+
+// DeleteContainerSnapshot destroys a snapshot via gRPC.
+func (c *GRPCClient) DeleteContainerSnapshot(req *pb.DeleteContainerSnapshotRequest) (*pb.DeleteContainerSnapshotResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	resp, err := c.client.DeleteContainerSnapshot(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to delete snapshot: %w", err)
+	}
+	return resp, nil
+}

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -2033,3 +2033,79 @@ func httpErr(op string, status int, body []byte) error {
 	}
 	return fmt.Errorf("%s: status %d", op, status)
 }
+
+// --- container snapshots (#1160) ----------------------------------------
+
+// CreateContainerSnapshot snapshots a container's dataset via HTTP.
+func (c *HTTPClient) CreateContainerSnapshot(req *pb.CreateContainerSnapshotRequest) (*pb.CreateContainerSnapshotResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	body, err := protojson.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("encode request: %w", err)
+	}
+	path := fmt.Sprintf("/v1/containers/%s/snapshots", url.PathEscape(req.GetUsername()))
+	resp, err := c.doRequest(ctx, http.MethodPost, path, json.RawMessage(body))
+	if err != nil {
+		return nil, fmt.Errorf("create snapshot: %w", err)
+	}
+	defer drainClose(resp)
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return nil, httpError(bodyBytes, resp.StatusCode, "create snapshot")
+	}
+	out := &pb.CreateContainerSnapshotResponse{}
+	if err := protojson.Unmarshal(bodyBytes, out); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return out, nil
+}
+
+// ListContainerSnapshots lists a container's snapshots via HTTP.
+func (c *HTTPClient) ListContainerSnapshots(req *pb.ListContainerSnapshotsRequest) (*pb.ListContainerSnapshotsResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	path := fmt.Sprintf("/v1/containers/%s/snapshots", url.PathEscape(req.GetUsername()))
+	resp, err := c.doRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("list snapshots: %w", err)
+	}
+	defer drainClose(resp)
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return nil, httpError(bodyBytes, resp.StatusCode, "list snapshots")
+	}
+	out := &pb.ListContainerSnapshotsResponse{}
+	if err := protojson.Unmarshal(bodyBytes, out); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return out, nil
+}
+
+// DeleteContainerSnapshot destroys a snapshot via HTTP.
+func (c *HTTPClient) DeleteContainerSnapshot(req *pb.DeleteContainerSnapshotRequest) (*pb.DeleteContainerSnapshotResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	path := fmt.Sprintf("/v1/containers/%s/snapshots/%s",
+		url.PathEscape(req.GetUsername()), url.PathEscape(req.GetName()))
+	resp, err := c.doRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("delete snapshot: %w", err)
+	}
+	defer drainClose(resp)
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return nil, httpError(bodyBytes, resp.StatusCode, "delete snapshot")
+	}
+	out := &pb.DeleteContainerSnapshotResponse{}
+	if err := protojson.Unmarshal(bodyBytes, out); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return out, nil
+}

--- a/internal/cmd/snapshot.go
+++ b/internal/cmd/snapshot.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/footprintai/containarium/internal/client"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"github.com/spf13/cobra"
+)
+
+// Container snapshots (#1160).
+//
+// A ZFS snapshot of a container's dataset: instant, space-efficient, and
+// takeable while the container runs. It is NOT a backup — it shares blocks
+// with the live dataset and dies with the pool. `containarium backup` is the
+// off-host one; this is the cheap rollback point you take before an upgrade.
+
+var snapshotCmd = &cobra.Command{
+	Use:   "snapshot",
+	Short: "Take, list, and delete point-in-time snapshots of a container's storage",
+	Long: `Manage ZFS snapshots of a container's dataset.
+
+A snapshot is instant and initially free — it shares every block with the
+live dataset and only starts consuming space as the two diverge. Take one
+before an upgrade or a risky change; it is the cheapest rollback point
+available.
+
+A snapshot is NOT a backup. It lives in the same pool as the data it
+snapshots, so it survives a bad "rm -rf" and not a lost disk. For off-host
+copies see ` + "`containarium backup`" + `.
+
+Snapshots work on encrypted containers with the key unloaded: ZFS allows it,
+and refusing would mean a key-custody outage silently stopped your backup
+window. Reading a snapshot back does need the key.
+
+  containarium snapshot create alice --name before-upgrade --server <host>
+  containarium snapshot list alice --server <host>
+  containarium snapshot delete alice before-upgrade --server <host>`,
+}
+
+func init() {
+	rootCmd.AddCommand(snapshotCmd)
+}
+
+// snapshotAPI is the subset of the typed client the snapshot commands use.
+// Both the gRPC and HTTP clients satisfy it, so the commands dispatch on
+// --http without duplicating call sites.
+type snapshotAPI interface {
+	CreateContainerSnapshot(req *pb.CreateContainerSnapshotRequest) (*pb.CreateContainerSnapshotResponse, error)
+	ListContainerSnapshots(req *pb.ListContainerSnapshotsRequest) (*pb.ListContainerSnapshotsResponse, error)
+	DeleteContainerSnapshot(req *pb.DeleteContainerSnapshotRequest) (*pb.DeleteContainerSnapshotResponse, error)
+	Close() error
+}
+
+// newSnapshotClientFn is the seam tests substitute to exercise output and
+// exit-code handling without a live daemon.
+var newSnapshotClientFn = newSnapshotClient
+
+func newSnapshotClient() (snapshotAPI, error) {
+	if serverAddr == "" {
+		return nil, fmt.Errorf("--server is required")
+	}
+	if httpMode {
+		return client.NewHTTPClient(serverAddr, authToken)
+	}
+	return client.NewGRPCClient(serverAddr, certsDir, insecure)
+}

--- a/internal/cmd/snapshot_ops.go
+++ b/internal/cmd/snapshot_ops.go
@@ -1,0 +1,134 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"github.com/spf13/cobra"
+)
+
+var snapshotCreateName string
+
+var snapshotCreateCmd = &cobra.Command{
+	Use:   "create <username>",
+	Short: "Take a snapshot of a container's storage",
+	Long: `Take a point-in-time ZFS snapshot of the container's dataset.
+
+Instant and initially free: the snapshot shares every block with the live
+dataset and only consumes space as the two diverge. Safe to take while the
+container is running, and while its encryption key is unloaded.
+
+  containarium snapshot create alice --name before-upgrade --server <host>`,
+	Args: cobra.ExactArgs(1),
+	RunE: runSnapshotCreate,
+}
+
+var snapshotListCmd = &cobra.Command{
+	Use:   "list <username>",
+	Short: "List a container's snapshots and what they cost",
+	Long: `List the container's snapshots with the space each one holds.
+
+USED is what deleting that snapshot would free — the number that matters,
+because a forgotten snapshot pins disk that nothing else accounts for.
+REFERENCED is the total data it points at, most of which is shared with the
+live dataset and would not be freed.
+
+  containarium snapshot list alice --server <host>`,
+	Args: cobra.ExactArgs(1),
+	RunE: runSnapshotList,
+}
+
+var snapshotDeleteCmd = &cobra.Command{
+	Use:   "delete <username> <snapshot>",
+	Short: "Delete a snapshot and reclaim its space",
+	Long: `Destroy the named snapshot and report the space reclaimed.
+
+  containarium snapshot delete alice before-upgrade --server <host>`,
+	Args: cobra.ExactArgs(2),
+	RunE: runSnapshotDelete,
+}
+
+func init() {
+	snapshotCmd.AddCommand(snapshotCreateCmd, snapshotListCmd, snapshotDeleteCmd)
+	snapshotCreateCmd.Flags().StringVar(&snapshotCreateName, "name", "",
+		"snapshot name (required); no '/', '@' or whitespace")
+}
+
+func runSnapshotCreate(cmd *cobra.Command, args []string) error {
+	if snapshotCreateName == "" {
+		return fmt.Errorf("--name is required")
+	}
+	c, err := newSnapshotClientFn()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = c.Close() }()
+
+	resp, err := c.CreateContainerSnapshot(&pb.CreateContainerSnapshotRequest{
+		Username: args[0],
+		Name:     snapshotCreateName,
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("✅ Snapshot %q created for %s\n", resp.GetSnapshot().GetName(), args[0])
+	// Said on every create, because the word "snapshot" reliably gets heard as
+	// "backup" and the difference only shows up on the day the pool is gone.
+	fmt.Println("   Note: a snapshot lives in the same pool as the data it snapshots. " +
+		"For an off-host copy use `containarium backup create`.")
+	return nil
+}
+
+func runSnapshotList(cmd *cobra.Command, args []string) error {
+	c, err := newSnapshotClientFn()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = c.Close() }()
+
+	resp, err := c.ListContainerSnapshots(&pb.ListContainerSnapshotsRequest{Username: args[0]})
+	if err != nil {
+		return err
+	}
+	if len(resp.GetSnapshots()) == 0 {
+		fmt.Printf("No snapshots for %s\n", args[0])
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "NAME\tUSED\tREFERENCED")
+	var total int64
+	for _, s := range resp.GetSnapshots() {
+		total += s.GetUsedBytes()
+		fmt.Fprintf(w, "%s\t%s\t%s\n", s.GetName(),
+			humanBytes(s.GetUsedBytes()), humanBytes(s.GetReferencedBytes()))
+	}
+	if err := w.Flush(); err != nil {
+		return err
+	}
+	fmt.Printf("\n%d snapshot(s), holding %s that deleting them would free\n",
+		len(resp.GetSnapshots()), humanBytes(total))
+	return nil
+}
+
+func runSnapshotDelete(cmd *cobra.Command, args []string) error {
+	c, err := newSnapshotClientFn()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = c.Close() }()
+
+	resp, err := c.DeleteContainerSnapshot(&pb.DeleteContainerSnapshotRequest{
+		Username: args[0],
+		Name:     args[1],
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("✅ Snapshot %q deleted, freeing %s\n", args[1], humanBytes(resp.GetFreedBytes()))
+	return nil
+}

--- a/internal/cmd/snapshot_test.go
+++ b/internal/cmd/snapshot_test.go
@@ -1,0 +1,226 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// CLI surface for container snapshots (#1160).
+//
+// The CLI is the canonical interface (CLAUDE.md: CLI-first, MCP wraps it), so
+// these check what an operator actually sees — including the two numbers that
+// are easy to confuse and the warning that stops a snapshot being mistaken
+// for a backup.
+
+// captureStdout runs fn with os.Stdout redirected and returns what it wrote.
+// The commands print for humans, so the human-visible text is the contract
+// worth asserting.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+
+	fn()
+
+	os.Stdout = orig
+	_ = w.Close()
+	out := <-done
+	_ = r.Close()
+	return out
+}
+
+// captureErr runs fn with its output swallowed and returns only its error.
+func captureErr(t *testing.T, fn func() error) error {
+	t.Helper()
+	var err error
+	captureStdout(t, func() { err = fn() })
+	return err
+}
+
+type fakeSnapshotAPI struct {
+	created  *pb.CreateContainerSnapshotRequest
+	deleted  *pb.DeleteContainerSnapshotRequest
+	listResp *pb.ListContainerSnapshotsResponse
+	err      error
+}
+
+func (f *fakeSnapshotAPI) CreateContainerSnapshot(req *pb.CreateContainerSnapshotRequest) (*pb.CreateContainerSnapshotResponse, error) {
+	f.created = req
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &pb.CreateContainerSnapshotResponse{
+		Snapshot: &pb.ContainerSnapshot{Name: req.GetName()},
+	}, nil
+}
+
+func (f *fakeSnapshotAPI) ListContainerSnapshots(*pb.ListContainerSnapshotsRequest) (*pb.ListContainerSnapshotsResponse, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.listResp, nil
+}
+
+func (f *fakeSnapshotAPI) DeleteContainerSnapshot(req *pb.DeleteContainerSnapshotRequest) (*pb.DeleteContainerSnapshotResponse, error) {
+	f.deleted = req
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &pb.DeleteContainerSnapshotResponse{FreedBytes: 4096}, nil
+}
+
+func (f *fakeSnapshotAPI) Close() error { return nil }
+
+func withSnapshotAPI(t *testing.T, api *fakeSnapshotAPI) {
+	t.Helper()
+	prev := newSnapshotClientFn
+	newSnapshotClientFn = func() (snapshotAPI, error) { return api, nil }
+	t.Cleanup(func() { newSnapshotClientFn = prev })
+}
+
+func TestSnapshotCreate_SendsTheNameAndUsername(t *testing.T) {
+	api := &fakeSnapshotAPI{}
+	withSnapshotAPI(t, api)
+	snapshotCreateName = "before-upgrade"
+	t.Cleanup(func() { snapshotCreateName = "" })
+
+	out := captureStdout(t, func() {
+		if err := runSnapshotCreate(nil, []string{"alice"}); err != nil {
+			t.Fatalf("runSnapshotCreate: %v", err)
+		}
+	})
+
+	if api.created.GetUsername() != "alice" || api.created.GetName() != "before-upgrade" {
+		t.Fatalf("sent %+v, want alice/before-upgrade", api.created)
+	}
+	// The warning is not decoration: "snapshot" gets heard as "backup", and
+	// the difference only surfaces on the day the pool is gone.
+	if !strings.Contains(out, "backup") {
+		t.Errorf("create output never mentions that this is not an off-host backup:\n%s", out)
+	}
+}
+
+func TestSnapshotCreate_RequiresAName(t *testing.T) {
+	api := &fakeSnapshotAPI{}
+	withSnapshotAPI(t, api)
+	snapshotCreateName = ""
+
+	if err := runSnapshotCreate(nil, []string{"alice"}); err == nil {
+		t.Fatal("a snapshot with no name was accepted")
+	}
+	if api.created != nil {
+		t.Errorf("the daemon was called anyway: %+v", api.created)
+	}
+}
+
+// USED and REFERENCED must both be shown and be distinguishable. Printing
+// only one — or the wrong one — is how an operator concludes a 60 GiB
+// snapshot is free and leaves it there.
+func TestSnapshotList_ShowsUsedAndReferencedSeparately(t *testing.T) {
+	withSnapshotAPI(t, &fakeSnapshotAPI{listResp: &pb.ListContainerSnapshotsResponse{
+		Snapshots: []*pb.ContainerSnapshot{
+			{Name: "nightly", UsedBytes: 1024, ReferencedBytes: 10 * 1024 * 1024 * 1024},
+		},
+	}})
+
+	out := captureStdout(t, func() {
+		if err := runSnapshotList(nil, []string{"alice"}); err != nil {
+			t.Fatalf("runSnapshotList: %v", err)
+		}
+	})
+
+	for _, want := range []string{"nightly", "1.0 KiB", "10.0 GiB", "USED", "REFERENCED"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("list output is missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestSnapshotList_SaysSoWhenThereAreNone(t *testing.T) {
+	withSnapshotAPI(t, &fakeSnapshotAPI{listResp: &pb.ListContainerSnapshotsResponse{}})
+
+	out := captureStdout(t, func() {
+		if err := runSnapshotList(nil, []string{"alice"}); err != nil {
+			t.Fatalf("runSnapshotList: %v", err)
+		}
+	})
+	if !strings.Contains(out, "No snapshots") {
+		t.Errorf("an empty list printed nothing an operator can read:\n%s", out)
+	}
+}
+
+func TestSnapshotDelete_ReportsWhatWasFreed(t *testing.T) {
+	api := &fakeSnapshotAPI{}
+	withSnapshotAPI(t, api)
+
+	out := captureStdout(t, func() {
+		if err := runSnapshotDelete(nil, []string{"alice", "nightly"}); err != nil {
+			t.Fatalf("runSnapshotDelete: %v", err)
+		}
+	})
+
+	if api.deleted.GetName() != "nightly" {
+		t.Fatalf("deleted %+v, want nightly", api.deleted)
+	}
+	if !strings.Contains(out, "4.0 KiB") {
+		t.Errorf("the reclaimed space is not reported:\n%s", out)
+	}
+}
+
+// A daemon-side failure must reach the exit code, not just stdout.
+func TestSnapshotCommands_PropagateTheDaemonError(t *testing.T) {
+	withSnapshotAPI(t, &fakeSnapshotAPI{err: errors.New("dataset is busy")})
+
+	snapshotCreateName = "x"
+	t.Cleanup(func() { snapshotCreateName = "" })
+	for name, run := range map[string]func() error{
+		"create": func() error { return runSnapshotCreate(nil, []string{"alice"}) },
+		"list":   func() error { return runSnapshotList(nil, []string{"alice"}) },
+		"delete": func() error { return runSnapshotDelete(nil, []string{"alice", "x"}) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := captureErr(t, run); err == nil {
+				t.Fatal("a daemon failure exited 0, so a script would carry on as if it worked")
+			}
+		})
+	}
+}
+
+// humanBytes is shared with `backup`, and the snapshot list output above is
+// asserted through it — so the sizes it produces are pinned here rather than
+// left to the eye.
+func TestHumanBytes(t *testing.T) {
+	cases := []struct {
+		in   int64
+		want string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1024, "1.0 KiB"},
+		{1536, "1.5 KiB"},
+		{1024 * 1024, "1.0 MiB"},
+		{3 * 1024 * 1024 * 1024, "3.0 GiB"},
+		{2 * 1024 * 1024 * 1024 * 1024, "2.0 TiB"},
+	}
+	for _, c := range cases {
+		if got := humanBytes(c.in); got != c.want {
+			t.Errorf("humanBytes(%d) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -91,7 +91,11 @@ type ContainerServer struct {
 	// encryption carries the per-tenant dataset hooks (#1199/#1201). A
 	// nil value is a valid no-op receiver, so the lifecycle paths do not
 	// branch on whether encryption is configured.
-	encryption          *encryptionHooks
+	encryption *encryptionHooks
+	// snapshots is the container-snapshot surface (#1160). nil when the
+	// storage backend is not ZFS, which the handlers report rather than
+	// panic on.
+	snapshots           *snapshotOps
 	collaboratorManager *container.CollaboratorManager
 	emitter             *events.Emitter
 	pendingCreations    map[string]*PendingCreation

--- a/internal/server/container_snapshot.go
+++ b/internal/server/container_snapshot.go
@@ -1,0 +1,227 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/pkg/core/zfscrypt"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// Container snapshots (#1160, slice a: the lifecycle).
+//
+// The ZFS mechanism has existed in pkg/core/zfscrypt since #1200 and is
+// verified against a real pool. What was missing is any way to reach it: no
+// RPC and no CLI, so taking a snapshot meant an operator with a shell on the
+// host, which is not a feature.
+//
+// Ownership is settled in docs/architecture/container-snapshots.md: these live
+// on ContainerService, not VolumeService, because the subject is a container.
+// The dataset is an implementation detail the daemon resolves, and the tenant
+// authorization a container RPC already performs is exactly the check a
+// snapshot needs.
+//
+// None of the three verbs requires the encryption key. That is deliberate and
+// load-bearing (encryption design, resolved decision #3): ZFS lets a snapshot
+// be created and destroyed with the key unloaded, and gating on key-custody
+// reachability would turn a KMS outage into a silently missed backup window,
+// or into unbounded snapshot growth. Reading a snapshot's CONTENTS does need
+// the key — that is what zfscrypt.EnsureInspectable exists for, and it belongs
+// with the inspection verbs rather than here.
+
+// snapshotOps is the daemon's container-snapshot surface: a zfscrypt manager
+// plus the two lookups needed to name the right dataset.
+//
+// A nil *snapshotOps is a valid receiver meaning "this daemon has no ZFS
+// snapshot support", so the handlers answer FailedPrecondition rather than
+// panicking on a backend that is not ZFS.
+type snapshotOps struct {
+	zfs *zfscrypt.Manager
+
+	// datasetFor resolves a container's own dataset on a given pool; "" pool
+	// means the daemon's configured one. Bound to incus.Client.ContainerDataset,
+	// which reads the pool's source from Incus rather than rebuilding the
+	// layout string — that rebuild is what #1336 got wrong.
+	datasetFor func(containerName, pool string) (string, error)
+
+	// poolFor reports the storage pool a container was placed on, or "" when
+	// it is on the default one. nil when encryption is not configured, in
+	// which case every container is on the default pool.
+	poolFor func(containerName string) (string, error)
+}
+
+// SetSnapshotStorage wires the snapshot surface.
+//
+// The pool lookup goes through the ENCRYPTION record, not the tenant naming
+// convention: an encrypted container lives under its tenant's pool, whose
+// source is the tenant encryptionroot (#1335), and the pool it was actually
+// placed on is recorded at create time. Recomputing the name instead would
+// mean that the day the convention changes, every existing container resolves
+// to a dataset that is not theirs — the same reasoning as encryptionRootFor.
+func (s *ContainerServer) SetSnapshotStorage(zfs *zfscrypt.Manager, datasetFor func(containerName, pool string) (string, error)) {
+	if zfs == nil || datasetFor == nil {
+		return
+	}
+	ops := &snapshotOps{zfs: zfs, datasetFor: datasetFor}
+	if h := s.encryption; h.enabled() {
+		ops.poolFor = h.refs.GetPool
+	}
+	s.snapshots = ops
+}
+
+// datasetOf resolves the dataset backing a container, honouring the pool it
+// was placed on.
+func (o *snapshotOps) datasetOf(containerName string) (string, error) {
+	pool := ""
+	if o.poolFor != nil {
+		var err error
+		if pool, err = o.poolFor(containerName); err != nil {
+			// Never fall back to the default pool here. The container may well
+			// be encrypted and living elsewhere, and the default pool's
+			// dataset of the same name is another tenant's storage — reading
+			// or destroying it would be both wrong and a tenancy violation.
+			return "", fmt.Errorf(
+				"cannot determine which storage pool %s is on, so its dataset cannot be named "+
+					"safely: %w", containerName, err)
+		}
+	}
+	return o.datasetFor(containerName, pool)
+}
+
+// snapshotDatasetFor is the shared preamble: authorize the caller for this
+// container and resolve the dataset to operate on.
+func (s *ContainerServer) snapshotDatasetFor(ctx context.Context, username, scope string) (*snapshotOps, string, error) {
+	if username == "" {
+		return nil, "", status.Error(codes.InvalidArgument, "username is required")
+	}
+	if err := auth.RequireScope(ctx, scope); err != nil {
+		return nil, "", err
+	}
+	if err := auth.AuthorizeTenant(ctx, username); err != nil {
+		return nil, "", err
+	}
+	if s.snapshots == nil {
+		return nil, "", status.Error(codes.FailedPrecondition,
+			"container snapshots need a ZFS storage backend, which this daemon is not configured with")
+	}
+
+	containerName := username + "-container"
+	dataset, err := s.snapshots.datasetOf(containerName)
+	if err != nil {
+		return nil, "", status.Errorf(codes.FailedPrecondition, "%v", err)
+	}
+	return s.snapshots, dataset, nil
+}
+
+// CreateContainerSnapshot takes a point-in-time snapshot of a container's
+// dataset. Instant and space-efficient — it shares blocks with the live
+// dataset until they diverge — and safe to take while the container runs.
+func (s *ContainerServer) CreateContainerSnapshot(ctx context.Context, req *pb.CreateContainerSnapshotRequest) (*pb.CreateContainerSnapshotResponse, error) {
+	ops, dataset, err := s.snapshotDatasetFor(ctx, req.GetUsername(), auth.ScopeContainersWrite)
+	if err != nil {
+		return nil, err
+	}
+
+	// Name validation lives in zfscrypt, which rejects anything containing
+	// '@', '/' or whitespace. Routing through it rather than concatenating
+	// here is the point: a name like "../other" would otherwise address a
+	// different dataset entirely.
+	full, err := ops.zfs.Snapshot(ctx, dataset, req.GetName())
+	if err != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "%v", err)
+	}
+
+	snap := &pb.ContainerSnapshot{Name: req.GetName()}
+	// Usage right after creation is ~0 (everything is still shared with the
+	// live dataset), but reading it costs one cheap call and makes the
+	// response the same shape as a list entry.
+	if used, referenced, err := ops.zfs.SnapshotUsage(ctx, full); err == nil {
+		snap.UsedBytes, snap.ReferencedBytes = used, referenced
+	}
+
+	return &pb.CreateContainerSnapshotResponse{
+		Snapshot: snap,
+		Message: fmt.Sprintf("created snapshot %s. It is not a backup until it is copied off this "+
+			"host — it shares blocks with the live dataset and dies with the pool", full),
+	}, nil
+}
+
+// ListContainerSnapshots lists a container's snapshots with their space usage.
+//
+// The usage is the reason this is not a bare name list: a forgotten snapshot
+// pins disk that nothing else in the API accounts for, and the first sign is
+// usually a full pool.
+func (s *ContainerServer) ListContainerSnapshots(ctx context.Context, req *pb.ListContainerSnapshotsRequest) (*pb.ListContainerSnapshotsResponse, error) {
+	ops, dataset, err := s.snapshotDatasetFor(ctx, req.GetUsername(), auth.ScopeContainersRead)
+	if err != nil {
+		return nil, err
+	}
+
+	names, err := ops.zfs.ListSnapshots(ctx, dataset)
+	if err != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "%v", err)
+	}
+
+	out := make([]*pb.ContainerSnapshot, 0, len(names))
+	for _, full := range names {
+		snap := &pb.ContainerSnapshot{Name: snapshotShortName(full)}
+		// Usage is decoration. A snapshot whose properties cannot be read is
+		// still listed with zeroes: dropping the row would hide a snapshot
+		// that exists, and an unreadable property is most likely on a pool
+		// that is already in trouble.
+		if used, referenced, err := ops.zfs.SnapshotUsage(ctx, full); err == nil {
+			snap.UsedBytes, snap.ReferencedBytes = used, referenced
+		}
+		out = append(out, snap)
+	}
+	return &pb.ListContainerSnapshotsResponse{Snapshots: out}, nil
+}
+
+// DeleteContainerSnapshot removes a snapshot and reports what it freed.
+func (s *ContainerServer) DeleteContainerSnapshot(ctx context.Context, req *pb.DeleteContainerSnapshotRequest) (*pb.DeleteContainerSnapshotResponse, error) {
+	ops, dataset, err := s.snapshotDatasetFor(ctx, req.GetUsername(), auth.ScopeContainersWrite)
+	if err != nil {
+		return nil, err
+	}
+	if req.GetName() == "" {
+		return nil, status.Error(codes.InvalidArgument, "snapshot name is required")
+	}
+	full := dataset + "@" + req.GetName()
+
+	// Read the usage BEFORE destroying: afterwards there is nothing left to
+	// read it from, and "how much did that free?" is the question an operator
+	// deleting a snapshot is actually asking. Best-effort — an unreadable
+	// property is not a reason to refuse a deletion, particularly since the
+	// most likely cause is a pool short on space.
+	freed, _, usageErr := ops.zfs.SnapshotUsage(ctx, full)
+	if usageErr != nil {
+		freed = 0
+	}
+
+	if err := ops.zfs.DestroySnapshot(ctx, full); err != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "%v", err)
+	}
+
+	msg := fmt.Sprintf("destroyed snapshot %s, freeing %d bytes", full, freed)
+	if usageErr != nil {
+		msg = fmt.Sprintf("destroyed snapshot %s; how much it freed could not be read beforehand", full)
+	}
+	return &pb.DeleteContainerSnapshotResponse{Message: msg, FreedBytes: freed}, nil
+}
+
+// snapshotShortName reduces "<dataset>@<name>" to "<name>".
+//
+// Callers asked about a container, so they get back the name they passed in
+// rather than a dataset path they would have to parse — and the dataset half
+// is a detail of the storage layout that no client should start depending on.
+func snapshotShortName(full string) string {
+	if _, name, ok := strings.Cut(full, "@"); ok {
+		return name
+	}
+	return full
+}

--- a/internal/server/container_snapshot_test.go
+++ b/internal/server/container_snapshot_test.go
@@ -1,0 +1,459 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/pkg/core/zfscrypt"
+	"github.com/footprintai/containarium/pkg/core/zfskey"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// Container snapshot lifecycle (#1160, slice a).
+//
+// The mechanism already exists in pkg/core/zfscrypt and is verified against a
+// real pool. What did not exist is any way to REACH it: no RPC, no CLI, so a
+// snapshot could only be taken by an operator with a shell on the host. These
+// tests pin the daemon-side half — which dataset gets snapshotted, who is
+// allowed to ask, and what the caller is told.
+//
+// The dataset resolution is the part worth testing hardest. An encrypted
+// container does not live under the default pool: it lives under its TENANT's
+// pool, whose source is the tenant encryptionroot (#1335). Snapshotting the
+// name the default pool would produce means snapshotting nothing, or worse,
+// another pool's identically-named dataset. See
+// docs/architecture/container-snapshots.md.
+
+// snapshotFixture builds a server whose snapshot surface runs against a fake
+// `zfs`, with a recorded pool per container so dataset resolution is
+// exercised rather than stubbed.
+func snapshotFixture(t *testing.T, z *zfsFake, poolOf map[string]string) *ContainerServer {
+	t.Helper()
+	return &ContainerServer{snapshots: &snapshotOps{
+		zfs: zfscrypt.NewManager(z),
+		// Stands in for incus.Client.ContainerDataset: the real one reads the
+		// pool's source from Incus and appends /containers/<name>. The shape
+		// here is that same layout, so a handler that passes the wrong pool
+		// produces a visibly wrong dataset instead of the right one.
+		datasetFor: func(containerName, pool string) (string, error) {
+			if pool == "" {
+				pool = "default"
+			}
+			return "tank/" + pool + "/containers/" + containerName, nil
+		},
+		poolFor: func(containerName string) (string, error) {
+			return poolOf[containerName], nil
+		},
+	}}
+}
+
+func writeCtx(tenant string) context.Context {
+	return tenantWithScopes(tenant, auth.ScopeContainersRead, auth.ScopeContainersWrite)
+}
+
+// The core of the slice: an encrypted container is snapshotted on ITS pool's
+// dataset, not the default pool's.
+func TestCreateContainerSnapshot_SnapshotsTheTenantPoolDataset(t *testing.T) {
+	z := newZFSFake()
+	s := snapshotFixture(t, z, map[string]string{
+		"alice-container": "containarium-tenant-alice",
+	})
+
+	resp, err := s.CreateContainerSnapshot(writeCtx("alice"),
+		&pb.CreateContainerSnapshotRequest{Username: "alice", Name: "nightly"})
+	if err != nil {
+		t.Fatalf("CreateContainerSnapshot: %v", err)
+	}
+
+	const want = "snapshot tank/containarium-tenant-alice/containers/alice-container@nightly"
+	if !z.ran(want) {
+		t.Fatalf("zfs calls = %v, want %q — an encrypted container lives under its TENANT's pool, "+
+			"so resolving through the default pool snapshots a dataset that is not theirs (or "+
+			"nothing at all)", z.calls, want)
+	}
+	if resp.GetSnapshot().GetName() != "nightly" {
+		t.Errorf("response names snapshot %q, want nightly", resp.GetSnapshot().GetName())
+	}
+}
+
+// An unencrypted container has no recorded pool and must still work — the
+// overwhelming majority of containers today are in exactly that state.
+func TestCreateContainerSnapshot_WorksForAnUnencryptedContainer(t *testing.T) {
+	z := newZFSFake()
+	s := snapshotFixture(t, z, map[string]string{})
+
+	if _, err := s.CreateContainerSnapshot(writeCtx("bob"),
+		&pb.CreateContainerSnapshotRequest{Username: "bob", Name: "before-upgrade"}); err != nil {
+		t.Fatalf("CreateContainerSnapshot: %v", err)
+	}
+	if !z.ran("snapshot tank/default/containers/bob-container@before-upgrade") {
+		t.Errorf("zfs calls = %v, want the default pool's dataset", z.calls)
+	}
+}
+
+// The deliberate one (encryption design, resolved decision #3): a snapshot is
+// takeable while the key is unloaded. Blocking on key custody would let a KMS
+// outage silently suppress the backup window — the opposite of what a backup
+// is for.
+//
+// The fake reports `zfs get keystatus` as "unavailable" by default, so if the
+// handler ever grew a key precondition this test would fail.
+func TestCreateContainerSnapshot_SucceedsWithTheKeyUnloaded(t *testing.T) {
+	z := newZFSFake()
+	z.stdout["get"] = "unavailable"
+	s := snapshotFixture(t, z, map[string]string{"alice-container": "containarium-tenant-alice"})
+
+	if _, err := s.CreateContainerSnapshot(writeCtx("alice"),
+		&pb.CreateContainerSnapshotRequest{Username: "alice", Name: "nightly"}); err != nil {
+		t.Fatalf("a snapshot was refused because the key was unloaded: %v — a key-custody outage "+
+			"would then silently stop backups, which is when they matter most", err)
+	}
+}
+
+func TestCreateContainerSnapshot_ReportsWhatZFSRefused(t *testing.T) {
+	z := newZFSFake()
+	z.errs["snapshot"] = errors.New("exit status 1")
+	z.stderr["snapshot"] = "cannot create snapshot: dataset already exists"
+	s := snapshotFixture(t, z, map[string]string{})
+
+	_, err := s.CreateContainerSnapshot(writeCtx("bob"),
+		&pb.CreateContainerSnapshotRequest{Username: "bob", Name: "nightly"})
+	if err == nil {
+		t.Fatal("a failed `zfs snapshot` was reported as success")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("the error drops what ZFS said, so a caller cannot tell a name clash from a "+
+			"broken pool: %v", err)
+	}
+}
+
+// --- listing -------------------------------------------------------------
+
+// Usage is the reason this RPC exists rather than a bare name list: a
+// forgotten snapshot pins disk and nothing else in the API reports it.
+func TestListContainerSnapshots_CarriesSpaceUsage(t *testing.T) {
+	z := newZFSFake()
+	delete(z.errs, "list")
+	z.stdout["list"] = "tank/containarium-tenant-alice/containers/alice-container@nightly\n" +
+		"tank/containarium-tenant-alice/containers/alice-container@weekly"
+	z.stdout["get"] = "1024\t65536"
+	s := snapshotFixture(t, z, map[string]string{"alice-container": "containarium-tenant-alice"})
+
+	resp, err := s.ListContainerSnapshots(tenantWithScopes("alice", auth.ScopeContainersRead),
+		&pb.ListContainerSnapshotsRequest{Username: "alice"})
+	if err != nil {
+		t.Fatalf("ListContainerSnapshots: %v", err)
+	}
+	if len(resp.GetSnapshots()) != 2 {
+		t.Fatalf("got %d snapshots, want 2", len(resp.GetSnapshots()))
+	}
+
+	// Names come back short, not as full dataset@snap references: the caller
+	// asked about a container and should not have to parse a dataset path to
+	// find the name they passed in.
+	if got := resp.Snapshots[0].GetName(); got != "nightly" {
+		t.Errorf("name = %q, want the bare snapshot name %q", got, "nightly")
+	}
+	if resp.Snapshots[0].GetUsedBytes() != 1024 {
+		t.Errorf("used_bytes = %d, want 1024 — this is the number that says what deleting the "+
+			"snapshot would free, and it is the whole reason to list usage",
+			resp.Snapshots[0].GetUsedBytes())
+	}
+	if resp.Snapshots[0].GetReferencedBytes() != 65536 {
+		t.Errorf("referenced_bytes = %d, want 65536", resp.Snapshots[0].GetReferencedBytes())
+	}
+}
+
+// A container with no snapshots is an empty list, not an error: `zfs list -t
+// snapshot` on a dataset with none exits 0 with no output, and a caller
+// polling this should not have to distinguish "none yet" from "broken".
+func TestListContainerSnapshots_EmptyIsNotAnError(t *testing.T) {
+	z := newZFSFake()
+	delete(z.errs, "list")
+	z.stdout["list"] = ""
+	s := snapshotFixture(t, z, map[string]string{})
+
+	resp, err := s.ListContainerSnapshots(tenantWithScopes("bob", auth.ScopeContainersRead),
+		&pb.ListContainerSnapshotsRequest{Username: "bob"})
+	if err != nil {
+		t.Fatalf("listing a container with no snapshots failed: %v", err)
+	}
+	if len(resp.GetSnapshots()) != 0 {
+		t.Errorf("got %d snapshots, want none", len(resp.GetSnapshots()))
+	}
+}
+
+// A snapshot whose usage cannot be read is still listed. Usage is decoration;
+// dropping the row would hide a snapshot that exists, and the operator most
+// likely to hit an unreadable property is the one whose pool is already sick.
+func TestListContainerSnapshots_ListsASnapshotWhoseUsageIsUnreadable(t *testing.T) {
+	z := newZFSFake()
+	delete(z.errs, "list")
+	z.stdout["list"] = "tank/default/containers/bob-container@nightly"
+	z.errs["get"] = errors.New("exit status 1")
+	s := snapshotFixture(t, z, map[string]string{})
+
+	resp, err := s.ListContainerSnapshots(tenantWithScopes("bob", auth.ScopeContainersRead),
+		&pb.ListContainerSnapshotsRequest{Username: "bob"})
+	if err != nil {
+		t.Fatalf("ListContainerSnapshots: %v", err)
+	}
+	if len(resp.GetSnapshots()) != 1 {
+		t.Fatalf("got %d snapshots, want the snapshot listed even with unreadable usage — hiding "+
+			"it makes a real backup invisible", len(resp.GetSnapshots()))
+	}
+	if resp.Snapshots[0].GetUsedBytes() != 0 {
+		t.Errorf("used_bytes = %d, want 0 when it could not be read",
+			resp.Snapshots[0].GetUsedBytes())
+	}
+}
+
+// --- deletion ------------------------------------------------------------
+
+func TestDeleteContainerSnapshot_DestroysTheTenantPoolSnapshot(t *testing.T) {
+	z := newZFSFake()
+	delete(z.errs, "list")
+	z.stdout["get"] = "4096\t65536"
+	s := snapshotFixture(t, z, map[string]string{"alice-container": "containarium-tenant-alice"})
+
+	resp, err := s.DeleteContainerSnapshot(writeCtx("alice"),
+		&pb.DeleteContainerSnapshotRequest{Username: "alice", Name: "nightly"})
+	if err != nil {
+		t.Fatalf("DeleteContainerSnapshot: %v", err)
+	}
+
+	const want = "destroy tank/containarium-tenant-alice/containers/alice-container@nightly"
+	if !z.ran(want) {
+		t.Fatalf("zfs calls = %v, want %q", z.calls, want)
+	}
+	// Reported BEFORE the destroy, because afterwards there is nothing left to
+	// read it from. A zero here means the number was read too late.
+	if resp.GetFreedBytes() != 4096 {
+		t.Errorf("freed_bytes = %d, want 4096 — read the usage before destroying, or the answer "+
+			"is unavailable by the time anyone asks", resp.GetFreedBytes())
+	}
+}
+
+// Deleting must not require the key either: retention has to keep working
+// through a custody outage, or an unreadable key turns into unbounded growth.
+func TestDeleteContainerSnapshot_SucceedsWithTheKeyUnloaded(t *testing.T) {
+	z := newZFSFake()
+	z.stdout["get"] = "unavailable" // not parseable as usage, and not a blocker
+	s := snapshotFixture(t, z, map[string]string{"alice-container": "containarium-tenant-alice"})
+
+	if _, err := s.DeleteContainerSnapshot(writeCtx("alice"),
+		&pb.DeleteContainerSnapshotRequest{Username: "alice", Name: "nightly"}); err != nil {
+		t.Fatalf("deletion was refused with the key unloaded: %v — retention would then stall "+
+			"exactly when custody is down", err)
+	}
+	if !z.ran("destroy") {
+		t.Errorf("nothing was destroyed; calls=%v", z.calls)
+	}
+}
+
+func TestDeleteContainerSnapshot_ReportsAFailedDestroy(t *testing.T) {
+	z := newZFSFake()
+	z.errs["destroy"] = errors.New("exit status 1")
+	z.stderr["destroy"] = "cannot destroy: snapshot has dependent clones"
+	s := snapshotFixture(t, z, map[string]string{})
+
+	_, err := s.DeleteContainerSnapshot(writeCtx("bob"),
+		&pb.DeleteContainerSnapshotRequest{Username: "bob", Name: "nightly"})
+	if err == nil {
+		t.Fatal("a failed destroy was reported as a successful deletion — the operator would " +
+			"believe they reclaimed space they still hold")
+	}
+	if !strings.Contains(err.Error(), "dependent clones") {
+		t.Errorf("the error drops what ZFS said: %v", err)
+	}
+}
+
+// --- authorization and validation ---------------------------------------
+
+// Snapshots are a per-container resource, so they inherit the container's
+// tenancy: one tenant must not be able to snapshot, list, or destroy
+// another's. Each verb is checked, because the gate is written per handler
+// and a missing one is invisible from the others.
+func TestContainerSnapshots_RefuseAnotherTenantsContainer(t *testing.T) {
+	z := newZFSFake()
+	delete(z.errs, "list")
+	s := snapshotFixture(t, z, map[string]string{})
+	mallory := writeCtx("mallory")
+
+	calls := map[string]func() error{
+		"create": func() error {
+			_, err := s.CreateContainerSnapshot(mallory,
+				&pb.CreateContainerSnapshotRequest{Username: "alice", Name: "x"})
+			return err
+		},
+		"list": func() error {
+			_, err := s.ListContainerSnapshots(mallory,
+				&pb.ListContainerSnapshotsRequest{Username: "alice"})
+			return err
+		},
+		"delete": func() error {
+			_, err := s.DeleteContainerSnapshot(mallory,
+				&pb.DeleteContainerSnapshotRequest{Username: "alice", Name: "x"})
+			return err
+		},
+	}
+	for verb, call := range calls {
+		t.Run(verb, func(t *testing.T) {
+			if err := call(); err == nil {
+				t.Fatalf("%s let mallory operate on alice's container snapshots", verb)
+			}
+		})
+	}
+	if z.ran("snapshot") || z.ran("destroy") {
+		t.Errorf("a cross-tenant call reached zfs anyway; calls=%v", z.calls)
+	}
+}
+
+// Reading is not writing: a read-only token can list snapshots but must not
+// create or destroy them.
+func TestContainerSnapshots_MutationsRequireTheWriteScope(t *testing.T) {
+	z := newZFSFake()
+	delete(z.errs, "list")
+	s := snapshotFixture(t, z, map[string]string{})
+	readOnly := tenantWithScopes("bob", auth.ScopeContainersRead)
+
+	if _, err := s.CreateContainerSnapshot(readOnly,
+		&pb.CreateContainerSnapshotRequest{Username: "bob", Name: "x"}); err == nil {
+		t.Error("a containers:read token created a snapshot")
+	}
+	if _, err := s.DeleteContainerSnapshot(readOnly,
+		&pb.DeleteContainerSnapshotRequest{Username: "bob", Name: "x"}); err == nil {
+		t.Error("a containers:read token destroyed a snapshot")
+	}
+	if _, err := s.ListContainerSnapshots(readOnly,
+		&pb.ListContainerSnapshotsRequest{Username: "bob"}); err != nil {
+		t.Errorf("a containers:read token could not list snapshots: %v", err)
+	}
+}
+
+// A name with a '/' or '@' would address a different dataset entirely. The
+// rejection lives in zfscrypt, but the handler has to actually route through
+// it rather than build the string itself.
+func TestCreateContainerSnapshot_RejectsANameThatEscapesTheDataset(t *testing.T) {
+	z := newZFSFake()
+	s := snapshotFixture(t, z, map[string]string{})
+
+	for _, name := range []string{"../escape", "a@b", "with space", ""} {
+		if _, err := s.CreateContainerSnapshot(writeCtx("bob"),
+			&pb.CreateContainerSnapshotRequest{Username: "bob", Name: name}); err == nil {
+			t.Errorf("snapshot name %q was accepted — it does not name a snapshot of this "+
+				"container's dataset", name)
+		}
+	}
+	if z.ran("snapshot") {
+		t.Errorf("a rejected name still reached zfs; calls=%v", z.calls)
+	}
+}
+
+func TestContainerSnapshots_RequireAUsername(t *testing.T) {
+	s := snapshotFixture(t, newZFSFake(), map[string]string{})
+	if _, err := s.CreateContainerSnapshot(adminCtx(),
+		&pb.CreateContainerSnapshotRequest{Name: "x"}); err == nil {
+		t.Error("an empty username was accepted for create")
+	}
+	if _, err := s.ListContainerSnapshots(adminCtx(),
+		&pb.ListContainerSnapshotsRequest{}); err == nil {
+		t.Error("an empty username was accepted for list")
+	}
+}
+
+// A daemon whose storage backend is not ZFS has no snapshots to offer, and
+// must say so rather than panic on a nil surface.
+func TestContainerSnapshots_UnconfiguredSaysSoInsteadOfPanicking(t *testing.T) {
+	s := &ContainerServer{}
+	_, err := s.CreateContainerSnapshot(writeCtx("bob"),
+		&pb.CreateContainerSnapshotRequest{Username: "bob", Name: "x"})
+	if err == nil {
+		t.Fatal("a daemon with no snapshot support claimed to have taken a snapshot")
+	}
+	if got := status.Code(err); got != codes.FailedPrecondition {
+		t.Errorf("code = %v, want FailedPrecondition", got)
+	}
+	if _, err := s.ListContainerSnapshots(tenantWithScopes("bob", auth.ScopeContainersRead),
+		&pb.ListContainerSnapshotsRequest{Username: "bob"}); err == nil {
+		t.Error("listing on an unconfigured daemon claimed success")
+	}
+}
+
+// The pool a container is recorded on comes from the same store the
+// encryption hooks write at create time. If that record is unreadable the
+// snapshot must not silently fall back to the default pool — that dataset
+// belongs to someone else.
+func TestContainerSnapshots_RefuseWhenThePoolRecordIsUnreadable(t *testing.T) {
+	z := newZFSFake()
+	s := &ContainerServer{snapshots: &snapshotOps{
+		zfs: zfscrypt.NewManager(z),
+		datasetFor: func(containerName, pool string) (string, error) {
+			return "tank/" + pool + "/containers/" + containerName, nil
+		},
+		poolFor: func(string) (string, error) { return "", errors.New("incus unreachable") },
+	}}
+
+	_, err := s.CreateContainerSnapshot(writeCtx("alice"),
+		&pb.CreateContainerSnapshotRequest{Username: "alice", Name: "nightly"})
+	if err == nil {
+		t.Fatal("an unreadable pool record fell through to the default pool — that dataset is " +
+			"another tenant's, and snapshotting it is both wrong and a cross-tenant read")
+	}
+	if z.ran("snapshot") {
+		t.Errorf("zfs was called anyway; calls=%v", z.calls)
+	}
+}
+
+// The wiring: SetSnapshotStorage must reuse the encryption hooks' pool record
+// when encryption is configured, or every encrypted container resolves to the
+// wrong dataset in production while the unit tests above stay green.
+func TestSetSnapshotStorage_ResolvesThePoolThroughTheEncryptionRecord(t *testing.T) {
+	z := newZFSFake()
+	refs := &fakeRefStore{
+		refs:  map[string]zfskey.KeyRef{"alice-container": {Scheme: zfskey.SchemeFile, URI: "/k"}},
+		pools: map[string]string{"alice-container": "containarium-tenant-alice"},
+	}
+	s := &ContainerServer{encryption: testHooksWith(t, newZFSFake(), &fakeKeyProvider{key: aKey(t)}, refs, newFakePools())}
+	s.SetSnapshotStorage(zfscrypt.NewManager(z), func(containerName, pool string) (string, error) {
+		if pool == "" {
+			pool = "default"
+		}
+		return "tank/" + pool + "/containers/" + containerName, nil
+	})
+
+	if _, err := s.CreateContainerSnapshot(writeCtx("alice"),
+		&pb.CreateContainerSnapshotRequest{Username: "alice", Name: "nightly"}); err != nil {
+		t.Fatalf("CreateContainerSnapshot: %v", err)
+	}
+	if !z.ran("snapshot tank/containarium-tenant-alice/containers/alice-container@nightly") {
+		t.Errorf("zfs calls = %v — the wiring did not consult the encryption record, so every "+
+			"encrypted container would be snapshotted on the wrong pool in production", z.calls)
+	}
+}
+
+// A daemon with encryption unwired must still snapshot, on the default pool.
+func TestSetSnapshotStorage_WorksWithoutEncryptionConfigured(t *testing.T) {
+	z := newZFSFake()
+	s := &ContainerServer{}
+	s.SetSnapshotStorage(zfscrypt.NewManager(z), func(containerName, pool string) (string, error) {
+		if pool == "" {
+			pool = "default"
+		}
+		return "tank/" + pool + "/containers/" + containerName, nil
+	})
+
+	if _, err := s.CreateContainerSnapshot(writeCtx("bob"),
+		&pb.CreateContainerSnapshotRequest{Username: "bob", Name: "x"}); err != nil {
+		t.Fatalf("CreateContainerSnapshot: %v", err)
+	}
+	if !z.ran("snapshot tank/default/containers/bob-container@x") {
+		t.Errorf("zfs calls = %v, want the default pool's dataset", z.calls)
+	}
+}

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -47,6 +47,7 @@ import (
 	"github.com/footprintai/containarium/pkg/core/network"
 	corecryptosecrets "github.com/footprintai/containarium/pkg/core/secrets"
 	"github.com/footprintai/containarium/pkg/core/skills"
+	"github.com/footprintai/containarium/pkg/core/zfscrypt"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"google.golang.org/grpc"
@@ -321,6 +322,17 @@ func NewDualServer(config *DualServerConfig) (*DualServer, error) {
 			}
 			log.Printf("[encryption] per-tenant dataset root: %s (%s)", tenantRoot, how)
 		}
+
+		// Container snapshots (#1160). Deliberately OUTSIDE the tenant-root
+		// branch above: an unencrypted container has a dataset too, and that
+		// is almost every container today — gating snapshots on encryption
+		// being configured would ship the feature to nobody.
+		//
+		// It must come AFTER SetEncryptionStorage, though, because it reads
+		// the encryption record to find which pool an encrypted container was
+		// placed on. Wired first, every encrypted container would resolve to
+		// the default pool's dataset — which is a different tenant's storage.
+		containerServer.SetSnapshotStorage(zfscrypt.NewManager(nil), encClient.ContainerDataset)
 	}
 	// NOTE: metrics-export resume (StartMetricsExportIfEnabled) is
 	// deliberately NOT called here. The resumed collector snapshots the

--- a/internal/server/encrypted_create_integration_test.go
+++ b/internal/server/encrypted_create_integration_test.go
@@ -56,6 +56,11 @@ func encTestServer(t *testing.T, client *incus.Client, tenantRoot string) *Conta
 	// The production wiring, then the provider on top — SetEncryptionStorage
 	// reads s.keyProvider, which is set above.
 	s.SetEncryptionStorage(tenantRoot, client)
+	// Same order the daemon uses (dual_server.go): snapshots read the
+	// encryption record to find which pool a container was placed on, so
+	// wiring them first would resolve every encrypted container to the
+	// default pool's dataset (#1160).
+	s.SetSnapshotStorage(zfscrypt.NewManager(nil), client.ContainerDataset)
 	return s
 }
 
@@ -336,4 +341,118 @@ func TestIntegrationIncus_StoppingTheLastContainerUnloadsTheTenantKey(t *testing
 			"way to release the pool's mount before unloading.", root, status)
 	}
 	t.Logf("the tenant key is unloaded after the last container stops; %s is ciphertext at rest", root)
+}
+
+// Container snapshots against a real encrypted container (#1160 slice a,
+// which is what makes #1202's third criterion demonstrable).
+//
+// Two things only a real pool can settle:
+//
+//  1. WHICH dataset gets snapshotted. An encrypted container lives under its
+//     tenant's pool, not the default one, and the daemon resolves that through
+//     incus.ContainerDataset. The unit tests drive a fake resolver, so they
+//     would stay green against a layout ZFS does not have — which is exactly
+//     how #1336 shipped a dataset name with a doubled path segment, defended
+//     by unit tests, for months.
+//
+//  2. That the lifecycle works with the key UNLOADED. ZFS documents this and
+//     zfscrypt asserts it directly; what is unproven until here is that the
+//     daemon's path — pool lookup, dataset resolution, the RPC — does not
+//     introduce a key dependency of its own along the way.
+func TestIntegrationIncus_SnapshotsAnEncryptedContainerWithTheKeyUnloaded(t *testing.T) {
+	s, _, tenantRoot := encTestEnv(t)
+	zfs := zfscrypt.NewManager(zfscrypt.ExecRunner{})
+	ctx := context.Background()
+
+	tenant := fmt.Sprintf("snp%d", os.Getpid())
+	t.Cleanup(func() { _ = zfs.Destroy(context.Background(), tenantRoot+"/"+tenant) })
+
+	instance := createEncrypted(t, s, tenant)
+	root := tenantRoot + "/" + tenant
+	writeCtx := tenantWithScopes(tenant, auth.ScopeContainersRead, auth.ScopeContainersWrite)
+
+	// (1) A snapshot while the container runs, and the proof that it landed on
+	// the container's ACTUAL dataset rather than a plausible-looking name.
+	if _, err := s.CreateContainerSnapshot(writeCtx, &pb.CreateContainerSnapshotRequest{
+		Username: tenant, Name: "running",
+	}); err != nil {
+		t.Fatalf("CreateContainerSnapshot on a running encrypted container: %v", err)
+	}
+
+	dataset := incusenv.DatasetFor(t, instance)
+	if dataset == "" {
+		t.Fatalf("instance %s has no ZFS dataset", instance)
+	}
+	onDisk, err := zfs.ListSnapshots(ctx, dataset)
+	if err != nil {
+		t.Fatalf("list snapshots of %s directly: %v", dataset, err)
+	}
+	// Asked of ZFS about the dataset Incus reports for the instance — not of
+	// the daemon, which would answer from the same resolution being tested.
+	want := dataset + "@running"
+	found := false
+	for _, s := range onDisk {
+		if s == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("ZFS reports %v under the instance's real dataset %s, and %q is not among them.\n\n"+
+			"The daemon resolved some other dataset — on a tenant pool that means either another "+
+			"tenant's storage or nothing at all, and the snapshot an operator believes they took "+
+			"does not exist", onDisk, dataset, want)
+	}
+
+	// (2) Now unload the key the way the daemon does, and prove the whole
+	// lifecycle still works. Blocking here would mean a key-custody outage
+	// silently suppresses the backup window — the one time backups matter.
+	if err := s.boxes().Stop(ctx, box.BoxRef{Tenant: tenant}, true); err != nil {
+		t.Fatalf("stopping %s: %v", instance, err)
+	}
+	s.encryption.PostStop(ctx, instance)
+
+	if status, err := zfs.KeyStatus(ctx, root); err != nil {
+		t.Fatalf("KeyStatus(%s): %v", root, err)
+	} else if status != zfscrypt.KeyUnavailable {
+		t.Fatalf("precondition: the key is %q after stopping the last container, want %q — the "+
+			"rest of this test would prove nothing about an unkeyed dataset", status, zfscrypt.KeyUnavailable)
+	}
+
+	if _, err := s.CreateContainerSnapshot(writeCtx, &pb.CreateContainerSnapshotRequest{
+		Username: tenant, Name: "unkeyed",
+	}); err != nil {
+		t.Fatalf("snapshotting with the key unloaded failed: %v — a key-custody outage would then "+
+			"silently stop backups", err)
+	}
+
+	list, err := s.ListContainerSnapshots(writeCtx, &pb.ListContainerSnapshotsRequest{Username: tenant})
+	if err != nil {
+		t.Fatalf("ListContainerSnapshots with the key unloaded: %v", err)
+	}
+	names := map[string]bool{}
+	for _, snap := range list.GetSnapshots() {
+		names[snap.GetName()] = true
+	}
+	if !names["running"] || !names["unkeyed"] {
+		t.Fatalf("list returned %v, want both snapshots — names are metadata and readable without "+
+			"the key", list.GetSnapshots())
+	}
+
+	if _, err := s.DeleteContainerSnapshot(writeCtx, &pb.DeleteContainerSnapshotRequest{
+		Username: tenant, Name: "unkeyed",
+	}); err != nil {
+		t.Fatalf("deleting with the key unloaded failed: %v — retention would stall exactly when "+
+			"custody is down, turning an outage into unbounded growth", err)
+	}
+
+	after, err := zfs.ListSnapshots(ctx, dataset)
+	if err != nil {
+		t.Fatalf("list snapshots after the delete: %v", err)
+	}
+	for _, s := range after {
+		if s == dataset+"@unkeyed" {
+			t.Fatalf("the snapshot survived a successful-looking delete: %v", after)
+		}
+	}
+	t.Logf("snapshot lifecycle works on %s with the key unloaded; remaining: %v", dataset, after)
 }

--- a/pkg/pb/containarium/v1/container.pb.go
+++ b/pkg/pb/containarium/v1/container.pb.go
@@ -4931,6 +4931,379 @@ func (x *AdoptMigratedContainerRequest) GetZfsPool() string {
 	return ""
 }
 
+// ContainerSnapshot is a point-in-time ZFS snapshot of a container's
+// dataset (#1160).
+type ContainerSnapshot struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Snapshot name, unique per container.
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// Bytes uniquely held by this snapshot — space that would be freed by
+	// deleting it. Surfaced because a forgotten snapshot silently pins disk,
+	// and nothing else in the API would say so.
+	UsedBytes int64 `protobuf:"varint,2,opt,name=used_bytes,json=usedBytes,proto3" json:"used_bytes,omitempty"`
+	// Bytes the snapshot references in total, including data it shares with
+	// the live dataset. Much larger than used_bytes for a fresh snapshot, and
+	// not the number that matters for reclaiming space.
+	ReferencedBytes int64 `protobuf:"varint,3,opt,name=referenced_bytes,json=referencedBytes,proto3" json:"referenced_bytes,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *ContainerSnapshot) Reset() {
+	*x = ContainerSnapshot{}
+	mi := &file_containarium_v1_container_proto_msgTypes[60]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ContainerSnapshot) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ContainerSnapshot) ProtoMessage() {}
+
+func (x *ContainerSnapshot) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_container_proto_msgTypes[60]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ContainerSnapshot.ProtoReflect.Descriptor instead.
+func (*ContainerSnapshot) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{60}
+}
+
+func (x *ContainerSnapshot) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *ContainerSnapshot) GetUsedBytes() int64 {
+	if x != nil {
+		return x.UsedBytes
+	}
+	return 0
+}
+
+func (x *ContainerSnapshot) GetReferencedBytes() int64 {
+	if x != nil {
+		return x.ReferencedBytes
+	}
+	return 0
+}
+
+// CreateContainerSnapshotRequest snapshots a container's dataset.
+//
+// Succeeds even when the container's encryption key is unloaded: ZFS allows
+// it, and blocking on key-custody reachability would let a transient outage
+// suppress the backup window (encryption design, resolved decision #3).
+type CreateContainerSnapshotRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The container to snapshot.
+	Username string `protobuf:"bytes,1,opt,name=username,proto3" json:"username,omitempty"`
+	// Snapshot name. Must be unique for this container.
+	Name          string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateContainerSnapshotRequest) Reset() {
+	*x = CreateContainerSnapshotRequest{}
+	mi := &file_containarium_v1_container_proto_msgTypes[61]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateContainerSnapshotRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateContainerSnapshotRequest) ProtoMessage() {}
+
+func (x *CreateContainerSnapshotRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_container_proto_msgTypes[61]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateContainerSnapshotRequest.ProtoReflect.Descriptor instead.
+func (*CreateContainerSnapshotRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{61}
+}
+
+func (x *CreateContainerSnapshotRequest) GetUsername() string {
+	if x != nil {
+		return x.Username
+	}
+	return ""
+}
+
+func (x *CreateContainerSnapshotRequest) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+type CreateContainerSnapshotResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Snapshot      *ContainerSnapshot     `protobuf:"bytes,1,opt,name=snapshot,proto3" json:"snapshot,omitempty"`
+	Message       string                 `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateContainerSnapshotResponse) Reset() {
+	*x = CreateContainerSnapshotResponse{}
+	mi := &file_containarium_v1_container_proto_msgTypes[62]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateContainerSnapshotResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateContainerSnapshotResponse) ProtoMessage() {}
+
+func (x *CreateContainerSnapshotResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_container_proto_msgTypes[62]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateContainerSnapshotResponse.ProtoReflect.Descriptor instead.
+func (*CreateContainerSnapshotResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{62}
+}
+
+func (x *CreateContainerSnapshotResponse) GetSnapshot() *ContainerSnapshot {
+	if x != nil {
+		return x.Snapshot
+	}
+	return nil
+}
+
+func (x *CreateContainerSnapshotResponse) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+type ListContainerSnapshotsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Username      string                 `protobuf:"bytes,1,opt,name=username,proto3" json:"username,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListContainerSnapshotsRequest) Reset() {
+	*x = ListContainerSnapshotsRequest{}
+	mi := &file_containarium_v1_container_proto_msgTypes[63]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListContainerSnapshotsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListContainerSnapshotsRequest) ProtoMessage() {}
+
+func (x *ListContainerSnapshotsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_container_proto_msgTypes[63]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListContainerSnapshotsRequest.ProtoReflect.Descriptor instead.
+func (*ListContainerSnapshotsRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{63}
+}
+
+func (x *ListContainerSnapshotsRequest) GetUsername() string {
+	if x != nil {
+		return x.Username
+	}
+	return ""
+}
+
+type ListContainerSnapshotsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Snapshots     []*ContainerSnapshot   `protobuf:"bytes,1,rep,name=snapshots,proto3" json:"snapshots,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListContainerSnapshotsResponse) Reset() {
+	*x = ListContainerSnapshotsResponse{}
+	mi := &file_containarium_v1_container_proto_msgTypes[64]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListContainerSnapshotsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListContainerSnapshotsResponse) ProtoMessage() {}
+
+func (x *ListContainerSnapshotsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_container_proto_msgTypes[64]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListContainerSnapshotsResponse.ProtoReflect.Descriptor instead.
+func (*ListContainerSnapshotsResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{64}
+}
+
+func (x *ListContainerSnapshotsResponse) GetSnapshots() []*ContainerSnapshot {
+	if x != nil {
+		return x.Snapshots
+	}
+	return nil
+}
+
+type DeleteContainerSnapshotRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Username      string                 `protobuf:"bytes,1,opt,name=username,proto3" json:"username,omitempty"`
+	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteContainerSnapshotRequest) Reset() {
+	*x = DeleteContainerSnapshotRequest{}
+	mi := &file_containarium_v1_container_proto_msgTypes[65]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteContainerSnapshotRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteContainerSnapshotRequest) ProtoMessage() {}
+
+func (x *DeleteContainerSnapshotRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_container_proto_msgTypes[65]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteContainerSnapshotRequest.ProtoReflect.Descriptor instead.
+func (*DeleteContainerSnapshotRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{65}
+}
+
+func (x *DeleteContainerSnapshotRequest) GetUsername() string {
+	if x != nil {
+		return x.Username
+	}
+	return ""
+}
+
+func (x *DeleteContainerSnapshotRequest) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+type DeleteContainerSnapshotResponse struct {
+	state   protoimpl.MessageState `protogen:"open.v1"`
+	Message string                 `protobuf:"bytes,1,opt,name=message,proto3" json:"message,omitempty"`
+	// Bytes reclaimed — what the snapshot uniquely held.
+	FreedBytes    int64 `protobuf:"varint,2,opt,name=freed_bytes,json=freedBytes,proto3" json:"freed_bytes,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteContainerSnapshotResponse) Reset() {
+	*x = DeleteContainerSnapshotResponse{}
+	mi := &file_containarium_v1_container_proto_msgTypes[66]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteContainerSnapshotResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteContainerSnapshotResponse) ProtoMessage() {}
+
+func (x *DeleteContainerSnapshotResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_container_proto_msgTypes[66]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteContainerSnapshotResponse.ProtoReflect.Descriptor instead.
+func (*DeleteContainerSnapshotResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{66}
+}
+
+func (x *DeleteContainerSnapshotResponse) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+func (x *DeleteContainerSnapshotResponse) GetFreedBytes() int64 {
+	if x != nil {
+		return x.FreedBytes
+	}
+	return 0
+}
+
 // DeleteTenantStorageRequest tears down a departing tenant's encrypted
 // storage (#1343): the Incus storage pool, and the encrypted dataset it is
 // sourced at.
@@ -4947,7 +5320,7 @@ type DeleteTenantStorageRequest struct {
 
 func (x *DeleteTenantStorageRequest) Reset() {
 	*x = DeleteTenantStorageRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[60]
+	mi := &file_containarium_v1_container_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4959,7 +5332,7 @@ func (x *DeleteTenantStorageRequest) String() string {
 func (*DeleteTenantStorageRequest) ProtoMessage() {}
 
 func (x *DeleteTenantStorageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[60]
+	mi := &file_containarium_v1_container_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4972,7 +5345,7 @@ func (x *DeleteTenantStorageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteTenantStorageRequest.ProtoReflect.Descriptor instead.
 func (*DeleteTenantStorageRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{60}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *DeleteTenantStorageRequest) GetTenant() string {
@@ -4999,7 +5372,7 @@ type DeleteTenantStorageResponse struct {
 
 func (x *DeleteTenantStorageResponse) Reset() {
 	*x = DeleteTenantStorageResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[61]
+	mi := &file_containarium_v1_container_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5011,7 +5384,7 @@ func (x *DeleteTenantStorageResponse) String() string {
 func (*DeleteTenantStorageResponse) ProtoMessage() {}
 
 func (x *DeleteTenantStorageResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[61]
+	mi := &file_containarium_v1_container_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5024,7 +5397,7 @@ func (x *DeleteTenantStorageResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteTenantStorageResponse.ProtoReflect.Descriptor instead.
 func (*DeleteTenantStorageResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{61}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *DeleteTenantStorageResponse) GetMessage() string {
@@ -5074,7 +5447,7 @@ type RewrapContainerRequest struct {
 
 func (x *RewrapContainerRequest) Reset() {
 	*x = RewrapContainerRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[62]
+	mi := &file_containarium_v1_container_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5086,7 +5459,7 @@ func (x *RewrapContainerRequest) String() string {
 func (*RewrapContainerRequest) ProtoMessage() {}
 
 func (x *RewrapContainerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[62]
+	mi := &file_containarium_v1_container_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5099,7 +5472,7 @@ func (x *RewrapContainerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RewrapContainerRequest.ProtoReflect.Descriptor instead.
 func (*RewrapContainerRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{62}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *RewrapContainerRequest) GetUsername() string {
@@ -5133,7 +5506,7 @@ type RewrapContainerResponse struct {
 
 func (x *RewrapContainerResponse) Reset() {
 	*x = RewrapContainerResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[63]
+	mi := &file_containarium_v1_container_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5145,7 +5518,7 @@ func (x *RewrapContainerResponse) String() string {
 func (*RewrapContainerResponse) ProtoMessage() {}
 
 func (x *RewrapContainerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[63]
+	mi := &file_containarium_v1_container_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5158,7 +5531,7 @@ func (x *RewrapContainerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RewrapContainerResponse.ProtoReflect.Descriptor instead.
 func (*RewrapContainerResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{63}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *RewrapContainerResponse) GetMessage() string {
@@ -5207,7 +5580,7 @@ type PrepareEncryptedMigrationRequest struct {
 
 func (x *PrepareEncryptedMigrationRequest) Reset() {
 	*x = PrepareEncryptedMigrationRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[64]
+	mi := &file_containarium_v1_container_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5219,7 +5592,7 @@ func (x *PrepareEncryptedMigrationRequest) String() string {
 func (*PrepareEncryptedMigrationRequest) ProtoMessage() {}
 
 func (x *PrepareEncryptedMigrationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[64]
+	mi := &file_containarium_v1_container_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5232,7 +5605,7 @@ func (x *PrepareEncryptedMigrationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PrepareEncryptedMigrationRequest.ProtoReflect.Descriptor instead.
 func (*PrepareEncryptedMigrationRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{64}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *PrepareEncryptedMigrationRequest) GetUsername() string {
@@ -5278,7 +5651,7 @@ type PrepareEncryptedMigrationResponse struct {
 
 func (x *PrepareEncryptedMigrationResponse) Reset() {
 	*x = PrepareEncryptedMigrationResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[65]
+	mi := &file_containarium_v1_container_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5290,7 +5663,7 @@ func (x *PrepareEncryptedMigrationResponse) String() string {
 func (*PrepareEncryptedMigrationResponse) ProtoMessage() {}
 
 func (x *PrepareEncryptedMigrationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[65]
+	mi := &file_containarium_v1_container_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5303,7 +5676,7 @@ func (x *PrepareEncryptedMigrationResponse) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use PrepareEncryptedMigrationResponse.ProtoReflect.Descriptor instead.
 func (*PrepareEncryptedMigrationResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{65}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *PrepareEncryptedMigrationResponse) GetCanResolve() bool {
@@ -5342,7 +5715,7 @@ type AdoptMigratedContainerResponse struct {
 
 func (x *AdoptMigratedContainerResponse) Reset() {
 	*x = AdoptMigratedContainerResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[66]
+	mi := &file_containarium_v1_container_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5354,7 +5727,7 @@ func (x *AdoptMigratedContainerResponse) String() string {
 func (*AdoptMigratedContainerResponse) ProtoMessage() {}
 
 func (x *AdoptMigratedContainerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[66]
+	mi := &file_containarium_v1_container_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5367,7 +5740,7 @@ func (x *AdoptMigratedContainerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdoptMigratedContainerResponse.ProtoReflect.Descriptor instead.
 func (*AdoptMigratedContainerResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{66}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *AdoptMigratedContainerResponse) GetMessage() string {
@@ -5741,7 +6114,29 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\busername\x18\x01 \x01(\tR\busername\x12#\n" +
 	"\rsource_routes\x18\x02 \x03(\tR\fsourceRoutes\x12\x1e\n" +
 	"\vzfs_key_ref\x18\x03 \x01(\tR\tzfsKeyRef\x12\x19\n" +
-	"\bzfs_pool\x18\x04 \x01(\tR\azfsPool\"4\n" +
+	"\bzfs_pool\x18\x04 \x01(\tR\azfsPool\"q\n" +
+	"\x11ContainerSnapshot\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1d\n" +
+	"\n" +
+	"used_bytes\x18\x02 \x01(\x03R\tusedBytes\x12)\n" +
+	"\x10referenced_bytes\x18\x03 \x01(\x03R\x0freferencedBytes\"P\n" +
+	"\x1eCreateContainerSnapshotRequest\x12\x1a\n" +
+	"\busername\x18\x01 \x01(\tR\busername\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\"{\n" +
+	"\x1fCreateContainerSnapshotResponse\x12>\n" +
+	"\bsnapshot\x18\x01 \x01(\v2\".containarium.v1.ContainerSnapshotR\bsnapshot\x12\x18\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\";\n" +
+	"\x1dListContainerSnapshotsRequest\x12\x1a\n" +
+	"\busername\x18\x01 \x01(\tR\busername\"b\n" +
+	"\x1eListContainerSnapshotsResponse\x12@\n" +
+	"\tsnapshots\x18\x01 \x03(\v2\".containarium.v1.ContainerSnapshotR\tsnapshots\"P\n" +
+	"\x1eDeleteContainerSnapshotRequest\x12\x1a\n" +
+	"\busername\x18\x01 \x01(\tR\busername\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\"\\\n" +
+	"\x1fDeleteContainerSnapshotResponse\x12\x18\n" +
+	"\amessage\x18\x01 \x01(\tR\amessage\x12\x1f\n" +
+	"\vfreed_bytes\x18\x02 \x01(\x03R\n" +
+	"freedBytes\"4\n" +
 	"\x1aDeleteTenantStorageRequest\x12\x16\n" +
 	"\x06tenant\x18\x01 \x01(\tR\x06tenant\"t\n" +
 	"\x1bDeleteTenantStorageResponse\x12\x18\n" +
@@ -5819,7 +6214,7 @@ func file_containarium_v1_container_proto_rawDescGZIP() []byte {
 }
 
 var file_containarium_v1_container_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
-var file_containarium_v1_container_proto_msgTypes = make([]protoimpl.MessageInfo, 73)
+var file_containarium_v1_container_proto_msgTypes = make([]protoimpl.MessageInfo, 80)
 var file_containarium_v1_container_proto_goTypes = []any{
 	(OSType)(0),                               // 0: containarium.v1.OSType
 	(AccessType)(0),                           // 1: containarium.v1.AccessType
@@ -5888,50 +6283,57 @@ var file_containarium_v1_container_proto_goTypes = []any{
 	(*MoveContainerRequest)(nil),              // 64: containarium.v1.MoveContainerRequest
 	(*MoveContainerResponse)(nil),             // 65: containarium.v1.MoveContainerResponse
 	(*AdoptMigratedContainerRequest)(nil),     // 66: containarium.v1.AdoptMigratedContainerRequest
-	(*DeleteTenantStorageRequest)(nil),        // 67: containarium.v1.DeleteTenantStorageRequest
-	(*DeleteTenantStorageResponse)(nil),       // 68: containarium.v1.DeleteTenantStorageResponse
-	(*RewrapContainerRequest)(nil),            // 69: containarium.v1.RewrapContainerRequest
-	(*RewrapContainerResponse)(nil),           // 70: containarium.v1.RewrapContainerResponse
-	(*PrepareEncryptedMigrationRequest)(nil),  // 71: containarium.v1.PrepareEncryptedMigrationRequest
-	(*PrepareEncryptedMigrationResponse)(nil), // 72: containarium.v1.PrepareEncryptedMigrationResponse
-	(*AdoptMigratedContainerResponse)(nil),    // 73: containarium.v1.AdoptMigratedContainerResponse
-	nil,                                       // 74: containarium.v1.Container.LabelsEntry
-	nil,                                       // 75: containarium.v1.CreateContainerRequest.LabelsEntry
-	nil,                                       // 76: containarium.v1.CreateContainerRequest.StackParametersEntry
-	nil,                                       // 77: containarium.v1.ListContainersRequest.LabelFilterEntry
-	nil,                                       // 78: containarium.v1.SetContainerAttributionRequest.LabelsEntry
-	nil,                                       // 79: containarium.v1.SetContainerAttributionResponse.LabelsEntry
-	(*timestamppb.Timestamp)(nil),             // 80: google.protobuf.Timestamp
-	(*descriptorpb.EnumValueOptions)(nil),     // 81: google.protobuf.EnumValueOptions
+	(*ContainerSnapshot)(nil),                 // 67: containarium.v1.ContainerSnapshot
+	(*CreateContainerSnapshotRequest)(nil),    // 68: containarium.v1.CreateContainerSnapshotRequest
+	(*CreateContainerSnapshotResponse)(nil),   // 69: containarium.v1.CreateContainerSnapshotResponse
+	(*ListContainerSnapshotsRequest)(nil),     // 70: containarium.v1.ListContainerSnapshotsRequest
+	(*ListContainerSnapshotsResponse)(nil),    // 71: containarium.v1.ListContainerSnapshotsResponse
+	(*DeleteContainerSnapshotRequest)(nil),    // 72: containarium.v1.DeleteContainerSnapshotRequest
+	(*DeleteContainerSnapshotResponse)(nil),   // 73: containarium.v1.DeleteContainerSnapshotResponse
+	(*DeleteTenantStorageRequest)(nil),        // 74: containarium.v1.DeleteTenantStorageRequest
+	(*DeleteTenantStorageResponse)(nil),       // 75: containarium.v1.DeleteTenantStorageResponse
+	(*RewrapContainerRequest)(nil),            // 76: containarium.v1.RewrapContainerRequest
+	(*RewrapContainerResponse)(nil),           // 77: containarium.v1.RewrapContainerResponse
+	(*PrepareEncryptedMigrationRequest)(nil),  // 78: containarium.v1.PrepareEncryptedMigrationRequest
+	(*PrepareEncryptedMigrationResponse)(nil), // 79: containarium.v1.PrepareEncryptedMigrationResponse
+	(*AdoptMigratedContainerResponse)(nil),    // 80: containarium.v1.AdoptMigratedContainerResponse
+	nil,                                       // 81: containarium.v1.Container.LabelsEntry
+	nil,                                       // 82: containarium.v1.CreateContainerRequest.LabelsEntry
+	nil,                                       // 83: containarium.v1.CreateContainerRequest.StackParametersEntry
+	nil,                                       // 84: containarium.v1.ListContainersRequest.LabelFilterEntry
+	nil,                                       // 85: containarium.v1.SetContainerAttributionRequest.LabelsEntry
+	nil,                                       // 86: containarium.v1.SetContainerAttributionResponse.LabelsEntry
+	(*timestamppb.Timestamp)(nil),             // 87: google.protobuf.Timestamp
+	(*descriptorpb.EnumValueOptions)(nil),     // 88: google.protobuf.EnumValueOptions
 }
 var file_containarium_v1_container_proto_depIdxs = []int32{
 	2,  // 0: containarium.v1.Container.state:type_name -> containarium.v1.ContainerState
 	7,  // 1: containarium.v1.Container.resources:type_name -> containarium.v1.ResourceLimits
 	8,  // 2: containarium.v1.Container.network:type_name -> containarium.v1.NetworkInfo
-	74, // 3: containarium.v1.Container.labels:type_name -> containarium.v1.Container.LabelsEntry
+	81, // 3: containarium.v1.Container.labels:type_name -> containarium.v1.Container.LabelsEntry
 	0,  // 4: containarium.v1.Container.os_type:type_name -> containarium.v1.OSType
 	1,  // 5: containarium.v1.Container.access_type:type_name -> containarium.v1.AccessType
-	80, // 6: containarium.v1.Container.ttl_expires_at:type_name -> google.protobuf.Timestamp
-	80, // 7: containarium.v1.Container.stopped_at:type_name -> google.protobuf.Timestamp
+	87, // 6: containarium.v1.Container.ttl_expires_at:type_name -> google.protobuf.Timestamp
+	87, // 7: containarium.v1.Container.stopped_at:type_name -> google.protobuf.Timestamp
 	3,  // 8: containarium.v1.Container.delete_policy:type_name -> containarium.v1.DeletePolicy
 	4,  // 9: containarium.v1.Container.encryption_state:type_name -> containarium.v1.EncryptionState
 	7,  // 10: containarium.v1.CreateContainerRequest.resources:type_name -> containarium.v1.ResourceLimits
-	75, // 11: containarium.v1.CreateContainerRequest.labels:type_name -> containarium.v1.CreateContainerRequest.LabelsEntry
+	82, // 11: containarium.v1.CreateContainerRequest.labels:type_name -> containarium.v1.CreateContainerRequest.LabelsEntry
 	0,  // 12: containarium.v1.CreateContainerRequest.os_type:type_name -> containarium.v1.OSType
-	76, // 13: containarium.v1.CreateContainerRequest.stack_parameters:type_name -> containarium.v1.CreateContainerRequest.StackParametersEntry
+	83, // 13: containarium.v1.CreateContainerRequest.stack_parameters:type_name -> containarium.v1.CreateContainerRequest.StackParametersEntry
 	9,  // 14: containarium.v1.CreateContainerResponse.container:type_name -> containarium.v1.Container
 	2,  // 15: containarium.v1.ListContainersRequest.state:type_name -> containarium.v1.ContainerState
-	77, // 16: containarium.v1.ListContainersRequest.label_filter:type_name -> containarium.v1.ListContainersRequest.LabelFilterEntry
+	84, // 16: containarium.v1.ListContainersRequest.label_filter:type_name -> containarium.v1.ListContainersRequest.LabelFilterEntry
 	9,  // 17: containarium.v1.ListContainersResponse.containers:type_name -> containarium.v1.Container
 	9,  // 18: containarium.v1.GetContainerResponse.container:type_name -> containarium.v1.Container
 	10, // 19: containarium.v1.GetContainerResponse.metrics:type_name -> containarium.v1.ContainerMetrics
 	9,  // 20: containarium.v1.StartContainerResponse.container:type_name -> containarium.v1.Container
 	9,  // 21: containarium.v1.StopContainerResponse.container:type_name -> containarium.v1.Container
-	80, // 22: containarium.v1.SetContainerTTLResponse.ttl_expires_at:type_name -> google.protobuf.Timestamp
+	87, // 22: containarium.v1.SetContainerTTLResponse.ttl_expires_at:type_name -> google.protobuf.Timestamp
 	3,  // 23: containarium.v1.SetContainerDeletePolicyRequest.delete_policy:type_name -> containarium.v1.DeletePolicy
 	3,  // 24: containarium.v1.SetContainerDeletePolicyResponse.delete_policy:type_name -> containarium.v1.DeletePolicy
-	78, // 25: containarium.v1.SetContainerAttributionRequest.labels:type_name -> containarium.v1.SetContainerAttributionRequest.LabelsEntry
-	79, // 26: containarium.v1.SetContainerAttributionResponse.labels:type_name -> containarium.v1.SetContainerAttributionResponse.LabelsEntry
+	85, // 25: containarium.v1.SetContainerAttributionRequest.labels:type_name -> containarium.v1.SetContainerAttributionRequest.LabelsEntry
+	86, // 26: containarium.v1.SetContainerAttributionResponse.labels:type_name -> containarium.v1.SetContainerAttributionResponse.LabelsEntry
 	10, // 27: containarium.v1.GetMetricsResponse.metrics:type_name -> containarium.v1.ContainerMetrics
 	9,  // 28: containarium.v1.ResizeContainerResponse.container:type_name -> containarium.v1.Container
 	43, // 29: containarium.v1.AddCollaboratorResponse.collaborator:type_name -> containarium.v1.Collaborator
@@ -5945,14 +6347,16 @@ var file_containarium_v1_container_proto_depIdxs = []int32{
 	5,  // 37: containarium.v1.SetMetricsExportResponse.provider:type_name -> containarium.v1.CloudMetricsProvider
 	6,  // 38: containarium.v1.SetMetricsExportResponse.groups:type_name -> containarium.v1.CloudMetricsGroup
 	5,  // 39: containarium.v1.GetMetricsExportResponse.provider:type_name -> containarium.v1.CloudMetricsProvider
-	80, // 40: containarium.v1.GetMetricsExportResponse.last_success_at:type_name -> google.protobuf.Timestamp
+	87, // 40: containarium.v1.GetMetricsExportResponse.last_success_at:type_name -> google.protobuf.Timestamp
 	6,  // 41: containarium.v1.GetMetricsExportResponse.groups:type_name -> containarium.v1.CloudMetricsGroup
-	81, // 42: containarium.v1.state_name:extendee -> google.protobuf.EnumValueOptions
-	43, // [43:43] is the sub-list for method output_type
-	43, // [43:43] is the sub-list for method input_type
-	43, // [43:43] is the sub-list for extension type_name
-	42, // [42:43] is the sub-list for extension extendee
-	0,  // [0:42] is the sub-list for field type_name
+	67, // 42: containarium.v1.CreateContainerSnapshotResponse.snapshot:type_name -> containarium.v1.ContainerSnapshot
+	67, // 43: containarium.v1.ListContainerSnapshotsResponse.snapshots:type_name -> containarium.v1.ContainerSnapshot
+	88, // 44: containarium.v1.state_name:extendee -> google.protobuf.EnumValueOptions
+	45, // [45:45] is the sub-list for method output_type
+	45, // [45:45] is the sub-list for method input_type
+	45, // [45:45] is the sub-list for extension type_name
+	44, // [44:45] is the sub-list for extension extendee
+	0,  // [0:44] is the sub-list for field type_name
 }
 
 func init() { file_containarium_v1_container_proto_init() }
@@ -5966,7 +6370,7 @@ func file_containarium_v1_container_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_v1_container_proto_rawDesc), len(file_containarium_v1_container_proto_rawDesc)),
 			NumEnums:      7,
-			NumMessages:   73,
+			NumMessages:   80,
 			NumExtensions: 1,
 			NumServices:   0,
 		},

--- a/pkg/pb/containarium/v1/service.pb.go
+++ b/pkg/pb/containarium/v1/service.pb.go
@@ -26,7 +26,7 @@ var File_containarium_v1_service_proto protoreflect.FileDescriptor
 
 const file_containarium_v1_service_proto_rawDesc = "" +
 	"\n" +
-	"\x1dcontainarium/v1/service.proto\x12\x0fcontainarium.v1\x1a\x1fcontainarium/v1/container.proto\x1a\x1ccontainarium/v1/config.proto\x1a\x19containarium/v1/app.proto\x1a\x1dcontainarium/v1/network.proto\x1a\x1bcontainarium/v1/alert.proto\x1a\x1dcontainarium/v1/secrets.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto2ڞ\x01\n" +
+	"\x1dcontainarium/v1/service.proto\x12\x0fcontainarium.v1\x1a\x1fcontainarium/v1/container.proto\x1a\x1ccontainarium/v1/config.proto\x1a\x19containarium/v1/app.proto\x1a\x1dcontainarium/v1/network.proto\x1a\x1bcontainarium/v1/alert.proto\x1a\x1dcontainarium/v1/secrets.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto2\xea\xa7\x01\n" +
 	"\x10ContainerService\x12\xae\x02\n" +
 	"\x0fCreateContainer\x12'.containarium.v1.CreateContainerRequest\x1a(.containarium.v1.CreateContainerResponse\"\xc7\x01\x92A\xaa\x01\n" +
 	"\n" +
@@ -50,7 +50,13 @@ const file_containarium_v1_service_proto_rawDesc = "" +
 	"\x0fResizeContainer\x12'.containarium.v1.ResizeContainerRequest\x1a(.containarium.v1.ResizeContainerResponse\"\xdc\x01\x92A\xad\x01\n" +
 	"\x14Container Operations\x12\x1aResize container resources\x1ayDynamically adjusts CPU, memory, and disk resources without container restart. Disk can only be increased, not decreased.\x82\xd3\xe4\x93\x02%:\x01*\x1a /v1/containers/{username}/resize\x12\xc8\x03\n" +
 	"\rMoveContainer\x12%.containarium.v1.MoveContainerRequest\x1a&.containarium.v1.MoveContainerResponse\"\xe7\x02\x92A\xba\x02\n" +
-	"\x14Container Operations\x12 Migrate container to peer daemon\x1a\xff\x01Pre-copy snapshot-based migration to a peer daemon. Sub-second downtime on ZFS/btrfs storage with low write rate; up to minutes on dir-pool or active workloads. Caller must have incus remotes configured both directions between the source and target hosts.\x82\xd3\xe4\x93\x02#:\x01*\"\x1e/v1/containers/{username}/move\x12\xe7\x03\n" +
+	"\x14Container Operations\x12 Migrate container to peer daemon\x1a\xff\x01Pre-copy snapshot-based migration to a peer daemon. Sub-second downtime on ZFS/btrfs storage with low write rate; up to minutes on dir-pool or active workloads. Caller must have incus remotes configured both directions between the source and target hosts.\x82\xd3\xe4\x93\x02#:\x01*\"\x1e/v1/containers/{username}/move\x12\xc0\x03\n" +
+	"\x17CreateContainerSnapshot\x12/.containarium.v1.CreateContainerSnapshotRequest\x1a0.containarium.v1.CreateContainerSnapshotResponse\"\xc1\x02\x92A\x8f\x02\n" +
+	"\x14Container Operations\x12\x14Snapshot a container\x1a\xe0\x01Takes a point-in-time ZFS snapshot of the container's dataset. Instant and space-efficient: it shares blocks with the live dataset until they diverge. Works while the container runs, and while its encryption key is unloaded.\x82\xd3\xe4\x93\x02(:\x01*\"#/v1/containers/{username}/snapshots\x12\xf0\x02\n" +
+	"\x16ListContainerSnapshots\x12..containarium.v1.ListContainerSnapshotsRequest\x1a/.containarium.v1.ListContainerSnapshotsResponse\"\xf4\x01\x92A\xc5\x01\n" +
+	"\x14Container Operations\x12\x1cList a container's snapshots\x1a\x8e\x01Lists the container's ZFS snapshots, each with the bytes it uniquely holds (what deleting it would free) and the bytes it references in total.\x82\xd3\xe4\x93\x02%\x12#/v1/containers/{username}/snapshots\x12\xd7\x02\n" +
+	"\x17DeleteContainerSnapshot\x12/.containarium.v1.DeleteContainerSnapshotRequest\x1a0.containarium.v1.DeleteContainerSnapshotResponse\"\xd8\x01\x92A\xa2\x01\n" +
+	"\x14Container Operations\x12\x1bDelete a container snapshot\x1amRemoves the snapshot and reports the bytes reclaimed. Works while the container's encryption key is unloaded.\x82\xd3\xe4\x93\x02,**/v1/containers/{username}/snapshots/{name}\x12\xe7\x03\n" +
 	"\x13DeleteTenantStorage\x12+.containarium.v1.DeleteTenantStorageRequest\x1a,.containarium.v1.DeleteTenantStorageResponse\"\xf4\x02\x92A\xcc\x02\n" +
 	"\x14Container Operations\x12.Destroy a departing tenant's encrypted storage\x1a\x83\x02Deletes the tenant's Incus storage pool and then the encrypted dataset it was sourced at. Refused while the tenant still has containers. Irreversible — the dataset is the tenant's encryptionroot, so this destroys the only key path to their data. Admin only.\x82\xd3\xe4\x93\x02\x1e*\x1c/v1/tenants/{tenant}/storage\x12\xc5\x03\n" +
 	"\x0fRewrapContainer\x12'.containarium.v1.RewrapContainerRequest\x1a(.containarium.v1.RewrapContainerResponse\"\xde\x02\x92A\xaf\x02\n" +
@@ -176,111 +182,117 @@ var file_containarium_v1_service_proto_goTypes = []any{
 	(*StopContainerRequest)(nil),              // 6: containarium.v1.StopContainerRequest
 	(*ResizeContainerRequest)(nil),            // 7: containarium.v1.ResizeContainerRequest
 	(*MoveContainerRequest)(nil),              // 8: containarium.v1.MoveContainerRequest
-	(*DeleteTenantStorageRequest)(nil),        // 9: containarium.v1.DeleteTenantStorageRequest
-	(*RewrapContainerRequest)(nil),            // 10: containarium.v1.RewrapContainerRequest
-	(*PrepareEncryptedMigrationRequest)(nil),  // 11: containarium.v1.PrepareEncryptedMigrationRequest
-	(*AdoptMigratedContainerRequest)(nil),     // 12: containarium.v1.AdoptMigratedContainerRequest
-	(*ToggleMonitoringRequest)(nil),           // 13: containarium.v1.ToggleMonitoringRequest
-	(*ToggleAutoSleepRequest)(nil),            // 14: containarium.v1.ToggleAutoSleepRequest
-	(*SetContainerTTLRequest)(nil),            // 15: containarium.v1.SetContainerTTLRequest
-	(*SetContainerDeletePolicyRequest)(nil),   // 16: containarium.v1.SetContainerDeletePolicyRequest
-	(*SetContainerAttributionRequest)(nil),    // 17: containarium.v1.SetContainerAttributionRequest
-	(*AddSSHKeyRequest)(nil),                  // 18: containarium.v1.AddSSHKeyRequest
-	(*RemoveSSHKeyRequest)(nil),               // 19: containarium.v1.RemoveSSHKeyRequest
-	(*AddCollaboratorRequest)(nil),            // 20: containarium.v1.AddCollaboratorRequest
-	(*RemoveCollaboratorRequest)(nil),         // 21: containarium.v1.RemoveCollaboratorRequest
-	(*ListCollaboratorsRequest)(nil),          // 22: containarium.v1.ListCollaboratorsRequest
-	(*GetMetricsRequest)(nil),                 // 23: containarium.v1.GetMetricsRequest
-	(*CleanupDiskRequest)(nil),                // 24: containarium.v1.CleanupDiskRequest
-	(*InstallStackRequest)(nil),               // 25: containarium.v1.InstallStackRequest
-	(*ListStacksRequest)(nil),                 // 26: containarium.v1.ListStacksRequest
-	(*GetSystemInfoRequest)(nil),              // 27: containarium.v1.GetSystemInfoRequest
-	(*ListBackendsRequest)(nil),               // 28: containarium.v1.ListBackendsRequest
-	(*AdvertiseCapacityRequest)(nil),          // 29: containarium.v1.AdvertiseCapacityRequest
-	(*WithdrawCapacityRequest)(nil),           // 30: containarium.v1.WithdrawCapacityRequest
-	(*GetCapacityHeadroomRequest)(nil),        // 31: containarium.v1.GetCapacityHeadroomRequest
-	(*ProfileBackendRequest)(nil),             // 32: containarium.v1.ProfileBackendRequest
-	(*GetCapabilityProfileRequest)(nil),       // 33: containarium.v1.GetCapabilityProfileRequest
-	(*GetSelfMeasurementRequest)(nil),         // 34: containarium.v1.GetSelfMeasurementRequest
-	(*GetLatestReleaseRequest)(nil),           // 35: containarium.v1.GetLatestReleaseRequest
-	(*ValidateGPURequest)(nil),                // 36: containarium.v1.ValidateGPURequest
-	(*TriggerUpgradeRequest)(nil),             // 37: containarium.v1.TriggerUpgradeRequest
-	(*GetUpgradeStatusRequest)(nil),           // 38: containarium.v1.GetUpgradeStatusRequest
-	(*GetMonitoringInfoRequest)(nil),          // 39: containarium.v1.GetMonitoringInfoRequest
-	(*SetMetricsExportRequest)(nil),           // 40: containarium.v1.SetMetricsExportRequest
-	(*GetMetricsExportRequest)(nil),           // 41: containarium.v1.GetMetricsExportRequest
-	(*CreateAlertRuleRequest)(nil),            // 42: containarium.v1.CreateAlertRuleRequest
-	(*ListAlertRulesRequest)(nil),             // 43: containarium.v1.ListAlertRulesRequest
-	(*GetAlertRuleRequest)(nil),               // 44: containarium.v1.GetAlertRuleRequest
-	(*UpdateAlertRuleRequest)(nil),            // 45: containarium.v1.UpdateAlertRuleRequest
-	(*DeleteAlertRuleRequest)(nil),            // 46: containarium.v1.DeleteAlertRuleRequest
-	(*GetAlertingInfoRequest)(nil),            // 47: containarium.v1.GetAlertingInfoRequest
-	(*ListDefaultAlertRulesRequest)(nil),      // 48: containarium.v1.ListDefaultAlertRulesRequest
-	(*UpdateAlertingConfigRequest)(nil),       // 49: containarium.v1.UpdateAlertingConfigRequest
-	(*TestWebhookRequest)(nil),                // 50: containarium.v1.TestWebhookRequest
-	(*ListWebhookDeliveriesRequest)(nil),      // 51: containarium.v1.ListWebhookDeliveriesRequest
-	(*SetSecretRequest)(nil),                  // 52: containarium.v1.SetSecretRequest
-	(*GetSecretRequest)(nil),                  // 53: containarium.v1.GetSecretRequest
-	(*ListSecretsRequest)(nil),                // 54: containarium.v1.ListSecretsRequest
-	(*DeleteSecretRequest)(nil),               // 55: containarium.v1.DeleteSecretRequest
-	(*RefreshSecretsRequest)(nil),             // 56: containarium.v1.RefreshSecretsRequest
-	(*CreateContainerResponse)(nil),           // 57: containarium.v1.CreateContainerResponse
-	(*ListContainersResponse)(nil),            // 58: containarium.v1.ListContainersResponse
-	(*GetContainerResponse)(nil),              // 59: containarium.v1.GetContainerResponse
-	(*DebugContainerResponse)(nil),            // 60: containarium.v1.DebugContainerResponse
-	(*DeleteContainerResponse)(nil),           // 61: containarium.v1.DeleteContainerResponse
-	(*StartContainerResponse)(nil),            // 62: containarium.v1.StartContainerResponse
-	(*StopContainerResponse)(nil),             // 63: containarium.v1.StopContainerResponse
-	(*ResizeContainerResponse)(nil),           // 64: containarium.v1.ResizeContainerResponse
-	(*MoveContainerResponse)(nil),             // 65: containarium.v1.MoveContainerResponse
-	(*DeleteTenantStorageResponse)(nil),       // 66: containarium.v1.DeleteTenantStorageResponse
-	(*RewrapContainerResponse)(nil),           // 67: containarium.v1.RewrapContainerResponse
-	(*PrepareEncryptedMigrationResponse)(nil), // 68: containarium.v1.PrepareEncryptedMigrationResponse
-	(*AdoptMigratedContainerResponse)(nil),    // 69: containarium.v1.AdoptMigratedContainerResponse
-	(*ToggleMonitoringResponse)(nil),          // 70: containarium.v1.ToggleMonitoringResponse
-	(*ToggleAutoSleepResponse)(nil),           // 71: containarium.v1.ToggleAutoSleepResponse
-	(*SetContainerTTLResponse)(nil),           // 72: containarium.v1.SetContainerTTLResponse
-	(*SetContainerDeletePolicyResponse)(nil),  // 73: containarium.v1.SetContainerDeletePolicyResponse
-	(*SetContainerAttributionResponse)(nil),   // 74: containarium.v1.SetContainerAttributionResponse
-	(*AddSSHKeyResponse)(nil),                 // 75: containarium.v1.AddSSHKeyResponse
-	(*RemoveSSHKeyResponse)(nil),              // 76: containarium.v1.RemoveSSHKeyResponse
-	(*AddCollaboratorResponse)(nil),           // 77: containarium.v1.AddCollaboratorResponse
-	(*RemoveCollaboratorResponse)(nil),        // 78: containarium.v1.RemoveCollaboratorResponse
-	(*ListCollaboratorsResponse)(nil),         // 79: containarium.v1.ListCollaboratorsResponse
-	(*GetMetricsResponse)(nil),                // 80: containarium.v1.GetMetricsResponse
-	(*CleanupDiskResponse)(nil),               // 81: containarium.v1.CleanupDiskResponse
-	(*InstallStackResponse)(nil),              // 82: containarium.v1.InstallStackResponse
-	(*ListStacksResponse)(nil),                // 83: containarium.v1.ListStacksResponse
-	(*GetSystemInfoResponse)(nil),             // 84: containarium.v1.GetSystemInfoResponse
-	(*ListBackendsResponse)(nil),              // 85: containarium.v1.ListBackendsResponse
-	(*AdvertiseCapacityResponse)(nil),         // 86: containarium.v1.AdvertiseCapacityResponse
-	(*WithdrawCapacityResponse)(nil),          // 87: containarium.v1.WithdrawCapacityResponse
-	(*GetCapacityHeadroomResponse)(nil),       // 88: containarium.v1.GetCapacityHeadroomResponse
-	(*ProfileBackendResponse)(nil),            // 89: containarium.v1.ProfileBackendResponse
-	(*GetCapabilityProfileResponse)(nil),      // 90: containarium.v1.GetCapabilityProfileResponse
-	(*GetSelfMeasurementResponse)(nil),        // 91: containarium.v1.GetSelfMeasurementResponse
-	(*GetLatestReleaseResponse)(nil),          // 92: containarium.v1.GetLatestReleaseResponse
-	(*ValidateGPUResponse)(nil),               // 93: containarium.v1.ValidateGPUResponse
-	(*TriggerUpgradeResponse)(nil),            // 94: containarium.v1.TriggerUpgradeResponse
-	(*GetUpgradeStatusResponse)(nil),          // 95: containarium.v1.GetUpgradeStatusResponse
-	(*GetMonitoringInfoResponse)(nil),         // 96: containarium.v1.GetMonitoringInfoResponse
-	(*SetMetricsExportResponse)(nil),          // 97: containarium.v1.SetMetricsExportResponse
-	(*GetMetricsExportResponse)(nil),          // 98: containarium.v1.GetMetricsExportResponse
-	(*CreateAlertRuleResponse)(nil),           // 99: containarium.v1.CreateAlertRuleResponse
-	(*ListAlertRulesResponse)(nil),            // 100: containarium.v1.ListAlertRulesResponse
-	(*GetAlertRuleResponse)(nil),              // 101: containarium.v1.GetAlertRuleResponse
-	(*UpdateAlertRuleResponse)(nil),           // 102: containarium.v1.UpdateAlertRuleResponse
-	(*DeleteAlertRuleResponse)(nil),           // 103: containarium.v1.DeleteAlertRuleResponse
-	(*GetAlertingInfoResponse)(nil),           // 104: containarium.v1.GetAlertingInfoResponse
-	(*ListDefaultAlertRulesResponse)(nil),     // 105: containarium.v1.ListDefaultAlertRulesResponse
-	(*UpdateAlertingConfigResponse)(nil),      // 106: containarium.v1.UpdateAlertingConfigResponse
-	(*TestWebhookResponse)(nil),               // 107: containarium.v1.TestWebhookResponse
-	(*ListWebhookDeliveriesResponse)(nil),     // 108: containarium.v1.ListWebhookDeliveriesResponse
-	(*SetSecretResponse)(nil),                 // 109: containarium.v1.SetSecretResponse
-	(*GetSecretResponse)(nil),                 // 110: containarium.v1.GetSecretResponse
-	(*ListSecretsResponse)(nil),               // 111: containarium.v1.ListSecretsResponse
-	(*DeleteSecretResponse)(nil),              // 112: containarium.v1.DeleteSecretResponse
-	(*RefreshSecretsResponse)(nil),            // 113: containarium.v1.RefreshSecretsResponse
+	(*CreateContainerSnapshotRequest)(nil),    // 9: containarium.v1.CreateContainerSnapshotRequest
+	(*ListContainerSnapshotsRequest)(nil),     // 10: containarium.v1.ListContainerSnapshotsRequest
+	(*DeleteContainerSnapshotRequest)(nil),    // 11: containarium.v1.DeleteContainerSnapshotRequest
+	(*DeleteTenantStorageRequest)(nil),        // 12: containarium.v1.DeleteTenantStorageRequest
+	(*RewrapContainerRequest)(nil),            // 13: containarium.v1.RewrapContainerRequest
+	(*PrepareEncryptedMigrationRequest)(nil),  // 14: containarium.v1.PrepareEncryptedMigrationRequest
+	(*AdoptMigratedContainerRequest)(nil),     // 15: containarium.v1.AdoptMigratedContainerRequest
+	(*ToggleMonitoringRequest)(nil),           // 16: containarium.v1.ToggleMonitoringRequest
+	(*ToggleAutoSleepRequest)(nil),            // 17: containarium.v1.ToggleAutoSleepRequest
+	(*SetContainerTTLRequest)(nil),            // 18: containarium.v1.SetContainerTTLRequest
+	(*SetContainerDeletePolicyRequest)(nil),   // 19: containarium.v1.SetContainerDeletePolicyRequest
+	(*SetContainerAttributionRequest)(nil),    // 20: containarium.v1.SetContainerAttributionRequest
+	(*AddSSHKeyRequest)(nil),                  // 21: containarium.v1.AddSSHKeyRequest
+	(*RemoveSSHKeyRequest)(nil),               // 22: containarium.v1.RemoveSSHKeyRequest
+	(*AddCollaboratorRequest)(nil),            // 23: containarium.v1.AddCollaboratorRequest
+	(*RemoveCollaboratorRequest)(nil),         // 24: containarium.v1.RemoveCollaboratorRequest
+	(*ListCollaboratorsRequest)(nil),          // 25: containarium.v1.ListCollaboratorsRequest
+	(*GetMetricsRequest)(nil),                 // 26: containarium.v1.GetMetricsRequest
+	(*CleanupDiskRequest)(nil),                // 27: containarium.v1.CleanupDiskRequest
+	(*InstallStackRequest)(nil),               // 28: containarium.v1.InstallStackRequest
+	(*ListStacksRequest)(nil),                 // 29: containarium.v1.ListStacksRequest
+	(*GetSystemInfoRequest)(nil),              // 30: containarium.v1.GetSystemInfoRequest
+	(*ListBackendsRequest)(nil),               // 31: containarium.v1.ListBackendsRequest
+	(*AdvertiseCapacityRequest)(nil),          // 32: containarium.v1.AdvertiseCapacityRequest
+	(*WithdrawCapacityRequest)(nil),           // 33: containarium.v1.WithdrawCapacityRequest
+	(*GetCapacityHeadroomRequest)(nil),        // 34: containarium.v1.GetCapacityHeadroomRequest
+	(*ProfileBackendRequest)(nil),             // 35: containarium.v1.ProfileBackendRequest
+	(*GetCapabilityProfileRequest)(nil),       // 36: containarium.v1.GetCapabilityProfileRequest
+	(*GetSelfMeasurementRequest)(nil),         // 37: containarium.v1.GetSelfMeasurementRequest
+	(*GetLatestReleaseRequest)(nil),           // 38: containarium.v1.GetLatestReleaseRequest
+	(*ValidateGPURequest)(nil),                // 39: containarium.v1.ValidateGPURequest
+	(*TriggerUpgradeRequest)(nil),             // 40: containarium.v1.TriggerUpgradeRequest
+	(*GetUpgradeStatusRequest)(nil),           // 41: containarium.v1.GetUpgradeStatusRequest
+	(*GetMonitoringInfoRequest)(nil),          // 42: containarium.v1.GetMonitoringInfoRequest
+	(*SetMetricsExportRequest)(nil),           // 43: containarium.v1.SetMetricsExportRequest
+	(*GetMetricsExportRequest)(nil),           // 44: containarium.v1.GetMetricsExportRequest
+	(*CreateAlertRuleRequest)(nil),            // 45: containarium.v1.CreateAlertRuleRequest
+	(*ListAlertRulesRequest)(nil),             // 46: containarium.v1.ListAlertRulesRequest
+	(*GetAlertRuleRequest)(nil),               // 47: containarium.v1.GetAlertRuleRequest
+	(*UpdateAlertRuleRequest)(nil),            // 48: containarium.v1.UpdateAlertRuleRequest
+	(*DeleteAlertRuleRequest)(nil),            // 49: containarium.v1.DeleteAlertRuleRequest
+	(*GetAlertingInfoRequest)(nil),            // 50: containarium.v1.GetAlertingInfoRequest
+	(*ListDefaultAlertRulesRequest)(nil),      // 51: containarium.v1.ListDefaultAlertRulesRequest
+	(*UpdateAlertingConfigRequest)(nil),       // 52: containarium.v1.UpdateAlertingConfigRequest
+	(*TestWebhookRequest)(nil),                // 53: containarium.v1.TestWebhookRequest
+	(*ListWebhookDeliveriesRequest)(nil),      // 54: containarium.v1.ListWebhookDeliveriesRequest
+	(*SetSecretRequest)(nil),                  // 55: containarium.v1.SetSecretRequest
+	(*GetSecretRequest)(nil),                  // 56: containarium.v1.GetSecretRequest
+	(*ListSecretsRequest)(nil),                // 57: containarium.v1.ListSecretsRequest
+	(*DeleteSecretRequest)(nil),               // 58: containarium.v1.DeleteSecretRequest
+	(*RefreshSecretsRequest)(nil),             // 59: containarium.v1.RefreshSecretsRequest
+	(*CreateContainerResponse)(nil),           // 60: containarium.v1.CreateContainerResponse
+	(*ListContainersResponse)(nil),            // 61: containarium.v1.ListContainersResponse
+	(*GetContainerResponse)(nil),              // 62: containarium.v1.GetContainerResponse
+	(*DebugContainerResponse)(nil),            // 63: containarium.v1.DebugContainerResponse
+	(*DeleteContainerResponse)(nil),           // 64: containarium.v1.DeleteContainerResponse
+	(*StartContainerResponse)(nil),            // 65: containarium.v1.StartContainerResponse
+	(*StopContainerResponse)(nil),             // 66: containarium.v1.StopContainerResponse
+	(*ResizeContainerResponse)(nil),           // 67: containarium.v1.ResizeContainerResponse
+	(*MoveContainerResponse)(nil),             // 68: containarium.v1.MoveContainerResponse
+	(*CreateContainerSnapshotResponse)(nil),   // 69: containarium.v1.CreateContainerSnapshotResponse
+	(*ListContainerSnapshotsResponse)(nil),    // 70: containarium.v1.ListContainerSnapshotsResponse
+	(*DeleteContainerSnapshotResponse)(nil),   // 71: containarium.v1.DeleteContainerSnapshotResponse
+	(*DeleteTenantStorageResponse)(nil),       // 72: containarium.v1.DeleteTenantStorageResponse
+	(*RewrapContainerResponse)(nil),           // 73: containarium.v1.RewrapContainerResponse
+	(*PrepareEncryptedMigrationResponse)(nil), // 74: containarium.v1.PrepareEncryptedMigrationResponse
+	(*AdoptMigratedContainerResponse)(nil),    // 75: containarium.v1.AdoptMigratedContainerResponse
+	(*ToggleMonitoringResponse)(nil),          // 76: containarium.v1.ToggleMonitoringResponse
+	(*ToggleAutoSleepResponse)(nil),           // 77: containarium.v1.ToggleAutoSleepResponse
+	(*SetContainerTTLResponse)(nil),           // 78: containarium.v1.SetContainerTTLResponse
+	(*SetContainerDeletePolicyResponse)(nil),  // 79: containarium.v1.SetContainerDeletePolicyResponse
+	(*SetContainerAttributionResponse)(nil),   // 80: containarium.v1.SetContainerAttributionResponse
+	(*AddSSHKeyResponse)(nil),                 // 81: containarium.v1.AddSSHKeyResponse
+	(*RemoveSSHKeyResponse)(nil),              // 82: containarium.v1.RemoveSSHKeyResponse
+	(*AddCollaboratorResponse)(nil),           // 83: containarium.v1.AddCollaboratorResponse
+	(*RemoveCollaboratorResponse)(nil),        // 84: containarium.v1.RemoveCollaboratorResponse
+	(*ListCollaboratorsResponse)(nil),         // 85: containarium.v1.ListCollaboratorsResponse
+	(*GetMetricsResponse)(nil),                // 86: containarium.v1.GetMetricsResponse
+	(*CleanupDiskResponse)(nil),               // 87: containarium.v1.CleanupDiskResponse
+	(*InstallStackResponse)(nil),              // 88: containarium.v1.InstallStackResponse
+	(*ListStacksResponse)(nil),                // 89: containarium.v1.ListStacksResponse
+	(*GetSystemInfoResponse)(nil),             // 90: containarium.v1.GetSystemInfoResponse
+	(*ListBackendsResponse)(nil),              // 91: containarium.v1.ListBackendsResponse
+	(*AdvertiseCapacityResponse)(nil),         // 92: containarium.v1.AdvertiseCapacityResponse
+	(*WithdrawCapacityResponse)(nil),          // 93: containarium.v1.WithdrawCapacityResponse
+	(*GetCapacityHeadroomResponse)(nil),       // 94: containarium.v1.GetCapacityHeadroomResponse
+	(*ProfileBackendResponse)(nil),            // 95: containarium.v1.ProfileBackendResponse
+	(*GetCapabilityProfileResponse)(nil),      // 96: containarium.v1.GetCapabilityProfileResponse
+	(*GetSelfMeasurementResponse)(nil),        // 97: containarium.v1.GetSelfMeasurementResponse
+	(*GetLatestReleaseResponse)(nil),          // 98: containarium.v1.GetLatestReleaseResponse
+	(*ValidateGPUResponse)(nil),               // 99: containarium.v1.ValidateGPUResponse
+	(*TriggerUpgradeResponse)(nil),            // 100: containarium.v1.TriggerUpgradeResponse
+	(*GetUpgradeStatusResponse)(nil),          // 101: containarium.v1.GetUpgradeStatusResponse
+	(*GetMonitoringInfoResponse)(nil),         // 102: containarium.v1.GetMonitoringInfoResponse
+	(*SetMetricsExportResponse)(nil),          // 103: containarium.v1.SetMetricsExportResponse
+	(*GetMetricsExportResponse)(nil),          // 104: containarium.v1.GetMetricsExportResponse
+	(*CreateAlertRuleResponse)(nil),           // 105: containarium.v1.CreateAlertRuleResponse
+	(*ListAlertRulesResponse)(nil),            // 106: containarium.v1.ListAlertRulesResponse
+	(*GetAlertRuleResponse)(nil),              // 107: containarium.v1.GetAlertRuleResponse
+	(*UpdateAlertRuleResponse)(nil),           // 108: containarium.v1.UpdateAlertRuleResponse
+	(*DeleteAlertRuleResponse)(nil),           // 109: containarium.v1.DeleteAlertRuleResponse
+	(*GetAlertingInfoResponse)(nil),           // 110: containarium.v1.GetAlertingInfoResponse
+	(*ListDefaultAlertRulesResponse)(nil),     // 111: containarium.v1.ListDefaultAlertRulesResponse
+	(*UpdateAlertingConfigResponse)(nil),      // 112: containarium.v1.UpdateAlertingConfigResponse
+	(*TestWebhookResponse)(nil),               // 113: containarium.v1.TestWebhookResponse
+	(*ListWebhookDeliveriesResponse)(nil),     // 114: containarium.v1.ListWebhookDeliveriesResponse
+	(*SetSecretResponse)(nil),                 // 115: containarium.v1.SetSecretResponse
+	(*GetSecretResponse)(nil),                 // 116: containarium.v1.GetSecretResponse
+	(*ListSecretsResponse)(nil),               // 117: containarium.v1.ListSecretsResponse
+	(*DeleteSecretResponse)(nil),              // 118: containarium.v1.DeleteSecretResponse
+	(*RefreshSecretsResponse)(nil),            // 119: containarium.v1.RefreshSecretsResponse
 }
 var file_containarium_v1_service_proto_depIdxs = []int32{
 	0,   // 0: containarium.v1.ContainerService.CreateContainer:input_type -> containarium.v1.CreateContainerRequest
@@ -292,113 +304,119 @@ var file_containarium_v1_service_proto_depIdxs = []int32{
 	6,   // 6: containarium.v1.ContainerService.StopContainer:input_type -> containarium.v1.StopContainerRequest
 	7,   // 7: containarium.v1.ContainerService.ResizeContainer:input_type -> containarium.v1.ResizeContainerRequest
 	8,   // 8: containarium.v1.ContainerService.MoveContainer:input_type -> containarium.v1.MoveContainerRequest
-	9,   // 9: containarium.v1.ContainerService.DeleteTenantStorage:input_type -> containarium.v1.DeleteTenantStorageRequest
-	10,  // 10: containarium.v1.ContainerService.RewrapContainer:input_type -> containarium.v1.RewrapContainerRequest
-	11,  // 11: containarium.v1.ContainerService.PrepareEncryptedMigration:input_type -> containarium.v1.PrepareEncryptedMigrationRequest
-	12,  // 12: containarium.v1.ContainerService.AdoptMigratedContainer:input_type -> containarium.v1.AdoptMigratedContainerRequest
-	13,  // 13: containarium.v1.ContainerService.ToggleMonitoring:input_type -> containarium.v1.ToggleMonitoringRequest
-	14,  // 14: containarium.v1.ContainerService.ToggleAutoSleep:input_type -> containarium.v1.ToggleAutoSleepRequest
-	15,  // 15: containarium.v1.ContainerService.SetContainerTTL:input_type -> containarium.v1.SetContainerTTLRequest
-	16,  // 16: containarium.v1.ContainerService.SetContainerDeletePolicy:input_type -> containarium.v1.SetContainerDeletePolicyRequest
-	17,  // 17: containarium.v1.ContainerService.SetContainerAttribution:input_type -> containarium.v1.SetContainerAttributionRequest
-	18,  // 18: containarium.v1.ContainerService.AddSSHKey:input_type -> containarium.v1.AddSSHKeyRequest
-	19,  // 19: containarium.v1.ContainerService.RemoveSSHKey:input_type -> containarium.v1.RemoveSSHKeyRequest
-	20,  // 20: containarium.v1.ContainerService.AddCollaborator:input_type -> containarium.v1.AddCollaboratorRequest
-	21,  // 21: containarium.v1.ContainerService.RemoveCollaborator:input_type -> containarium.v1.RemoveCollaboratorRequest
-	22,  // 22: containarium.v1.ContainerService.ListCollaborators:input_type -> containarium.v1.ListCollaboratorsRequest
-	23,  // 23: containarium.v1.ContainerService.GetMetrics:input_type -> containarium.v1.GetMetricsRequest
-	24,  // 24: containarium.v1.ContainerService.CleanupDisk:input_type -> containarium.v1.CleanupDiskRequest
-	25,  // 25: containarium.v1.ContainerService.InstallStack:input_type -> containarium.v1.InstallStackRequest
-	26,  // 26: containarium.v1.ContainerService.ListStacks:input_type -> containarium.v1.ListStacksRequest
-	27,  // 27: containarium.v1.ContainerService.GetSystemInfo:input_type -> containarium.v1.GetSystemInfoRequest
-	28,  // 28: containarium.v1.ContainerService.ListBackends:input_type -> containarium.v1.ListBackendsRequest
-	29,  // 29: containarium.v1.ContainerService.AdvertiseCapacity:input_type -> containarium.v1.AdvertiseCapacityRequest
-	30,  // 30: containarium.v1.ContainerService.WithdrawCapacity:input_type -> containarium.v1.WithdrawCapacityRequest
-	31,  // 31: containarium.v1.ContainerService.GetCapacityHeadroom:input_type -> containarium.v1.GetCapacityHeadroomRequest
-	32,  // 32: containarium.v1.ContainerService.ProfileBackend:input_type -> containarium.v1.ProfileBackendRequest
-	33,  // 33: containarium.v1.ContainerService.GetCapabilityProfile:input_type -> containarium.v1.GetCapabilityProfileRequest
-	34,  // 34: containarium.v1.ContainerService.GetSelfMeasurement:input_type -> containarium.v1.GetSelfMeasurementRequest
-	35,  // 35: containarium.v1.ContainerService.GetLatestRelease:input_type -> containarium.v1.GetLatestReleaseRequest
-	36,  // 36: containarium.v1.ContainerService.ValidateGPU:input_type -> containarium.v1.ValidateGPURequest
-	37,  // 37: containarium.v1.ContainerService.TriggerUpgrade:input_type -> containarium.v1.TriggerUpgradeRequest
-	38,  // 38: containarium.v1.ContainerService.GetUpgradeStatus:input_type -> containarium.v1.GetUpgradeStatusRequest
-	39,  // 39: containarium.v1.ContainerService.GetMonitoringInfo:input_type -> containarium.v1.GetMonitoringInfoRequest
-	40,  // 40: containarium.v1.ContainerService.SetMetricsExport:input_type -> containarium.v1.SetMetricsExportRequest
-	41,  // 41: containarium.v1.ContainerService.GetMetricsExport:input_type -> containarium.v1.GetMetricsExportRequest
-	42,  // 42: containarium.v1.ContainerService.CreateAlertRule:input_type -> containarium.v1.CreateAlertRuleRequest
-	43,  // 43: containarium.v1.ContainerService.ListAlertRules:input_type -> containarium.v1.ListAlertRulesRequest
-	44,  // 44: containarium.v1.ContainerService.GetAlertRule:input_type -> containarium.v1.GetAlertRuleRequest
-	45,  // 45: containarium.v1.ContainerService.UpdateAlertRule:input_type -> containarium.v1.UpdateAlertRuleRequest
-	46,  // 46: containarium.v1.ContainerService.DeleteAlertRule:input_type -> containarium.v1.DeleteAlertRuleRequest
-	47,  // 47: containarium.v1.ContainerService.GetAlertingInfo:input_type -> containarium.v1.GetAlertingInfoRequest
-	48,  // 48: containarium.v1.ContainerService.ListDefaultAlertRules:input_type -> containarium.v1.ListDefaultAlertRulesRequest
-	49,  // 49: containarium.v1.ContainerService.UpdateAlertingConfig:input_type -> containarium.v1.UpdateAlertingConfigRequest
-	50,  // 50: containarium.v1.ContainerService.TestWebhook:input_type -> containarium.v1.TestWebhookRequest
-	51,  // 51: containarium.v1.ContainerService.ListWebhookDeliveries:input_type -> containarium.v1.ListWebhookDeliveriesRequest
-	52,  // 52: containarium.v1.ContainerService.SetSecret:input_type -> containarium.v1.SetSecretRequest
-	53,  // 53: containarium.v1.ContainerService.GetSecret:input_type -> containarium.v1.GetSecretRequest
-	54,  // 54: containarium.v1.ContainerService.ListSecrets:input_type -> containarium.v1.ListSecretsRequest
-	55,  // 55: containarium.v1.ContainerService.DeleteSecret:input_type -> containarium.v1.DeleteSecretRequest
-	56,  // 56: containarium.v1.ContainerService.RefreshSecrets:input_type -> containarium.v1.RefreshSecretsRequest
-	57,  // 57: containarium.v1.ContainerService.CreateContainer:output_type -> containarium.v1.CreateContainerResponse
-	58,  // 58: containarium.v1.ContainerService.ListContainers:output_type -> containarium.v1.ListContainersResponse
-	59,  // 59: containarium.v1.ContainerService.GetContainer:output_type -> containarium.v1.GetContainerResponse
-	60,  // 60: containarium.v1.ContainerService.DebugContainer:output_type -> containarium.v1.DebugContainerResponse
-	61,  // 61: containarium.v1.ContainerService.DeleteContainer:output_type -> containarium.v1.DeleteContainerResponse
-	62,  // 62: containarium.v1.ContainerService.StartContainer:output_type -> containarium.v1.StartContainerResponse
-	63,  // 63: containarium.v1.ContainerService.StopContainer:output_type -> containarium.v1.StopContainerResponse
-	64,  // 64: containarium.v1.ContainerService.ResizeContainer:output_type -> containarium.v1.ResizeContainerResponse
-	65,  // 65: containarium.v1.ContainerService.MoveContainer:output_type -> containarium.v1.MoveContainerResponse
-	66,  // 66: containarium.v1.ContainerService.DeleteTenantStorage:output_type -> containarium.v1.DeleteTenantStorageResponse
-	67,  // 67: containarium.v1.ContainerService.RewrapContainer:output_type -> containarium.v1.RewrapContainerResponse
-	68,  // 68: containarium.v1.ContainerService.PrepareEncryptedMigration:output_type -> containarium.v1.PrepareEncryptedMigrationResponse
-	69,  // 69: containarium.v1.ContainerService.AdoptMigratedContainer:output_type -> containarium.v1.AdoptMigratedContainerResponse
-	70,  // 70: containarium.v1.ContainerService.ToggleMonitoring:output_type -> containarium.v1.ToggleMonitoringResponse
-	71,  // 71: containarium.v1.ContainerService.ToggleAutoSleep:output_type -> containarium.v1.ToggleAutoSleepResponse
-	72,  // 72: containarium.v1.ContainerService.SetContainerTTL:output_type -> containarium.v1.SetContainerTTLResponse
-	73,  // 73: containarium.v1.ContainerService.SetContainerDeletePolicy:output_type -> containarium.v1.SetContainerDeletePolicyResponse
-	74,  // 74: containarium.v1.ContainerService.SetContainerAttribution:output_type -> containarium.v1.SetContainerAttributionResponse
-	75,  // 75: containarium.v1.ContainerService.AddSSHKey:output_type -> containarium.v1.AddSSHKeyResponse
-	76,  // 76: containarium.v1.ContainerService.RemoveSSHKey:output_type -> containarium.v1.RemoveSSHKeyResponse
-	77,  // 77: containarium.v1.ContainerService.AddCollaborator:output_type -> containarium.v1.AddCollaboratorResponse
-	78,  // 78: containarium.v1.ContainerService.RemoveCollaborator:output_type -> containarium.v1.RemoveCollaboratorResponse
-	79,  // 79: containarium.v1.ContainerService.ListCollaborators:output_type -> containarium.v1.ListCollaboratorsResponse
-	80,  // 80: containarium.v1.ContainerService.GetMetrics:output_type -> containarium.v1.GetMetricsResponse
-	81,  // 81: containarium.v1.ContainerService.CleanupDisk:output_type -> containarium.v1.CleanupDiskResponse
-	82,  // 82: containarium.v1.ContainerService.InstallStack:output_type -> containarium.v1.InstallStackResponse
-	83,  // 83: containarium.v1.ContainerService.ListStacks:output_type -> containarium.v1.ListStacksResponse
-	84,  // 84: containarium.v1.ContainerService.GetSystemInfo:output_type -> containarium.v1.GetSystemInfoResponse
-	85,  // 85: containarium.v1.ContainerService.ListBackends:output_type -> containarium.v1.ListBackendsResponse
-	86,  // 86: containarium.v1.ContainerService.AdvertiseCapacity:output_type -> containarium.v1.AdvertiseCapacityResponse
-	87,  // 87: containarium.v1.ContainerService.WithdrawCapacity:output_type -> containarium.v1.WithdrawCapacityResponse
-	88,  // 88: containarium.v1.ContainerService.GetCapacityHeadroom:output_type -> containarium.v1.GetCapacityHeadroomResponse
-	89,  // 89: containarium.v1.ContainerService.ProfileBackend:output_type -> containarium.v1.ProfileBackendResponse
-	90,  // 90: containarium.v1.ContainerService.GetCapabilityProfile:output_type -> containarium.v1.GetCapabilityProfileResponse
-	91,  // 91: containarium.v1.ContainerService.GetSelfMeasurement:output_type -> containarium.v1.GetSelfMeasurementResponse
-	92,  // 92: containarium.v1.ContainerService.GetLatestRelease:output_type -> containarium.v1.GetLatestReleaseResponse
-	93,  // 93: containarium.v1.ContainerService.ValidateGPU:output_type -> containarium.v1.ValidateGPUResponse
-	94,  // 94: containarium.v1.ContainerService.TriggerUpgrade:output_type -> containarium.v1.TriggerUpgradeResponse
-	95,  // 95: containarium.v1.ContainerService.GetUpgradeStatus:output_type -> containarium.v1.GetUpgradeStatusResponse
-	96,  // 96: containarium.v1.ContainerService.GetMonitoringInfo:output_type -> containarium.v1.GetMonitoringInfoResponse
-	97,  // 97: containarium.v1.ContainerService.SetMetricsExport:output_type -> containarium.v1.SetMetricsExportResponse
-	98,  // 98: containarium.v1.ContainerService.GetMetricsExport:output_type -> containarium.v1.GetMetricsExportResponse
-	99,  // 99: containarium.v1.ContainerService.CreateAlertRule:output_type -> containarium.v1.CreateAlertRuleResponse
-	100, // 100: containarium.v1.ContainerService.ListAlertRules:output_type -> containarium.v1.ListAlertRulesResponse
-	101, // 101: containarium.v1.ContainerService.GetAlertRule:output_type -> containarium.v1.GetAlertRuleResponse
-	102, // 102: containarium.v1.ContainerService.UpdateAlertRule:output_type -> containarium.v1.UpdateAlertRuleResponse
-	103, // 103: containarium.v1.ContainerService.DeleteAlertRule:output_type -> containarium.v1.DeleteAlertRuleResponse
-	104, // 104: containarium.v1.ContainerService.GetAlertingInfo:output_type -> containarium.v1.GetAlertingInfoResponse
-	105, // 105: containarium.v1.ContainerService.ListDefaultAlertRules:output_type -> containarium.v1.ListDefaultAlertRulesResponse
-	106, // 106: containarium.v1.ContainerService.UpdateAlertingConfig:output_type -> containarium.v1.UpdateAlertingConfigResponse
-	107, // 107: containarium.v1.ContainerService.TestWebhook:output_type -> containarium.v1.TestWebhookResponse
-	108, // 108: containarium.v1.ContainerService.ListWebhookDeliveries:output_type -> containarium.v1.ListWebhookDeliveriesResponse
-	109, // 109: containarium.v1.ContainerService.SetSecret:output_type -> containarium.v1.SetSecretResponse
-	110, // 110: containarium.v1.ContainerService.GetSecret:output_type -> containarium.v1.GetSecretResponse
-	111, // 111: containarium.v1.ContainerService.ListSecrets:output_type -> containarium.v1.ListSecretsResponse
-	112, // 112: containarium.v1.ContainerService.DeleteSecret:output_type -> containarium.v1.DeleteSecretResponse
-	113, // 113: containarium.v1.ContainerService.RefreshSecrets:output_type -> containarium.v1.RefreshSecretsResponse
-	57,  // [57:114] is the sub-list for method output_type
-	0,   // [0:57] is the sub-list for method input_type
+	9,   // 9: containarium.v1.ContainerService.CreateContainerSnapshot:input_type -> containarium.v1.CreateContainerSnapshotRequest
+	10,  // 10: containarium.v1.ContainerService.ListContainerSnapshots:input_type -> containarium.v1.ListContainerSnapshotsRequest
+	11,  // 11: containarium.v1.ContainerService.DeleteContainerSnapshot:input_type -> containarium.v1.DeleteContainerSnapshotRequest
+	12,  // 12: containarium.v1.ContainerService.DeleteTenantStorage:input_type -> containarium.v1.DeleteTenantStorageRequest
+	13,  // 13: containarium.v1.ContainerService.RewrapContainer:input_type -> containarium.v1.RewrapContainerRequest
+	14,  // 14: containarium.v1.ContainerService.PrepareEncryptedMigration:input_type -> containarium.v1.PrepareEncryptedMigrationRequest
+	15,  // 15: containarium.v1.ContainerService.AdoptMigratedContainer:input_type -> containarium.v1.AdoptMigratedContainerRequest
+	16,  // 16: containarium.v1.ContainerService.ToggleMonitoring:input_type -> containarium.v1.ToggleMonitoringRequest
+	17,  // 17: containarium.v1.ContainerService.ToggleAutoSleep:input_type -> containarium.v1.ToggleAutoSleepRequest
+	18,  // 18: containarium.v1.ContainerService.SetContainerTTL:input_type -> containarium.v1.SetContainerTTLRequest
+	19,  // 19: containarium.v1.ContainerService.SetContainerDeletePolicy:input_type -> containarium.v1.SetContainerDeletePolicyRequest
+	20,  // 20: containarium.v1.ContainerService.SetContainerAttribution:input_type -> containarium.v1.SetContainerAttributionRequest
+	21,  // 21: containarium.v1.ContainerService.AddSSHKey:input_type -> containarium.v1.AddSSHKeyRequest
+	22,  // 22: containarium.v1.ContainerService.RemoveSSHKey:input_type -> containarium.v1.RemoveSSHKeyRequest
+	23,  // 23: containarium.v1.ContainerService.AddCollaborator:input_type -> containarium.v1.AddCollaboratorRequest
+	24,  // 24: containarium.v1.ContainerService.RemoveCollaborator:input_type -> containarium.v1.RemoveCollaboratorRequest
+	25,  // 25: containarium.v1.ContainerService.ListCollaborators:input_type -> containarium.v1.ListCollaboratorsRequest
+	26,  // 26: containarium.v1.ContainerService.GetMetrics:input_type -> containarium.v1.GetMetricsRequest
+	27,  // 27: containarium.v1.ContainerService.CleanupDisk:input_type -> containarium.v1.CleanupDiskRequest
+	28,  // 28: containarium.v1.ContainerService.InstallStack:input_type -> containarium.v1.InstallStackRequest
+	29,  // 29: containarium.v1.ContainerService.ListStacks:input_type -> containarium.v1.ListStacksRequest
+	30,  // 30: containarium.v1.ContainerService.GetSystemInfo:input_type -> containarium.v1.GetSystemInfoRequest
+	31,  // 31: containarium.v1.ContainerService.ListBackends:input_type -> containarium.v1.ListBackendsRequest
+	32,  // 32: containarium.v1.ContainerService.AdvertiseCapacity:input_type -> containarium.v1.AdvertiseCapacityRequest
+	33,  // 33: containarium.v1.ContainerService.WithdrawCapacity:input_type -> containarium.v1.WithdrawCapacityRequest
+	34,  // 34: containarium.v1.ContainerService.GetCapacityHeadroom:input_type -> containarium.v1.GetCapacityHeadroomRequest
+	35,  // 35: containarium.v1.ContainerService.ProfileBackend:input_type -> containarium.v1.ProfileBackendRequest
+	36,  // 36: containarium.v1.ContainerService.GetCapabilityProfile:input_type -> containarium.v1.GetCapabilityProfileRequest
+	37,  // 37: containarium.v1.ContainerService.GetSelfMeasurement:input_type -> containarium.v1.GetSelfMeasurementRequest
+	38,  // 38: containarium.v1.ContainerService.GetLatestRelease:input_type -> containarium.v1.GetLatestReleaseRequest
+	39,  // 39: containarium.v1.ContainerService.ValidateGPU:input_type -> containarium.v1.ValidateGPURequest
+	40,  // 40: containarium.v1.ContainerService.TriggerUpgrade:input_type -> containarium.v1.TriggerUpgradeRequest
+	41,  // 41: containarium.v1.ContainerService.GetUpgradeStatus:input_type -> containarium.v1.GetUpgradeStatusRequest
+	42,  // 42: containarium.v1.ContainerService.GetMonitoringInfo:input_type -> containarium.v1.GetMonitoringInfoRequest
+	43,  // 43: containarium.v1.ContainerService.SetMetricsExport:input_type -> containarium.v1.SetMetricsExportRequest
+	44,  // 44: containarium.v1.ContainerService.GetMetricsExport:input_type -> containarium.v1.GetMetricsExportRequest
+	45,  // 45: containarium.v1.ContainerService.CreateAlertRule:input_type -> containarium.v1.CreateAlertRuleRequest
+	46,  // 46: containarium.v1.ContainerService.ListAlertRules:input_type -> containarium.v1.ListAlertRulesRequest
+	47,  // 47: containarium.v1.ContainerService.GetAlertRule:input_type -> containarium.v1.GetAlertRuleRequest
+	48,  // 48: containarium.v1.ContainerService.UpdateAlertRule:input_type -> containarium.v1.UpdateAlertRuleRequest
+	49,  // 49: containarium.v1.ContainerService.DeleteAlertRule:input_type -> containarium.v1.DeleteAlertRuleRequest
+	50,  // 50: containarium.v1.ContainerService.GetAlertingInfo:input_type -> containarium.v1.GetAlertingInfoRequest
+	51,  // 51: containarium.v1.ContainerService.ListDefaultAlertRules:input_type -> containarium.v1.ListDefaultAlertRulesRequest
+	52,  // 52: containarium.v1.ContainerService.UpdateAlertingConfig:input_type -> containarium.v1.UpdateAlertingConfigRequest
+	53,  // 53: containarium.v1.ContainerService.TestWebhook:input_type -> containarium.v1.TestWebhookRequest
+	54,  // 54: containarium.v1.ContainerService.ListWebhookDeliveries:input_type -> containarium.v1.ListWebhookDeliveriesRequest
+	55,  // 55: containarium.v1.ContainerService.SetSecret:input_type -> containarium.v1.SetSecretRequest
+	56,  // 56: containarium.v1.ContainerService.GetSecret:input_type -> containarium.v1.GetSecretRequest
+	57,  // 57: containarium.v1.ContainerService.ListSecrets:input_type -> containarium.v1.ListSecretsRequest
+	58,  // 58: containarium.v1.ContainerService.DeleteSecret:input_type -> containarium.v1.DeleteSecretRequest
+	59,  // 59: containarium.v1.ContainerService.RefreshSecrets:input_type -> containarium.v1.RefreshSecretsRequest
+	60,  // 60: containarium.v1.ContainerService.CreateContainer:output_type -> containarium.v1.CreateContainerResponse
+	61,  // 61: containarium.v1.ContainerService.ListContainers:output_type -> containarium.v1.ListContainersResponse
+	62,  // 62: containarium.v1.ContainerService.GetContainer:output_type -> containarium.v1.GetContainerResponse
+	63,  // 63: containarium.v1.ContainerService.DebugContainer:output_type -> containarium.v1.DebugContainerResponse
+	64,  // 64: containarium.v1.ContainerService.DeleteContainer:output_type -> containarium.v1.DeleteContainerResponse
+	65,  // 65: containarium.v1.ContainerService.StartContainer:output_type -> containarium.v1.StartContainerResponse
+	66,  // 66: containarium.v1.ContainerService.StopContainer:output_type -> containarium.v1.StopContainerResponse
+	67,  // 67: containarium.v1.ContainerService.ResizeContainer:output_type -> containarium.v1.ResizeContainerResponse
+	68,  // 68: containarium.v1.ContainerService.MoveContainer:output_type -> containarium.v1.MoveContainerResponse
+	69,  // 69: containarium.v1.ContainerService.CreateContainerSnapshot:output_type -> containarium.v1.CreateContainerSnapshotResponse
+	70,  // 70: containarium.v1.ContainerService.ListContainerSnapshots:output_type -> containarium.v1.ListContainerSnapshotsResponse
+	71,  // 71: containarium.v1.ContainerService.DeleteContainerSnapshot:output_type -> containarium.v1.DeleteContainerSnapshotResponse
+	72,  // 72: containarium.v1.ContainerService.DeleteTenantStorage:output_type -> containarium.v1.DeleteTenantStorageResponse
+	73,  // 73: containarium.v1.ContainerService.RewrapContainer:output_type -> containarium.v1.RewrapContainerResponse
+	74,  // 74: containarium.v1.ContainerService.PrepareEncryptedMigration:output_type -> containarium.v1.PrepareEncryptedMigrationResponse
+	75,  // 75: containarium.v1.ContainerService.AdoptMigratedContainer:output_type -> containarium.v1.AdoptMigratedContainerResponse
+	76,  // 76: containarium.v1.ContainerService.ToggleMonitoring:output_type -> containarium.v1.ToggleMonitoringResponse
+	77,  // 77: containarium.v1.ContainerService.ToggleAutoSleep:output_type -> containarium.v1.ToggleAutoSleepResponse
+	78,  // 78: containarium.v1.ContainerService.SetContainerTTL:output_type -> containarium.v1.SetContainerTTLResponse
+	79,  // 79: containarium.v1.ContainerService.SetContainerDeletePolicy:output_type -> containarium.v1.SetContainerDeletePolicyResponse
+	80,  // 80: containarium.v1.ContainerService.SetContainerAttribution:output_type -> containarium.v1.SetContainerAttributionResponse
+	81,  // 81: containarium.v1.ContainerService.AddSSHKey:output_type -> containarium.v1.AddSSHKeyResponse
+	82,  // 82: containarium.v1.ContainerService.RemoveSSHKey:output_type -> containarium.v1.RemoveSSHKeyResponse
+	83,  // 83: containarium.v1.ContainerService.AddCollaborator:output_type -> containarium.v1.AddCollaboratorResponse
+	84,  // 84: containarium.v1.ContainerService.RemoveCollaborator:output_type -> containarium.v1.RemoveCollaboratorResponse
+	85,  // 85: containarium.v1.ContainerService.ListCollaborators:output_type -> containarium.v1.ListCollaboratorsResponse
+	86,  // 86: containarium.v1.ContainerService.GetMetrics:output_type -> containarium.v1.GetMetricsResponse
+	87,  // 87: containarium.v1.ContainerService.CleanupDisk:output_type -> containarium.v1.CleanupDiskResponse
+	88,  // 88: containarium.v1.ContainerService.InstallStack:output_type -> containarium.v1.InstallStackResponse
+	89,  // 89: containarium.v1.ContainerService.ListStacks:output_type -> containarium.v1.ListStacksResponse
+	90,  // 90: containarium.v1.ContainerService.GetSystemInfo:output_type -> containarium.v1.GetSystemInfoResponse
+	91,  // 91: containarium.v1.ContainerService.ListBackends:output_type -> containarium.v1.ListBackendsResponse
+	92,  // 92: containarium.v1.ContainerService.AdvertiseCapacity:output_type -> containarium.v1.AdvertiseCapacityResponse
+	93,  // 93: containarium.v1.ContainerService.WithdrawCapacity:output_type -> containarium.v1.WithdrawCapacityResponse
+	94,  // 94: containarium.v1.ContainerService.GetCapacityHeadroom:output_type -> containarium.v1.GetCapacityHeadroomResponse
+	95,  // 95: containarium.v1.ContainerService.ProfileBackend:output_type -> containarium.v1.ProfileBackendResponse
+	96,  // 96: containarium.v1.ContainerService.GetCapabilityProfile:output_type -> containarium.v1.GetCapabilityProfileResponse
+	97,  // 97: containarium.v1.ContainerService.GetSelfMeasurement:output_type -> containarium.v1.GetSelfMeasurementResponse
+	98,  // 98: containarium.v1.ContainerService.GetLatestRelease:output_type -> containarium.v1.GetLatestReleaseResponse
+	99,  // 99: containarium.v1.ContainerService.ValidateGPU:output_type -> containarium.v1.ValidateGPUResponse
+	100, // 100: containarium.v1.ContainerService.TriggerUpgrade:output_type -> containarium.v1.TriggerUpgradeResponse
+	101, // 101: containarium.v1.ContainerService.GetUpgradeStatus:output_type -> containarium.v1.GetUpgradeStatusResponse
+	102, // 102: containarium.v1.ContainerService.GetMonitoringInfo:output_type -> containarium.v1.GetMonitoringInfoResponse
+	103, // 103: containarium.v1.ContainerService.SetMetricsExport:output_type -> containarium.v1.SetMetricsExportResponse
+	104, // 104: containarium.v1.ContainerService.GetMetricsExport:output_type -> containarium.v1.GetMetricsExportResponse
+	105, // 105: containarium.v1.ContainerService.CreateAlertRule:output_type -> containarium.v1.CreateAlertRuleResponse
+	106, // 106: containarium.v1.ContainerService.ListAlertRules:output_type -> containarium.v1.ListAlertRulesResponse
+	107, // 107: containarium.v1.ContainerService.GetAlertRule:output_type -> containarium.v1.GetAlertRuleResponse
+	108, // 108: containarium.v1.ContainerService.UpdateAlertRule:output_type -> containarium.v1.UpdateAlertRuleResponse
+	109, // 109: containarium.v1.ContainerService.DeleteAlertRule:output_type -> containarium.v1.DeleteAlertRuleResponse
+	110, // 110: containarium.v1.ContainerService.GetAlertingInfo:output_type -> containarium.v1.GetAlertingInfoResponse
+	111, // 111: containarium.v1.ContainerService.ListDefaultAlertRules:output_type -> containarium.v1.ListDefaultAlertRulesResponse
+	112, // 112: containarium.v1.ContainerService.UpdateAlertingConfig:output_type -> containarium.v1.UpdateAlertingConfigResponse
+	113, // 113: containarium.v1.ContainerService.TestWebhook:output_type -> containarium.v1.TestWebhookResponse
+	114, // 114: containarium.v1.ContainerService.ListWebhookDeliveries:output_type -> containarium.v1.ListWebhookDeliveriesResponse
+	115, // 115: containarium.v1.ContainerService.SetSecret:output_type -> containarium.v1.SetSecretResponse
+	116, // 116: containarium.v1.ContainerService.GetSecret:output_type -> containarium.v1.GetSecretResponse
+	117, // 117: containarium.v1.ContainerService.ListSecrets:output_type -> containarium.v1.ListSecretsResponse
+	118, // 118: containarium.v1.ContainerService.DeleteSecret:output_type -> containarium.v1.DeleteSecretResponse
+	119, // 119: containarium.v1.ContainerService.RefreshSecrets:output_type -> containarium.v1.RefreshSecretsResponse
+	60,  // [60:120] is the sub-list for method output_type
+	0,   // [0:60] is the sub-list for method input_type
 	0,   // [0:0] is the sub-list for extension type_name
 	0,   // [0:0] is the sub-list for extension extendee
 	0,   // [0:0] is the sub-list for field type_name

--- a/pkg/pb/containarium/v1/service.pb.gw.go
+++ b/pkg/pb/containarium/v1/service.pb.gw.go
@@ -408,6 +408,145 @@ func local_request_ContainerService_MoveContainer_0(ctx context.Context, marshal
 	return msg, metadata, err
 }
 
+func request_ContainerService_CreateContainerSnapshot_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq CreateContainerSnapshotRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	val, ok := pathParams["username"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "username")
+	}
+	protoReq.Username, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "username", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.CreateContainerSnapshot(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ContainerService_CreateContainerSnapshot_0(ctx context.Context, marshaler runtime.Marshaler, server ContainerServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq CreateContainerSnapshotRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	val, ok := pathParams["username"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "username")
+	}
+	protoReq.Username, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "username", err)
+	}
+	msg, err := server.CreateContainerSnapshot(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_ContainerService_ListContainerSnapshots_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListContainerSnapshotsRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	val, ok := pathParams["username"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "username")
+	}
+	protoReq.Username, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "username", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.ListContainerSnapshots(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ContainerService_ListContainerSnapshots_0(ctx context.Context, marshaler runtime.Marshaler, server ContainerServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListContainerSnapshotsRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	val, ok := pathParams["username"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "username")
+	}
+	protoReq.Username, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "username", err)
+	}
+	msg, err := server.ListContainerSnapshots(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_ContainerService_DeleteContainerSnapshot_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq DeleteContainerSnapshotRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	val, ok := pathParams["username"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "username")
+	}
+	protoReq.Username, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "username", err)
+	}
+	val, ok = pathParams["name"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
+	}
+	protoReq.Name, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "name", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.DeleteContainerSnapshot(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ContainerService_DeleteContainerSnapshot_0(ctx context.Context, marshaler runtime.Marshaler, server ContainerServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq DeleteContainerSnapshotRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	val, ok := pathParams["username"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "username")
+	}
+	protoReq.Username, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "username", err)
+	}
+	val, ok = pathParams["name"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
+	}
+	protoReq.Name, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "name", err)
+	}
+	msg, err := server.DeleteContainerSnapshot(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_ContainerService_DeleteTenantStorage_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq DeleteTenantStorageRequest
@@ -2345,6 +2484,66 @@ func RegisterContainerServiceHandlerServer(ctx context.Context, mux *runtime.Ser
 		}
 		forward_ContainerService_MoveContainer_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_ContainerService_CreateContainerSnapshot_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.ContainerService/CreateContainerSnapshot", runtime.WithHTTPPathPattern("/v1/containers/{username}/snapshots"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ContainerService_CreateContainerSnapshot_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_CreateContainerSnapshot_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_ContainerService_ListContainerSnapshots_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.ContainerService/ListContainerSnapshots", runtime.WithHTTPPathPattern("/v1/containers/{username}/snapshots"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ContainerService_ListContainerSnapshots_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_ListContainerSnapshots_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodDelete, pattern_ContainerService_DeleteContainerSnapshot_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.ContainerService/DeleteContainerSnapshot", runtime.WithHTTPPathPattern("/v1/containers/{username}/snapshots/{name}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ContainerService_DeleteContainerSnapshot_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_DeleteContainerSnapshot_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodDelete, pattern_ContainerService_DeleteTenantStorage_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -3518,6 +3717,57 @@ func RegisterContainerServiceHandlerClient(ctx context.Context, mux *runtime.Ser
 		}
 		forward_ContainerService_MoveContainer_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_ContainerService_CreateContainerSnapshot_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.ContainerService/CreateContainerSnapshot", runtime.WithHTTPPathPattern("/v1/containers/{username}/snapshots"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ContainerService_CreateContainerSnapshot_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_CreateContainerSnapshot_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_ContainerService_ListContainerSnapshots_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.ContainerService/ListContainerSnapshots", runtime.WithHTTPPathPattern("/v1/containers/{username}/snapshots"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ContainerService_ListContainerSnapshots_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_ListContainerSnapshots_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodDelete, pattern_ContainerService_DeleteContainerSnapshot_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.ContainerService/DeleteContainerSnapshot", runtime.WithHTTPPathPattern("/v1/containers/{username}/snapshots/{name}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ContainerService_DeleteContainerSnapshot_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_DeleteContainerSnapshot_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodDelete, pattern_ContainerService_DeleteTenantStorage_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -4364,6 +4614,9 @@ var (
 	pattern_ContainerService_StopContainer_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "stop"}, ""))
 	pattern_ContainerService_ResizeContainer_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "resize"}, ""))
 	pattern_ContainerService_MoveContainer_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "move"}, ""))
+	pattern_ContainerService_CreateContainerSnapshot_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "snapshots"}, ""))
+	pattern_ContainerService_ListContainerSnapshots_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "snapshots"}, ""))
+	pattern_ContainerService_DeleteContainerSnapshot_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3, 1, 0, 4, 1, 5, 4}, []string{"v1", "containers", "username", "snapshots", "name"}, ""))
 	pattern_ContainerService_DeleteTenantStorage_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "tenants", "tenant", "storage"}, ""))
 	pattern_ContainerService_RewrapContainer_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "rewrap"}, ""))
 	pattern_ContainerService_PrepareEncryptedMigration_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "prepare-encrypted-migration"}, ""))
@@ -4425,6 +4678,9 @@ var (
 	forward_ContainerService_StopContainer_0             = runtime.ForwardResponseMessage
 	forward_ContainerService_ResizeContainer_0           = runtime.ForwardResponseMessage
 	forward_ContainerService_MoveContainer_0             = runtime.ForwardResponseMessage
+	forward_ContainerService_CreateContainerSnapshot_0   = runtime.ForwardResponseMessage
+	forward_ContainerService_ListContainerSnapshots_0    = runtime.ForwardResponseMessage
+	forward_ContainerService_DeleteContainerSnapshot_0   = runtime.ForwardResponseMessage
 	forward_ContainerService_DeleteTenantStorage_0       = runtime.ForwardResponseMessage
 	forward_ContainerService_RewrapContainer_0           = runtime.ForwardResponseMessage
 	forward_ContainerService_PrepareEncryptedMigration_0 = runtime.ForwardResponseMessage

--- a/pkg/pb/containarium/v1/service_grpc.pb.go
+++ b/pkg/pb/containarium/v1/service_grpc.pb.go
@@ -28,6 +28,9 @@ const (
 	ContainerService_StopContainer_FullMethodName             = "/containarium.v1.ContainerService/StopContainer"
 	ContainerService_ResizeContainer_FullMethodName           = "/containarium.v1.ContainerService/ResizeContainer"
 	ContainerService_MoveContainer_FullMethodName             = "/containarium.v1.ContainerService/MoveContainer"
+	ContainerService_CreateContainerSnapshot_FullMethodName   = "/containarium.v1.ContainerService/CreateContainerSnapshot"
+	ContainerService_ListContainerSnapshots_FullMethodName    = "/containarium.v1.ContainerService/ListContainerSnapshots"
+	ContainerService_DeleteContainerSnapshot_FullMethodName   = "/containarium.v1.ContainerService/DeleteContainerSnapshot"
 	ContainerService_DeleteTenantStorage_FullMethodName       = "/containarium.v1.ContainerService/DeleteTenantStorage"
 	ContainerService_RewrapContainer_FullMethodName           = "/containarium.v1.ContainerService/RewrapContainer"
 	ContainerService_PrepareEncryptedMigration_FullMethodName = "/containarium.v1.ContainerService/PrepareEncryptedMigration"
@@ -110,6 +113,23 @@ type ContainerServiceClient interface {
 	// for active workloads on dir-pool. Prereq: incus remotes
 	// configured both ways between the source and target VMs.
 	MoveContainer(ctx context.Context, in *MoveContainerRequest, opts ...grpc.CallOption) (*MoveContainerResponse, error)
+	// CreateContainerSnapshot takes a point-in-time ZFS snapshot of a
+	// container's dataset (#1160).
+	//
+	// On ContainerService rather than VolumeService because the subject is a
+	// container: the dataset is an implementation detail the daemon resolves
+	// itself, and the tenant authorization here is already the right shape.
+	// See docs/architecture/container-snapshots.md.
+	//
+	// Succeeds with the encryption key unloaded — ZFS permits it, and blocking
+	// on key custody would let a transient outage suppress the backup window.
+	CreateContainerSnapshot(ctx context.Context, in *CreateContainerSnapshotRequest, opts ...grpc.CallOption) (*CreateContainerSnapshotResponse, error)
+	// ListContainerSnapshots lists a container's snapshots with their space
+	// usage. The usage is the point: a forgotten snapshot silently pins disk,
+	// and nothing else in the API reports it.
+	ListContainerSnapshots(ctx context.Context, in *ListContainerSnapshotsRequest, opts ...grpc.CallOption) (*ListContainerSnapshotsResponse, error)
+	// DeleteContainerSnapshot removes a snapshot and reports what it freed.
+	DeleteContainerSnapshot(ctx context.Context, in *DeleteContainerSnapshotRequest, opts ...grpc.CallOption) (*DeleteContainerSnapshotResponse, error)
 	// DeleteTenantStorage tears down a departing tenant's encrypted storage
 	// (#1343) — the Incus storage pool, then the encrypted dataset it is
 	// sourced at, in that order.
@@ -442,6 +462,36 @@ func (c *containerServiceClient) MoveContainer(ctx context.Context, in *MoveCont
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(MoveContainerResponse)
 	err := c.cc.Invoke(ctx, ContainerService_MoveContainer_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *containerServiceClient) CreateContainerSnapshot(ctx context.Context, in *CreateContainerSnapshotRequest, opts ...grpc.CallOption) (*CreateContainerSnapshotResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(CreateContainerSnapshotResponse)
+	err := c.cc.Invoke(ctx, ContainerService_CreateContainerSnapshot_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *containerServiceClient) ListContainerSnapshots(ctx context.Context, in *ListContainerSnapshotsRequest, opts ...grpc.CallOption) (*ListContainerSnapshotsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListContainerSnapshotsResponse)
+	err := c.cc.Invoke(ctx, ContainerService_ListContainerSnapshots_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *containerServiceClient) DeleteContainerSnapshot(ctx context.Context, in *DeleteContainerSnapshotRequest, opts ...grpc.CallOption) (*DeleteContainerSnapshotResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DeleteContainerSnapshotResponse)
+	err := c.cc.Invoke(ctx, ContainerService_DeleteContainerSnapshot_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -960,6 +1010,23 @@ type ContainerServiceServer interface {
 	// for active workloads on dir-pool. Prereq: incus remotes
 	// configured both ways between the source and target VMs.
 	MoveContainer(context.Context, *MoveContainerRequest) (*MoveContainerResponse, error)
+	// CreateContainerSnapshot takes a point-in-time ZFS snapshot of a
+	// container's dataset (#1160).
+	//
+	// On ContainerService rather than VolumeService because the subject is a
+	// container: the dataset is an implementation detail the daemon resolves
+	// itself, and the tenant authorization here is already the right shape.
+	// See docs/architecture/container-snapshots.md.
+	//
+	// Succeeds with the encryption key unloaded — ZFS permits it, and blocking
+	// on key custody would let a transient outage suppress the backup window.
+	CreateContainerSnapshot(context.Context, *CreateContainerSnapshotRequest) (*CreateContainerSnapshotResponse, error)
+	// ListContainerSnapshots lists a container's snapshots with their space
+	// usage. The usage is the point: a forgotten snapshot silently pins disk,
+	// and nothing else in the API reports it.
+	ListContainerSnapshots(context.Context, *ListContainerSnapshotsRequest) (*ListContainerSnapshotsResponse, error)
+	// DeleteContainerSnapshot removes a snapshot and reports what it freed.
+	DeleteContainerSnapshot(context.Context, *DeleteContainerSnapshotRequest) (*DeleteContainerSnapshotResponse, error)
 	// DeleteTenantStorage tears down a departing tenant's encrypted storage
 	// (#1343) — the Incus storage pool, then the encrypted dataset it is
 	// sourced at, in that order.
@@ -1234,6 +1301,15 @@ func (UnimplementedContainerServiceServer) ResizeContainer(context.Context, *Res
 }
 func (UnimplementedContainerServiceServer) MoveContainer(context.Context, *MoveContainerRequest) (*MoveContainerResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method MoveContainer not implemented")
+}
+func (UnimplementedContainerServiceServer) CreateContainerSnapshot(context.Context, *CreateContainerSnapshotRequest) (*CreateContainerSnapshotResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method CreateContainerSnapshot not implemented")
+}
+func (UnimplementedContainerServiceServer) ListContainerSnapshots(context.Context, *ListContainerSnapshotsRequest) (*ListContainerSnapshotsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListContainerSnapshots not implemented")
+}
+func (UnimplementedContainerServiceServer) DeleteContainerSnapshot(context.Context, *DeleteContainerSnapshotRequest) (*DeleteContainerSnapshotResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method DeleteContainerSnapshot not implemented")
 }
 func (UnimplementedContainerServiceServer) DeleteTenantStorage(context.Context, *DeleteTenantStorageRequest) (*DeleteTenantStorageResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteTenantStorage not implemented")
@@ -1558,6 +1634,60 @@ func _ContainerService_MoveContainer_Handler(srv interface{}, ctx context.Contex
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(ContainerServiceServer).MoveContainer(ctx, req.(*MoveContainerRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ContainerService_CreateContainerSnapshot_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CreateContainerSnapshotRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ContainerServiceServer).CreateContainerSnapshot(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ContainerService_CreateContainerSnapshot_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ContainerServiceServer).CreateContainerSnapshot(ctx, req.(*CreateContainerSnapshotRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ContainerService_ListContainerSnapshots_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListContainerSnapshotsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ContainerServiceServer).ListContainerSnapshots(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ContainerService_ListContainerSnapshots_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ContainerServiceServer).ListContainerSnapshots(ctx, req.(*ListContainerSnapshotsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ContainerService_DeleteContainerSnapshot_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteContainerSnapshotRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ContainerServiceServer).DeleteContainerSnapshot(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ContainerService_DeleteContainerSnapshot_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ContainerServiceServer).DeleteContainerSnapshot(ctx, req.(*DeleteContainerSnapshotRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -2468,6 +2598,18 @@ var ContainerService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "MoveContainer",
 			Handler:    _ContainerService_MoveContainer_Handler,
+		},
+		{
+			MethodName: "CreateContainerSnapshot",
+			Handler:    _ContainerService_CreateContainerSnapshot_Handler,
+		},
+		{
+			MethodName: "ListContainerSnapshots",
+			Handler:    _ContainerService_ListContainerSnapshots_Handler,
+		},
+		{
+			MethodName: "DeleteContainerSnapshot",
+			Handler:    _ContainerService_DeleteContainerSnapshot_Handler,
 		},
 		{
 			MethodName: "DeleteTenantStorage",

--- a/proto/containarium/v1/container.proto
+++ b/proto/containarium/v1/container.proto
@@ -1250,6 +1250,61 @@ message AdoptMigratedContainerRequest {
   string zfs_pool = 4;
 }
 
+// ContainerSnapshot is a point-in-time ZFS snapshot of a container's
+// dataset (#1160).
+message ContainerSnapshot {
+  // Snapshot name, unique per container.
+  string name = 1;
+
+  // Bytes uniquely held by this snapshot — space that would be freed by
+  // deleting it. Surfaced because a forgotten snapshot silently pins disk,
+  // and nothing else in the API would say so.
+  int64 used_bytes = 2;
+
+  // Bytes the snapshot references in total, including data it shares with
+  // the live dataset. Much larger than used_bytes for a fresh snapshot, and
+  // not the number that matters for reclaiming space.
+  int64 referenced_bytes = 3;
+}
+
+// CreateContainerSnapshotRequest snapshots a container's dataset.
+//
+// Succeeds even when the container's encryption key is unloaded: ZFS allows
+// it, and blocking on key-custody reachability would let a transient outage
+// suppress the backup window (encryption design, resolved decision #3).
+message CreateContainerSnapshotRequest {
+  // The container to snapshot.
+  string username = 1;
+
+  // Snapshot name. Must be unique for this container.
+  string name = 2;
+}
+
+message CreateContainerSnapshotResponse {
+  ContainerSnapshot snapshot = 1;
+  string message = 2;
+}
+
+message ListContainerSnapshotsRequest {
+  string username = 1;
+}
+
+message ListContainerSnapshotsResponse {
+  repeated ContainerSnapshot snapshots = 1;
+}
+
+message DeleteContainerSnapshotRequest {
+  string username = 1;
+  string name = 2;
+}
+
+message DeleteContainerSnapshotResponse {
+  string message = 1;
+
+  // Bytes reclaimed — what the snapshot uniquely held.
+  int64 freed_bytes = 2;
+}
+
 // DeleteTenantStorageRequest tears down a departing tenant's encrypted
 // storage (#1343): the Incus storage pool, and the encrypted dataset it is
 // sourced at.

--- a/proto/containarium/v1/service.proto
+++ b/proto/containarium/v1/service.proto
@@ -173,6 +173,54 @@ service ContainerService {
     };
   }
 
+  // CreateContainerSnapshot takes a point-in-time ZFS snapshot of a
+  // container's dataset (#1160).
+  //
+  // On ContainerService rather than VolumeService because the subject is a
+  // container: the dataset is an implementation detail the daemon resolves
+  // itself, and the tenant authorization here is already the right shape.
+  // See docs/architecture/container-snapshots.md.
+  //
+  // Succeeds with the encryption key unloaded — ZFS permits it, and blocking
+  // on key custody would let a transient outage suppress the backup window.
+  rpc CreateContainerSnapshot(CreateContainerSnapshotRequest) returns (CreateContainerSnapshotResponse) {
+    option (google.api.http) = {
+      post: "/v1/containers/{username}/snapshots"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Snapshot a container";
+      description: "Takes a point-in-time ZFS snapshot of the container's dataset. Instant and space-efficient: it shares blocks with the live dataset until they diverge. Works while the container runs, and while its encryption key is unloaded.";
+      tags: "Container Operations";
+    };
+  }
+
+  // ListContainerSnapshots lists a container's snapshots with their space
+  // usage. The usage is the point: a forgotten snapshot silently pins disk,
+  // and nothing else in the API reports it.
+  rpc ListContainerSnapshots(ListContainerSnapshotsRequest) returns (ListContainerSnapshotsResponse) {
+    option (google.api.http) = {
+      get: "/v1/containers/{username}/snapshots"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "List a container's snapshots";
+      description: "Lists the container's ZFS snapshots, each with the bytes it uniquely holds (what deleting it would free) and the bytes it references in total.";
+      tags: "Container Operations";
+    };
+  }
+
+  // DeleteContainerSnapshot removes a snapshot and reports what it freed.
+  rpc DeleteContainerSnapshot(DeleteContainerSnapshotRequest) returns (DeleteContainerSnapshotResponse) {
+    option (google.api.http) = {
+      delete: "/v1/containers/{username}/snapshots/{name}"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Delete a container snapshot";
+      description: "Removes the snapshot and reports the bytes reclaimed. Works while the container's encryption key is unloaded.";
+      tags: "Container Operations";
+    };
+  }
+
   // DeleteTenantStorage tears down a departing tenant's encrypted storage
   // (#1343) — the Incus storage pool, then the encrypted dataset it is
   // sourced at, in that order.


### PR DESCRIPTION
Slice (a) of #1160, per the accepted design in `docs/architecture/container-snapshots.md`.

The ZFS mechanism has existed in `pkg/core/zfscrypt` since #1200 and is verified against a real pool. What was missing is any way to reach it — no RPC, no CLI — so taking a snapshot meant an operator with a shell on the host.

## What changed

- **Contract first.** `CreateContainerSnapshot` / `ListContainerSnapshots` / `DeleteContainerSnapshot` on `ContainerService`, with the REST mappings the design names, plus a `ContainerSnapshot` message carrying `used_bytes` and `referenced_bytes`. Regenerated via `make proto`; no generated file hand-edited.
- **Dataset resolution** (`internal/server/container_snapshot.go`) — the part worth reviewing first. An encrypted container does not live under the default pool: it lives under its tenant's pool, whose source is the tenant encryptionroot (#1335). The pool it was placed on is read back from the encryption record rather than recomputed from the naming convention, and **an unreadable record refuses rather than falling back** — the default pool's dataset of the same name is another tenant's storage, so a fallback would be both wrong and a cross-tenant read.
- **CLI** — `containarium snapshot create|list|delete`, typed client methods on both transports.
- **No key requirement on any of the three verbs.** Deliberate, per the encryption design's resolved decision #3: gating on key-custody reachability would turn a KMS outage into a silently missed backup window, or into unbounded snapshot growth. Reading a snapshot's *contents* does need the key; that belongs with the inspection verbs, not here.

Wiring order matters and is commented at the call site: `SetSnapshotStorage` must run **after** `SetEncryptionStorage`, or every encrypted container resolves to the default pool.

## Acceptance criteria

| # | Criterion | Covered by |
|---|---|---|
| 1 | Three tenant-scoped RPCs over the existing gateway | `TestCreateContainerSnapshot_*`, `TestListContainerSnapshots_*`, `TestDeleteContainerSnapshot_*`, `TestContainerSnapshots_RefuseAnotherTenantsContainer`, `TestContainerSnapshots_MutationsRequireTheWriteScope` |
| 2 | List carries space usage | `TestListContainerSnapshots_CarriesSpaceUsage`, `TestSnapshotList_ShowsUsedAndReferencedSeparately` |
| 3 | A CLI verb per RPC | `internal/cmd/snapshot_test.go` (7 tests) |
| 4 | Create + delete work with the key **unloaded**, on a real pool | `TestIntegrationIncus_SnapshotsAnEncryptedContainerWithTheKeyUnloaded` |

Criterion 4 is what unblocks #1202's third criterion.

## Test evidence

25 tests added (17 unit + 1 real-pool + 7 CLI). `go vet` clean under every build tag (none / `zfs` / `incus` / `k8s` / `integration`) — `go vet ./...` alone does not compile tagged files, and a build-tagged fake going stale has bitten this sprint twice.

Green on the first run proves nothing, so the six load-bearing assertions were mutation-tested. Each mutation was applied to the implementation and the suite re-run; all six were caught:

| Mutation | Result |
|---|---|
| Pool record ignored, default pool used | caught (4 tests) |
| Tenant authorization dropped | caught (4 tests) |
| Usage read *after* the destroy | caught |
| Wiring forgets the encryption pool record | caught |
| Unreadable pool record silently falls back to default | caught |
| List drops a snapshot whose usage is unreadable | caught |

**CI: all 10 checks green.** The one that matters is the Incus lane ([run](https://github.com/FootprintAI/Containarium/actions/runs/31927605043/job/95117473746), 10m5s), and a green lane is not evidence the new test ran — the log confirms it did:

```
=== RUN   TestIntegrationIncus_SnapshotsAnEncryptedContainerWithTheKeyUnloaded
--- PASS: TestIntegrationIncus_SnapshotsAnEncryptedContainerWithTheKeyUnloaded (35.53s)
```

on a real Incus over a real ZFS pool, with the lane's "assert nothing was skipped" guard holding.

## Deviations from the design doc

Two, both deliberate:

1. **CLI is `containarium snapshot ...`, not `containarium container snapshot ...`.** There is no `container` parent command in this CLI — container verbs are top-level (`create`, `delete`, `list`, `info`, `move`, `label`, `backup`). The design's wording would have produced the only command under a group that does not exist.
2. **The Incus lane is extended**, which the design said would not be needed. The design's reasoning holds for the ZFS mechanism, which the `zfs` lane already covers. It does not hold for *which dataset the daemon resolves*: that goes through a tenant Incus **pool**, and the placement record only exists on a real Incus. This is exactly the bug class of #1336 — a wrong dataset name defended by unit tests for months — so a fake resolver was not enough. The new lane test is additive; nothing was moved off the ZFS lane.

## Follow-ups, not in this PR

- #1160b (rollback) and #1160c (clone) per the design's split.
- No MCP tool yet; the CLI is the canonical surface and the MCP wrapper is mechanical once the shape settles across all three slices.

