### PR TITLE
ci: the govulncheck gate could not fail when govulncheck did not run

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -52,22 +52,38 @@ jobs:
 
       - name: Run govulncheck
         run: |
-          # Run govulncheck and capture output for review.
-          # Allow exit code 3 (vulns found) when all findings are upstream
-          # issues with no fix available (Fixed in: N/A).
-          govulncheck -show verbose ./... 2>&1 | tee govulncheck-output.txt || true
-
-          # Fail the build only if there are vulns with a known fix we haven't applied
-          if grep -q "Fixed in:" govulncheck-output.txt && ! grep -q "Fixed in: N/A" govulncheck-output.txt; then
-            echo "::error::govulncheck found vulnerabilities with available fixes"
+          # govulncheck's exit codes are documented: 0 = no vulnerabilities,
+          # 3 = vulnerabilities found, anything else = the scan did not
+          # complete. `|| true` swallowed all three alike — and since every
+          # check below is a grep over the report, a scan that never ran left
+          # an empty file, matched nothing, and printed "govulncheck passed".
+          #
+          # That is a gate which is green precisely when the scanner is
+          # broken. Exit code 3 is still tolerated, because unfixable upstream
+          # findings are the normal state here; a tool that failed to run is
+          # not, and is now told apart from a tool that ran and found things.
+          set -o pipefail
+          rc=0
+          govulncheck -show verbose ./this-package-does-not-exist/... 2>&1 | tee govulncheck-output.txt || rc=$?  # CANARY
+          if [ "$rc" -ne 0 ] && [ "$rc" -ne 3 ]; then
+            echo "::error::govulncheck did not complete (exit $rc). A scan that did not run is not a clean scan."
             exit 1
           fi
-          # Check if ALL "Fixed in:" lines are N/A (unfixable upstream)
+          if [ ! -s govulncheck-output.txt ]; then
+            echo "::error::govulncheck produced no output. An empty report is not a clean report."
+            exit 1
+          fi
+
+          # Fail only on vulnerabilities that have a fix we have not applied.
+          # One condition, not two: the previous first check ("there are
+          # findings and NONE is N/A") is a strict subset of this one ("at
+          # least one finding is not N/A"), so it never fired on its own and
+          # only made the authoritative rule harder to identify.
           if grep "Fixed in:" govulncheck-output.txt | grep -qv "N/A"; then
             echo "::error::govulncheck found vulnerabilities with available fixes"
             exit 1
           fi
-          echo "govulncheck passed (any remaining vulns have no upstream fix)"
+          echo "govulncheck passed (the scan ran; any remaining vulns have no upstream fix)"
 
   trivy:
     name: Dependency Scan (Trivy)

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -64,7 +64,7 @@ jobs:
           # not, and is now told apart from a tool that ran and found things.
           set -o pipefail
           rc=0
-          govulncheck -show verbose ./this-package-does-not-exist/... 2>&1 | tee govulncheck-output.txt || rc=$?  # CANARY
+          govulncheck -show verbose ./... 2>&1 | tee govulncheck-output.txt || rc=$?
           if [ "$rc" -ne 0 ] && [ "$rc" -ne 3 ]; then
             echo "::error::govulncheck did not complete (exit $rc). A scan that did not run is not a clean scan."
             exit 1


### PR DESCRIPTION
Found while auditing every workflow for the `| tee` exit-code hole fixed in #1387. This one is a different mechanism and a worse outcome.

## The gate was green precisely when the scanner was broken

```bash
govulncheck -show verbose ./... 2>&1 | tee govulncheck-output.txt || true
```

`|| true` was there to tolerate **exit code 3** — vulnerabilities found — because this project's remaining findings are all upstream issues with `Fixed in: N/A`. That part is legitimate. But it swallows every other exit code identically, including the scan failing to run at all.

Everything after it is a `grep` over the report. A scan that never ran leaves an **empty file**, the greps match nothing, and the step prints:

```
govulncheck passed (any remaining vulns have no upstream fix)
```

Reproduced locally with `govulncheck` stubbed to fail:

```
go: cannot load module: network unreachable
govulncheck passed (any remaining vulns have no upstream fix)
OLD GATE exit = 0
```

A network blip, a toolchain mismatch, a module that stops resolving — any of them turn the vulnerability gate into a rubber stamp, silently, with a reassuring message.

## The fix

Read the documented exit codes instead of discarding them: **0** = clean, **3** = vulnerabilities found, **anything else** = the scan did not complete. Exit 3 is still tolerated, because unfixable upstream findings are this repo's normal state; a tool that failed to run is not, and is now told apart from one that ran and found things. An empty report also fails, as a second, cheaper check on the same condition.

Also collapses the two fix-available conditions into one. The first (`there are findings AND none is N/A`) is a strict subset of the second (`at least one finding is not N/A`), so it could never fire on its own — it only made it ambiguous which rule was authoritative.

## Proven, not asserted

A canary was pushed that pointed the scan at a package that does not exist, so `govulncheck` exits 1 without producing a report:

- [Run 31939181176](https://github.com/FootprintAI/Containarium/actions/runs/31939181176/job/95145757401) — **fail**:
  ```
  ##[error]govulncheck did not complete (exit 1). A scan that did not run is not a clean scan.
  ```
  Under the previous gate that same condition printed "govulncheck passed" and exited 0.

- Canary removed; [the real scan passes](https://github.com/FootprintAI/Containarium/actions/runs/31939280776/job/95145997400) the hardened gate, still reporting its 23 `Fixed in: N/A` findings.

## Audit result for the rest of the workflows

Every lane piping a command into `tee` was checked. `incus-create.yml` and `zfs-encryption.yml` already set `pipefail`; `store-integration.yml` is fixed in #1387; `security.yml` is this PR. No others carry the pattern.

Independent of every other open PR.
