### PR TITLE
feat(container): snapshot rollback RPC and CLI (#1160b)

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -2745,6 +2745,53 @@
         ]
       }
     },
+    "/v1/containers/{username}/snapshots/{name}/rollback": {
+      "post": {
+        "summary": "Roll a container back to a snapshot",
+        "description": "Discards everything written since the snapshot. Refuses a running container unless force is set, refuses to destroy newer snapshots unless destroy_newer is set, and refuses when the container's encryption key is unavailable.",
+        "operationId": "ContainerService_RollbackContainerSnapshot",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/RollbackContainerSnapshotResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "description": "The snapshot to roll back to.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RollbackContainerSnapshotBody"
+            }
+          }
+        ],
+        "tags": [
+          "Container Operations"
+        ]
+      }
+    },
     "/v1/containers/{username}/ssh-keys": {
       "post": {
         "summary": "Add SSH key",
@@ -11375,6 +11422,39 @@
         }
       },
       "description": "RewrapContainerResponse reports the outcome of a rotation."
+    },
+    "RollbackContainerSnapshotBody": {
+      "type": "object",
+      "properties": {
+        "force": {
+          "type": "boolean",
+          "description": "Stop the container first. Without it, a rollback of a running container\nis refused: ZFS would fail on the busy dataset anyway, and \"dataset is\nbusy\" is a far worse message than \"stop the container first\"."
+        },
+        "destroyNewer": {
+          "type": "boolean",
+          "description": "Destroy snapshots taken after the target, which ZFS requires in order to\nroll back past them. Opt-in because it silently widens the blast radius\nfrom \"lose writes since the snapshot\" to \"lose other restore points too\"."
+        }
+      },
+      "description": "RollbackContainerSnapshotRequest returns a container's dataset to the state\ncaptured by a snapshot.\n\nDestructive twice over: everything written since the snapshot is discarded,\nand any snapshot taken after it must be destroyed too. Both are refusals by\ndefault (#1160b)."
+    },
+    "RollbackContainerSnapshotResponse": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string"
+        },
+        "containerStopped": {
+          "type": "boolean",
+          "description": "Whether the daemon stopped the container to perform the rollback. It is\nleft stopped — restarting it is the caller's decision, since the data\nunderneath just changed."
+        },
+        "destroyedSnapshots": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Snapshots destroyed to make the rollback possible, so the caller has a\nrecord of the restore points they no longer have."
+        }
+      }
     },
     "RouteEvent": {
       "type": "object",

--- a/internal/client/grpc.go
+++ b/internal/client/grpc.go
@@ -1225,3 +1225,15 @@ func (c *GRPCClient) DeleteContainerSnapshot(req *pb.DeleteContainerSnapshotRequ
 	}
 	return resp, nil
 }
+
+// RollbackContainerSnapshot rolls a container back to a snapshot via gRPC.
+func (c *GRPCClient) RollbackContainerSnapshot(req *pb.RollbackContainerSnapshotRequest) (*pb.RollbackContainerSnapshotResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	resp, err := c.client.RollbackContainerSnapshot(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to roll back snapshot: %w", err)
+	}
+	return resp, nil
+}

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -2109,3 +2109,31 @@ func (c *HTTPClient) DeleteContainerSnapshot(req *pb.DeleteContainerSnapshotRequ
 	}
 	return out, nil
 }
+
+// RollbackContainerSnapshot rolls a container back to a snapshot via HTTP.
+func (c *HTTPClient) RollbackContainerSnapshot(req *pb.RollbackContainerSnapshotRequest) (*pb.RollbackContainerSnapshotResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	body, err := protojson.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("encode request: %w", err)
+	}
+	path := fmt.Sprintf("/v1/containers/%s/snapshots/%s/rollback",
+		url.PathEscape(req.GetUsername()), url.PathEscape(req.GetName()))
+	resp, err := c.doRequest(ctx, http.MethodPost, path, json.RawMessage(body))
+	if err != nil {
+		return nil, fmt.Errorf("rollback snapshot: %w", err)
+	}
+	defer drainClose(resp)
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return nil, httpError(bodyBytes, resp.StatusCode, "rollback snapshot")
+	}
+	out := &pb.RollbackContainerSnapshotResponse{}
+	if err := protojson.Unmarshal(bodyBytes, out); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return out, nil
+}

--- a/internal/cmd/snapshot.go
+++ b/internal/cmd/snapshot.go
@@ -35,7 +35,8 @@ window. Reading a snapshot back does need the key.
 
   containarium snapshot create alice --name before-upgrade --server <host>
   containarium snapshot list alice --server <host>
