### PR TITLE
test(app): cover the daemon config store against Postgres (#1300)

### DIFF
--- a/.github/workflows/store-integration.yml
+++ b/.github/workflows/store-integration.yml
@@ -104,7 +104,7 @@ jobs:
 
           # And a run that matched nothing would also be green. Require that
           # the suite actually executed.
-          for want in TestAgentTaskQueue_ConcurrentLeasesAreDistinct TestAuditChain_ConcurrentAppendersDoNotFork TestSecretsStore_Roundtrip TestStoreOperations TestRevocationStore_RevokedTokenReadsAsRevoked TestCollaboratorStore_ListingIsScopedToTheSubject TestRouteStore_SaveIsAnUpsertByDomain TestAlertStore_RuleRoundTrips TestPassthroughStore_PortAndProtocolAreDistinctRoutes; do
+          for want in TestAgentTaskQueue_ConcurrentLeasesAreDistinct TestAuditChain_ConcurrentAppendersDoNotFork TestSecretsStore_Roundtrip TestStoreOperations TestRevocationStore_RevokedTokenReadsAsRevoked TestCollaboratorStore_ListingIsScopedToTheSubject TestRouteStore_SaveIsAnUpsertByDomain TestAlertStore_RuleRoundTrips TestPassthroughStore_PortAndProtocolAreDistinctRoutes TestDaemonConfigStore_SetAllRollsBackAPartialBatch; do
             if ! grep -q -- "--- PASS: $want" integration.log; then
               echo "::error::$want did not run — renamed, retagged, or filtered out."
               exit 1

--- a/internal/app/daemon_config_store.go
+++ b/internal/app/daemon_config_store.go
@@ -2,9 +2,11 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -35,13 +37,33 @@ func (s *DaemonConfigStore) initSchema(ctx context.Context) error {
 	return err
 }
 
-// Get retrieves a single config value by key. Returns empty string if not found.
+// ErrDaemonConfigNotFound reports that no value is stored under a key.
+//
+// A sentinel because absence is a normal answer here and has to be
+// distinguishable from a database failure: the daemon reads this store while
+// bootstrapping, and "nothing configured yet" means fall back to defaults
+// while "the database is unreachable" means do not.
+//
+// It wraps pgx.ErrNoRows rather than replacing it, so callers already
+// matching on that keep working.
+var ErrDaemonConfigNotFound = errors.New("no daemon config stored under that key")
+
+// Get retrieves a single config value by key.
+//
+// A missing key is an ERROR wrapping ErrDaemonConfigNotFound, not an empty
+// string — the doc used to claim otherwise, and it was wrong (#1300). The
+// distinction matters: a stored empty value is a real setting ("switched
+// off"), and collapsing it together with absence and with a failed query
+// would have the daemon boot on defaults believing they were configured.
 func (s *DaemonConfigStore) Get(ctx context.Context, key string) (string, error) {
 	var value string
 	err := s.pool.QueryRow(ctx,
 		"SELECT value FROM daemon_config WHERE key = $1", key,
 	).Scan(&value)
 	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return "", fmt.Errorf("%s: %w: %w", key, ErrDaemonConfigNotFound, err)
+		}
 		return "", err
 	}
 	return value, nil

