### PR TITLE
docs(architecture): revise the clone design — the lane disproved its premise (#1160c)

### DIFF
--- a/docs/architecture/container-snapshots.md
+++ b/docs/architecture/container-snapshots.md
@@ -1,83 +1,127 @@
 # Design: container snapshots — which service owns them
 
-**Date:** 2026-08-16
-**Status:** proposed
-**Decides:** the open question on #1160, which blocks two of #1202's three criteria
+**Date:** 2026-08-16 (revised same day; see History)
+**Status:** **accepted** for ownership and the lifecycle (shipped in #1381, #1383) · **proposed** for clone (#1160c, revised below)
+**Decides:** the open question on #1160; unblocked #1202, now closed
 **Stack:** Go only — no new language, no new deployable, no new dependency
 
 ## Problem
 
-There is **no snapshot primitive exposed anywhere**. `grep -rn 'rpc.*Snapshot' proto/containarium/v1/` returns nothing.
+There was **no snapshot primitive exposed anywhere**. The ZFS layer beneath one had existed and been tested against a real pool for some time — `zfscrypt` has `Snapshot`, `ListSnapshots`, `DestroySnapshot`, `RollbackToSnapshot`, `SnapshotUsage` and `EnsureInspectable` — but everything above it was missing, which blocked #1202.
 
-The ZFS layer beneath one has existed and been tested against a real pool for some time — `zfscrypt` has `Snapshot`, `ListSnapshots`, `DestroySnapshot`, `RollbackToSnapshot`, `SnapshotUsage` and `EnsureInspectable`, all exercised on the `zfs-encryption` lane. What is missing is everything above it.
-
-That gap blocks work: **#1202's AC2 and AC3 name snapshot behaviour that cannot be implemented against a surface that does not exist**, and #1202 is a sprint issue (#1333). #1160 proposes filling the gap by adding the RPCs to `VolumeService`.
-
-**Before any of it is written, one question needs an answer: which service owns container snapshots?** Answering it inside a feature PR would settle an architecture decision by implementation, quietly.
+The original open question was **which service owns container snapshots**, because answering it inside a feature PR would settle an architecture decision by implementation, quietly.
 
 ## Decision
 
-**`ContainerService`.**
+**`ContainerService`.** Shipped in #1381 and #1383; #1202 closed on the result.
 
-A container snapshot's subject is a container. The caller holds a username; the dataset is an implementation detail the daemon already resolves for itself (`incus.ContainerDataset`). Three things follow, and together they decide it:
+A container snapshot's subject is a container. The caller holds a username; the dataset is an implementation detail the daemon already resolves (`incus.ContainerDataset`). Three things follow:
 
-1. **Authorization is already correct there.** Every `ContainerService` RPC runs `AuthorizeTenant(ctx, req.Username)`. A snapshot is tenant-scoped in exactly the same way. On `VolumeService` the subject is a shared volume that several tenants attach, so the tenant check means something different.
-2. **The encryption interactions live there.** #1202 is about snapshot behaviour *under encryption* — whether the key is loaded, what `EnsureInspectable` reports. `encryptionHooks` is a `ContainerServer` field. Putting the RPCs elsewhere means a second server reaching into that state.
-3. **It needs no new service to exist.** A `SnapshotService` would be justified by a second consumer; there is exactly one today.
+1. **Authorization is already correct there.** Every `ContainerService` RPC runs `AuthorizeTenant(ctx, req.Username)`. On `VolumeService` the subject is a shared volume several tenants attach, so the tenant check means something different.
+2. **The encryption interactions live there.** `encryptionHooks` is a `ContainerServer` field. Putting the RPCs elsewhere means a second server reaching into that state.
+3. **It needs no new service to exist.** A `SnapshotService` would be justified by a second consumer; there is exactly one.
 
 ### What this is not
 
-**Not `VolumeService`.** That service is **CephFS shared multi-writer volumes** (#384). `volume.Manager` shells out to `incus storage volume`, and the service is capability-gated on a CephFS pool being present — `ListVolumes` even reports `shared_volumes_supported` for the backend. Adding ZFS container-dataset snapshots there produces a service spanning two substrates with two different capability gates, where a host with no CephFS has half a service working and half not, and every RPC must disambiguate *which kind of thing am I snapshotting*.
+**Not `VolumeService`.** That service is **CephFS shared multi-writer volumes** (#384), capability-gated on a CephFS pool. Adding ZFS container-dataset snapshots there produces a service spanning two substrates with two capability gates, where every RPC must disambiguate *which kind of thing am I snapshotting*.
 
-**Not `BackupService`**, despite the name. That is **logical database backup** — `pg_dump`-shaped, into GCS, with `RestoreBackup` loading into a *different* target container. It leaves the host and is portable across them. A ZFS snapshot is physical, host-local, instantaneous, and is the substrate under rollback and clone. The two answer different questions ("can I get this data somewhere else?" vs "can I return this container to how it was ten minutes ago?"), and conflating them would make `RestoreBackup` and `RollbackToSnapshot` look like variants of one operation when their failure modes share nothing.
+**Not `BackupService`**, despite the name. That is **logical database backup** — `pg_dump`-shaped, into GCS, restorable into a *different* container. A ZFS snapshot is physical, host-local and instantaneous. The two answer different questions ("can I get this data somewhere else?" vs "can I return this container to how it was ten minutes ago?").
 
-**Not both.** If CephFS volume snapshots are wanted later they belong on `VolumeService`, over the same `zfscrypt`-shaped primitive underneath. Two thin surfaces over one shared layer beats one surface spanning two substrates.
+**Not both.** If CephFS volume snapshots are wanted later they belong on `VolumeService`, over the same primitive underneath.
 
 ## Contracts
 
-Added to `ContainerService`, all tenant-scoped, all over the existing grpc-gateway REST mapping:
+On `ContainerService`, tenant-scoped, over the existing grpc-gateway REST mapping.
 
-| RPC | HTTP | Notes |
+| RPC | HTTP | Status |
 |---|---|---|
-| `CreateContainerSnapshot` | `POST /v1/containers/{username}/snapshots` | Succeeds with the key unloaded — see below |
-| `ListContainerSnapshots` | `GET /v1/containers/{username}/snapshots` | Carries per-snapshot space usage |
-| `DeleteContainerSnapshot` | `DELETE /v1/containers/{username}/snapshots/{name}` | Also works with the key unloaded |
-| `RollbackContainerSnapshot` | `POST /v1/containers/{username}/snapshots/{name}/rollback` | Destructive; refuses a running container unless forced |
+| `CreateContainerSnapshot` | `POST /v1/containers/{username}/snapshots` | shipped #1381 — succeeds with the key unloaded |
+| `ListContainerSnapshots` | `GET /v1/containers/{username}/snapshots` | shipped #1381 — carries per-snapshot space usage |
+| `DeleteContainerSnapshot` | `DELETE /v1/containers/{username}/snapshots/{name}` | shipped #1381 — works with the key unloaded |
+| `RollbackContainerSnapshot` | `POST /v1/containers/{username}/snapshots/{name}/rollback` | shipped #1383 — three guards, below |
+| `CloneContainerFromSnapshot` | `POST /v1/containers/{username}/snapshots/{name}/clone` | **proposed** — #1160c, revised below |
 
-Every one gets a `containarium container snapshot ...` CLI verb in the same PR that adds it. An RPC with no CLI counterpart is this repo's documented anti-pattern (CLAUDE.md, "CLI-first, MCP wraps it"), and the MCP tool then wraps the same function for free.
+CLI is **`containarium snapshot <verb>`**, not `containarium container snapshot`: there is no `container` parent command in this CLI — container verbs are top-level (`create`, `delete`, `list`, `info`, `move`, `label`, `backup`). The earlier wording in this doc described a command group that does not exist.
 
-**Space usage is not optional.** #1160's third criterion exists because a forgotten snapshot silently pins disk; `SnapshotUsage` already reports it, so `ListContainerSnapshots` carries it rather than making an operator shell out to `zfs list -t snapshot`.
+**Space usage is not optional.** A forgotten snapshot silently pins disk, so `ListContainerSnapshots` carries `used_bytes` (what deleting it frees) and `referenced_bytes` rather than making an operator shell out to `zfs list -t snapshot`.
 
-## The encryption interaction, which is the whole of #1202
+## The encryption interaction (#1202, closed)
 
-Resolved decision #3 of the encryption design says snapshot creation is **allowed** when the key is unavailable, and inspection fails predictably. That asymmetry is deliberate: blocking creation on key-custody reachability would let a transient outage suppress the backup window. It is also already true of ZFS and proven on the lane (`TestIntegration_SnapshotsWorkWithTheKeyUnloaded`).
+Resolved decision #3 of the encryption design allows snapshot creation when the key is unavailable and makes inspection fail predictably. Blocking creation on key-custody reachability would let a transient outage suppress the backup window.
 
-What the API must add on top:
+- **Create and delete succeed with the key unloaded.** No key check. Proven on the Incus lane against a real pool.
+- **Inspection fails with a specific error naming key custody.** This landed on **rollback**, not on the lifecycle slice: the lifecycle deliberately needs no key, so nothing in it inspects anything. Rollback is the first operation that depends on a snapshot's *contents* being readable — a rollback whose result cannot be opened is not a restore.
+- **`encryption_state` reports `KEY_UNAVAILABLE`** on the container itself.
 
-- **Create and delete succeed with the key unloaded.** No key check on those paths.
-- **Inspection fails with a specific error, not an opaque ZFS one.** `EnsureInspectable` exists for this; the RPC maps its failure to `FailedPrecondition` naming key custody, so a caller can tell "your key is not loaded" from "that snapshot does not exist".
-- **The container's `encryption_state` already reports `KEY_UNAVAILABLE`** (#1202 AC1, merged). A caller listing snapshots on such a container has the explanation on the container itself.
+**A latent bug this surfaced.** `EnsureInspectable` propagated `KeyStatus`'s error verbatim, and `KeyStatus` errors on an *unencrypted* dataset. As written it would have refused inspection and rollback for essentially every container on the platform, while its own tests stayed green because they only ever supplied an encrypted one. "Not encrypted" is now the `zfscrypt.ErrNotEncrypted` sentinel — three distinguishable answers ("no key here" / "key missing" / "zfs did not answer") instead of one error string.
 
-With those three, #1202's AC2 and AC3 are satisfiable.
+## What the lane established about clone — and what it disproved
+
+This doc previously deferred clone saying *"a ZFS clone must stay within its origin's encryptionroot, so a clone across tenants is not expressible"*, and asked for that to be confirmed on the lane first. It was confirmed, and **the premise is wrong** (#1384, `pkg/core/zfscrypt/clone_constraints_integration_test.go`).
+
+| # | Established on a real pool | Consequence |
+|---|---|---|
+| 1 | A clone of tenant A's snapshot **can** be created under tenant B's dataset. ZFS does not confine it. | A cross-tenant clone **is** expressible and must be refused by the **daemon** — the substrate will not refuse it |
+| 2 | The clone keeps **A's** encryptionroot. With A's key unloaded and B's loaded, the clone under B reports `keystatus unavailable` | The isolation claim behind #1199 **holds**. B gains no readable copy |
+| 3 | Cloning **requires** the origin's key loaded | Clone does not follow the lifecycle's no-key rule; it needs a key precondition like rollback |
+| 4 | A clone **pins** its origin snapshot (`snapshot has dependent clones`) | Clone introduces a way for a previously-reliable `DeleteContainerSnapshot` to start failing |
+
+This is the same rule #1335 found for Incus instance volumes: **a clone inherits encryption from its origin, not from its location.** The hazard is not the one the design feared — it is *placement*, not key isolation. Tenant A's data can come to rest inside tenant B's subtree, where B's lifecycle operations act on it. Filed as **#1385** (tenant offboarding walks a tenant's own subtree and would both miss and mis-report such a clone).
+
+## The clone design (#1160c)
+
+**Clone is `incus copy`, not `zfs clone`.**
+
+#1160 proposes `CloneFromSnapshot` → "a new volume backed by a ZFS clone". Under the ownership decision above the subject is a container, and that changes the mechanism.
+
+A raw `zfs clone` produces a **dataset Incus does not know about**: not an instance, no config, no devices, absent from `incus list` and from the daemon's own container listing, outside quota accounting, and with no encryption placement record. It is storage nobody can boot. Making it bootable means reconstructing everything Incus stores about an instance — which is a re-implementation of `incus copy` with a worse failure surface.
+
+The daemon **already does this correctly elsewhere**: `MoveContainer` runs `incus snapshot <c> <snap>` then `incus copy <c>/<snap> <remote>:<c> --instance-only --storage <pool>` (`pkg/core/incus/migration.go`), and #1203 already threads the tenant pool through `--storage`. Clone is that same call with a local destination and a new instance name.
+
+The four established facts land as follows:
+
+- **Fact 1 → the daemon refuses cross-tenant.** `CloneContainerFromSnapshot` is tenant-scoped like every other `ContainerService` RPC; source and destination are both `{username}`'s. There is no cross-tenant form of the RPC, so the refusal is structural rather than a check that can be forgotten. Targeting `--storage <tenant-pool>` keeps the copy inside the tenant's encryptionroot by construction.
+- **Fact 3 → clone requires the key**, and maps its absence to `FailedPrecondition` naming key custody, exactly as rollback does. This is a *deliberate asymmetry* with create/delete and must be stated in the RPC's own doc comment: an API where some verbs need custody and others do not is one an operator cannot reason about unless it says so.
+- **Fact 4 → does not arise via `incus copy`**, which produces an independent instance rather than a dependent clone. This is the strongest argument for the mechanism: choosing `zfs clone` would import a permanent new failure mode into an already-shipped delete path, in exchange for speed.
+
+**The honest cost.** `incus copy` is a full copy where `zfs clone` is instant and initially free. A clone of a 50 GB container costs 50 GB and minutes, not bytes and milliseconds. That is the trade: an instance that exists and can be booted, against a dataset that is cheap and inert. **Open question for the lane, not for review:** whether Incus optimises a same-pool copy into a CoW clone, which would remove most of the cost. Confirm before implementation and record the answer here — the last unverified assumption in this file cost a redesign.
+
+If the CoW cost turns out to matter for a real workload, the follow-up is *`zfs clone` plus instance registration*, designed then against a measured need, not now against a guess.
+
+## Two snapshot registries — a finding against merged code
+
+The daemon now creates snapshots two ways on the same dataset:
+
+- **`incus snapshot <container> <name>`** — Incus-managed, recorded in Incus's database, used by `MoveContainer` (`containarium-move-sync0`, …).
+- **`zfs snapshot <dataset>@<name>`** — what #1160a ships.
+
+`zfscrypt.ListSnapshots` runs `zfs list -t snapshot -r <dataset>` **unfiltered**, so it returns every snapshot on that dataset regardless of origin. Two consequences follow, both against already-merged code:
+
+1. `ListContainerSnapshots` will report Incus's internal snapshots — including a migration's sync snapshots while a move is in flight — as though a tenant had taken them.
+2. `DeleteContainerSnapshot` will `zfs destroy` one, leaving Incus's database referencing a snapshot that no longer exists. During a migration that is a destroyed sync point.
+
+**Not yet confirmed:** the exact name Incus gives its ZFS snapshots (likely a `snapshot-` prefix, unverified — nothing in the repo records it). That detail decides whether the fix is a prefix filter, an Incus-side listing, or reconciling the two registries. It is one lane test to establish, and it should be established before the fix is designed.
+
+Filed separately rather than folded into #1160c: it is a defect in shipped code, not a clone decision.
 
 ## Test strategy
 
 | Component | Tests |
 |---|---|
-| `ContainerServer` snapshot RPCs | Table-driven unit tests over a fake `zfscrypt` runner: name validation, tenant authorization, the rollback refusal, and the error mapping for an unloadable key |
-| Rollback guard | `TestRollbackContainerSnapshot_RefusesARunningContainerUnlessForced` — the destructive path, so the refusal is asserted rather than assumed |
-| Encryption behaviour | On the **`zfs-encryption` lane**, against a real pool: create and delete a snapshot with the key unloaded, then confirm inspection fails with the mapped error. A fake cannot answer whether ZFS permits the operation |
-| Space usage | Real pool: write, snapshot, delete the data, and assert the snapshot still reports non-zero usage — the property that makes a forgotten snapshot expensive |
+| Snapshot RPCs (shipped) | Table-driven units over a fake `zfscrypt` runner: dataset resolution through the **tenant** pool, name validation, tenant authorization, scope gating, error mapping. Mutation-tested — six mutations applied, all caught |
+| Rollback guards (shipped) | One test per refusal, each asserting the destructive command **did not run**; a guard that errors after rolling back is not a guard. Eight mutations, all caught |
+| Encryption behaviour (shipped) | Incus lane, real pool: create/list/delete with the key genuinely unloaded via `PostStop`; rollback restores real file content and is refused when the key is unavailable |
+| **Clone (#1160c)** | Unit: cross-tenant is unexpressible in the request shape; key-unavailable maps to `FailedPrecondition` naming custody; destination-name collision refused. **Lane, before implementation:** does a same-pool `incus copy` produce a CoW clone or a full copy, and does the result land in the tenant's encryptionroot? |
+| **Two registries** | Lane: create an Incus instance snapshot, then assert what `ListContainerSnapshots` reports — the naming question above |
 
-Nothing here needs a real Incus, so the existing ZFS lane covers it; the Incus lane is not extended.
+The clone row deliberately puts a lane test **before** the implementation. That ordering is what turned this revision from a plausible constraint into a disproved one.
 
 ## Suggested split
 
-Three PRs, each with its RPC, CLI verb and tests:
-
-1. **#1160a — snapshot lifecycle** (create / list+usage / delete). Closes #1160's ACs 1, 3, 4 and **unblocks #1202's AC2 and AC3**, which is why it goes first.
-2. **#1160b — rollback.** #1160's AC2. Destructive, so it earns its own review.
-3. **#1160c — clone.** Needs a `zfscrypt` clone primitive that does not exist, and carries a real constraint: a ZFS clone must stay within its origin's encryptionroot, so a clone across tenants is not expressible. Worth confirming on the lane before designing the API.
+1. ~~**#1160a — snapshot lifecycle**~~ — **shipped** (#1380 / PR #1381).
+2. ~~**#1160b — rollback**~~ — **shipped** (#1382 / PR #1383).
+3. **#1160c — clone**, revised above: `incus copy` with a local destination, gated on the lane answering the CoW question first.
+4. **New — the two-registry defect**, against merged code, gated on the naming question.
 
 ## Deviations from the default stack
 
@@ -85,16 +129,19 @@ Three PRs, each with its RPC, CLI verb and tests:
 
 ## Rejected alternatives
 
-**Add to `VolumeService`** (as #1160 proposes) — two substrates, two capability gates, one service; every RPC would need to disambiguate its subject. Rejected above.
+**`zfs clone` for the clone verb** — the mechanism #1160 proposes. It produces a dataset Incus does not know about: unbootable without re-implementing instance registration, invisible to quota accounting and the encryption placement record, and it pins its origin snapshot, importing a new failure mode into the shipped delete path. Rejected in favour of `incus copy`, which the daemon already uses for migration. Revisit only if a measured CoW need appears.
 
-**Add to `BackupService`** — logical, portable, off-host backups are a different operation from physical, host-local snapshots, and the naming similarity is the only thing they share.
+**Add to `VolumeService`** (as #1160 proposes) — two substrates, two capability gates, one service; every RPC would need to disambiguate its subject.
 
-**A new `SnapshotService`** — the cleanest separation, and the right answer the day a second substrate needs snapshotting. Today it would be a service, its registration, its client and its CLI namespace, all for one consumer. Reconsider when CephFS volume snapshots are actually wanted.
+**Add to `BackupService`** — logical, portable, off-host backups are a different operation from physical, host-local snapshots; the naming similarity is all they share.
 
-**Expose nothing; let operators use `zfs` directly** — the status quo. Rejected because it is what blocks #1202, and because a snapshot taken outside the daemon is invisible to quota accounting and to the encryption state the daemon reports.
+**A new `SnapshotService`** — the right answer the day a second substrate needs snapshotting. Today it is a service, its registration, its client and its CLI namespace for one consumer.
+
+**Expose nothing; let operators use `zfs` directly** — the status quo that blocked #1202. A snapshot taken outside the daemon is invisible to quota accounting and to the encryption state the daemon reports.
 
 ## History
 
 | Date | Author | Change |
 |---|---|---|
-| 2026-08-16 | drafted with Claude (`agent-c9aced4b`) | Initial draft, answering #1160's service-ownership question so #1202 can be unblocked. Status: proposed. |
+| 2026-08-16 | drafted with Claude (`agent-c9aced4b`) | Initial draft, answering #1160's service-ownership question so #1202 could be unblocked. Status: proposed. |
+| 2026-08-16 | revised with Claude (`agent-c9aced4b`) | Ownership **accepted** — implemented and merged (#1381, #1383); #1202 closed. **Clone section rewritten**: the lane (#1384) disproved this doc's premise that ZFS confines a clone to its origin's encryptionroot, so clone moves from `zfs clone` to `incus copy` and the cross-tenant refusal moves to the daemon. Added the two-snapshot-registry finding against merged code. Corrected the CLI namespace to `containarium snapshot`. |


### PR DESCRIPTION
Revises the clone section of `docs/architecture/container-snapshots.md` after #1384 answered the question this doc asked it to answer.

## What changed and why

The doc deferred clone to #1160c on this claim:

> a ZFS clone must stay within its origin's encryptionroot, so a clone across tenants is not expressible

and said it was *"worth confirming on the lane before designing the API"*. #1384 confirmed it. **It is wrong.**

ZFS permits the cross-tenant clone — it simply does not **re-key** it. The clone keeps its origin's encryptionroot. Same rule #1335 found for Incus instance volumes: a clone inherits encryption from its **origin**, not its **location**.

- **Isolation holds.** Asserted directly on the lane: origin's key unloaded, destination tenant's key loaded, the clone under the destination reports `keystatus unavailable`. #1199 is unaffected.
- **The conclusion does not.** A cross-tenant clone **is** expressible, so the **daemon** must refuse it. The substrate will not.
- **The hazard moved rather than vanishing:** it is *placement*, not key isolation — one tenant's data coming to rest in another's subtree. Filed as #1385.

## The mechanism changes: `incus copy`, not `zfs clone`

#1160 proposes "a new volume backed by a ZFS clone". Under this doc's ownership decision the subject is a **container**, and that changes the mechanism.

A raw `zfs clone` produces a dataset **Incus does not know about**: not an instance, no config, no devices, absent from `incus list` and the daemon's own listing, outside quota accounting, with no encryption placement record. Making it bootable means re-implementing everything Incus stores about an instance.

The daemon already does this correctly: `MoveContainer` runs `incus snapshot` then `incus copy <c>/<snap> … --storage <pool>`, and #1203 already threads the tenant pool through `--storage`. Clone is that call with a local destination.

It also **avoids fact 4**: an `incus copy` produces an independent instance, not a dependent clone, so it does not import "snapshot has dependent clones" as a new failure mode into the already-shipped delete path.

**The honest cost** — `incus copy` is a full copy where `zfs clone` is instant and initially free — is recorded as an **open question for the lane to answer before implementation**, not for review to guess at: does Incus optimise a same-pool copy into a CoW clone? That ordering is exactly what turned this revision from a plausible constraint into a disproved one.

## A finding against merged code

The daemon now snapshots **two ways on the same dataset**: `incus snapshot` (Incus-managed, used by `MoveContainer`) and `zfs snapshot` (#1160a). `zfscrypt.ListSnapshots` runs `zfs list -t snapshot -r <dataset>` **unfiltered**, so:

1. `ListContainerSnapshots` reports Incus's internal snapshots — including a migration's sync points while a move is in flight.
2. `DeleteContainerSnapshot` will `zfs destroy` one, leaving Incus's database referencing a snapshot that no longer exists.

The exact name Incus gives its ZFS snapshots is **not recorded anywhere in the repo**, and that detail decides whether the fix is a prefix filter, an Incus-side listing, or reconciling the registries. Marked as one lane test to run **before** the fix is designed, rather than asserted here. Filed separately — it is a defect in shipped code, not a clone decision.

## Also in this revision

- Ownership marked **accepted** — implemented in #1381/#1383, #1202 closed on the result.
- Contracts table updated to shipped reality, with per-RPC status.
- CLI namespace corrected to `containarium snapshot`; the doc described `containarium container snapshot`, and there is no `container` parent command in this CLI.
- Recorded the `EnsureInspectable` latent bug and where #1202's AC2 actually landed (rollback, not the lifecycle slice).

Docs only — no code, no proto, no behaviour change.