-  containarium snapshot delete alice before-upgrade --server <host>`,
+  containarium snapshot delete alice before-upgrade --server <host>
+  containarium snapshot rollback alice before-upgrade --force --server <host>`,
 }
 
 func init() {
@@ -49,6 +50,7 @@ type snapshotAPI interface {
 	CreateContainerSnapshot(req *pb.CreateContainerSnapshotRequest) (*pb.CreateContainerSnapshotResponse, error)
 	ListContainerSnapshots(req *pb.ListContainerSnapshotsRequest) (*pb.ListContainerSnapshotsResponse, error)
 	DeleteContainerSnapshot(req *pb.DeleteContainerSnapshotRequest) (*pb.DeleteContainerSnapshotResponse, error)
+	RollbackContainerSnapshot(req *pb.RollbackContainerSnapshotRequest) (*pb.RollbackContainerSnapshotResponse, error)
 	Close() error
 }
 

--- a/internal/cmd/snapshot_ops.go
+++ b/internal/cmd/snapshot_ops.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 	"text/tabwriter"
 
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
@@ -130,5 +131,71 @@ func runSnapshotDelete(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("✅ Snapshot %q deleted, freeing %s\n", args[1], humanBytes(resp.GetFreedBytes()))
+	return nil
+}
+
+var (
+	snapshotRollbackForce        bool
+	snapshotRollbackDestroyNewer bool
+)
+
+var snapshotRollbackCmd = &cobra.Command{
+	Use:   "rollback <username> <snapshot>",
+	Short: "Return a container's storage to the state captured by a snapshot",
+	Long: `Discard everything written since the snapshot.
+
+DESTRUCTIVE, and destructive twice over: every change made since the
+snapshot is gone, and any snapshot taken AFTER the target has to be
+destroyed too. Both are refused by default.
+
+  --force          stop the container first (it is left stopped, because
+                   the data underneath just changed)
+  --destroy-newer  accept losing the restore points taken after the target
+
+A container whose encryption key is unavailable is refused: the rollback
+would succeed, but the result would be ciphertext the daemon cannot open.
+
+  containarium snapshot rollback alice before-upgrade --force --server <host>`,
+	Args: cobra.ExactArgs(2),
+	RunE: runSnapshotRollback,
+}
+
+func init() {
+	snapshotCmd.AddCommand(snapshotRollbackCmd)
+	f := snapshotRollbackCmd.Flags()
+	f.BoolVar(&snapshotRollbackForce, "force", false,
+		"stop the container first if it is running (it is left stopped)")
+	f.BoolVar(&snapshotRollbackDestroyNewer, "destroy-newer", false,
+		"destroy snapshots taken after the target, which ZFS requires to roll back past them")
+}
+
+func runSnapshotRollback(cmd *cobra.Command, args []string) error {
+	c, err := newSnapshotClientFn()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = c.Close() }()
+
+	resp, err := c.RollbackContainerSnapshot(&pb.RollbackContainerSnapshotRequest{
+		Username:     args[0],
+		Name:         args[1],
+		Force:        snapshotRollbackForce,
+		DestroyNewer: snapshotRollbackDestroyNewer,
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("✅ %s rolled back to %q\n", args[0], args[1])
+	if resp.GetContainerStopped() {
+		fmt.Printf("   The container was stopped to do this and is still stopped — "+
+			"start it with `containarium wake %s` when you have checked the data.\n", args[0])
+	}
+	// Named, not counted: these restore points no longer exist and nothing
+	// else records which they were.
+	if n := len(resp.GetDestroyedSnapshots()); n > 0 {
+		fmt.Printf("   Destroyed %d newer snapshot(s): %s\n", n,
+			strings.Join(resp.GetDestroyedSnapshots(), ", "))
+	}
 	return nil
 }

--- a/internal/cmd/snapshot_test.go
+++ b/internal/cmd/snapshot_test.go
@@ -54,10 +54,12 @@ func captureErr(t *testing.T, fn func() error) error {
 }
 
 type fakeSnapshotAPI struct {
-	created  *pb.CreateContainerSnapshotRequest
-	deleted  *pb.DeleteContainerSnapshotRequest
-	listResp *pb.ListContainerSnapshotsResponse
-	err      error
+	created      *pb.CreateContainerSnapshotRequest
+	deleted      *pb.DeleteContainerSnapshotRequest
+	listResp     *pb.ListContainerSnapshotsResponse
+	rolledBack   *pb.RollbackContainerSnapshotRequest
+	rollbackResp *pb.RollbackContainerSnapshotResponse
+	err          error
 }
 
 func (f *fakeSnapshotAPI) CreateContainerSnapshot(req *pb.CreateContainerSnapshotRequest) (*pb.CreateContainerSnapshotResponse, error) {
@@ -83,6 +85,14 @@ func (f *fakeSnapshotAPI) DeleteContainerSnapshot(req *pb.DeleteContainerSnapsho
 		return nil, f.err
 	}
 	return &pb.DeleteContainerSnapshotResponse{FreedBytes: 4096}, nil
+}
+
+func (f *fakeSnapshotAPI) RollbackContainerSnapshot(req *pb.RollbackContainerSnapshotRequest) (*pb.RollbackContainerSnapshotResponse, error) {
+	f.rolledBack = req
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.rollbackResp, nil
 }
 
 func (f *fakeSnapshotAPI) Close() error { return nil }
@@ -222,5 +232,81 @@ func TestHumanBytes(t *testing.T) {
 		if got := humanBytes(c.in); got != c.want {
 			t.Errorf("humanBytes(%d) = %q, want %q", c.in, got, c.want)
 		}
+	}
+}
+
+// Rollback CLI (#1160b). The flags gate a destructive operation, so what
+// matters is that they reach the daemon exactly as typed — a `--force` that
+// silently does not travel turns a refusal into a confusing one, and a
+// `--destroy-newer` that travels when unset destroys restore points nobody
+// agreed to lose.
+func TestSnapshotRollback_ForwardsTheDestructiveFlags(t *testing.T) {
+	cases := []struct {
+		name                      string
+		force, destroyNewer       bool
+		wantForce, wantDestroyNew bool
+	}{
+		{name: "neither"},
+		{name: "force only", force: true, wantForce: true},
+		{name: "destroy-newer only", destroyNewer: true, wantDestroyNew: true},
+		{name: "both", force: true, destroyNewer: true, wantForce: true, wantDestroyNew: true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			api := &fakeSnapshotAPI{rollbackResp: &pb.RollbackContainerSnapshotResponse{}}
+			withSnapshotAPI(t, api)
+			snapshotRollbackForce, snapshotRollbackDestroyNewer = c.force, c.destroyNewer
+			t.Cleanup(func() { snapshotRollbackForce, snapshotRollbackDestroyNewer = false, false })
+
+			captureStdout(t, func() {
+				if err := runSnapshotRollback(nil, []string{"alice", "nightly"}); err != nil {
+					t.Fatalf("runSnapshotRollback: %v", err)
+				}
+			})
+
+			if api.rolledBack.GetForce() != c.wantForce {
+				t.Errorf("force = %v, want %v", api.rolledBack.GetForce(), c.wantForce)
+			}
+			if api.rolledBack.GetDestroyNewer() != c.wantDestroyNew {
+				t.Errorf("destroy_newer = %v, want %v", api.rolledBack.GetDestroyNewer(), c.wantDestroyNew)
+			}
+		})
+	}
+}
+
+// Two things the operator must not have to discover for themselves: that the
+// container is down, and which restore points are gone.
+func TestSnapshotRollback_ReportsTheAftermath(t *testing.T) {
+	withSnapshotAPI(t, &fakeSnapshotAPI{rollbackResp: &pb.RollbackContainerSnapshotResponse{
+		ContainerStopped:   true,
+		DestroyedSnapshots: []string{"weekly", "monthly"},
+	}})
+
+	out := captureStdout(t, func() {
+		if err := runSnapshotRollback(nil, []string{"alice", "nightly"}); err != nil {
+			t.Fatalf("runSnapshotRollback: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "stopped") {
+		t.Errorf("the output does not say the container is down, so an operator would assume it "+
+			"came back up:\n%s", out)
+	}
+	for _, want := range []string{"weekly", "monthly"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("the destroyed snapshot %q is not named — nothing else records which restore "+
+				"points were lost:\n%s", want, out)
+		}
+	}
+}
+
+func TestSnapshotRollback_PropagatesTheRefusal(t *testing.T) {
+	withSnapshotAPI(t, &fakeSnapshotAPI{err: errors.New("container alice is running")})
+
+	if err := captureErr(t, func() error {
+		return runSnapshotRollback(nil, []string{"alice", "nightly"})
+	}); err == nil {
+		t.Fatal("a refused rollback exited 0, so a script would carry on as if the data had been " +
+			"restored")
 	}
 }

--- a/internal/server/container_rollback.go
+++ b/internal/server/container_rollback.go
@@ -1,0 +1,169 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/pkg/core/box"
+	"github.com/footprintai/containarium/pkg/core/zfscrypt"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// Container snapshot rollback (#1160b).
+//
+// `zfscrypt.RollbackToSnapshot` has existed since #1200 and is verified
+// against a real pool. What this adds is the three refusals that make a
+// destructive operation safe to expose over an API — and each of them is
+// checked BEFORE anything is destroyed, because a guard that reports an
+// error after rolling back is not a guard.
+//
+//  1. A running container. ZFS would refuse the busy dataset anyway, but
+//     "dataset is busy" sends an operator looking for a mount problem
+//     instead of telling them the one thing to do. With force, the daemon
+//     stops it first and leaves it stopped.
+//  2. Newer snapshots. Rolling back past them destroys them, which widens
+//     the blast radius from "lose writes since the snapshot" to "lose other
+//     restore points too". Opt-in, and the response names what went.
+//  3. An unavailable encryption key. A rollback whose result cannot be read
+//     is not a restore — the operator would believe they recovered data they
+//     cannot open. This is #1202's second acceptance criterion.
+
+// RollbackContainerSnapshot returns a container's dataset to the state
+// captured by a snapshot. Destructive: everything written since is discarded.
+func (s *ContainerServer) RollbackContainerSnapshot(ctx context.Context, req *pb.RollbackContainerSnapshotRequest) (*pb.RollbackContainerSnapshotResponse, error) {
+	ops, dataset, err := s.snapshotDatasetFor(ctx, req.GetUsername(), auth.ScopeContainersWrite)
+	if err != nil {
+		return nil, err
+	}
+	if req.GetName() == "" {
+		return nil, status.Error(codes.InvalidArgument,
+			"snapshot name is required; without one the reference would be a bare '@'")
+	}
+	snapshot := dataset + "@" + req.GetName()
+
+	// Guard 3 first, because it is the cheapest and the only one whose remedy
+	// lies outside this daemon: if key custody is down, stopping the container
+	// to satisfy guard 1 would be work spent on an operation that cannot
+	// succeed usefully anyway.
+	if err := ops.zfs.EnsureInspectable(ctx, snapshot); err != nil {
+		if errors.Is(err, zfscrypt.ErrKeyUnavailableForInspection) {
+			return nil, status.Errorf(codes.FailedPrecondition,
+				"refusing to roll %s back to %s: %v. The rollback itself would succeed, but the "+
+					"result would be ciphertext this daemon cannot open — restore key custody and "+
+					"retry, and the snapshot is unharmed in the meantime",
+				req.GetUsername(), req.GetName(), err)
+		}
+		return nil, status.Errorf(codes.FailedPrecondition,
+			"cannot determine whether %s can be read back, so refusing to roll it back: %v",
+			snapshot, err)
+	}
+
+	// Guard 1.
+	stopped, err := s.stopForRollback(ctx, req.GetUsername(), req.GetForce())
+	if err != nil {
+		return nil, err
+	}
+
+	// Read the snapshots that a -r rollback would take with it, BEFORE doing
+	// it — afterwards they are gone and nothing records which they were.
+	var doomed []string
+	if req.GetDestroyNewer() {
+		doomed = snapshotsAfter(ctx, ops, dataset, req.GetName())
+	}
+
+	// Guard 2 is ZFS's own refusal, translated. Its message does not say the
+	// fix is an explicit flag rather than a retry.
+	if err := ops.zfs.RollbackToSnapshot(ctx, snapshot, req.GetDestroyNewer()); err != nil {
+		if errors.Is(err, zfscrypt.ErrNewerSnapshotsExist) {
+			return nil, status.Errorf(codes.FailedPrecondition,
+				"refusing to roll %s back to %s: snapshots taken after it would have to be "+
+					"destroyed. Re-run with --destroy-newer to accept losing them. %v",
+				req.GetUsername(), req.GetName(), err)
+		}
+		return nil, status.Errorf(codes.FailedPrecondition, "%v", err)
+	}
+
+	msg := fmt.Sprintf("rolled %s back to snapshot %s; everything written since is gone",
+		req.GetUsername(), req.GetName())
+	if stopped {
+		// Left stopped deliberately: the data underneath just changed, and
+		// whether to bring the container up on it is the operator's call.
+		msg += ". The container was stopped to do this and has been left stopped"
+	}
+	if len(doomed) > 0 {
+		msg += fmt.Sprintf(". Destroyed %d newer snapshot(s): %s", len(doomed), strings.Join(doomed, ", "))
+	}
+	log.Printf("[snapshot] rollback %s -> %s (stopped=%v destroyed=%v)",
+		req.GetUsername(), snapshot, stopped, doomed)
+
+	return &pb.RollbackContainerSnapshotResponse{
+		Message:            msg,
+		ContainerStopped:   stopped,
+		DestroyedSnapshots: doomed,
+	}, nil
+}
+
+// stopForRollback enforces guard 1, reporting whether it stopped the
+// container.
+func (s *ContainerServer) stopForRollback(ctx context.Context, username string, force bool) (bool, error) {
+	ref := box.BoxRef{Tenant: username}
+	st, err := s.boxes().Get(ctx, ref)
+	if err != nil {
+		// "I could not tell" is not "it is safe". Rolling back a dataset that
+		// might be live is the one outcome this guard exists to prevent.
+		return false, status.Errorf(codes.FailedPrecondition,
+			"cannot determine whether %s is running, so refusing to roll it back: %v", username, err)
+	}
+	if st.State != pb.ContainerState_CONTAINER_STATE_RUNNING {
+		return false, nil
+	}
+
+	if !force {
+		return false, status.Errorf(codes.FailedPrecondition,
+			"container %s is running; roll back a stopped container, or pass --force to have the "+
+				"daemon stop it first. A rollback discards everything written since the snapshot, "+
+				"including whatever the running container has in flight", username)
+	}
+
+	// Before, not after: ZFS refuses a busy dataset, so a stop that came
+	// afterwards would fail on exactly the containers force exists for.
+	if err := s.boxes().Stop(ctx, ref, true); err != nil {
+		return false, status.Errorf(codes.FailedPrecondition,
+			"could not stop %s for the rollback, so nothing was rolled back: %v", username, err)
+	}
+	return true, nil
+}
+
+// snapshotsAfter lists the snapshots that come after target, which a -r
+// rollback destroys.
+//
+// Best-effort: this is for the record an operator reads afterwards, and
+// failing to build it is not a reason to refuse a rollback they explicitly
+// opted into. ListSnapshots returns oldest-first (`-s creation`), so
+// "after" is positional.
+func snapshotsAfter(ctx context.Context, ops *snapshotOps, dataset, target string) []string {
+	all, err := ops.zfs.ListSnapshots(ctx, dataset)
+	if err != nil {
+		return nil
+	}
+	var out []string
+	seen := false
+	for _, full := range all {
+		name := snapshotShortName(full)
+		if seen {
+			out = append(out, name)
+			continue
+		}
+		if name == target {
+			seen = true
+		}
+	}
+	return out
+}

--- a/internal/server/container_rollback_test.go
+++ b/internal/server/container_rollback_test.go
@@ -1,0 +1,341 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/pkg/core/box"
+	"github.com/footprintai/containarium/pkg/core/zfscrypt"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// Container snapshot rollback (#1160b).
+//
+// Rollback is destructive twice over: everything written since the snapshot
+// is discarded, and any snapshot taken after it has to be destroyed too. So
+// nearly all of this file is about what the RPC REFUSES, and each refusal is
+// asserted to have also not run the destructive command — a guard that
+// returns an error after already rolling back is not a guard.
+//
+// The third refusal is #1202's second acceptance criterion: rolling back a
+// container whose encryption key is unavailable produces a dataset nobody can
+// read. `zfscrypt.EnsureInspectable` gives that a specific error instead of
+// whatever ZFS says when a read hits an unkeyed dataset, which reads like
+// corruption and sends an operator hunting the wrong problem.
+
+// stubBoxes reports a fixed state and records whether Stop was called, so the
+// running-container guard can be tested without a container runtime.
+type stubBoxes struct {
+	box.BoxBackend
+	state    pb.ContainerState
+	getErr   error
+	stopped  []string
+	stopErr  error
+	stopSeen func()
+}
+
+func (s *stubBoxes) Get(_ context.Context, ref box.BoxRef) (*box.BoxStatus, error) {
+	if s.getErr != nil {
+		return nil, s.getErr
+	}
+	return &box.BoxStatus{Ref: ref, State: s.state}, nil
+}
+
+func (s *stubBoxes) Stop(_ context.Context, ref box.BoxRef, _ bool) error {
+	if s.stopSeen != nil {
+		s.stopSeen()
+	}
+	if s.stopErr != nil {
+		return s.stopErr
+	}
+	s.stopped = append(s.stopped, ref.Tenant)
+	return nil
+}
+
+// rollbackFixture wires a server whose snapshots run against a fake `zfs` and
+// whose box backend reports the given state.
+func rollbackFixture(t *testing.T, z *zfsFake, boxes *stubBoxes) *ContainerServer {
+	t.Helper()
+	return &ContainerServer{
+		boxBackend: boxes,
+		snapshots: &snapshotOps{
+			zfs: zfscrypt.NewManager(z),
+			datasetFor: func(containerName, pool string) (string, error) {
+				if pool == "" {
+					pool = "default"
+				}
+				return "tank/" + pool + "/containers/" + containerName, nil
+			},
+		},
+	}
+}
+
+// keyed makes the fake report a loaded key, so tests about the OTHER guards
+// are not silently passing because the key guard fired first.
+func keyed(z *zfsFake) *zfsFake {
+	z.stdout["get"] = string(zfscrypt.KeyAvailable)
+	return z
+}
+
+func stoppedBoxes() *stubBoxes {
+	return &stubBoxes{state: pb.ContainerState_CONTAINER_STATE_STOPPED}
+}
+
+func TestRollbackContainerSnapshot_RollsBackAStoppedContainer(t *testing.T) {
+	z := keyed(newZFSFake())
+	s := rollbackFixture(t, z, stoppedBoxes())
+
+	resp, err := s.RollbackContainerSnapshot(writeCtx("bob"),
+		&pb.RollbackContainerSnapshotRequest{Username: "bob", Name: "nightly"})
+	if err != nil {
+		t.Fatalf("RollbackContainerSnapshot: %v", err)
+	}
+	if !z.ran("rollback tank/default/containers/bob-container@nightly") {
+		t.Fatalf("zfs calls = %v, want a rollback of the container's dataset", z.calls)
+	}
+	if resp.GetContainerStopped() {
+		t.Error("reported stopping a container that was already stopped")
+	}
+}
+
+// Guard 1: a running container. ZFS would refuse the busy dataset anyway, but
+// "dataset is busy" sends an operator looking for a mount problem instead of
+// telling them the one thing they need to do.
+func TestRollbackContainerSnapshot_RefusesARunningContainerUnlessForced(t *testing.T) {
+	z := keyed(newZFSFake())
+	boxes := &stubBoxes{state: pb.ContainerState_CONTAINER_STATE_RUNNING}
+	s := rollbackFixture(t, z, boxes)
+
+	_, err := s.RollbackContainerSnapshot(writeCtx("bob"),
+		&pb.RollbackContainerSnapshotRequest{Username: "bob", Name: "nightly"})
+	if err == nil {
+		t.Fatal("rolled back a running container without --force")
+	}
+	if !strings.Contains(err.Error(), "running") || !strings.Contains(err.Error(), "force") {
+		t.Errorf("the refusal does not say what is wrong or how to proceed: %v", err)
+	}
+	if z.ran("rollback") {
+		t.Fatalf("the dataset was rolled back anyway — the guard returned an error AFTER "+
+			"destroying data; calls=%v", z.calls)
+	}
+	if len(boxes.stopped) != 0 {
+		t.Errorf("the container was stopped despite the refusal: %v", boxes.stopped)
+	}
+}
+
+// With force, the daemon stops it first — and must stop it BEFORE rolling
+// back, or ZFS refuses the busy dataset and force achieves nothing.
+func TestRollbackContainerSnapshot_ForceStopsBeforeRollingBack(t *testing.T) {
+	z := keyed(newZFSFake())
+	rolledBackFirst := false
+	boxes := &stubBoxes{state: pb.ContainerState_CONTAINER_STATE_RUNNING}
+	boxes.stopSeen = func() { rolledBackFirst = z.ran("rollback") }
+	s := rollbackFixture(t, z, boxes)
+
+	resp, err := s.RollbackContainerSnapshot(writeCtx("bob"),
+		&pb.RollbackContainerSnapshotRequest{Username: "bob", Name: "nightly", Force: true})
+	if err != nil {
+		t.Fatalf("forced rollback: %v", err)
+	}
+	if len(boxes.stopped) != 1 {
+		t.Fatalf("the container was not stopped: %v", boxes.stopped)
+	}
+	if rolledBackFirst {
+		t.Error("the rollback ran BEFORE the stop — ZFS refuses a busy dataset, so force would " +
+			"fail on exactly the containers it exists for")
+	}
+	if !z.ran("rollback") {
+		t.Fatalf("nothing was rolled back; calls=%v", z.calls)
+	}
+	// The caller has to know the container is down: its data just changed
+	// underneath, and restarting is their decision, not the daemon's.
+	if !resp.GetContainerStopped() {
+		t.Error("the response does not report that the container was stopped and left stopped")
+	}
+}
+
+// A container that cannot be inspected must not be rolled back on the
+// assumption that it is stopped. "I could not tell" is not "it is safe".
+func TestRollbackContainerSnapshot_RefusesWhenTheStateIsUnknown(t *testing.T) {
+	z := keyed(newZFSFake())
+	s := rollbackFixture(t, z, &stubBoxes{getErr: errors.New("incus unreachable")})
+
+	if _, err := s.RollbackContainerSnapshot(writeCtx("bob"),
+		&pb.RollbackContainerSnapshotRequest{Username: "bob", Name: "nightly"}); err == nil {
+		t.Fatal("rolled back a container whose state could not be read")
+	}
+	if z.ran("rollback") {
+		t.Errorf("the dataset was rolled back anyway; calls=%v", z.calls)
+	}
+}
+
+// Guard 2: newer snapshots. ZFS refuses, and the refusal has to be translated
+// — its own message does not say which restore points are at stake or that
+// the fix is an explicit flag rather than a retry.
+func TestRollbackContainerSnapshot_RefusesToDestroyNewerSnapshots(t *testing.T) {
+	z := keyed(newZFSFake())
+	z.errs["rollback"] = errors.New("exit status 1")
+	z.stderr["rollback"] = "cannot rollback to 'tank/x@nightly': more recent snapshots or bookmarks exist\nuse '-r' to force deletion of the following snapshots and bookmarks:\ntank/x@weekly"
+	s := rollbackFixture(t, z, stoppedBoxes())
+
+	_, err := s.RollbackContainerSnapshot(writeCtx("bob"),
+		&pb.RollbackContainerSnapshotRequest{Username: "bob", Name: "nightly"})
+	if err == nil {
+		t.Fatal("a refused rollback was reported as success")
+	}
+	// The operator needs to know what they would lose and how to say yes.
+	for _, want := range []string{"destroy-newer", "weekly"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the error is missing %q, so the operator can neither see the cost nor act "+
+				"on it: %v", want, err)
+		}
+	}
+	if !strings.Contains(z.calls[len(z.calls)-1], "rollback") || z.ran("rollback -r") {
+		t.Errorf("the refused attempt should not have passed -r; calls=%v", z.calls)
+	}
+}
+
+func TestRollbackContainerSnapshot_DestroyNewerPassesTheFlag(t *testing.T) {
+	z := keyed(newZFSFake())
+	// The snapshots that will be destroyed, so the response can name them.
+	delete(z.errs, "list")
+	z.stdout["list"] = "tank/default/containers/bob-container@nightly\n" +
+		"tank/default/containers/bob-container@weekly"
+	s := rollbackFixture(t, z, stoppedBoxes())
+
+	// The list has to be read BEFORE the rollback: afterwards those snapshots
+	// are gone and nothing records which they were. The fake replays a static
+	// listing, so only the ORDER can expose a read that came too late.
+	listedAfterRollback := false
+	z.onCall = func(sub string) {
+		if sub == "list" && z.ran("rollback") {
+			listedAfterRollback = true
+		}
+	}
+
+	resp, err := s.RollbackContainerSnapshot(writeCtx("bob"),
+		&pb.RollbackContainerSnapshotRequest{Username: "bob", Name: "nightly", DestroyNewer: true})
+	if err != nil {
+		t.Fatalf("rollback with destroy_newer: %v", err)
+	}
+	if listedAfterRollback {
+		t.Error("the snapshots about to be destroyed were listed AFTER the rollback destroyed " +
+			"them — on a real pool that list comes back empty and the operator is told nothing " +
+			"about the restore points they just lost")
+	}
+	if !z.ran("rollback -r tank/default/containers/bob-container@nightly") {
+		t.Fatalf("zfs calls = %v, want -r passed", z.calls)
+	}
+	// Naming them is the point: the operator has just lost restore points and
+	// nothing else records which.
+	if len(resp.GetDestroyedSnapshots()) != 1 || resp.GetDestroyedSnapshots()[0] != "weekly" {
+		t.Errorf("destroyed_snapshots = %v, want [weekly] — the restore points that no longer "+
+			"exist are otherwise unrecorded", resp.GetDestroyedSnapshots())
+	}
+}
+
+// Guard 3 — #1202's second acceptance criterion.
+//
+// Rolling back a dataset whose key is unavailable leaves the container's data
+// as ciphertext nobody can open. ZFS's own error for a read against an unkeyed
+// dataset reads like corruption; this one names key custody.
+func TestRollbackContainerSnapshot_RefusesWhenTheKeyIsUnavailable(t *testing.T) {
+	z := newZFSFake()
+	z.stdout["get"] = string(zfscrypt.KeyUnavailable)
+	s := rollbackFixture(t, z, stoppedBoxes())
+
+	_, err := s.RollbackContainerSnapshot(writeCtx("alice"),
+		&pb.RollbackContainerSnapshotRequest{Username: "alice", Name: "nightly"})
+	if err == nil {
+		t.Fatal("rolled back to a snapshot whose contents cannot be read — the operator would " +
+			"believe they restored data they cannot open")
+	}
+	if !errors.Is(err, zfscrypt.ErrKeyUnavailableForInspection) &&
+		!strings.Contains(err.Error(), "key") {
+		t.Errorf("the error does not name key custody, so it reads like corruption and sends the "+
+			"operator after the wrong problem: %v", err)
+	}
+	if got := status.Code(err); got != codes.FailedPrecondition {
+		t.Errorf("code = %v, want FailedPrecondition — this is a fixable precondition, not a "+
+			"malformed request", got)
+	}
+	if z.ran("rollback") {
+		t.Fatalf("the dataset was rolled back anyway; calls=%v", z.calls)
+	}
+}
+
+// The key guard must not fire on an UNENCRYPTED container: keystatus is "-"
+// for a dataset with no encryption, and treating that as "unavailable" would
+// block rollback for essentially every container on the platform.
+func TestRollbackContainerSnapshot_AllowsAnUnencryptedContainer(t *testing.T) {
+	z := newZFSFake()
+	z.stdout["get"] = "-"
+	s := rollbackFixture(t, z, stoppedBoxes())
+
+	if _, err := s.RollbackContainerSnapshot(writeCtx("bob"),
+		&pb.RollbackContainerSnapshotRequest{Username: "bob", Name: "nightly"}); err != nil {
+		t.Fatalf("an unencrypted container was refused: %v — keystatus is \"-\" when there is no "+
+			"encryption, and that is not an unavailable key", err)
+	}
+	if !z.ran("rollback") {
+		t.Errorf("nothing was rolled back; calls=%v", z.calls)
+	}
+}
+
+// --- authorization and validation ---------------------------------------
+
+func TestRollbackContainerSnapshot_RefusesAnotherTenant(t *testing.T) {
+	z := keyed(newZFSFake())
+	s := rollbackFixture(t, z, stoppedBoxes())
+
+	if _, err := s.RollbackContainerSnapshot(writeCtx("mallory"),
+		&pb.RollbackContainerSnapshotRequest{Username: "alice", Name: "x"}); err == nil {
+		t.Fatal("mallory rolled back alice's container")
+	}
+	if z.ran("rollback") {
+		t.Errorf("zfs was reached anyway; calls=%v", z.calls)
+	}
+}
+
+func TestRollbackContainerSnapshot_RequiresTheWriteScope(t *testing.T) {
+	z := keyed(newZFSFake())
+	s := rollbackFixture(t, z, stoppedBoxes())
+
+	if _, err := s.RollbackContainerSnapshot(
+		tenantWithScopes("bob", auth.ScopeContainersRead),
+		&pb.RollbackContainerSnapshotRequest{Username: "bob", Name: "x"}); err == nil {
+		t.Fatal("a containers:read token performed a destructive rollback")
+	}
+}
+
+func TestRollbackContainerSnapshot_RequiresASnapshotName(t *testing.T) {
+	z := keyed(newZFSFake())
+	s := rollbackFixture(t, z, stoppedBoxes())
+
+	_, err := s.RollbackContainerSnapshot(writeCtx("bob"),
+		&pb.RollbackContainerSnapshotRequest{Username: "bob"})
+	if err == nil {
+		t.Fatal("an empty snapshot name was accepted — the reference would be a bare '@'")
+	}
+	if got := status.Code(err); got != codes.InvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", got)
+	}
+}
+
+func TestRollbackContainerSnapshot_UnconfiguredSaysSo(t *testing.T) {
+	s := &ContainerServer{}
+	_, err := s.RollbackContainerSnapshot(writeCtx("bob"),
+		&pb.RollbackContainerSnapshotRequest{Username: "bob", Name: "x"})
+	if err == nil {
+		t.Fatal("a daemon with no snapshot support claimed to have rolled back")
+	}
+	if got := status.Code(err); got != codes.FailedPrecondition {
+		t.Errorf("code = %v, want FailedPrecondition", got)
+	}
+}

--- a/internal/server/encrypted_create_integration_test.go
+++ b/internal/server/encrypted_create_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -455,4 +456,107 @@ func TestIntegrationIncus_SnapshotsAnEncryptedContainerWithTheKeyUnloaded(t *tes
 		}
 	}
 	t.Logf("snapshot lifecycle works on %s with the key unloaded; remaining: %v", dataset, after)