--- a/internal/app/daemon_config_store_test.go
+++ b/internal/app/daemon_config_store_test.go
@@ -1,0 +1,242 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// Postgres coverage for the daemon config store (#1300).
+//
+// This store exists so the daemon can self-bootstrap after its VM is
+// recreated: it is where the alert webhook secret and the metrics-export
+// config live between restarts. A bug here is not visible at write time —
+// the daemon comes back up and is quietly missing the configuration it was
+// running with, which is the failure mode #1080 already burned this project
+// on once.
+//
+// It had no test of any kind. Gated on the DSN like the rest of this
+// package, not skipped unconditionally: the store-integration lane sets it
+// and asserts these ran.
+
+func newDaemonConfigStoreForTest(t *testing.T) (*DaemonConfigStore, string) {
+	t.Helper()
+	store, err := NewDaemonConfigStore(context.Background(), routeTestPool(t))
+	if err != nil {
+		t.Fatalf("NewDaemonConfigStore: %v", err)
+	}
+	// Unique per test so repeated or parallel runs cannot collide on the
+	// primary key, and so cleanup can be scoped to this test's rows.
+	prefix := fmt.Sprintf("test.%s.%d.", strings.ReplaceAll(t.Name(), "/", "_"), os.Getpid())
+	t.Cleanup(func() {
+		_, _ = store.pool.Exec(context.Background(),
+			"DELETE FROM daemon_config WHERE key LIKE $1", prefix+"%")
+	})
+	return store, prefix
+}
+
+// Set has to be an upsert. The daemon writes the same keys on every start,
+// so a plain INSERT would fail on the primary key the second time the daemon
+// ever booted — and the value it failed to write is the one it needs after
+// the NEXT restart.
+func TestDaemonConfigStore_SetIsAnUpsert(t *testing.T) {
+	ctx := context.Background()
+	store, prefix := newDaemonConfigStoreForTest(t)
+	key := prefix + "webhook_secret"
+
+	if err := store.Set(ctx, key, "first"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if err := store.Set(ctx, key, "second"); err != nil {
+		t.Fatalf("re-Set the same key: %v — a non-upsert fails on the primary key, and the "+
+			"daemon rewrites these on every start", err)
+	}
+
+	got, err := store.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != "second" {
+		t.Errorf("value = %q, want the updated %q", got, "second")
+	}
+}
+
+// A missing key returns an ERROR, not ("", nil).
+//
+// The doc comment on Get says "Returns empty string if not found", and that
+// is wrong — it returns pgx.ErrNoRows. Worth pinning rather than quietly
+// fixing the comment, because the difference decides how a caller is written:
+// the one production reader (metrics_export_server.go) does
+// `if raw, err := Get(...); err == nil && raw != ""`, which is correct against
+// the real behaviour and would silently swallow genuine database errors if it
+// had been written against the comment instead.
+func TestDaemonConfigStore_GetReportsAMissingKeyAsAnError(t *testing.T) {
+	ctx := context.Background()
+	store, prefix := newDaemonConfigStoreForTest(t)
+
+	got, err := store.Get(ctx, prefix+"definitely-absent")
+	if err == nil {
+		t.Fatalf("Get on an absent key returned (%q, nil) — a caller cannot then tell 'never "+
+			"configured' from 'configured as the empty string' from 'the database is down', and "+
+			"the daemon would boot with defaults believing that was the stored config", got)
+	}
+	if !errors.Is(err, ErrDaemonConfigNotFound) {
+		t.Errorf("err = %v, want ErrDaemonConfigNotFound — matching on the message instead is "+
+			"what the sentinel exists to avoid", err)
+	}
+	// The underlying pgx error stays reachable, so existing callers that
+	// match on it are not broken by the sentinel.
+	if !errors.Is(err, pgx.ErrNoRows) {
+		t.Errorf("err = %v, want pgx.ErrNoRows to remain matchable underneath", err)
+	}
+	if got != "" {
+		t.Errorf("value = %q alongside the error, want empty", got)
+	}
+}
+
+// An empty stored value is a real value, distinguishable from absence. This
+// is the case the sentinel buys: without it, "" and not-found are the same
+// answer.
+func TestDaemonConfigStore_AnEmptyValueIsNotAbsence(t *testing.T) {
+	ctx := context.Background()
+	store, prefix := newDaemonConfigStoreForTest(t)
+	key := prefix + "deliberately_empty"
+
+	if err := store.Set(ctx, key, ""); err != nil {
+		t.Fatalf("Set to empty: %v", err)
+	}
+	got, err := store.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("Get of a deliberately-empty value returned an error (%v) — the daemon cannot "+
+			"then store 'this is switched off' as distinct from 'never set'", err)
+	}
+	if got != "" {
+		t.Errorf("value = %q, want the empty string that was stored", got)
+	}
+}
+
+func TestDaemonConfigStore_GetAllReturnsWhatWasWritten(t *testing.T) {
+	ctx := context.Background()
+	store, prefix := newDaemonConfigStoreForTest(t)
+
+	want := map[string]string{
+		prefix + "a": "1",
+		prefix + "b": "2",
+		prefix + "c": "3",
+	}
+	if err := store.SetAll(ctx, want); err != nil {
+		t.Fatalf("SetAll: %v", err)
+	}
+
+	all, err := store.GetAll(ctx)
+	if err != nil {
+		t.Fatalf("GetAll: %v", err)
+	}
+	for k, v := range want {
+		if all[k] != v {
+			t.Errorf("GetAll()[%q] = %q, want %q — this is the map the daemon rehydrates from "+
+				"after a VM recreation, so a missing pair is config silently lost", k, all[k], v)
+		}
+	}
+}
+
+// SetAll must upsert too, for the same reason Set does.
+func TestDaemonConfigStore_SetAllOverwritesExistingKeys(t *testing.T) {
+	ctx := context.Background()
+	store, prefix := newDaemonConfigStoreForTest(t)
+	key := prefix + "rewritten"
+
+	if err := store.Set(ctx, key, "before"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if err := store.SetAll(ctx, map[string]string{key: "after"}); err != nil {
+		t.Fatalf("SetAll over an existing key: %v", err)
+	}
+
+	got, err := store.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != "after" {
+		t.Errorf("value = %q, want %q", got, "after")
+	}
+}
+
+// SetAll is a transaction, and the rollback is the reason it is one.
+//
+// A partial batch is worse than a failed one: the daemon would come back with
+// half of one configuration and half of another, and nothing would report it.
+// The failure is induced with a NUL byte, which PostgreSQL rejects in TEXT —
+// a deterministic mid-statement error that needs no fault injection.
+//
+// Map iteration order is random, so which key hits the bad row first varies.
+// With many good keys and one bad one, the run that writes nothing before
+// failing is rare; every run still asserts the same thing, and the assertion
+// holds either way.
+func TestDaemonConfigStore_SetAllRollsBackAPartialBatch(t *testing.T) {
+	ctx := context.Background()
+	store, prefix := newDaemonConfigStoreForTest(t)
+
+	batch := map[string]string{}
+	for i := 0; i < 20; i++ {
+		key := fmt.Sprintf("%sgood%02d", prefix, i)
+		if err := store.Set(ctx, key, "before"); err != nil {
+			t.Fatalf("seed %s: %v", key, err)
+		}
+		batch[key] = "after"
+	}
+	batch[prefix+"poison"] = "bad\x00value" // PostgreSQL rejects NUL in TEXT
+
+	if err := store.SetAll(ctx, batch); err == nil {
+		t.Fatal("SetAll accepted a value PostgreSQL cannot store — the induced failure did not " +
+			"happen, so this test proves nothing about rollback")
+	}
+
+	after, err := store.GetAll(ctx)
+	if err != nil {
+		t.Fatalf("GetAll: %v", err)
+	}
+	for key := range batch {
+		if key == prefix+"poison" {
+			if _, present := after[key]; present {
+				t.Errorf("the poison key %q was committed despite the batch failing", key)
+			}
+			continue
+		}
+		if after[key] != "before" {
+			t.Errorf("%q = %q after a failed batch, want the original %q — the transaction did "+
+				"not roll back, so the daemon now holds half of one configuration and half of "+
+				"another with nothing reporting it", key, after[key], "before")
+		}
+	}
+}
+
+// The schema initialiser runs on every daemon start, so it has to be safe to
+// run against a database that already has the table.
+func TestDaemonConfigStore_SchemaInitIsRepeatable(t *testing.T) {
+	ctx := context.Background()
+	store, prefix := newDaemonConfigStoreForTest(t)
+	key := prefix + "survivor"
+
+	if err := store.Set(ctx, key, "value"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	// A second store over the same database, as a restart produces.
+	if _, err := NewDaemonConfigStore(ctx, store.pool); err != nil {
+		t.Fatalf("re-initialising the schema failed: %v — the daemon would not start twice", err)
+	}
+
+	got, err := store.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("Get after re-init: %v", err)
+	}
+	if got != "value" {
+		t.Errorf("value = %q after re-initialising the schema, want %q — a re-init that dropped "+
+			"data would erase the config the daemon restarted to recover", got, "value")
+	}
+}


### PR DESCRIPTION
Next store in the #1300 sweep. This one is how the daemon self-bootstraps after its VM is recreated — the alert webhook secret and the metrics-export config live here between restarts — and it had **no test of any kind**. Its failure mode is invisible at write time: the daemon comes back up quietly missing the configuration it was running with, which is the shape of bug #1080 already cost this project once.

## What the tests found

**`Get`'s doc comment was wrong, in the dangerous direction.** It claimed *"Returns empty string if not found"*; it actually returned `pgx.ErrNoRows`. A caller written against the comment would do `v, _ := Get(...)` and read a **database outage** as "not configured" — then boot on defaults believing they were the stored config.

Fixed by making absence a sentinel rather than by editing the comment, matching this package's own `ErrRouteNotFound` precedent:

```go
var ErrDaemonConfigNotFound = errors.New("no daemon config stored under that key")
```

It **wraps** `pgx.ErrNoRows` rather than replacing it, so anything already matching on that keeps working. The one production reader (`metrics_export_server.go:107`, `err == nil && raw != ""`) is correct against both old and new behaviour and is untouched.

A stored **empty value** is a real setting ("switched off") and stays distinguishable from absence — that distinction is what the sentinel buys, and it has its own test.

## The seven tests

| Test | What breaks without it |
|---|---|
| `SetIsAnUpsert` | A plain INSERT fails the second time the daemon ever boots — and the value it failed to write is the one needed after the *next* restart |
| `GetReportsAMissingKeyAsAnError` | Absence, an empty value, and a dead database become one answer |
| `AnEmptyValueIsNotAbsence` | "Switched off" cannot be stored |
| `GetAllReturnsWhatWasWritten` | The map the daemon rehydrates from is silently short |
| `SetAllOverwritesExistingKeys` | Same as Set, one layer up |
| `SetAllRollsBackAPartialBatch` | The daemon holds half of one configuration and half of another, with nothing reporting it |
| `SchemaInitIsRepeatable` | The daemon cannot start twice |

The rollback test induces its failure with a **NUL byte**, which PostgreSQL rejects in `TEXT` — deterministic, no fault injection needed. Map iteration order is random, so the comment records that the "wrote some rows, then rolled back" path is overwhelmingly but not certainly exercised on any single run; the assertion holds either way rather than passing vacuously.

## Test evidence — please read this bit

**I could not run these against a real Postgres.** This environment has no working Docker, so they compile and skip locally, and **the store-integration lane is the only gate.** I am flagging it rather than implying a local green run, because my last #1300 PR shipped a wrong expectation that was caught *only* by running against real Postgres first — the route store returns a sentinel on absence, not `(nil, nil)`.

The specific assumptions the lane is adjudicating:
- `QueryRow(...).Scan()` returns `pgx.ErrNoRows` for a missing row (so the sentinel wraps the right error).
- PostgreSQL rejects `\x00` in a `TEXT` parameter, mid-transaction.

The lane sets `CONTAINARIUM_TEST_DSN`, runs `./internal/app/`, and fails on any `--- SKIP` — so a green tick means these actually ran rather than quietly opting out.

### Verdict: both assumptions held

`stores against a real Postgres` — [pass, 2m34s](https://github.com/FootprintAI/Containarium/actions/runs/31932429790/job/95129195012):

```
--- PASS: TestDaemonConfigStore_SetIsAnUpsert (0.02s)
--- PASS: TestDaemonConfigStore_GetReportsAMissingKeyAsAnError (0.01s)
--- PASS: TestDaemonConfigStore_AnEmptyValueIsNotAbsence (0.01s)
--- PASS: TestDaemonConfigStore_GetAllReturnsWhatWasWritten (0.01s)
--- PASS: TestDaemonConfigStore_SetAllOverwritesExistingKeys (0.01s)
--- PASS: TestDaemonConfigStore_SetAllRollsBackAPartialBatch (0.02s)
--- PASS: TestDaemonConfigStore_SchemaInitIsRepeatable (0.01s)
```

`SetAllRollsBackAPartialBatch` passing is the load-bearing one: it means PostgreSQL did reject the NUL byte mid-transaction *and* the rollback put every seeded row back.

Refs #1300.