+}
+
+// Rollback against a real encrypted container (#1160b).
+//
+// Two claims the unit tests cannot make, because both are properties of ZFS
+// rather than of the daemon:
+//
+//  1. A rollback actually restores the data. The fake asserts that `zfs
+//     rollback` was invoked; only a real pool can show that a file written
+//     after the snapshot is gone afterwards, and one written before survives.
+//  2. The key guard fires on a genuinely unkeyed dataset. The unit test feeds
+//     the fake a canned "unavailable"; here the key is really unloaded, so
+//     the guard is proven against ZFS's real keystatus rather than against a
+//     string this test chose.
+func TestIntegrationIncus_RollbackRestoresDataAndRefusesWithoutTheKey(t *testing.T) {
+	s, _, tenantRoot := encTestEnv(t)
+	zfs := zfscrypt.NewManager(zfscrypt.ExecRunner{})
+	ctx := context.Background()
+
+	tenant := fmt.Sprintf("rbk%d", os.Getpid())
+	t.Cleanup(func() { _ = zfs.Destroy(context.Background(), tenantRoot+"/"+tenant) })
+
+	instance := createEncrypted(t, s, tenant)
+	root := tenantRoot + "/" + tenant
+	rbCtx := tenantWithScopes(tenant, auth.ScopeContainersRead, auth.ScopeContainersWrite)
+
+	exec, ok := s.boxes().(box.ExecCapable)
+	if !ok {
+		t.Fatalf("the box backend cannot exec, so this test cannot show that rollback restores " +
+			"anything; it would degrade to asserting that a command ran")
+	}
+	run := func(what string, cmd ...string) string {
+		t.Helper()
+		stdout, stderr, err := exec.Exec(ctx, box.BoxRef{Tenant: tenant}, cmd)
+		if err != nil {
+			t.Fatalf("%s: %v (stderr: %s)", what, err, stderr)
+		}
+		return stdout
+	}
+
+	// A file that exists at snapshot time, and must survive the rollback.
+	run("seed the container", "sh", "-c", "echo before > /root/marker")
+	if _, err := s.CreateContainerSnapshot(rbCtx, &pb.CreateContainerSnapshotRequest{
+		Username: tenant, Name: "restorepoint",
+	}); err != nil {
+		t.Fatalf("CreateContainerSnapshot: %v", err)
+	}
+	// ...and a change made after it, which must not.
+	run("dirty the container", "sh", "-c", "echo after > /root/marker")
+
+	// Guard 1, against a really-running container.
+	if _, err := s.RollbackContainerSnapshot(rbCtx, &pb.RollbackContainerSnapshotRequest{
+		Username: tenant, Name: "restorepoint",
+	}); err == nil {
+		t.Fatal("rolled back a running container without force — ZFS refuses a busy dataset, so " +
+			"this either failed obscurely or operated on something that was not mounted")
+	}
+
+	// Forced: the daemon stops it, rolls back, and leaves it stopped.
+	resp, ferr := s.RollbackContainerSnapshot(rbCtx, &pb.RollbackContainerSnapshotRequest{
+		Username: tenant, Name: "restorepoint", Force: true,
+	})
+	if ferr != nil {
+		t.Fatalf("forced rollback: %v", ferr)
+	}
+	if !resp.GetContainerStopped() {
+		t.Error("the response does not report stopping a container that was running")
+	}
+
+	// The data claim. Start it again and read the marker back.
+	if err := s.boxes().Start(ctx, box.BoxRef{Tenant: tenant}); err != nil {
+		t.Fatalf("restarting %s after the rollback: %v", instance, err)
+	}
+	out := run("read the marker back", "cat", "/root/marker")
+	if strings.TrimSpace(out) != "before" {
+		t.Fatalf("marker = %q after rolling back, want %q — the rollback ran without restoring "+
+			"anything, which is the outcome an operator would discover during an incident",
+			strings.TrimSpace(out), "before")
+	}
+
+	// Guard 3, against a genuinely unloaded key rather than a canned string.
+	if err := s.boxes().Stop(ctx, box.BoxRef{Tenant: tenant}, true); err != nil {
+		t.Fatalf("stopping %s: %v", instance, err)
+	}
+	s.encryption.PostStop(ctx, instance)
+	if st, err := zfs.KeyStatus(ctx, root); err != nil {
+		t.Fatalf("KeyStatus(%s): %v", root, err)
+	} else if st != zfscrypt.KeyUnavailable {
+		t.Fatalf("precondition: keystatus is %q, want %q — the guard below would prove nothing",
+			st, zfscrypt.KeyUnavailable)
+	}
+
+	_, err := s.RollbackContainerSnapshot(rbCtx, &pb.RollbackContainerSnapshotRequest{
+		Username: tenant, Name: "restorepoint",
+	})
+	if err == nil {
+		t.Fatal("rolled back to a snapshot the daemon cannot read — the operator would believe " +
+			"they had restored data that is ciphertext to them")
+	}
+	if !strings.Contains(err.Error(), "key") {
+		t.Errorf("the refusal does not name key custody, so it reads like corruption: %v", err)
+	}
+	t.Logf("rollback restored the data, and is refused with the key unloaded: %v", err)
 }

--- a/internal/server/encryption_hooks_test.go
+++ b/internal/server/encryption_hooks_test.go
@@ -164,6 +164,11 @@ type zfsFake struct {
 	stdout map[string]string
 	errs   map[string]error
 	stderr map[string]string
+	// onCall fires with the subcommand before each call is answered, so a
+	// test can observe what had already happened at that point. Ordering
+	// assertions need it: a flag the fake sets unconditionally is true
+	// either way round and proves nothing.
+	onCall func(sub string)
 }
 
 func newZFSFake() *zfsFake {
@@ -188,11 +193,14 @@ func (z *zfsFake) datasetPresent(encryptionRoot string) {
 }
 
 func (z *zfsFake) Run(_ context.Context, _ []byte, args ...string) (string, string, error) {
-	z.calls = append(z.calls, strings.Join(args, " "))
 	sub := ""
 	if len(args) > 0 {
 		sub = args[0]
 	}
+	if z.onCall != nil {
+		z.onCall(sub)
+	}
+	z.calls = append(z.calls, strings.Join(args, " "))
 	return z.stdout[sub], z.stderr[sub], z.errs[sub]
 }
 

--- a/pkg/core/zfscrypt/snapshot.go
+++ b/pkg/core/zfscrypt/snapshot.go
@@ -2,6 +2,7 @@ package zfscrypt
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -117,6 +118,14 @@ func (m *Manager) EnsureInspectable(ctx context.Context, snapshot string) error 
 
 	status, err := m.KeyStatus(ctx, dataset)
 	if err != nil {
+		// An unencrypted snapshot's contents are readable, which is the
+		// question this function asks — so that is a pass, not a failure.
+		// Returning the error here would refuse inspection of every
+		// unencrypted container on the platform, which is nearly all of
+		// them.
+		if errors.Is(err, ErrNotEncrypted) {
+			return nil
+		}
 		return err
 	}
 	if status != KeyAvailable {

--- a/pkg/core/zfscrypt/snapshot_test.go
+++ b/pkg/core/zfscrypt/snapshot_test.go
@@ -206,3 +206,47 @@ func TestSnapshotUsageRejectsUnparseableOutput(t *testing.T) {
 		t.Error("accepted human-readable sizes as byte counts")
 	}
 }
+
+// An UNENCRYPTED snapshot's contents are readable, so inspecting one must
+// pass (#1160b).
+//
+// This is not hypothetical tidying. EnsureInspectable propagated KeyStatus's
+// error verbatim, and KeyStatus errors on an unencrypted dataset — so the
+// guard would have refused inspection and rollback for essentially every
+// container on the platform, while the tests above (which only ever supply an
+// encrypted dataset) stayed green.
+func TestEnsureInspectablePassesForAnUnencryptedDataset(t *testing.T) {
+	f := newFakeRunner()
+	f.stdout["get"] = "-" // what ZFS reports for a dataset with no encryption
+	if err := NewManager(f).EnsureInspectable(context.Background(), "pool/c/bob@snap"); err != nil {
+		t.Fatalf("EnsureInspectable on an unencrypted dataset = %v, want nil — its contents can "+
+			"be read, which is the question this asks", err)
+	}
+}
+
+// "zfs did not answer" is not "there is no key here". A guard that treats
+// them alike either blocks the fleet or fails open on a broken pool.
+func TestEnsureInspectableStillFailsWhenZFSCannotAnswer(t *testing.T) {
+	f := newFakeRunner()
+	f.errs["get"] = errors.New("exit status 1")
+	f.stderr["get"] = "cannot open 'pool/c/bob': dataset does not exist"
+
+	err := NewManager(f).EnsureInspectable(context.Background(), "pool/c/bob@snap")
+	if err == nil {
+		t.Fatal("an unreadable keystatus was reported as inspectable")
+	}
+	if errors.Is(err, ErrNotEncrypted) {
+		t.Errorf("a zfs failure was classified as 'not encrypted': %v", err)
+	}
+}
+
+func TestKeyStatusMarksAnUnencryptedDatasetDistinctly(t *testing.T) {
+	f := newFakeRunner()
+	f.stdout["get"] = "-"
+
+	_, err := NewManager(f).KeyStatus(context.Background(), "pool/c/bob")
+	if !errors.Is(err, ErrNotEncrypted) {
+		t.Fatalf("err = %v, want ErrNotEncrypted — callers distinguish this from a real failure, "+
+			"and matching on the message instead is what the sentinel exists to avoid", err)
+	}
+}

--- a/pkg/core/zfscrypt/zfscrypt.go
+++ b/pkg/core/zfscrypt/zfscrypt.go
@@ -258,6 +258,16 @@ func isKeyInUse(stderr string) bool {
 	return strings.Contains(s, "busy") || strings.Contains(s, "in use")
 }
 
+// ErrNotEncrypted reports that a dataset carries no encryption at all.
+//
+// A sentinel rather than a message, because it is the one "error" that is
+// often the right answer. Most containers on this platform are unencrypted,
+// so a caller asking a key question about one has to tell "there is no key
+// here" apart from "the key is missing" and from "zfs did not answer" — a
+// guard that cannot tell them apart either blocks the whole fleet or fails
+// open on a broken pool.
+var ErrNotEncrypted = fmt.Errorf("dataset is not encrypted")
+
 // KeyStatus reports whether the dataset's key is currently loaded.
 func (m *Manager) KeyStatus(ctx context.Context, dataset string) (KeyStatus, error) {
 	if err := validateDataset(dataset); err != nil {
@@ -273,11 +283,13 @@ func (m *Manager) KeyStatus(ctx context.Context, dataset string) (KeyStatus, err
 	case string(KeyUnavailable):
 		return KeyUnavailable, nil
 	case "", "-":
-		// An unencrypted dataset reports "-". Treated as an error
-		// rather than as "unavailable": the caller asked about an
-		// encrypted dataset and got one that is not, which means the
-		// two sides disagree about what this container is.
-		return "", fmt.Errorf("dataset %s is not encrypted (keystatus %q)", dataset, v)
+		// An unencrypted dataset reports "-". Still an error, because the
+		// caller asked a key question about a dataset that has no key —
+		// the two sides disagree about what this container is. But it is a
+		// DISTINGUISHABLE error: some callers (EnsureInspectable) have a
+		// correct answer for an unencrypted dataset, and must not confuse
+		// "there is no key to be missing" with "zfs did not answer".
+		return "", fmt.Errorf("dataset %s: %w (keystatus %q)", dataset, ErrNotEncrypted, v)
 	default:
 		return "", fmt.Errorf("unexpected keystatus %q for %s", v, dataset)
 	}
@@ -296,7 +308,7 @@ func (m *Manager) EncryptionRoot(ctx context.Context, dataset string) (string, e
 	}
 	root := strings.TrimSpace(stdout)
 	if root == "" || root == "-" {
-		return "", fmt.Errorf("dataset %s has no encryptionroot (it is not encrypted)", dataset)
+		return "", fmt.Errorf("dataset %s has no encryptionroot: %w", dataset, ErrNotEncrypted)
 	}
 	return root, nil
 }

--- a/pkg/pb/containarium/v1/container.pb.go
+++ b/pkg/pb/containarium/v1/container.pb.go
@@ -5304,6 +5304,152 @@ func (x *DeleteContainerSnapshotResponse) GetFreedBytes() int64 {
 	return 0
 }
 
+// RollbackContainerSnapshotRequest returns a container's dataset to the state
+// captured by a snapshot.
+//
+// Destructive twice over: everything written since the snapshot is discarded,
+// and any snapshot taken after it must be destroyed too. Both are refusals by
+// default (#1160b).
+type RollbackContainerSnapshotRequest struct {
+	state    protoimpl.MessageState `protogen:"open.v1"`
+	Username string                 `protobuf:"bytes,1,opt,name=username,proto3" json:"username,omitempty"`
+	// The snapshot to roll back to.
+	Name string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	// Stop the container first. Without it, a rollback of a running container
+	// is refused: ZFS would fail on the busy dataset anyway, and "dataset is
+	// busy" is a far worse message than "stop the container first".
+	Force bool `protobuf:"varint,3,opt,name=force,proto3" json:"force,omitempty"`
+	// Destroy snapshots taken after the target, which ZFS requires in order to
+	// roll back past them. Opt-in because it silently widens the blast radius
+	// from "lose writes since the snapshot" to "lose other restore points too".
+	DestroyNewer  bool `protobuf:"varint,4,opt,name=destroy_newer,json=destroyNewer,proto3" json:"destroy_newer,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RollbackContainerSnapshotRequest) Reset() {
+	*x = RollbackContainerSnapshotRequest{}
+	mi := &file_containarium_v1_container_proto_msgTypes[67]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RollbackContainerSnapshotRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RollbackContainerSnapshotRequest) ProtoMessage() {}
+
+func (x *RollbackContainerSnapshotRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_container_proto_msgTypes[67]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RollbackContainerSnapshotRequest.ProtoReflect.Descriptor instead.
+func (*RollbackContainerSnapshotRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{67}
+}
+
+func (x *RollbackContainerSnapshotRequest) GetUsername() string {
+	if x != nil {
+		return x.Username
+	}
+	return ""
+}
+
+func (x *RollbackContainerSnapshotRequest) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *RollbackContainerSnapshotRequest) GetForce() bool {
+	if x != nil {
+		return x.Force
+	}
+	return false
+}
+
+func (x *RollbackContainerSnapshotRequest) GetDestroyNewer() bool {
+	if x != nil {
+		return x.DestroyNewer
+	}
+	return false
+}
+
+type RollbackContainerSnapshotResponse struct {
+	state   protoimpl.MessageState `protogen:"open.v1"`
+	Message string                 `protobuf:"bytes,1,opt,name=message,proto3" json:"message,omitempty"`
+	// Whether the daemon stopped the container to perform the rollback. It is
+	// left stopped — restarting it is the caller's decision, since the data
+	// underneath just changed.
+	ContainerStopped bool `protobuf:"varint,2,opt,name=container_stopped,json=containerStopped,proto3" json:"container_stopped,omitempty"`
+	// Snapshots destroyed to make the rollback possible, so the caller has a
+	// record of the restore points they no longer have.
+	DestroyedSnapshots []string `protobuf:"bytes,3,rep,name=destroyed_snapshots,json=destroyedSnapshots,proto3" json:"destroyed_snapshots,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *RollbackContainerSnapshotResponse) Reset() {
+	*x = RollbackContainerSnapshotResponse{}
+	mi := &file_containarium_v1_container_proto_msgTypes[68]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RollbackContainerSnapshotResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RollbackContainerSnapshotResponse) ProtoMessage() {}
+
+func (x *RollbackContainerSnapshotResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_container_proto_msgTypes[68]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RollbackContainerSnapshotResponse.ProtoReflect.Descriptor instead.
+func (*RollbackContainerSnapshotResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{68}
+}
+
+func (x *RollbackContainerSnapshotResponse) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+func (x *RollbackContainerSnapshotResponse) GetContainerStopped() bool {
+	if x != nil {
+		return x.ContainerStopped
+	}
+	return false
+}
+
+func (x *RollbackContainerSnapshotResponse) GetDestroyedSnapshots() []string {
+	if x != nil {
+		return x.DestroyedSnapshots
+	}
+	return nil
+}
+
 // DeleteTenantStorageRequest tears down a departing tenant's encrypted
 // storage (#1343): the Incus storage pool, and the encrypted dataset it is
 // sourced at.
@@ -5320,7 +5466,7 @@ type DeleteTenantStorageRequest struct {
 
 func (x *DeleteTenantStorageRequest) Reset() {
 	*x = DeleteTenantStorageRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[67]
+	mi := &file_containarium_v1_container_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5332,7 +5478,7 @@ func (x *DeleteTenantStorageRequest) String() string {
 func (*DeleteTenantStorageRequest) ProtoMessage() {}
 
 func (x *DeleteTenantStorageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[67]
+	mi := &file_containarium_v1_container_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5345,7 +5491,7 @@ func (x *DeleteTenantStorageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteTenantStorageRequest.ProtoReflect.Descriptor instead.
 func (*DeleteTenantStorageRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{67}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *DeleteTenantStorageRequest) GetTenant() string {
@@ -5372,7 +5518,7 @@ type DeleteTenantStorageResponse struct {
 
 func (x *DeleteTenantStorageResponse) Reset() {
 	*x = DeleteTenantStorageResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[68]
+	mi := &file_containarium_v1_container_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5384,7 +5530,7 @@ func (x *DeleteTenantStorageResponse) String() string {
 func (*DeleteTenantStorageResponse) ProtoMessage() {}
 
 func (x *DeleteTenantStorageResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[68]
+	mi := &file_containarium_v1_container_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5397,7 +5543,7 @@ func (x *DeleteTenantStorageResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteTenantStorageResponse.ProtoReflect.Descriptor instead.
 func (*DeleteTenantStorageResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{68}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *DeleteTenantStorageResponse) GetMessage() string {
@@ -5447,7 +5593,7 @@ type RewrapContainerRequest struct {
 
 func (x *RewrapContainerRequest) Reset() {
 	*x = RewrapContainerRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[69]
+	mi := &file_containarium_v1_container_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5459,7 +5605,7 @@ func (x *RewrapContainerRequest) String() string {
 func (*RewrapContainerRequest) ProtoMessage() {}
 
 func (x *RewrapContainerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[69]
+	mi := &file_containarium_v1_container_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5472,7 +5618,7 @@ func (x *RewrapContainerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RewrapContainerRequest.ProtoReflect.Descriptor instead.
 func (*RewrapContainerRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{69}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *RewrapContainerRequest) GetUsername() string {
@@ -5506,7 +5652,7 @@ type RewrapContainerResponse struct {
 
 func (x *RewrapContainerResponse) Reset() {
 	*x = RewrapContainerResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[70]
+	mi := &file_containarium_v1_container_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5518,7 +5664,7 @@ func (x *RewrapContainerResponse) String() string {
 func (*RewrapContainerResponse) ProtoMessage() {}
 
 func (x *RewrapContainerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[70]
+	mi := &file_containarium_v1_container_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5531,7 +5677,7 @@ func (x *RewrapContainerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RewrapContainerResponse.ProtoReflect.Descriptor instead.
 func (*RewrapContainerResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{70}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *RewrapContainerResponse) GetMessage() string {
@@ -5580,7 +5726,7 @@ type PrepareEncryptedMigrationRequest struct {
 
 func (x *PrepareEncryptedMigrationRequest) Reset() {
 	*x = PrepareEncryptedMigrationRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[71]
+	mi := &file_containarium_v1_container_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5592,7 +5738,7 @@ func (x *PrepareEncryptedMigrationRequest) String() string {
 func (*PrepareEncryptedMigrationRequest) ProtoMessage() {}
 
 func (x *PrepareEncryptedMigrationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[71]
+	mi := &file_containarium_v1_container_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5605,7 +5751,7 @@ func (x *PrepareEncryptedMigrationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PrepareEncryptedMigrationRequest.ProtoReflect.Descriptor instead.
 func (*PrepareEncryptedMigrationRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{71}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *PrepareEncryptedMigrationRequest) GetUsername() string {
@@ -5651,7 +5797,7 @@ type PrepareEncryptedMigrationResponse struct {
 
 func (x *PrepareEncryptedMigrationResponse) Reset() {
 	*x = PrepareEncryptedMigrationResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[72]
+	mi := &file_containarium_v1_container_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5663,7 +5809,7 @@ func (x *PrepareEncryptedMigrationResponse) String() string {
 func (*PrepareEncryptedMigrationResponse) ProtoMessage() {}
 
 func (x *PrepareEncryptedMigrationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[72]
+	mi := &file_containarium_v1_container_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5676,7 +5822,7 @@ func (x *PrepareEncryptedMigrationResponse) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use PrepareEncryptedMigrationResponse.ProtoReflect.Descriptor instead.
 func (*PrepareEncryptedMigrationResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{72}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *PrepareEncryptedMigrationResponse) GetCanResolve() bool {
@@ -5715,7 +5861,7 @@ type AdoptMigratedContainerResponse struct {
 
 func (x *AdoptMigratedContainerResponse) Reset() {
 	*x = AdoptMigratedContainerResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[73]
+	mi := &file_containarium_v1_container_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5727,7 +5873,7 @@ func (x *AdoptMigratedContainerResponse) String() string {
 func (*AdoptMigratedContainerResponse) ProtoMessage() {}
 
 func (x *AdoptMigratedContainerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[73]
+	mi := &file_containarium_v1_container_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5740,7 +5886,7 @@ func (x *AdoptMigratedContainerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdoptMigratedContainerResponse.ProtoReflect.Descriptor instead.
 func (*AdoptMigratedContainerResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{73}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *AdoptMigratedContainerResponse) GetMessage() string {
@@ -6136,7 +6282,16 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\x1fDeleteContainerSnapshotResponse\x12\x18\n" +
 	"\amessage\x18\x01 \x01(\tR\amessage\x12\x1f\n" +
 	"\vfreed_bytes\x18\x02 \x01(\x03R\n" +
-	"freedBytes\"4\n" +
+	"freedBytes\"\x8d\x01\n" +
+	" RollbackContainerSnapshotRequest\x12\x1a\n" +
+	"\busername\x18\x01 \x01(\tR\busername\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x12\x14\n" +
+	"\x05force\x18\x03 \x01(\bR\x05force\x12#\n" +
+	"\rdestroy_newer\x18\x04 \x01(\bR\fdestroyNewer\"\x9b\x01\n" +
+	"!RollbackContainerSnapshotResponse\x12\x18\n" +
+	"\amessage\x18\x01 \x01(\tR\amessage\x12+\n" +
+	"\x11container_stopped\x18\x02 \x01(\bR\x10containerStopped\x12/\n" +
+	"\x13destroyed_snapshots\x18\x03 \x03(\tR\x12destroyedSnapshots\"4\n" +
 	"\x1aDeleteTenantStorageRequest\x12\x16\n" +
 	"\x06tenant\x18\x01 \x01(\tR\x06tenant\"t\n" +
 	"\x1bDeleteTenantStorageResponse\x12\x18\n" +
@@ -6214,7 +6369,7 @@ func file_containarium_v1_container_proto_rawDescGZIP() []byte {
 }
 
 var file_containarium_v1_container_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
-var file_containarium_v1_container_proto_msgTypes = make([]protoimpl.MessageInfo, 80)
+var file_containarium_v1_container_proto_msgTypes = make([]protoimpl.MessageInfo, 82)
 var file_containarium_v1_container_proto_goTypes = []any{
 	(OSType)(0),                               // 0: containarium.v1.OSType
 	(AccessType)(0),                           // 1: containarium.v1.AccessType
@@ -6290,50 +6445,52 @@ var file_containarium_v1_container_proto_goTypes = []any{
 	(*ListContainerSnapshotsResponse)(nil),    // 71: containarium.v1.ListContainerSnapshotsResponse
 	(*DeleteContainerSnapshotRequest)(nil),    // 72: containarium.v1.DeleteContainerSnapshotRequest
 	(*DeleteContainerSnapshotResponse)(nil),   // 73: containarium.v1.DeleteContainerSnapshotResponse
-	(*DeleteTenantStorageRequest)(nil),        // 74: containarium.v1.DeleteTenantStorageRequest
-	(*DeleteTenantStorageResponse)(nil),       // 75: containarium.v1.DeleteTenantStorageResponse
-	(*RewrapContainerRequest)(nil),            // 76: containarium.v1.RewrapContainerRequest
-	(*RewrapContainerResponse)(nil),           // 77: containarium.v1.RewrapContainerResponse
-	(*PrepareEncryptedMigrationRequest)(nil),  // 78: containarium.v1.PrepareEncryptedMigrationRequest
-	(*PrepareEncryptedMigrationResponse)(nil), // 79: containarium.v1.PrepareEncryptedMigrationResponse
-	(*AdoptMigratedContainerResponse)(nil),    // 80: containarium.v1.AdoptMigratedContainerResponse
-	nil,                                       // 81: containarium.v1.Container.LabelsEntry
-	nil,                                       // 82: containarium.v1.CreateContainerRequest.LabelsEntry
-	nil,                                       // 83: containarium.v1.CreateContainerRequest.StackParametersEntry
-	nil,                                       // 84: containarium.v1.ListContainersRequest.LabelFilterEntry
-	nil,                                       // 85: containarium.v1.SetContainerAttributionRequest.LabelsEntry
-	nil,                                       // 86: containarium.v1.SetContainerAttributionResponse.LabelsEntry
-	(*timestamppb.Timestamp)(nil),             // 87: google.protobuf.Timestamp
-	(*descriptorpb.EnumValueOptions)(nil),     // 88: google.protobuf.EnumValueOptions
+	(*RollbackContainerSnapshotRequest)(nil),  // 74: containarium.v1.RollbackContainerSnapshotRequest
+	(*RollbackContainerSnapshotResponse)(nil), // 75: containarium.v1.RollbackContainerSnapshotResponse
+	(*DeleteTenantStorageRequest)(nil),        // 76: containarium.v1.DeleteTenantStorageRequest
+	(*DeleteTenantStorageResponse)(nil),       // 77: containarium.v1.DeleteTenantStorageResponse
+	(*RewrapContainerRequest)(nil),            // 78: containarium.v1.RewrapContainerRequest
+	(*RewrapContainerResponse)(nil),           // 79: containarium.v1.RewrapContainerResponse
+	(*PrepareEncryptedMigrationRequest)(nil),  // 80: containarium.v1.PrepareEncryptedMigrationRequest
+	(*PrepareEncryptedMigrationResponse)(nil), // 81: containarium.v1.PrepareEncryptedMigrationResponse
+	(*AdoptMigratedContainerResponse)(nil),    // 82: containarium.v1.AdoptMigratedContainerResponse
+	nil,                                       // 83: containarium.v1.Container.LabelsEntry
+	nil,                                       // 84: containarium.v1.CreateContainerRequest.LabelsEntry
+	nil,                                       // 85: containarium.v1.CreateContainerRequest.StackParametersEntry
+	nil,                                       // 86: containarium.v1.ListContainersRequest.LabelFilterEntry
+	nil,                                       // 87: containarium.v1.SetContainerAttributionRequest.LabelsEntry
+	nil,                                       // 88: containarium.v1.SetContainerAttributionResponse.LabelsEntry
+	(*timestamppb.Timestamp)(nil),             // 89: google.protobuf.Timestamp
+	(*descriptorpb.EnumValueOptions)(nil),     // 90: google.protobuf.EnumValueOptions
 }
 var file_containarium_v1_container_proto_depIdxs = []int32{
 	2,  // 0: containarium.v1.Container.state:type_name -> containarium.v1.ContainerState
 	7,  // 1: containarium.v1.Container.resources:type_name -> containarium.v1.ResourceLimits
 	8,  // 2: containarium.v1.Container.network:type_name -> containarium.v1.NetworkInfo
-	81, // 3: containarium.v1.Container.labels:type_name -> containarium.v1.Container.LabelsEntry
+	83, // 3: containarium.v1.Container.labels:type_name -> containarium.v1.Container.LabelsEntry
 	0,  // 4: containarium.v1.Container.os_type:type_name -> containarium.v1.OSType
 	1,  // 5: containarium.v1.Container.access_type:type_name -> containarium.v1.AccessType
-	87, // 6: containarium.v1.Container.ttl_expires_at:type_name -> google.protobuf.Timestamp
-	87, // 7: containarium.v1.Container.stopped_at:type_name -> google.protobuf.Timestamp
+	89, // 6: containarium.v1.Container.ttl_expires_at:type_name -> google.protobuf.Timestamp
+	89, // 7: containarium.v1.Container.stopped_at:type_name -> google.protobuf.Timestamp
 	3,  // 8: containarium.v1.Container.delete_policy:type_name -> containarium.v1.DeletePolicy
 	4,  // 9: containarium.v1.Container.encryption_state:type_name -> containarium.v1.EncryptionState
 	7,  // 10: containarium.v1.CreateContainerRequest.resources:type_name -> containarium.v1.ResourceLimits
-	82, // 11: containarium.v1.CreateContainerRequest.labels:type_name -> containarium.v1.CreateContainerRequest.LabelsEntry
+	84, // 11: containarium.v1.CreateContainerRequest.labels:type_name -> containarium.v1.CreateContainerRequest.LabelsEntry
 	0,  // 12: containarium.v1.CreateContainerRequest.os_type:type_name -> containarium.v1.OSType
-	83, // 13: containarium.v1.CreateContainerRequest.stack_parameters:type_name -> containarium.v1.CreateContainerRequest.StackParametersEntry
+	85, // 13: containarium.v1.CreateContainerRequest.stack_parameters:type_name -> containarium.v1.CreateContainerRequest.StackParametersEntry
 	9,  // 14: containarium.v1.CreateContainerResponse.container:type_name -> containarium.v1.Container
 	2,  // 15: containarium.v1.ListContainersRequest.state:type_name -> containarium.v1.ContainerState
-	84, // 16: containarium.v1.ListContainersRequest.label_filter:type_name -> containarium.v1.ListContainersRequest.LabelFilterEntry
+	86, // 16: containarium.v1.ListContainersRequest.label_filter:type_name -> containarium.v1.ListContainersRequest.LabelFilterEntry
 	9,  // 17: containarium.v1.ListContainersResponse.containers:type_name -> containarium.v1.Container
 	9,  // 18: containarium.v1.GetContainerResponse.container:type_name -> containarium.v1.Container
 	10, // 19: containarium.v1.GetContainerResponse.metrics:type_name -> containarium.v1.ContainerMetrics
 	9,  // 20: containarium.v1.StartContainerResponse.container:type_name -> containarium.v1.Container
 	9,  // 21: containarium.v1.StopContainerResponse.container:type_name -> containarium.v1.Container
-	87, // 22: containarium.v1.SetContainerTTLResponse.ttl_expires_at:type_name -> google.protobuf.Timestamp
+	89, // 22: containarium.v1.SetContainerTTLResponse.ttl_expires_at:type_name -> google.protobuf.Timestamp
 	3,  // 23: containarium.v1.SetContainerDeletePolicyRequest.delete_policy:type_name -> containarium.v1.DeletePolicy
 	3,  // 24: containarium.v1.SetContainerDeletePolicyResponse.delete_policy:type_name -> containarium.v1.DeletePolicy
-	85, // 25: containarium.v1.SetContainerAttributionRequest.labels:type_name -> containarium.v1.SetContainerAttributionRequest.LabelsEntry
-	86, // 26: containarium.v1.SetContainerAttributionResponse.labels:type_name -> containarium.v1.SetContainerAttributionResponse.LabelsEntry
+	87, // 25: containarium.v1.SetContainerAttributionRequest.labels:type_name -> containarium.v1.SetContainerAttributionRequest.LabelsEntry
+	88, // 26: containarium.v1.SetContainerAttributionResponse.labels:type_name -> containarium.v1.SetContainerAttributionResponse.LabelsEntry
 	10, // 27: containarium.v1.GetMetricsResponse.metrics:type_name -> containarium.v1.ContainerMetrics
 	9,  // 28: containarium.v1.ResizeContainerResponse.container:type_name -> containarium.v1.Container
 	43, // 29: containarium.v1.AddCollaboratorResponse.collaborator:type_name -> containarium.v1.Collaborator
@@ -6347,11 +6504,11 @@ var file_containarium_v1_container_proto_depIdxs = []int32{
 	5,  // 37: containarium.v1.SetMetricsExportResponse.provider:type_name -> containarium.v1.CloudMetricsProvider
 	6,  // 38: containarium.v1.SetMetricsExportResponse.groups:type_name -> containarium.v1.CloudMetricsGroup
 	5,  // 39: containarium.v1.GetMetricsExportResponse.provider:type_name -> containarium.v1.CloudMetricsProvider
-	87, // 40: containarium.v1.GetMetricsExportResponse.last_success_at:type_name -> google.protobuf.Timestamp
+	89, // 40: containarium.v1.GetMetricsExportResponse.last_success_at:type_name -> google.protobuf.Timestamp
 	6,  // 41: containarium.v1.GetMetricsExportResponse.groups:type_name -> containarium.v1.CloudMetricsGroup
 	67, // 42: containarium.v1.CreateContainerSnapshotResponse.snapshot:type_name -> containarium.v1.ContainerSnapshot
 	67, // 43: containarium.v1.ListContainerSnapshotsResponse.snapshots:type_name -> containarium.v1.ContainerSnapshot
-	88, // 44: containarium.v1.state_name:extendee -> google.protobuf.EnumValueOptions
+	90, // 44: containarium.v1.state_name:extendee -> google.protobuf.EnumValueOptions
 	45, // [45:45] is the sub-list for method output_type
 	45, // [45:45] is the sub-list for method input_type
 	45, // [45:45] is the sub-list for extension type_name
@@ -6370,7 +6527,7 @@ func file_containarium_v1_container_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_v1_container_proto_rawDesc), len(file_containarium_v1_container_proto_rawDesc)),
 			NumEnums:      7,
-			NumMessages:   80,
+			NumMessages:   82,
 			NumExtensions: 1,
 			NumServices:   0,
 		},

--- a/pkg/pb/containarium/v1/service.pb.go
+++ b/pkg/pb/containarium/v1/service.pb.go
@@ -26,7 +26,7 @@ var File_containarium_v1_service_proto protoreflect.FileDescriptor
 
 const file_containarium_v1_service_proto_rawDesc = "" +
 	"\n" +
-	"\x1dcontainarium/v1/service.proto\x12\x0fcontainarium.v1\x1a\x1fcontainarium/v1/container.proto\x1a\x1ccontainarium/v1/config.proto\x1a\x19containarium/v1/app.proto\x1a\x1dcontainarium/v1/network.proto\x1a\x1bcontainarium/v1/alert.proto\x1a\x1dcontainarium/v1/secrets.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto2\xea\xa7\x01\n" +
+	"\x1dcontainarium/v1/service.proto\x12\x0fcontainarium.v1\x1a\x1fcontainarium/v1/container.proto\x1a\x1ccontainarium/v1/config.proto\x1a\x19containarium/v1/app.proto\x1a\x1dcontainarium/v1/network.proto\x1a\x1bcontainarium/v1/alert.proto\x1a\x1dcontainarium/v1/secrets.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto2ҫ\x01\n" +
 	"\x10ContainerService\x12\xae\x02\n" +
 	"\x0fCreateContainer\x12'.containarium.v1.CreateContainerRequest\x1a(.containarium.v1.CreateContainerResponse\"\xc7\x01\x92A\xaa\x01\n" +
 	"\n" +
@@ -56,7 +56,9 @@ const file_containarium_v1_service_proto_rawDesc = "" +
 	"\x16ListContainerSnapshots\x12..containarium.v1.ListContainerSnapshotsRequest\x1a/.containarium.v1.ListContainerSnapshotsResponse\"\xf4\x01\x92A\xc5\x01\n" +
 	"\x14Container Operations\x12\x1cList a container's snapshots\x1a\x8e\x01Lists the container's ZFS snapshots, each with the bytes it uniquely holds (what deleting it would free) and the bytes it references in total.\x82\xd3\xe4\x93\x02%\x12#/v1/containers/{username}/snapshots\x12\xd7\x02\n" +
 	"\x17DeleteContainerSnapshot\x12/.containarium.v1.DeleteContainerSnapshotRequest\x1a0.containarium.v1.DeleteContainerSnapshotResponse\"\xd8\x01\x92A\xa2\x01\n" +
-	"\x14Container Operations\x12\x1bDelete a container snapshot\x1amRemoves the snapshot and reports the bytes reclaimed. Works while the container's encryption key is unloaded.\x82\xd3\xe4\x93\x02,**/v1/containers/{username}/snapshots/{name}\x12\xe7\x03\n" +
+	"\x14Container Operations\x12\x1bDelete a container snapshot\x1amRemoves the snapshot and reports the bytes reclaimed. Works while the container's encryption key is unloaded.\x82\xd3\xe4\x93\x02,**/v1/containers/{username}/snapshots/{name}\x12\xe5\x03\n" +
+	"\x19RollbackContainerSnapshot\x121.containarium.v1.RollbackContainerSnapshotRequest\x1a2.containarium.v1.RollbackContainerSnapshotResponse\"\xe0\x02\x92A\x9e\x02\n" +
+	"\x14Container Operations\x12#Roll a container back to a snapshot\x1a\xe0\x01Discards everything written since the snapshot. Refuses a running container unless force is set, refuses to destroy newer snapshots unless destroy_newer is set, and refuses when the container's encryption key is unavailable.\x82\xd3\xe4\x93\x028:\x01*\"3/v1/containers/{username}/snapshots/{name}/rollback\x12\xe7\x03\n" +
 	"\x13DeleteTenantStorage\x12+.containarium.v1.DeleteTenantStorageRequest\x1a,.containarium.v1.DeleteTenantStorageResponse\"\xf4\x02\x92A\xcc\x02\n" +
 	"\x14Container Operations\x12.Destroy a departing tenant's encrypted storage\x1a\x83\x02Deletes the tenant's Incus storage pool and then the encrypted dataset it was sourced at. Refused while the tenant still has containers. Irreversible — the dataset is the tenant's encryptionroot, so this destroys the only key path to their data. Admin only.\x82\xd3\xe4\x93\x02\x1e*\x1c/v1/tenants/{tenant}/storage\x12\xc5\x03\n" +
 	"\x0fRewrapContainer\x12'.containarium.v1.RewrapContainerRequest\x1a(.containarium.v1.RewrapContainerResponse\"\xde\x02\x92A\xaf\x02\n" +
@@ -185,114 +187,116 @@ var file_containarium_v1_service_proto_goTypes = []any{
 	(*CreateContainerSnapshotRequest)(nil),    // 9: containarium.v1.CreateContainerSnapshotRequest
 	(*ListContainerSnapshotsRequest)(nil),     // 10: containarium.v1.ListContainerSnapshotsRequest
 	(*DeleteContainerSnapshotRequest)(nil),    // 11: containarium.v1.DeleteContainerSnapshotRequest
-	(*DeleteTenantStorageRequest)(nil),        // 12: containarium.v1.DeleteTenantStorageRequest
-	(*RewrapContainerRequest)(nil),            // 13: containarium.v1.RewrapContainerRequest
-	(*PrepareEncryptedMigrationRequest)(nil),  // 14: containarium.v1.PrepareEncryptedMigrationRequest
-	(*AdoptMigratedContainerRequest)(nil),     // 15: containarium.v1.AdoptMigratedContainerRequest
-	(*ToggleMonitoringRequest)(nil),           // 16: containarium.v1.ToggleMonitoringRequest
-	(*ToggleAutoSleepRequest)(nil),            // 17: containarium.v1.ToggleAutoSleepRequest
-	(*SetContainerTTLRequest)(nil),            // 18: containarium.v1.SetContainerTTLRequest
-	(*SetContainerDeletePolicyRequest)(nil),   // 19: containarium.v1.SetContainerDeletePolicyRequest
-	(*SetContainerAttributionRequest)(nil),    // 20: containarium.v1.SetContainerAttributionRequest
-	(*AddSSHKeyRequest)(nil),                  // 21: containarium.v1.AddSSHKeyRequest
-	(*RemoveSSHKeyRequest)(nil),               // 22: containarium.v1.RemoveSSHKeyRequest
-	(*AddCollaboratorRequest)(nil),            // 23: containarium.v1.AddCollaboratorRequest
-	(*RemoveCollaboratorRequest)(nil),         // 24: containarium.v1.RemoveCollaboratorRequest
-	(*ListCollaboratorsRequest)(nil),          // 25: containarium.v1.ListCollaboratorsRequest
-	(*GetMetricsRequest)(nil),                 // 26: containarium.v1.GetMetricsRequest
-	(*CleanupDiskRequest)(nil),                // 27: containarium.v1.CleanupDiskRequest
-	(*InstallStackRequest)(nil),               // 28: containarium.v1.InstallStackRequest
-	(*ListStacksRequest)(nil),                 // 29: containarium.v1.ListStacksRequest
-	(*GetSystemInfoRequest)(nil),              // 30: containarium.v1.GetSystemInfoRequest
-	(*ListBackendsRequest)(nil),               // 31: containarium.v1.ListBackendsRequest
-	(*AdvertiseCapacityRequest)(nil),          // 32: containarium.v1.AdvertiseCapacityRequest
-	(*WithdrawCapacityRequest)(nil),           // 33: containarium.v1.WithdrawCapacityRequest
-	(*GetCapacityHeadroomRequest)(nil),        // 34: containarium.v1.GetCapacityHeadroomRequest
-	(*ProfileBackendRequest)(nil),             // 35: containarium.v1.ProfileBackendRequest
-	(*GetCapabilityProfileRequest)(nil),       // 36: containarium.v1.GetCapabilityProfileRequest
-	(*GetSelfMeasurementRequest)(nil),         // 37: containarium.v1.GetSelfMeasurementRequest
-	(*GetLatestReleaseRequest)(nil),           // 38: containarium.v1.GetLatestReleaseRequest
-	(*ValidateGPURequest)(nil),                // 39: containarium.v1.ValidateGPURequest
-	(*TriggerUpgradeRequest)(nil),             // 40: containarium.v1.TriggerUpgradeRequest
-	(*GetUpgradeStatusRequest)(nil),           // 41: containarium.v1.GetUpgradeStatusRequest
-	(*GetMonitoringInfoRequest)(nil),          // 42: containarium.v1.GetMonitoringInfoRequest
-	(*SetMetricsExportRequest)(nil),           // 43: containarium.v1.SetMetricsExportRequest
-	(*GetMetricsExportRequest)(nil),           // 44: containarium.v1.GetMetricsExportRequest
-	(*CreateAlertRuleRequest)(nil),            // 45: containarium.v1.CreateAlertRuleRequest
-	(*ListAlertRulesRequest)(nil),             // 46: containarium.v1.ListAlertRulesRequest
-	(*GetAlertRuleRequest)(nil),               // 47: containarium.v1.GetAlertRuleRequest
-	(*UpdateAlertRuleRequest)(nil),            // 48: containarium.v1.UpdateAlertRuleRequest
-	(*DeleteAlertRuleRequest)(nil),            // 49: containarium.v1.DeleteAlertRuleRequest
-	(*GetAlertingInfoRequest)(nil),            // 50: containarium.v1.GetAlertingInfoRequest
-	(*ListDefaultAlertRulesRequest)(nil),      // 51: containarium.v1.ListDefaultAlertRulesRequest
-	(*UpdateAlertingConfigRequest)(nil),       // 52: containarium.v1.UpdateAlertingConfigRequest
-	(*TestWebhookRequest)(nil),                // 53: containarium.v1.TestWebhookRequest
-	(*ListWebhookDeliveriesRequest)(nil),      // 54: containarium.v1.ListWebhookDeliveriesRequest
-	(*SetSecretRequest)(nil),                  // 55: containarium.v1.SetSecretRequest
-	(*GetSecretRequest)(nil),                  // 56: containarium.v1.GetSecretRequest
-	(*ListSecretsRequest)(nil),                // 57: containarium.v1.ListSecretsRequest
-	(*DeleteSecretRequest)(nil),               // 58: containarium.v1.DeleteSecretRequest
-	(*RefreshSecretsRequest)(nil),             // 59: containarium.v1.RefreshSecretsRequest
-	(*CreateContainerResponse)(nil),           // 60: containarium.v1.CreateContainerResponse
-	(*ListContainersResponse)(nil),            // 61: containarium.v1.ListContainersResponse
-	(*GetContainerResponse)(nil),              // 62: containarium.v1.GetContainerResponse
-	(*DebugContainerResponse)(nil),            // 63: containarium.v1.DebugContainerResponse
-	(*DeleteContainerResponse)(nil),           // 64: containarium.v1.DeleteContainerResponse
-	(*StartContainerResponse)(nil),            // 65: containarium.v1.StartContainerResponse
-	(*StopContainerResponse)(nil),             // 66: containarium.v1.StopContainerResponse
-	(*ResizeContainerResponse)(nil),           // 67: containarium.v1.ResizeContainerResponse
-	(*MoveContainerResponse)(nil),             // 68: containarium.v1.MoveContainerResponse
-	(*CreateContainerSnapshotResponse)(nil),   // 69: containarium.v1.CreateContainerSnapshotResponse
-	(*ListContainerSnapshotsResponse)(nil),    // 70: containarium.v1.ListContainerSnapshotsResponse
-	(*DeleteContainerSnapshotResponse)(nil),   // 71: containarium.v1.DeleteContainerSnapshotResponse
-	(*DeleteTenantStorageResponse)(nil),       // 72: containarium.v1.DeleteTenantStorageResponse
-	(*RewrapContainerResponse)(nil),           // 73: containarium.v1.RewrapContainerResponse
-	(*PrepareEncryptedMigrationResponse)(nil), // 74: containarium.v1.PrepareEncryptedMigrationResponse
-	(*AdoptMigratedContainerResponse)(nil),    // 75: containarium.v1.AdoptMigratedContainerResponse
-	(*ToggleMonitoringResponse)(nil),          // 76: containarium.v1.ToggleMonitoringResponse
-	(*ToggleAutoSleepResponse)(nil),           // 77: containarium.v1.ToggleAutoSleepResponse
-	(*SetContainerTTLResponse)(nil),           // 78: containarium.v1.SetContainerTTLResponse
-	(*SetContainerDeletePolicyResponse)(nil),  // 79: containarium.v1.SetContainerDeletePolicyResponse
-	(*SetContainerAttributionResponse)(nil),   // 80: containarium.v1.SetContainerAttributionResponse
-	(*AddSSHKeyResponse)(nil),                 // 81: containarium.v1.AddSSHKeyResponse
-	(*RemoveSSHKeyResponse)(nil),              // 82: containarium.v1.RemoveSSHKeyResponse
-	(*AddCollaboratorResponse)(nil),           // 83: containarium.v1.AddCollaboratorResponse
-	(*RemoveCollaboratorResponse)(nil),        // 84: containarium.v1.RemoveCollaboratorResponse
-	(*ListCollaboratorsResponse)(nil),         // 85: containarium.v1.ListCollaboratorsResponse
-	(*GetMetricsResponse)(nil),                // 86: containarium.v1.GetMetricsResponse
-	(*CleanupDiskResponse)(nil),               // 87: containarium.v1.CleanupDiskResponse
-	(*InstallStackResponse)(nil),              // 88: containarium.v1.InstallStackResponse
-	(*ListStacksResponse)(nil),                // 89: containarium.v1.ListStacksResponse
-	(*GetSystemInfoResponse)(nil),             // 90: containarium.v1.GetSystemInfoResponse
-	(*ListBackendsResponse)(nil),              // 91: containarium.v1.ListBackendsResponse
-	(*AdvertiseCapacityResponse)(nil),         // 92: containarium.v1.AdvertiseCapacityResponse
-	(*WithdrawCapacityResponse)(nil),          // 93: containarium.v1.WithdrawCapacityResponse
-	(*GetCapacityHeadroomResponse)(nil),       // 94: containarium.v1.GetCapacityHeadroomResponse
-	(*ProfileBackendResponse)(nil),            // 95: containarium.v1.ProfileBackendResponse
-	(*GetCapabilityProfileResponse)(nil),      // 96: containarium.v1.GetCapabilityProfileResponse
-	(*GetSelfMeasurementResponse)(nil),        // 97: containarium.v1.GetSelfMeasurementResponse
-	(*GetLatestReleaseResponse)(nil),          // 98: containarium.v1.GetLatestReleaseResponse
-	(*ValidateGPUResponse)(nil),               // 99: containarium.v1.ValidateGPUResponse
-	(*TriggerUpgradeResponse)(nil),            // 100: containarium.v1.TriggerUpgradeResponse
-	(*GetUpgradeStatusResponse)(nil),          // 101: containarium.v1.GetUpgradeStatusResponse
-	(*GetMonitoringInfoResponse)(nil),         // 102: containarium.v1.GetMonitoringInfoResponse
-	(*SetMetricsExportResponse)(nil),          // 103: containarium.v1.SetMetricsExportResponse
-	(*GetMetricsExportResponse)(nil),          // 104: containarium.v1.GetMetricsExportResponse
-	(*CreateAlertRuleResponse)(nil),           // 105: containarium.v1.CreateAlertRuleResponse
-	(*ListAlertRulesResponse)(nil),            // 106: containarium.v1.ListAlertRulesResponse
-	(*GetAlertRuleResponse)(nil),              // 107: containarium.v1.GetAlertRuleResponse
-	(*UpdateAlertRuleResponse)(nil),           // 108: containarium.v1.UpdateAlertRuleResponse
-	(*DeleteAlertRuleResponse)(nil),           // 109: containarium.v1.DeleteAlertRuleResponse
-	(*GetAlertingInfoResponse)(nil),           // 110: containarium.v1.GetAlertingInfoResponse
-	(*ListDefaultAlertRulesResponse)(nil),     // 111: containarium.v1.ListDefaultAlertRulesResponse
-	(*UpdateAlertingConfigResponse)(nil),      // 112: containarium.v1.UpdateAlertingConfigResponse
-	(*TestWebhookResponse)(nil),               // 113: containarium.v1.TestWebhookResponse
-	(*ListWebhookDeliveriesResponse)(nil),     // 114: containarium.v1.ListWebhookDeliveriesResponse
-	(*SetSecretResponse)(nil),                 // 115: containarium.v1.SetSecretResponse
-	(*GetSecretResponse)(nil),                 // 116: containarium.v1.GetSecretResponse
-	(*ListSecretsResponse)(nil),               // 117: containarium.v1.ListSecretsResponse
-	(*DeleteSecretResponse)(nil),              // 118: containarium.v1.DeleteSecretResponse
-	(*RefreshSecretsResponse)(nil),            // 119: containarium.v1.RefreshSecretsResponse
+	(*RollbackContainerSnapshotRequest)(nil),  // 12: containarium.v1.RollbackContainerSnapshotRequest
+	(*DeleteTenantStorageRequest)(nil),        // 13: containarium.v1.DeleteTenantStorageRequest
+	(*RewrapContainerRequest)(nil),            // 14: containarium.v1.RewrapContainerRequest
+	(*PrepareEncryptedMigrationRequest)(nil),  // 15: containarium.v1.PrepareEncryptedMigrationRequest
+	(*AdoptMigratedContainerRequest)(nil),     // 16: containarium.v1.AdoptMigratedContainerRequest
+	(*ToggleMonitoringRequest)(nil),           // 17: containarium.v1.ToggleMonitoringRequest
+	(*ToggleAutoSleepRequest)(nil),            // 18: containarium.v1.ToggleAutoSleepRequest
+	(*SetContainerTTLRequest)(nil),            // 19: containarium.v1.SetContainerTTLRequest
+	(*SetContainerDeletePolicyRequest)(nil),   // 20: containarium.v1.SetContainerDeletePolicyRequest
+	(*SetContainerAttributionRequest)(nil),    // 21: containarium.v1.SetContainerAttributionRequest
+	(*AddSSHKeyRequest)(nil),                  // 22: containarium.v1.AddSSHKeyRequest
+	(*RemoveSSHKeyRequest)(nil),               // 23: containarium.v1.RemoveSSHKeyRequest
+	(*AddCollaboratorRequest)(nil),            // 24: containarium.v1.AddCollaboratorRequest
+	(*RemoveCollaboratorRequest)(nil),         // 25: containarium.v1.RemoveCollaboratorRequest
+	(*ListCollaboratorsRequest)(nil),          // 26: containarium.v1.ListCollaboratorsRequest
+	(*GetMetricsRequest)(nil),                 // 27: containarium.v1.GetMetricsRequest
+	(*CleanupDiskRequest)(nil),                // 28: containarium.v1.CleanupDiskRequest
+	(*InstallStackRequest)(nil),               // 29: containarium.v1.InstallStackRequest
+	(*ListStacksRequest)(nil),                 // 30: containarium.v1.ListStacksRequest
+	(*GetSystemInfoRequest)(nil),              // 31: containarium.v1.GetSystemInfoRequest
+	(*ListBackendsRequest)(nil),               // 32: containarium.v1.ListBackendsRequest
+	(*AdvertiseCapacityRequest)(nil),          // 33: containarium.v1.AdvertiseCapacityRequest
+	(*WithdrawCapacityRequest)(nil),           // 34: containarium.v1.WithdrawCapacityRequest
+	(*GetCapacityHeadroomRequest)(nil),        // 35: containarium.v1.GetCapacityHeadroomRequest
+	(*ProfileBackendRequest)(nil),             // 36: containarium.v1.ProfileBackendRequest
+	(*GetCapabilityProfileRequest)(nil),       // 37: containarium.v1.GetCapabilityProfileRequest
+	(*GetSelfMeasurementRequest)(nil),         // 38: containarium.v1.GetSelfMeasurementRequest
+	(*GetLatestReleaseRequest)(nil),           // 39: containarium.v1.GetLatestReleaseRequest
+	(*ValidateGPURequest)(nil),                // 40: containarium.v1.ValidateGPURequest
+	(*TriggerUpgradeRequest)(nil),             // 41: containarium.v1.TriggerUpgradeRequest
+	(*GetUpgradeStatusRequest)(nil),           // 42: containarium.v1.GetUpgradeStatusRequest
+	(*GetMonitoringInfoRequest)(nil),          // 43: containarium.v1.GetMonitoringInfoRequest
+	(*SetMetricsExportRequest)(nil),           // 44: containarium.v1.SetMetricsExportRequest
+	(*GetMetricsExportRequest)(nil),           // 45: containarium.v1.GetMetricsExportRequest
+	(*CreateAlertRuleRequest)(nil),            // 46: containarium.v1.CreateAlertRuleRequest
+	(*ListAlertRulesRequest)(nil),             // 47: containarium.v1.ListAlertRulesRequest
+	(*GetAlertRuleRequest)(nil),               // 48: containarium.v1.GetAlertRuleRequest
+	(*UpdateAlertRuleRequest)(nil),            // 49: containarium.v1.UpdateAlertRuleRequest
+	(*DeleteAlertRuleRequest)(nil),            // 50: containarium.v1.DeleteAlertRuleRequest
+	(*GetAlertingInfoRequest)(nil),            // 51: containarium.v1.GetAlertingInfoRequest
+	(*ListDefaultAlertRulesRequest)(nil),      // 52: containarium.v1.ListDefaultAlertRulesRequest
+	(*UpdateAlertingConfigRequest)(nil),       // 53: containarium.v1.UpdateAlertingConfigRequest
+	(*TestWebhookRequest)(nil),                // 54: containarium.v1.TestWebhookRequest
+	(*ListWebhookDeliveriesRequest)(nil),      // 55: containarium.v1.ListWebhookDeliveriesRequest
+	(*SetSecretRequest)(nil),                  // 56: containarium.v1.SetSecretRequest
+	(*GetSecretRequest)(nil),                  // 57: containarium.v1.GetSecretRequest
+	(*ListSecretsRequest)(nil),                // 58: containarium.v1.ListSecretsRequest
+	(*DeleteSecretRequest)(nil),               // 59: containarium.v1.DeleteSecretRequest
+	(*RefreshSecretsRequest)(nil),             // 60: containarium.v1.RefreshSecretsRequest
+	(*CreateContainerResponse)(nil),           // 61: containarium.v1.CreateContainerResponse
+	(*ListContainersResponse)(nil),            // 62: containarium.v1.ListContainersResponse
+	(*GetContainerResponse)(nil),              // 63: containarium.v1.GetContainerResponse
+	(*DebugContainerResponse)(nil),            // 64: containarium.v1.DebugContainerResponse
+	(*DeleteContainerResponse)(nil),           // 65: containarium.v1.DeleteContainerResponse
+	(*StartContainerResponse)(nil),            // 66: containarium.v1.StartContainerResponse
+	(*StopContainerResponse)(nil),             // 67: containarium.v1.StopContainerResponse
+	(*ResizeContainerResponse)(nil),           // 68: containarium.v1.ResizeContainerResponse
+	(*MoveContainerResponse)(nil),             // 69: containarium.v1.MoveContainerResponse
+	(*CreateContainerSnapshotResponse)(nil),   // 70: containarium.v1.CreateContainerSnapshotResponse
+	(*ListContainerSnapshotsResponse)(nil),    // 71: containarium.v1.ListContainerSnapshotsResponse
+	(*DeleteContainerSnapshotResponse)(nil),   // 72: containarium.v1.DeleteContainerSnapshotResponse
+	(*RollbackContainerSnapshotResponse)(nil), // 73: containarium.v1.RollbackContainerSnapshotResponse
+	(*DeleteTenantStorageResponse)(nil),       // 74: containarium.v1.DeleteTenantStorageResponse
+	(*RewrapContainerResponse)(nil),           // 75: containarium.v1.RewrapContainerResponse
+	(*PrepareEncryptedMigrationResponse)(nil), // 76: containarium.v1.PrepareEncryptedMigrationResponse
+	(*AdoptMigratedContainerResponse)(nil),    // 77: containarium.v1.AdoptMigratedContainerResponse
+	(*ToggleMonitoringResponse)(nil),          // 78: containarium.v1.ToggleMonitoringResponse
+	(*ToggleAutoSleepResponse)(nil),           // 79: containarium.v1.ToggleAutoSleepResponse
+	(*SetContainerTTLResponse)(nil),           // 80: containarium.v1.SetContainerTTLResponse
+	(*SetContainerDeletePolicyResponse)(nil),  // 81: containarium.v1.SetContainerDeletePolicyResponse
+	(*SetContainerAttributionResponse)(nil),   // 82: containarium.v1.SetContainerAttributionResponse
+	(*AddSSHKeyResponse)(nil),                 // 83: containarium.v1.AddSSHKeyResponse
+	(*RemoveSSHKeyResponse)(nil),              // 84: containarium.v1.RemoveSSHKeyResponse
+	(*AddCollaboratorResponse)(nil),           // 85: containarium.v1.AddCollaboratorResponse
+	(*RemoveCollaboratorResponse)(nil),        // 86: containarium.v1.RemoveCollaboratorResponse
+	(*ListCollaboratorsResponse)(nil),         // 87: containarium.v1.ListCollaboratorsResponse
+	(*GetMetricsResponse)(nil),                // 88: containarium.v1.GetMetricsResponse
+	(*CleanupDiskResponse)(nil),               // 89: containarium.v1.CleanupDiskResponse
+	(*InstallStackResponse)(nil),              // 90: containarium.v1.InstallStackResponse
+	(*ListStacksResponse)(nil),                // 91: containarium.v1.ListStacksResponse
+	(*GetSystemInfoResponse)(nil),             // 92: containarium.v1.GetSystemInfoResponse
+	(*ListBackendsResponse)(nil),              // 93: containarium.v1.ListBackendsResponse
+	(*AdvertiseCapacityResponse)(nil),         // 94: containarium.v1.AdvertiseCapacityResponse
+	(*WithdrawCapacityResponse)(nil),          // 95: containarium.v1.WithdrawCapacityResponse
+	(*GetCapacityHeadroomResponse)(nil),       // 96: containarium.v1.GetCapacityHeadroomResponse
+	(*ProfileBackendResponse)(nil),            // 97: containarium.v1.ProfileBackendResponse
+	(*GetCapabilityProfileResponse)(nil),      // 98: containarium.v1.GetCapabilityProfileResponse
+	(*GetSelfMeasurementResponse)(nil),        // 99: containarium.v1.GetSelfMeasurementResponse
+	(*GetLatestReleaseResponse)(nil),          // 100: containarium.v1.GetLatestReleaseResponse
+	(*ValidateGPUResponse)(nil),               // 101: containarium.v1.ValidateGPUResponse
+	(*TriggerUpgradeResponse)(nil),            // 102: containarium.v1.TriggerUpgradeResponse
+	(*GetUpgradeStatusResponse)(nil),          // 103: containarium.v1.GetUpgradeStatusResponse
+	(*GetMonitoringInfoResponse)(nil),         // 104: containarium.v1.GetMonitoringInfoResponse
+	(*SetMetricsExportResponse)(nil),          // 105: containarium.v1.SetMetricsExportResponse
+	(*GetMetricsExportResponse)(nil),          // 106: containarium.v1.GetMetricsExportResponse
+	(*CreateAlertRuleResponse)(nil),           // 107: containarium.v1.CreateAlertRuleResponse
+	(*ListAlertRulesResponse)(nil),            // 108: containarium.v1.ListAlertRulesResponse
+	(*GetAlertRuleResponse)(nil),              // 109: containarium.v1.GetAlertRuleResponse
+	(*UpdateAlertRuleResponse)(nil),           // 110: containarium.v1.UpdateAlertRuleResponse
+	(*DeleteAlertRuleResponse)(nil),           // 111: containarium.v1.DeleteAlertRuleResponse
+	(*GetAlertingInfoResponse)(nil),           // 112: containarium.v1.GetAlertingInfoResponse
+	(*ListDefaultAlertRulesResponse)(nil),     // 113: containarium.v1.ListDefaultAlertRulesResponse
+	(*UpdateAlertingConfigResponse)(nil),      // 114: containarium.v1.UpdateAlertingConfigResponse
+	(*TestWebhookResponse)(nil),               // 115: containarium.v1.TestWebhookResponse
+	(*ListWebhookDeliveriesResponse)(nil),     // 116: containarium.v1.ListWebhookDeliveriesResponse
+	(*SetSecretResponse)(nil),                 // 117: containarium.v1.SetSecretResponse
+	(*GetSecretResponse)(nil),                 // 118: containarium.v1.GetSecretResponse
+	(*ListSecretsResponse)(nil),               // 119: containarium.v1.ListSecretsResponse
+	(*DeleteSecretResponse)(nil),              // 120: containarium.v1.DeleteSecretResponse
+	(*RefreshSecretsResponse)(nil),            // 121: containarium.v1.RefreshSecretsResponse
 }
 var file_containarium_v1_service_proto_depIdxs = []int32{
 	0,   // 0: containarium.v1.ContainerService.CreateContainer:input_type -> containarium.v1.CreateContainerRequest
@@ -307,116 +311,118 @@ var file_containarium_v1_service_proto_depIdxs = []int32{
 	9,   // 9: containarium.v1.ContainerService.CreateContainerSnapshot:input_type -> containarium.v1.CreateContainerSnapshotRequest
 	10,  // 10: containarium.v1.ContainerService.ListContainerSnapshots:input_type -> containarium.v1.ListContainerSnapshotsRequest
 	11,  // 11: containarium.v1.ContainerService.DeleteContainerSnapshot:input_type -> containarium.v1.DeleteContainerSnapshotRequest
-	12,  // 12: containarium.v1.ContainerService.DeleteTenantStorage:input_type -> containarium.v1.DeleteTenantStorageRequest
-	13,  // 13: containarium.v1.ContainerService.RewrapContainer:input_type -> containarium.v1.RewrapContainerRequest
-	14,  // 14: containarium.v1.ContainerService.PrepareEncryptedMigration:input_type -> containarium.v1.PrepareEncryptedMigrationRequest
-	15,  // 15: containarium.v1.ContainerService.AdoptMigratedContainer:input_type -> containarium.v1.AdoptMigratedContainerRequest
-	16,  // 16: containarium.v1.ContainerService.ToggleMonitoring:input_type -> containarium.v1.ToggleMonitoringRequest
-	17,  // 17: containarium.v1.ContainerService.ToggleAutoSleep:input_type -> containarium.v1.ToggleAutoSleepRequest
-	18,  // 18: containarium.v1.ContainerService.SetContainerTTL:input_type -> containarium.v1.SetContainerTTLRequest
-	19,  // 19: containarium.v1.ContainerService.SetContainerDeletePolicy:input_type -> containarium.v1.SetContainerDeletePolicyRequest
-	20,  // 20: containarium.v1.ContainerService.SetContainerAttribution:input_type -> containarium.v1.SetContainerAttributionRequest
-	21,  // 21: containarium.v1.ContainerService.AddSSHKey:input_type -> containarium.v1.AddSSHKeyRequest
-	22,  // 22: containarium.v1.ContainerService.RemoveSSHKey:input_type -> containarium.v1.RemoveSSHKeyRequest
-	23,  // 23: containarium.v1.ContainerService.AddCollaborator:input_type -> containarium.v1.AddCollaboratorRequest
-	24,  // 24: containarium.v1.ContainerService.RemoveCollaborator:input_type -> containarium.v1.RemoveCollaboratorRequest
-	25,  // 25: containarium.v1.ContainerService.ListCollaborators:input_type -> containarium.v1.ListCollaboratorsRequest
-	26,  // 26: containarium.v1.ContainerService.GetMetrics:input_type -> containarium.v1.GetMetricsRequest
-	27,  // 27: containarium.v1.ContainerService.CleanupDisk:input_type -> containarium.v1.CleanupDiskRequest
-	28,  // 28: containarium.v1.ContainerService.InstallStack:input_type -> containarium.v1.InstallStackRequest
-	29,  // 29: containarium.v1.ContainerService.ListStacks:input_type -> containarium.v1.ListStacksRequest
-	30,  // 30: containarium.v1.ContainerService.GetSystemInfo:input_type -> containarium.v1.GetSystemInfoRequest
-	31,  // 31: containarium.v1.ContainerService.ListBackends:input_type -> containarium.v1.ListBackendsRequest
-	32,  // 32: containarium.v1.ContainerService.AdvertiseCapacity:input_type -> containarium.v1.AdvertiseCapacityRequest
-	33,  // 33: containarium.v1.ContainerService.WithdrawCapacity:input_type -> containarium.v1.WithdrawCapacityRequest
-	34,  // 34: containarium.v1.ContainerService.GetCapacityHeadroom:input_type -> containarium.v1.GetCapacityHeadroomRequest
-	35,  // 35: containarium.v1.ContainerService.ProfileBackend:input_type -> containarium.v1.ProfileBackendRequest
-	36,  // 36: containarium.v1.ContainerService.GetCapabilityProfile:input_type -> containarium.v1.GetCapabilityProfileRequest
-	37,  // 37: containarium.v1.ContainerService.GetSelfMeasurement:input_type -> containarium.v1.GetSelfMeasurementRequest
-	38,  // 38: containarium.v1.ContainerService.GetLatestRelease:input_type -> containarium.v1.GetLatestReleaseRequest
-	39,  // 39: containarium.v1.ContainerService.ValidateGPU:input_type -> containarium.v1.ValidateGPURequest
-	40,  // 40: containarium.v1.ContainerService.TriggerUpgrade:input_type -> containarium.v1.TriggerUpgradeRequest
-	41,  // 41: containarium.v1.ContainerService.GetUpgradeStatus:input_type -> containarium.v1.GetUpgradeStatusRequest
-	42,  // 42: containarium.v1.ContainerService.GetMonitoringInfo:input_type -> containarium.v1.GetMonitoringInfoRequest
-	43,  // 43: containarium.v1.ContainerService.SetMetricsExport:input_type -> containarium.v1.SetMetricsExportRequest
-	44,  // 44: containarium.v1.ContainerService.GetMetricsExport:input_type -> containarium.v1.GetMetricsExportRequest
-	45,  // 45: containarium.v1.ContainerService.CreateAlertRule:input_type -> containarium.v1.CreateAlertRuleRequest
-	46,  // 46: containarium.v1.ContainerService.ListAlertRules:input_type -> containarium.v1.ListAlertRulesRequest
-	47,  // 47: containarium.v1.ContainerService.GetAlertRule:input_type -> containarium.v1.GetAlertRuleRequest
-	48,  // 48: containarium.v1.ContainerService.UpdateAlertRule:input_type -> containarium.v1.UpdateAlertRuleRequest
-	49,  // 49: containarium.v1.ContainerService.DeleteAlertRule:input_type -> containarium.v1.DeleteAlertRuleRequest
-	50,  // 50: containarium.v1.ContainerService.GetAlertingInfo:input_type -> containarium.v1.GetAlertingInfoRequest
-	51,  // 51: containarium.v1.ContainerService.ListDefaultAlertRules:input_type -> containarium.v1.ListDefaultAlertRulesRequest
-	52,  // 52: containarium.v1.ContainerService.UpdateAlertingConfig:input_type -> containarium.v1.UpdateAlertingConfigRequest
-	53,  // 53: containarium.v1.ContainerService.TestWebhook:input_type -> containarium.v1.TestWebhookRequest
-	54,  // 54: containarium.v1.ContainerService.ListWebhookDeliveries:input_type -> containarium.v1.ListWebhookDeliveriesRequest
-	55,  // 55: containarium.v1.ContainerService.SetSecret:input_type -> containarium.v1.SetSecretRequest
-	56,  // 56: containarium.v1.ContainerService.GetSecret:input_type -> containarium.v1.GetSecretRequest
-	57,  // 57: containarium.v1.ContainerService.ListSecrets:input_type -> containarium.v1.ListSecretsRequest
-	58,  // 58: containarium.v1.ContainerService.DeleteSecret:input_type -> containarium.v1.DeleteSecretRequest
-	59,  // 59: containarium.v1.ContainerService.RefreshSecrets:input_type -> containarium.v1.RefreshSecretsRequest
-	60,  // 60: containarium.v1.ContainerService.CreateContainer:output_type -> containarium.v1.CreateContainerResponse
-	61,  // 61: containarium.v1.ContainerService.ListContainers:output_type -> containarium.v1.ListContainersResponse
-	62,  // 62: containarium.v1.ContainerService.GetContainer:output_type -> containarium.v1.GetContainerResponse
-	63,  // 63: containarium.v1.ContainerService.DebugContainer:output_type -> containarium.v1.DebugContainerResponse
-	64,  // 64: containarium.v1.ContainerService.DeleteContainer:output_type -> containarium.v1.DeleteContainerResponse
-	65,  // 65: containarium.v1.ContainerService.StartContainer:output_type -> containarium.v1.StartContainerResponse
-	66,  // 66: containarium.v1.ContainerService.StopContainer:output_type -> containarium.v1.StopContainerResponse
-	67,  // 67: containarium.v1.ContainerService.ResizeContainer:output_type -> containarium.v1.ResizeContainerResponse
-	68,  // 68: containarium.v1.ContainerService.MoveContainer:output_type -> containarium.v1.MoveContainerResponse
-	69,  // 69: containarium.v1.ContainerService.CreateContainerSnapshot:output_type -> containarium.v1.CreateContainerSnapshotResponse
-	70,  // 70: containarium.v1.ContainerService.ListContainerSnapshots:output_type -> containarium.v1.ListContainerSnapshotsResponse
-	71,  // 71: containarium.v1.ContainerService.DeleteContainerSnapshot:output_type -> containarium.v1.DeleteContainerSnapshotResponse
-	72,  // 72: containarium.v1.ContainerService.DeleteTenantStorage:output_type -> containarium.v1.DeleteTenantStorageResponse
-	73,  // 73: containarium.v1.ContainerService.RewrapContainer:output_type -> containarium.v1.RewrapContainerResponse
-	74,  // 74: containarium.v1.ContainerService.PrepareEncryptedMigration:output_type -> containarium.v1.PrepareEncryptedMigrationResponse
-	75,  // 75: containarium.v1.ContainerService.AdoptMigratedContainer:output_type -> containarium.v1.AdoptMigratedContainerResponse
-	76,  // 76: containarium.v1.ContainerService.ToggleMonitoring:output_type -> containarium.v1.ToggleMonitoringResponse
-	77,  // 77: containarium.v1.ContainerService.ToggleAutoSleep:output_type -> containarium.v1.ToggleAutoSleepResponse
-	78,  // 78: containarium.v1.ContainerService.SetContainerTTL:output_type -> containarium.v1.SetContainerTTLResponse
-	79,  // 79: containarium.v1.ContainerService.SetContainerDeletePolicy:output_type -> containarium.v1.SetContainerDeletePolicyResponse
-	80,  // 80: containarium.v1.ContainerService.SetContainerAttribution:output_type -> containarium.v1.SetContainerAttributionResponse
-	81,  // 81: containarium.v1.ContainerService.AddSSHKey:output_type -> containarium.v1.AddSSHKeyResponse
-	82,  // 82: containarium.v1.ContainerService.RemoveSSHKey:output_type -> containarium.v1.RemoveSSHKeyResponse
-	83,  // 83: containarium.v1.ContainerService.AddCollaborator:output_type -> containarium.v1.AddCollaboratorResponse
-	84,  // 84: containarium.v1.ContainerService.RemoveCollaborator:output_type -> containarium.v1.RemoveCollaboratorResponse
-	85,  // 85: containarium.v1.ContainerService.ListCollaborators:output_type -> containarium.v1.ListCollaboratorsResponse
-	86,  // 86: containarium.v1.ContainerService.GetMetrics:output_type -> containarium.v1.GetMetricsResponse
-	87,  // 87: containarium.v1.ContainerService.CleanupDisk:output_type -> containarium.v1.CleanupDiskResponse
-	88,  // 88: containarium.v1.ContainerService.InstallStack:output_type -> containarium.v1.InstallStackResponse
-	89,  // 89: containarium.v1.ContainerService.ListStacks:output_type -> containarium.v1.ListStacksResponse
-	90,  // 90: containarium.v1.ContainerService.GetSystemInfo:output_type -> containarium.v1.GetSystemInfoResponse
-	91,  // 91: containarium.v1.ContainerService.ListBackends:output_type -> containarium.v1.ListBackendsResponse
-	92,  // 92: containarium.v1.ContainerService.AdvertiseCapacity:output_type -> containarium.v1.AdvertiseCapacityResponse
-	93,  // 93: containarium.v1.ContainerService.WithdrawCapacity:output_type -> containarium.v1.WithdrawCapacityResponse
-	94,  // 94: containarium.v1.ContainerService.GetCapacityHeadroom:output_type -> containarium.v1.GetCapacityHeadroomResponse
-	95,  // 95: containarium.v1.ContainerService.ProfileBackend:output_type -> containarium.v1.ProfileBackendResponse
-	96,  // 96: containarium.v1.ContainerService.GetCapabilityProfile:output_type -> containarium.v1.GetCapabilityProfileResponse
-	97,  // 97: containarium.v1.ContainerService.GetSelfMeasurement:output_type -> containarium.v1.GetSelfMeasurementResponse
-	98,  // 98: containarium.v1.ContainerService.GetLatestRelease:output_type -> containarium.v1.GetLatestReleaseResponse
-	99,  // 99: containarium.v1.ContainerService.ValidateGPU:output_type -> containarium.v1.ValidateGPUResponse
-	100, // 100: containarium.v1.ContainerService.TriggerUpgrade:output_type -> containarium.v1.TriggerUpgradeResponse
-	101, // 101: containarium.v1.ContainerService.GetUpgradeStatus:output_type -> containarium.v1.GetUpgradeStatusResponse
-	102, // 102: containarium.v1.ContainerService.GetMonitoringInfo:output_type -> containarium.v1.GetMonitoringInfoResponse
-	103, // 103: containarium.v1.ContainerService.SetMetricsExport:output_type -> containarium.v1.SetMetricsExportResponse
-	104, // 104: containarium.v1.ContainerService.GetMetricsExport:output_type -> containarium.v1.GetMetricsExportResponse
-	105, // 105: containarium.v1.ContainerService.CreateAlertRule:output_type -> containarium.v1.CreateAlertRuleResponse
-	106, // 106: containarium.v1.ContainerService.ListAlertRules:output_type -> containarium.v1.ListAlertRulesResponse
-	107, // 107: containarium.v1.ContainerService.GetAlertRule:output_type -> containarium.v1.GetAlertRuleResponse
-	108, // 108: containarium.v1.ContainerService.UpdateAlertRule:output_type -> containarium.v1.UpdateAlertRuleResponse
-	109, // 109: containarium.v1.ContainerService.DeleteAlertRule:output_type -> containarium.v1.DeleteAlertRuleResponse
-	110, // 110: containarium.v1.ContainerService.GetAlertingInfo:output_type -> containarium.v1.GetAlertingInfoResponse
-	111, // 111: containarium.v1.ContainerService.ListDefaultAlertRules:output_type -> containarium.v1.ListDefaultAlertRulesResponse
-	112, // 112: containarium.v1.ContainerService.UpdateAlertingConfig:output_type -> containarium.v1.UpdateAlertingConfigResponse
-	113, // 113: containarium.v1.ContainerService.TestWebhook:output_type -> containarium.v1.TestWebhookResponse
-	114, // 114: containarium.v1.ContainerService.ListWebhookDeliveries:output_type -> containarium.v1.ListWebhookDeliveriesResponse
-	115, // 115: containarium.v1.ContainerService.SetSecret:output_type -> containarium.v1.SetSecretResponse
-	116, // 116: containarium.v1.ContainerService.GetSecret:output_type -> containarium.v1.GetSecretResponse
-	117, // 117: containarium.v1.ContainerService.ListSecrets:output_type -> containarium.v1.ListSecretsResponse
-	118, // 118: containarium.v1.ContainerService.DeleteSecret:output_type -> containarium.v1.DeleteSecretResponse
-	119, // 119: containarium.v1.ContainerService.RefreshSecrets:output_type -> containarium.v1.RefreshSecretsResponse
-	60,  // [60:120] is the sub-list for method output_type
-	0,   // [0:60] is the sub-list for method input_type
+	12,  // 12: containarium.v1.ContainerService.RollbackContainerSnapshot:input_type -> containarium.v1.RollbackContainerSnapshotRequest
+	13,  // 13: containarium.v1.ContainerService.DeleteTenantStorage:input_type -> containarium.v1.DeleteTenantStorageRequest
+	14,  // 14: containarium.v1.ContainerService.RewrapContainer:input_type -> containarium.v1.RewrapContainerRequest
+	15,  // 15: containarium.v1.ContainerService.PrepareEncryptedMigration:input_type -> containarium.v1.PrepareEncryptedMigrationRequest
+	16,  // 16: containarium.v1.ContainerService.AdoptMigratedContainer:input_type -> containarium.v1.AdoptMigratedContainerRequest
+	17,  // 17: containarium.v1.ContainerService.ToggleMonitoring:input_type -> containarium.v1.ToggleMonitoringRequest
+	18,  // 18: containarium.v1.ContainerService.ToggleAutoSleep:input_type -> containarium.v1.ToggleAutoSleepRequest
+	19,  // 19: containarium.v1.ContainerService.SetContainerTTL:input_type -> containarium.v1.SetContainerTTLRequest
+	20,  // 20: containarium.v1.ContainerService.SetContainerDeletePolicy:input_type -> containarium.v1.SetContainerDeletePolicyRequest
+	21,  // 21: containarium.v1.ContainerService.SetContainerAttribution:input_type -> containarium.v1.SetContainerAttributionRequest
+	22,  // 22: containarium.v1.ContainerService.AddSSHKey:input_type -> containarium.v1.AddSSHKeyRequest
+	23,  // 23: containarium.v1.ContainerService.RemoveSSHKey:input_type -> containarium.v1.RemoveSSHKeyRequest
+	24,  // 24: containarium.v1.ContainerService.AddCollaborator:input_type -> containarium.v1.AddCollaboratorRequest
+	25,  // 25: containarium.v1.ContainerService.RemoveCollaborator:input_type -> containarium.v1.RemoveCollaboratorRequest
+	26,  // 26: containarium.v1.ContainerService.ListCollaborators:input_type -> containarium.v1.ListCollaboratorsRequest
+	27,  // 27: containarium.v1.ContainerService.GetMetrics:input_type -> containarium.v1.GetMetricsRequest
+	28,  // 28: containarium.v1.ContainerService.CleanupDisk:input_type -> containarium.v1.CleanupDiskRequest
+	29,  // 29: containarium.v1.ContainerService.InstallStack:input_type -> containarium.v1.InstallStackRequest
+	30,  // 30: containarium.v1.ContainerService.ListStacks:input_type -> containarium.v1.ListStacksRequest
+	31,  // 31: containarium.v1.ContainerService.GetSystemInfo:input_type -> containarium.v1.GetSystemInfoRequest
+	32,  // 32: containarium.v1.ContainerService.ListBackends:input_type -> containarium.v1.ListBackendsRequest
+	33,  // 33: containarium.v1.ContainerService.AdvertiseCapacity:input_type -> containarium.v1.AdvertiseCapacityRequest
+	34,  // 34: containarium.v1.ContainerService.WithdrawCapacity:input_type -> containarium.v1.WithdrawCapacityRequest
+	35,  // 35: containarium.v1.ContainerService.GetCapacityHeadroom:input_type -> containarium.v1.GetCapacityHeadroomRequest
+	36,  // 36: containarium.v1.ContainerService.ProfileBackend:input_type -> containarium.v1.ProfileBackendRequest
+	37,  // 37: containarium.v1.ContainerService.GetCapabilityProfile:input_type -> containarium.v1.GetCapabilityProfileRequest
+	38,  // 38: containarium.v1.ContainerService.GetSelfMeasurement:input_type -> containarium.v1.GetSelfMeasurementRequest
+	39,  // 39: containarium.v1.ContainerService.GetLatestRelease:input_type -> containarium.v1.GetLatestReleaseRequest
+	40,  // 40: containarium.v1.ContainerService.ValidateGPU:input_type -> containarium.v1.ValidateGPURequest
+	41,  // 41: containarium.v1.ContainerService.TriggerUpgrade:input_type -> containarium.v1.TriggerUpgradeRequest
+	42,  // 42: containarium.v1.ContainerService.GetUpgradeStatus:input_type -> containarium.v1.GetUpgradeStatusRequest
+	43,  // 43: containarium.v1.ContainerService.GetMonitoringInfo:input_type -> containarium.v1.GetMonitoringInfoRequest
+	44,  // 44: containarium.v1.ContainerService.SetMetricsExport:input_type -> containarium.v1.SetMetricsExportRequest
+	45,  // 45: containarium.v1.ContainerService.GetMetricsExport:input_type -> containarium.v1.GetMetricsExportRequest
+	46,  // 46: containarium.v1.ContainerService.CreateAlertRule:input_type -> containarium.v1.CreateAlertRuleRequest
+	47,  // 47: containarium.v1.ContainerService.ListAlertRules:input_type -> containarium.v1.ListAlertRulesRequest
+	48,  // 48: containarium.v1.ContainerService.GetAlertRule:input_type -> containarium.v1.GetAlertRuleRequest
+	49,  // 49: containarium.v1.ContainerService.UpdateAlertRule:input_type -> containarium.v1.UpdateAlertRuleRequest
+	50,  // 50: containarium.v1.ContainerService.DeleteAlertRule:input_type -> containarium.v1.DeleteAlertRuleRequest
+	51,  // 51: containarium.v1.ContainerService.GetAlertingInfo:input_type -> containarium.v1.GetAlertingInfoRequest
+	52,  // 52: containarium.v1.ContainerService.ListDefaultAlertRules:input_type -> containarium.v1.ListDefaultAlertRulesRequest
+	53,  // 53: containarium.v1.ContainerService.UpdateAlertingConfig:input_type -> containarium.v1.UpdateAlertingConfigRequest
+	54,  // 54: containarium.v1.ContainerService.TestWebhook:input_type -> containarium.v1.TestWebhookRequest
+	55,  // 55: containarium.v1.ContainerService.ListWebhookDeliveries:input_type -> containarium.v1.ListWebhookDeliveriesRequest
+	56,  // 56: containarium.v1.ContainerService.SetSecret:input_type -> containarium.v1.SetSecretRequest
+	57,  // 57: containarium.v1.ContainerService.GetSecret:input_type -> containarium.v1.GetSecretRequest
+	58,  // 58: containarium.v1.ContainerService.ListSecrets:input_type -> containarium.v1.ListSecretsRequest
+	59,  // 59: containarium.v1.ContainerService.DeleteSecret:input_type -> containarium.v1.DeleteSecretRequest
+	60,  // 60: containarium.v1.ContainerService.RefreshSecrets:input_type -> containarium.v1.RefreshSecretsRequest
+	61,  // 61: containarium.v1.ContainerService.CreateContainer:output_type -> containarium.v1.CreateContainerResponse
+	62,  // 62: containarium.v1.ContainerService.ListContainers:output_type -> containarium.v1.ListContainersResponse
+	63,  // 63: containarium.v1.ContainerService.GetContainer:output_type -> containarium.v1.GetContainerResponse
+	64,  // 64: containarium.v1.ContainerService.DebugContainer:output_type -> containarium.v1.DebugContainerResponse
+	65,  // 65: containarium.v1.ContainerService.DeleteContainer:output_type -> containarium.v1.DeleteContainerResponse
+	66,  // 66: containarium.v1.ContainerService.StartContainer:output_type -> containarium.v1.StartContainerResponse
+	67,  // 67: containarium.v1.ContainerService.StopContainer:output_type -> containarium.v1.StopContainerResponse
+	68,  // 68: containarium.v1.ContainerService.ResizeContainer:output_type -> containarium.v1.ResizeContainerResponse
+	69,  // 69: containarium.v1.ContainerService.MoveContainer:output_type -> containarium.v1.MoveContainerResponse
+	70,  // 70: containarium.v1.ContainerService.CreateContainerSnapshot:output_type -> containarium.v1.CreateContainerSnapshotResponse
+	71,  // 71: containarium.v1.ContainerService.ListContainerSnapshots:output_type -> containarium.v1.ListContainerSnapshotsResponse
+	72,  // 72: containarium.v1.ContainerService.DeleteContainerSnapshot:output_type -> containarium.v1.DeleteContainerSnapshotResponse
+	73,  // 73: containarium.v1.ContainerService.RollbackContainerSnapshot:output_type -> containarium.v1.RollbackContainerSnapshotResponse
+	74,  // 74: containarium.v1.ContainerService.DeleteTenantStorage:output_type -> containarium.v1.DeleteTenantStorageResponse
+	75,  // 75: containarium.v1.ContainerService.RewrapContainer:output_type -> containarium.v1.RewrapContainerResponse
+	76,  // 76: containarium.v1.ContainerService.PrepareEncryptedMigration:output_type -> containarium.v1.PrepareEncryptedMigrationResponse
+	77,  // 77: containarium.v1.ContainerService.AdoptMigratedContainer:output_type -> containarium.v1.AdoptMigratedContainerResponse
+	78,  // 78: containarium.v1.ContainerService.ToggleMonitoring:output_type -> containarium.v1.ToggleMonitoringResponse
+	79,  // 79: containarium.v1.ContainerService.ToggleAutoSleep:output_type -> containarium.v1.ToggleAutoSleepResponse
+	80,  // 80: containarium.v1.ContainerService.SetContainerTTL:output_type -> containarium.v1.SetContainerTTLResponse
+	81,  // 81: containarium.v1.ContainerService.SetContainerDeletePolicy:output_type -> containarium.v1.SetContainerDeletePolicyResponse
+	82,  // 82: containarium.v1.ContainerService.SetContainerAttribution:output_type -> containarium.v1.SetContainerAttributionResponse
+	83,  // 83: containarium.v1.ContainerService.AddSSHKey:output_type -> containarium.v1.AddSSHKeyResponse
+	84,  // 84: containarium.v1.ContainerService.RemoveSSHKey:output_type -> containarium.v1.RemoveSSHKeyResponse
+	85,  // 85: containarium.v1.ContainerService.AddCollaborator:output_type -> containarium.v1.AddCollaboratorResponse
+	86,  // 86: containarium.v1.ContainerService.RemoveCollaborator:output_type -> containarium.v1.RemoveCollaboratorResponse
+	87,  // 87: containarium.v1.ContainerService.ListCollaborators:output_type -> containarium.v1.ListCollaboratorsResponse
+	88,  // 88: containarium.v1.ContainerService.GetMetrics:output_type -> containarium.v1.GetMetricsResponse
+	89,  // 89: containarium.v1.ContainerService.CleanupDisk:output_type -> containarium.v1.CleanupDiskResponse
+	90,  // 90: containarium.v1.ContainerService.InstallStack:output_type -> containarium.v1.InstallStackResponse
+	91,  // 91: containarium.v1.ContainerService.ListStacks:output_type -> containarium.v1.ListStacksResponse
+	92,  // 92: containarium.v1.ContainerService.GetSystemInfo:output_type -> containarium.v1.GetSystemInfoResponse
+	93,  // 93: containarium.v1.ContainerService.ListBackends:output_type -> containarium.v1.ListBackendsResponse
+	94,  // 94: containarium.v1.ContainerService.AdvertiseCapacity:output_type -> containarium.v1.AdvertiseCapacityResponse
+	95,  // 95: containarium.v1.ContainerService.WithdrawCapacity:output_type -> containarium.v1.WithdrawCapacityResponse
+	96,  // 96: containarium.v1.ContainerService.GetCapacityHeadroom:output_type -> containarium.v1.GetCapacityHeadroomResponse
+	97,  // 97: containarium.v1.ContainerService.ProfileBackend:output_type -> containarium.v1.ProfileBackendResponse
+	98,  // 98: containarium.v1.ContainerService.GetCapabilityProfile:output_type -> containarium.v1.GetCapabilityProfileResponse
+	99,  // 99: containarium.v1.ContainerService.GetSelfMeasurement:output_type -> containarium.v1.GetSelfMeasurementResponse
+	100, // 100: containarium.v1.ContainerService.GetLatestRelease:output_type -> containarium.v1.GetLatestReleaseResponse
+	101, // 101: containarium.v1.ContainerService.ValidateGPU:output_type -> containarium.v1.ValidateGPUResponse
+	102, // 102: containarium.v1.ContainerService.TriggerUpgrade:output_type -> containarium.v1.TriggerUpgradeResponse
+	103, // 103: containarium.v1.ContainerService.GetUpgradeStatus:output_type -> containarium.v1.GetUpgradeStatusResponse
+	104, // 104: containarium.v1.ContainerService.GetMonitoringInfo:output_type -> containarium.v1.GetMonitoringInfoResponse
+	105, // 105: containarium.v1.ContainerService.SetMetricsExport:output_type -> containarium.v1.SetMetricsExportResponse
+	106, // 106: containarium.v1.ContainerService.GetMetricsExport:output_type -> containarium.v1.GetMetricsExportResponse
+	107, // 107: containarium.v1.ContainerService.CreateAlertRule:output_type -> containarium.v1.CreateAlertRuleResponse
+	108, // 108: containarium.v1.ContainerService.ListAlertRules:output_type -> containarium.v1.ListAlertRulesResponse
+	109, // 109: containarium.v1.ContainerService.GetAlertRule:output_type -> containarium.v1.GetAlertRuleResponse
+	110, // 110: containarium.v1.ContainerService.UpdateAlertRule:output_type -> containarium.v1.UpdateAlertRuleResponse
+	111, // 111: containarium.v1.ContainerService.DeleteAlertRule:output_type -> containarium.v1.DeleteAlertRuleResponse
+	112, // 112: containarium.v1.ContainerService.GetAlertingInfo:output_type -> containarium.v1.GetAlertingInfoResponse
+	113, // 113: containarium.v1.ContainerService.ListDefaultAlertRules:output_type -> containarium.v1.ListDefaultAlertRulesResponse
+	114, // 114: containarium.v1.ContainerService.UpdateAlertingConfig:output_type -> containarium.v1.UpdateAlertingConfigResponse
+	115, // 115: containarium.v1.ContainerService.TestWebhook:output_type -> containarium.v1.TestWebhookResponse
+	116, // 116: containarium.v1.ContainerService.ListWebhookDeliveries:output_type -> containarium.v1.ListWebhookDeliveriesResponse
+	117, // 117: containarium.v1.ContainerService.SetSecret:output_type -> containarium.v1.SetSecretResponse
+	118, // 118: containarium.v1.ContainerService.GetSecret:output_type -> containarium.v1.GetSecretResponse
+	119, // 119: containarium.v1.ContainerService.ListSecrets:output_type -> containarium.v1.ListSecretsResponse
+	120, // 120: containarium.v1.ContainerService.DeleteSecret:output_type -> containarium.v1.DeleteSecretResponse
+	121, // 121: containarium.v1.ContainerService.RefreshSecrets:output_type -> containarium.v1.RefreshSecretsResponse
+	61,  // [61:122] is the sub-list for method output_type
+	0,   // [0:61] is the sub-list for method input_type
 	0,   // [0:0] is the sub-list for extension type_name
 	0,   // [0:0] is the sub-list for extension extendee
 	0,   // [0:0] is the sub-list for field type_name

--- a/pkg/pb/containarium/v1/service.pb.gw.go
+++ b/pkg/pb/containarium/v1/service.pb.gw.go
@@ -547,6 +547,67 @@ func local_request_ContainerService_DeleteContainerSnapshot_0(ctx context.Contex
 	return msg, metadata, err
 }
 
+func request_ContainerService_RollbackContainerSnapshot_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq RollbackContainerSnapshotRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	val, ok := pathParams["username"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "username")
+	}
+	protoReq.Username, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "username", err)
+	}
+	val, ok = pathParams["name"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
+	}
+	protoReq.Name, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "name", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.RollbackContainerSnapshot(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ContainerService_RollbackContainerSnapshot_0(ctx context.Context, marshaler runtime.Marshaler, server ContainerServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq RollbackContainerSnapshotRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	val, ok := pathParams["username"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "username")
+	}
+	protoReq.Username, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "username", err)
+	}
+	val, ok = pathParams["name"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
+	}
+	protoReq.Name, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "name", err)
+	}
+	msg, err := server.RollbackContainerSnapshot(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_ContainerService_DeleteTenantStorage_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq DeleteTenantStorageRequest
@@ -2544,6 +2605,26 @@ func RegisterContainerServiceHandlerServer(ctx context.Context, mux *runtime.Ser
 		}
 		forward_ContainerService_DeleteContainerSnapshot_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_ContainerService_RollbackContainerSnapshot_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.ContainerService/RollbackContainerSnapshot", runtime.WithHTTPPathPattern("/v1/containers/{username}/snapshots/{name}/rollback"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ContainerService_RollbackContainerSnapshot_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_RollbackContainerSnapshot_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodDelete, pattern_ContainerService_DeleteTenantStorage_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -3768,6 +3849,23 @@ func RegisterContainerServiceHandlerClient(ctx context.Context, mux *runtime.Ser
 		}
 		forward_ContainerService_DeleteContainerSnapshot_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_ContainerService_RollbackContainerSnapshot_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.ContainerService/RollbackContainerSnapshot", runtime.WithHTTPPathPattern("/v1/containers/{username}/snapshots/{name}/rollback"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ContainerService_RollbackContainerSnapshot_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_RollbackContainerSnapshot_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodDelete, pattern_ContainerService_DeleteTenantStorage_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -4617,6 +4715,7 @@ var (
 	pattern_ContainerService_CreateContainerSnapshot_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "snapshots"}, ""))
 	pattern_ContainerService_ListContainerSnapshots_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "snapshots"}, ""))
 	pattern_ContainerService_DeleteContainerSnapshot_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3, 1, 0, 4, 1, 5, 4}, []string{"v1", "containers", "username", "snapshots", "name"}, ""))
+	pattern_ContainerService_RollbackContainerSnapshot_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3, 1, 0, 4, 1, 5, 4, 2, 5}, []string{"v1", "containers", "username", "snapshots", "name", "rollback"}, ""))
 	pattern_ContainerService_DeleteTenantStorage_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "tenants", "tenant", "storage"}, ""))
 	pattern_ContainerService_RewrapContainer_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "rewrap"}, ""))
 	pattern_ContainerService_PrepareEncryptedMigration_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "prepare-encrypted-migration"}, ""))
@@ -4681,6 +4780,7 @@ var (
 	forward_ContainerService_CreateContainerSnapshot_0   = runtime.ForwardResponseMessage
 	forward_ContainerService_ListContainerSnapshots_0    = runtime.ForwardResponseMessage
 	forward_ContainerService_DeleteContainerSnapshot_0   = runtime.ForwardResponseMessage
+	forward_ContainerService_RollbackContainerSnapshot_0 = runtime.ForwardResponseMessage
 	forward_ContainerService_DeleteTenantStorage_0       = runtime.ForwardResponseMessage
 	forward_ContainerService_RewrapContainer_0           = runtime.ForwardResponseMessage
 	forward_ContainerService_PrepareEncryptedMigration_0 = runtime.ForwardResponseMessage

--- a/pkg/pb/containarium/v1/service_grpc.pb.go
+++ b/pkg/pb/containarium/v1/service_grpc.pb.go
@@ -31,6 +31,7 @@ const (
 	ContainerService_CreateContainerSnapshot_FullMethodName   = "/containarium.v1.ContainerService/CreateContainerSnapshot"
 	ContainerService_ListContainerSnapshots_FullMethodName    = "/containarium.v1.ContainerService/ListContainerSnapshots"
 	ContainerService_DeleteContainerSnapshot_FullMethodName   = "/containarium.v1.ContainerService/DeleteContainerSnapshot"
+	ContainerService_RollbackContainerSnapshot_FullMethodName = "/containarium.v1.ContainerService/RollbackContainerSnapshot"
 	ContainerService_DeleteTenantStorage_FullMethodName       = "/containarium.v1.ContainerService/DeleteTenantStorage"
 	ContainerService_RewrapContainer_FullMethodName           = "/containarium.v1.ContainerService/RewrapContainer"
 	ContainerService_PrepareEncryptedMigration_FullMethodName = "/containarium.v1.ContainerService/PrepareEncryptedMigration"
@@ -130,6 +131,14 @@ type ContainerServiceClient interface {
 	ListContainerSnapshots(ctx context.Context, in *ListContainerSnapshotsRequest, opts ...grpc.CallOption) (*ListContainerSnapshotsResponse, error)
 	// DeleteContainerSnapshot removes a snapshot and reports what it freed.
 	DeleteContainerSnapshot(ctx context.Context, in *DeleteContainerSnapshotRequest, opts ...grpc.CallOption) (*DeleteContainerSnapshotResponse, error)
+	// RollbackContainerSnapshot returns a container's dataset to the state
+	// captured by a snapshot (#1160b).
+	//
+	// Destructive, and guarded three ways: it refuses a running container
+	// (unless force), refuses to destroy newer snapshots (unless destroy_newer),
+	// and refuses when the encryption key is unavailable — a rollback whose
+	// result cannot be read is not a restore (#1202 AC2).
+	RollbackContainerSnapshot(ctx context.Context, in *RollbackContainerSnapshotRequest, opts ...grpc.CallOption) (*RollbackContainerSnapshotResponse, error)
 	// DeleteTenantStorage tears down a departing tenant's encrypted storage
 	// (#1343) — the Incus storage pool, then the encrypted dataset it is
 	// sourced at, in that order.
@@ -492,6 +501,16 @@ func (c *containerServiceClient) DeleteContainerSnapshot(ctx context.Context, in
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(DeleteContainerSnapshotResponse)
 	err := c.cc.Invoke(ctx, ContainerService_DeleteContainerSnapshot_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *containerServiceClient) RollbackContainerSnapshot(ctx context.Context, in *RollbackContainerSnapshotRequest, opts ...grpc.CallOption) (*RollbackContainerSnapshotResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RollbackContainerSnapshotResponse)
+	err := c.cc.Invoke(ctx, ContainerService_RollbackContainerSnapshot_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1027,6 +1046,14 @@ type ContainerServiceServer interface {
 	ListContainerSnapshots(context.Context, *ListContainerSnapshotsRequest) (*ListContainerSnapshotsResponse, error)
 	// DeleteContainerSnapshot removes a snapshot and reports what it freed.
 	DeleteContainerSnapshot(context.Context, *DeleteContainerSnapshotRequest) (*DeleteContainerSnapshotResponse, error)
+	// RollbackContainerSnapshot returns a container's dataset to the state
+	// captured by a snapshot (#1160b).
+	//
+	// Destructive, and guarded three ways: it refuses a running container
+	// (unless force), refuses to destroy newer snapshots (unless destroy_newer),
+	// and refuses when the encryption key is unavailable — a rollback whose
+	// result cannot be read is not a restore (#1202 AC2).
+	RollbackContainerSnapshot(context.Context, *RollbackContainerSnapshotRequest) (*RollbackContainerSnapshotResponse, error)
 	// DeleteTenantStorage tears down a departing tenant's encrypted storage
 	// (#1343) — the Incus storage pool, then the encrypted dataset it is
 	// sourced at, in that order.
@@ -1310,6 +1337,9 @@ func (UnimplementedContainerServiceServer) ListContainerSnapshots(context.Contex
 }
 func (UnimplementedContainerServiceServer) DeleteContainerSnapshot(context.Context, *DeleteContainerSnapshotRequest) (*DeleteContainerSnapshotResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteContainerSnapshot not implemented")
+}
+func (UnimplementedContainerServiceServer) RollbackContainerSnapshot(context.Context, *RollbackContainerSnapshotRequest) (*RollbackContainerSnapshotResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method RollbackContainerSnapshot not implemented")
 }
 func (UnimplementedContainerServiceServer) DeleteTenantStorage(context.Context, *DeleteTenantStorageRequest) (*DeleteTenantStorageResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteTenantStorage not implemented")
@@ -1688,6 +1718,24 @@ func _ContainerService_DeleteContainerSnapshot_Handler(srv interface{}, ctx cont
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(ContainerServiceServer).DeleteContainerSnapshot(ctx, req.(*DeleteContainerSnapshotRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ContainerService_RollbackContainerSnapshot_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RollbackContainerSnapshotRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ContainerServiceServer).RollbackContainerSnapshot(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ContainerService_RollbackContainerSnapshot_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ContainerServiceServer).RollbackContainerSnapshot(ctx, req.(*RollbackContainerSnapshotRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -2610,6 +2658,10 @@ var ContainerService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "DeleteContainerSnapshot",
 			Handler:    _ContainerService_DeleteContainerSnapshot_Handler,
+		},
+		{
+			MethodName: "RollbackContainerSnapshot",
+			Handler:    _ContainerService_RollbackContainerSnapshot_Handler,
 		},
 		{
 			MethodName: "DeleteTenantStorage",

--- a/proto/containarium/v1/container.proto
+++ b/proto/containarium/v1/container.proto
@@ -1305,6 +1305,42 @@ message DeleteContainerSnapshotResponse {
   int64 freed_bytes = 2;
 }
 
+// RollbackContainerSnapshotRequest returns a container's dataset to the state
+// captured by a snapshot.
+//
+// Destructive twice over: everything written since the snapshot is discarded,
+// and any snapshot taken after it must be destroyed too. Both are refusals by
+// default (#1160b).
+message RollbackContainerSnapshotRequest {
+  string username = 1;
+
+  // The snapshot to roll back to.
+  string name = 2;
+
+  // Stop the container first. Without it, a rollback of a running container
+  // is refused: ZFS would fail on the busy dataset anyway, and "dataset is
+  // busy" is a far worse message than "stop the container first".
+  bool force = 3;
+
+  // Destroy snapshots taken after the target, which ZFS requires in order to
+  // roll back past them. Opt-in because it silently widens the blast radius
+  // from "lose writes since the snapshot" to "lose other restore points too".
+  bool destroy_newer = 4;
+}
+
+message RollbackContainerSnapshotResponse {
+  string message = 1;
+
+  // Whether the daemon stopped the container to perform the rollback. It is
+  // left stopped — restarting it is the caller's decision, since the data
+  // underneath just changed.
+  bool container_stopped = 2;
+
+  // Snapshots destroyed to make the rollback possible, so the caller has a
+  // record of the restore points they no longer have.
+  repeated string destroyed_snapshots = 3;
+}
+
 // DeleteTenantStorageRequest tears down a departing tenant's encrypted
 // storage (#1343): the Incus storage pool, and the encrypted dataset it is
 // sourced at.

--- a/proto/containarium/v1/service.proto
+++ b/proto/containarium/v1/service.proto
@@ -221,6 +221,25 @@ service ContainerService {
     };
   }
 
+  // RollbackContainerSnapshot returns a container's dataset to the state
+  // captured by a snapshot (#1160b).
+  //
+  // Destructive, and guarded three ways: it refuses a running container
+  // (unless force), refuses to destroy newer snapshots (unless destroy_newer),
+  // and refuses when the encryption key is unavailable — a rollback whose
+  // result cannot be read is not a restore (#1202 AC2).
+  rpc RollbackContainerSnapshot(RollbackContainerSnapshotRequest) returns (RollbackContainerSnapshotResponse) {
+    option (google.api.http) = {
+      post: "/v1/containers/{username}/snapshots/{name}/rollback"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Roll a container back to a snapshot";
+      description: "Discards everything written since the snapshot. Refuses a running container unless force is set, refuses to destroy newer snapshots unless destroy_newer is set, and refuses when the container's encryption key is unavailable.";
+      tags: "Container Operations";
+    };
+  }
+
   // DeleteTenantStorage tears down a departing tenant's encrypted storage
   // (#1343) — the Incus storage pool, then the encrypted dataset it is
   // sourced at, in that order.


### PR DESCRIPTION
Slice (b) of #1160, per the accepted design in `docs/architecture/container-snapshots.md`.

> ⚠️ **Stacked on #1381** (`feat/1160a-snapshot-lifecycle`), which adds the dataset resolution this reuses. Review #1381 first. When merging #1381, **do not pass `--delete-branch`** — deleting the base auto-closes this PR, and it cannot be reopened or retargeted.

`zfscrypt.RollbackToSnapshot` has existed since #1200 and is verified against a real pool. What this adds is the three refusals that make a destructive operation safe to expose over an API — each checked **before** anything is destroyed, because a guard that reports an error after rolling back is not a guard.

## The three guards

1. **A running container**, unless `--force`, in which case the daemon stops it first and leaves it stopped (the data underneath just changed; restarting is the operator's call). ZFS would refuse the busy dataset anyway, but "dataset is busy" sends an operator looking for a mount problem instead of telling them the one thing to do. The stop must come *before* the rollback, or force fails on exactly the containers it exists for.
2. **Newer snapshots**, unless `--destroy-newer`. The response **names** what went — these restore points no longer exist and nothing else records which they were. The list is read before the rollback; afterwards it comes back empty.
3. **An unavailable encryption key.** A rollback whose result cannot be read is not a restore: the operator would believe they recovered data that is ciphertext to them.

Guard 3 closes **#1202's second acceptance criterion**, which had no home after the lifecycle slice. Rollback is the first operation that actually depends on a snapshot's contents being readable.

## A latent bug this had to fix first

`EnsureInspectable` propagated `KeyStatus`'s error verbatim — and `KeyStatus` returns an **error** for an *unencrypted* dataset (ZFS reports `keystatus` as `-`). As written, the guard would have refused inspection and rollback for essentially every container on the platform, while its own tests stayed green because they only ever supplied an encrypted dataset.

"Not encrypted" is now `zfscrypt.ErrNotEncrypted`, a sentinel rather than a message, so a caller can distinguish three genuinely different situations — *there is no key here* / *the key is missing* / *zfs did not answer* — without matching on text. A guard that cannot tell them apart either blocks the whole fleet or fails open on a broken pool.

## Test evidence

18 tests added (13 unit + 1 real-pool + 4 CLI), plus 3 in `zfscrypt` for the sentinel.

Green on the first run proves nothing, so every guard was mutation-tested. All eight caught:

| Mutation | Result |
|---|---|
| Key-availability guard removed | caught |
| Running-container refusal removed | caught |
| Unknown box state treated as safe | caught |
| Stop happens *after* the rollback | caught (3 tests) |
| Doomed-snapshot list read *after* the rollback | caught |
| Doomed-snapshot list not read at all | caught |
| `ErrNewerSnapshotsExist` not translated | caught |
| `destroy_newer` flag not forwarded | caught |

The "list read after the rollback" case needed a new ordering hook on the shared `zfsFake` — with a static canned listing, only the *order* can expose a read that came too late.

`go vet` clean under all five build tags.

### What only the lane can show

`TestIntegrationIncus_RollbackRestoresDataAndRefusesWithoutTheKey` makes two claims the unit tests cannot, because both are properties of ZFS rather than of the daemon:

- **The rollback actually restores data.** It writes `/root/marker`, snapshots, overwrites it, rolls back, restarts the container and reads it back. A fake can only show that `zfs rollback` was invoked — the outcome an operator would otherwise discover mid-incident.
- **The key guard fires on a genuinely unkeyed dataset**, with the key really unloaded via `PostStop`, rather than against a canned `"unavailable"` string this test chose itself.

**CI: all 11 checks green.** A green lane is not evidence the new test ran, so — from the Incus lane log ([run](https://github.com/FootprintAI/Containarium/actions/runs/31931017171/job/95125734631), 11m30s):

```
=== RUN   TestIntegrationIncus_RollbackRestoresDataAndRefusesWithoutTheKey
--- PASS: TestIntegrationIncus_RollbackRestoresDataAndRefusesWithoutTheKey (38.94s)
```

and the refusal it produced against a genuinely unkeyed dataset — this is the message an operator sees, not one a fake supplied:

```
refusing to roll <tenant> back to restorepoint: <pool>/tenants/<tenant>/containers/<tenant>-container@restorepoint:
snapshot contents cannot be read: the dataset's encryption key is not loaded
(dataset <pool>/tenants/<tenant>/containers/<tenant>-container, keystatus "unavailable").
The rollback itself would succeed, but the result would be ciphertext this daemon cannot open —
restore key custody and retry, and the snapshot is unharmed in the meantime
```

The lane's "assert nothing was skipped" guard held. The `zfscrypt` sentinel tests and the unit/CLI tests ran in the unit lane (`ok internal/server 9.417s`, `ok internal/cmd 2.052s`, `ok pkg/core/zfscrypt 1.012s`).

## Follow-up

#1160c (clone) remains unfiled: it needs a `zfscrypt` clone primitive that does not exist, and the constraint that a ZFS clone cannot leave its origin's encryptionroot is worth confirming on the lane before designing the API.

