### PR TITLE
fix(migration): containarium move is broken on Incus 6.0.0 (#1392), found while pinning #1390

### DIFF
--- a/internal/server/encrypted_create_integration_test.go
+++ b/internal/server/encrypted_create_integration_test.go
@@ -608,13 +608,28 @@ func TestIntegrationIncus_TenantSnapshotAPISeesIncusOwnSnapshots(t *testing.T) {
 		t.Fatalf("CreateContainer: %v", err)
 	}
 
-	// Take an Incus-level snapshot exactly as MoveContainer does.
-	runner := &incus.ExecRunner{}
+	// Take an Incus-level snapshot, the way MoveContainer means to.
+	//
+	// NOT through incus.ExecRunner.Snapshot, which is what MoveContainer
+	// actually calls: this test's first run showed that shells out to
+	// `incus snapshot <c> <name>`, and Incus 6.0.0 rejects it because
+	// `incus snapshot` is a command GROUP there. That is a separate defect in
+	// production migration code — see
+	// TestIntegrationIncus_MigrationRunnerCLISurface, which establishes the
+	// whole surface, and the issue filed from it.
+	//
+	// Both forms are tried here so this test survives whichever Incus the lane
+	// runs, and so it keeps working after ExecRunner is fixed.
 	const incusSnap = "containarium-move-sync0"
-	if err := runner.Snapshot(instance, incusSnap); err != nil {
-		t.Fatalf("incus snapshot: %v", err)
+	snapArgv := probeCandidates(t, "snapshot", [][]string{
+		{"snapshot", "create", instance, incusSnap},
+		{"snapshot", instance, incusSnap},
+	})
+	if snapArgv == nil {
+		t.Fatal("could not create an Incus-level snapshot by any known syntax, so the leak this " +
+			"test exists to pin cannot be produced")
 	}
-	t.Cleanup(func() { _ = runner.DeleteSnapshot(instance, incusSnap) })
+	t.Cleanup(func() { _, _ = incusRun("delete", instance+"/"+incusSnap) })
 
 	// And a tenant-facing one through the shipped API, so the listing below
 	// has one of each to tell apart.

--- a/internal/server/encrypted_create_integration_test.go
+++ b/internal/server/encrypted_create_integration_test.go
@@ -560,3 +560,140 @@ func TestIntegrationIncus_RollbackRestoresDataAndRefusesWithoutTheKey(t *testing
 	}
 	t.Logf("rollback restored the data, and is refused with the key unloaded: %v", err)
 }
+
+// What Incus names ITS ZFS snapshots, and what the tenant snapshot API does
+// with them (#1390).
+//
+// The daemon now snapshots two ways on one dataset:
+//
+//   - `incus snapshot <container> <name>` — Incus-managed, recorded in Incus's
+//     own database, used by MoveContainer for its sync points.
+//   - `zfs snapshot <dataset>@<name>` — the tenant-facing API shipped in
+//     #1160a.
+//
+// `zfscrypt.ListSnapshots` runs `zfs list -t snapshot -r <dataset>`
+// UNFILTERED, so it returns both. Nothing in the repo records what Incus names
+// its snapshots, and that detail decides the fix: a distinct prefix means
+// filter and refuse by name; no distinguishable prefix means list through
+// Incus instead.
+//
+// This test establishes the fact rather than guessing it — the ordering that
+// turned #1160c's premise from plausible into disproved (#1384).
+//
+// It is a CHARACTERIZATION test: it asserts the behaviour that exists today,
+// which is the defective one, so it passes now and FAILS the moment the leak
+// is fixed. Asserting the correct behaviour instead would leave a red test on
+// main until someone got to it, and a permanently-red lane teaches everyone to
+// ignore it.
+func TestIntegrationIncus_TenantSnapshotAPISeesIncusOwnSnapshots(t *testing.T) {
+	s, _, _ := encTestEnv(t)
+	ctx := context.Background()
+
+	tenant := fmt.Sprintf("reg%d", os.Getpid())
+	instance := tenant + "-container"
+	t.Cleanup(func() { incusenv.DeleteInstance(t, instance) })
+
+	rpcCtx, cancel := context.WithTimeout(
+		tenantWithScopes(tenant, auth.ScopeContainersRead, auth.ScopeContainersWrite), 25*time.Minute)
+	defer cancel()
+
+	// An ordinary unencrypted container: this defect has nothing to do with
+	// encryption, and using the plain path keeps that clear.
+	if _, err := s.CreateContainer(rpcCtx, &pb.CreateContainerRequest{
+		Username:  tenant,
+		Image:     incusenv.BoxImage(),
+		OsType:    pb.OSType_OS_TYPE_UBUNTU_2404,
+		Resources: &pb.ResourceLimits{Disk: "5GB"},
+	}); err != nil {
+		t.Fatalf("CreateContainer: %v", err)
+	}
+
+	// Take an Incus-level snapshot exactly as MoveContainer does.
+	runner := &incus.ExecRunner{}
+	const incusSnap = "containarium-move-sync0"
+	if err := runner.Snapshot(instance, incusSnap); err != nil {
+		t.Fatalf("incus snapshot: %v", err)
+	}
+	t.Cleanup(func() { _ = runner.DeleteSnapshot(instance, incusSnap) })
+
+	// And a tenant-facing one through the shipped API, so the listing below
+	// has one of each to tell apart.
+	if _, err := s.CreateContainerSnapshot(rpcCtx, &pb.CreateContainerSnapshotRequest{
+		Username: tenant, Name: "tenant-taken",
+	}); err != nil {
+		t.Fatalf("CreateContainerSnapshot: %v", err)
+	}
+
+	// THE FACT: what ZFS actually calls Incus's snapshot.
+	dataset := incusenv.DatasetFor(t, instance)
+	if dataset == "" {
+		t.Fatalf("instance %s has no ZFS dataset", instance)
+	}
+	zfs := zfscrypt.NewManager(zfscrypt.ExecRunner{})
+	onDisk, err := zfs.ListSnapshots(ctx, dataset)
+	if err != nil {
+		t.Fatalf("list snapshots of %s: %v", dataset, err)
+	}
+	t.Logf("FACT for #1390: ZFS snapshots on %s after one `incus snapshot %s` and one "+
+		"CreateContainerSnapshot: %v", dataset, incusSnap, onDisk)
+
+	// The tenant-facing listing, which is where the defect shows.
+	resp, err := s.ListContainerSnapshots(rpcCtx, &pb.ListContainerSnapshotsRequest{Username: tenant})
+	if err != nil {
+		t.Fatalf("ListContainerSnapshots: %v", err)
+	}
+	var names []string
+	for _, snap := range resp.GetSnapshots() {
+		names = append(names, snap.GetName())
+	}
+	t.Logf("FACT for #1390: ListContainerSnapshots reports %v", names)
+
+	// The tenant's own snapshot must be there — otherwise the rest says
+	// nothing, because an empty listing would also contain no Incus snapshot.
+	tenantVisible := false
+	for _, n := range names {
+		if n == "tenant-taken" {
+			tenantVisible = true
+		}
+	}
+	if !tenantVisible {
+		t.Fatalf("the tenant's own snapshot is missing from %v — this test cannot say anything "+
+			"about leakage until the listing is known to work", names)
+	}
+
+	// Which of the reported names corresponds to Incus's snapshot? Matched by
+	// substring rather than by an assumed prefix, precisely because the prefix
+	// is the unknown this test exists to record.
+	leaked := ""
+	for _, n := range names {
+		if strings.Contains(n, incusSnap) {
+			leaked = n
+		}
+	}
+	// This is a CHARACTERIZATION assertion: it pins the behaviour that exists
+	// today, which is the defective one. Written this way deliberately.
+	//
+	// Asserting the CORRECT behaviour would leave a red test on main until
+	// someone fixes it, and a permanently-red lane teaches everyone to ignore
+	// it. Merely LOGGING whichever answer came back would be worse: a check
+	// that cannot fail proves nothing and rots silently, which is how the
+	// premise in #1160c survived review for as long as it did.
+	//
+	// So this passes while the defect exists and FAILS the moment it is fixed,
+	// telling whoever fixed it to convert this into the positive assertion.
+	if leaked == "" {
+		t.Fatalf("#1390 no longer reproduces: no name in %v contains %q.\n\n"+
+			"If you just fixed the leak, this test has done its job — replace this block with "+
+			"the positive assertion (Incus's snapshot must NOT appear, and DeleteContainerSnapshot "+
+			"must refuse it by name) rather than deleting the test. If you did not touch the "+
+			"snapshot paths, something else changed how Incus names its snapshots, and the fix "+
+			"designed against the old name may no longer be right.", names, incusSnap)
+	}
+
+	t.Logf("REPRODUCED #1390: the tenant snapshot API reports Incus's own snapshot as %q. "+
+		"During a migration these are live sync points; a tenant deleting an unfamiliar row "+
+		"destroys one, and Incus's database is left referencing a snapshot that no longer "+
+		"exists.\n\nThe ZFS-level name is in the FACT line above — that is what decides whether "+
+		"the fix is a prefix filter, an Incus-side listing, or reconciling the two registries.",
+		leaked)
+}

--- a/internal/server/incus_cli_surface_integration_test.go
+++ b/internal/server/incus_cli_surface_integration_test.go
@@ -1,0 +1,151 @@
+//go:build incus
+
+package server
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/internal/testsupport/incusenv"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// Which `incus` CLI commands the migration runner uses actually exist.
+//
+// Found the hard way: #1390's test called `incus snapshot <c> <name>` — copied
+// from pkg/core/incus/migration.go, which is the PRODUCTION migration runner —
+// and Incus 6.0.0 answered:
+//
+//	Error: unknown command "reg19801-container" for "incus snapshot"
+//
+// `incus snapshot` is a command GROUP in Incus 6.x, not a verb. Every
+// MoveContainer test substitutes a fake MigrationRunner, and dual_server.go
+// wires the real ExecRunner only in production — so these six shell-outs have
+// never run against a real Incus in CI, and at least one of them cannot work.
+//
+// This file probes each command against a real Incus and records the answer,
+// so the fix is designed against demonstrated behaviour rather than against a
+// plausible reading of the CLI docs. Same ordering that turned #1160c's
+// premise from plausible into disproved (#1384) — applied here to a defect in
+// shipped code rather than to a design.
+//
+// It asserts nothing about which syntax SHOULD win. It asserts that for each
+// operation, at least one candidate works, and it logs which — because the
+// point is to learn the answer, and a probe that presumes it is not a probe.
+
+// incusRun runs the incus CLI and returns combined output plus whether it
+// succeeded, without failing the test — a non-zero exit is data here.
+func incusRun(args ...string) (string, bool) {
+	out, err := exec.Command("incus", args...).CombinedOutput() // #nosec G204 -- literal args below
+	return strings.TrimSpace(string(out)), err == nil
+}
+
+// probeCandidates tries each candidate argv for one operation and returns the
+// first that worked, or "" if none did.
+func probeCandidates(t *testing.T, op string, candidates [][]string) []string {
+	t.Helper()
+	for _, argv := range candidates {
+		out, ok := incusRun(argv...)
+		if ok {
+			t.Logf("FACT [%s]: `incus %s` works", op, strings.Join(argv, " "))
+			return argv
+		}
+		t.Logf("  [%s] `incus %s` failed: %s", op, strings.Join(argv, " "), firstLine(out))
+	}
+	return nil
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+// TestIntegrationIncus_MigrationRunnerCLISurface establishes the syntax for
+// every command pkg/core/incus/migration.go shells out to.
+//
+// Deliberately NOT a fix: this PR establishes facts. The fix to ExecRunner is
+// its own change, designed against what this records.
+func TestIntegrationIncus_MigrationRunnerCLISurface(t *testing.T) {
+	s, _, _ := encTestEnv(t)
+
+	if v, ok := incusRun("version"); ok {
+		t.Logf("incus version:\n%s", v)
+	}
+
+	tenant := fmt.Sprintf("cli%d", os.Getpid())
+	instance := tenant + "-container"
+	t.Cleanup(func() { incusenv.DeleteInstance(t, instance) })
+
+	ctx, cancel := context.WithTimeout(
+		tenantWithScopes(tenant, auth.ScopeContainersWrite), 25*time.Minute)
+	defer cancel()
+	if _, err := s.CreateContainer(ctx, &pb.CreateContainerRequest{
+		Username:  tenant,
+		Image:     incusenv.BoxImage(),
+		OsType:    pb.OSType_OS_TYPE_UBUNTU_2404,
+		Resources: &pb.ResourceLimits{Disk: "5GB"},
+	}); err != nil {
+		t.Fatalf("CreateContainer: %v", err)
+	}
+
+	const snap = "probe-snap"
+
+	// 1. Snapshot — the one already known to be wrong.
+	snapArgv := probeCandidates(t, "snapshot", [][]string{
+		{"snapshot", instance, snap},           // what ExecRunner.Snapshot does today
+		{"snapshot", "create", instance, snap}, // Incus 6.x command group
+	})
+	if snapArgv == nil {
+		t.Fatal("no candidate creates a snapshot — the migration runner cannot work at all, and " +
+			"the fix needs a syntax this test does not know about")
+	}
+	if snapArgv[0] == "snapshot" && len(snapArgv) == 3 {
+		t.Log("ExecRunner.Snapshot's current syntax works on this Incus; the failure seen in " +
+			"#1390's test came from somewhere else and needs re-examining")
+	} else {
+		t.Errorf("DEFECT: ExecRunner.Snapshot shells out to `incus snapshot <c> <n>`, which this "+
+			"Incus rejects. The working form is `incus %s`. MoveContainer fails at phase 1 on "+
+			"this version, and no test caught it because every move test uses a fake runner",
+			strings.Join(snapArgv, " "))
+	}
+
+	// 2. DeleteSnapshot — `incus delete <c>/<snap>`.
+	delArgv := probeCandidates(t, "delete-snapshot", [][]string{
+		{"delete", instance + "/" + snap},      // what ExecRunner.DeleteSnapshot does today
+		{"snapshot", "delete", instance, snap}, // the command-group form
+	})
+	if delArgv == nil {
+		t.Error("DEFECT: no candidate deletes a snapshot — a migration would leave its sync " +
+			"snapshots behind on every run")
+	}
+
+	// 3/4. Stop and Start, used either side of the cutover.
+	if argv := probeCandidates(t, "stop", [][]string{{"stop", instance}}); argv == nil {
+		t.Error("DEFECT: `incus stop` failed — the migration cutover cannot stop the source")
+	}
+	if argv := probeCandidates(t, "start", [][]string{{"start", instance}}); argv == nil {
+		t.Error("DEFECT: `incus start` failed — a rolled-back migration cannot restart the source")
+	}
+
+	// 5/6. Copy. Not run for real (it needs a second daemon), so only the
+	// argument shape is checked — `--help` proves the flags parse, which is
+	// what the runner gets wrong when a CLI changes under it.
+	if out, ok := incusRun("copy", "--help"); !ok {
+		t.Errorf("DEFECT: `incus copy --help` failed: %s", firstLine(out))
+	} else {
+		for _, flag := range []string{"--instance-only", "--refresh", "--storage"} {
+			if !strings.Contains(out, flag) {
+				t.Errorf("DEFECT: `incus copy` does not advertise %s, which CopyInitial/CopyRefresh "+
+					"pass — the migration would fail on an unknown flag", flag)
+			}
+		}
+	}
+}

--- a/internal/server/incus_cli_surface_integration_test.go
+++ b/internal/server/incus_cli_surface_integration_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/footprintai/containarium/internal/auth"
 	"github.com/footprintai/containarium/internal/testsupport/incusenv"
+	"github.com/footprintai/containarium/pkg/core/incus"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 )
 
@@ -35,9 +36,14 @@ import (
 // premise from plausible into disproved (#1384) — applied here to a defect in
 // shipped code rather than to a design.
 //
-// It asserts nothing about which syntax SHOULD win. It asserts that for each
-// operation, at least one candidate works, and it logs which — because the
-// point is to learn the answer, and a probe that presumes it is not a probe.
+// It calls the PRODUCTION ExecRunner methods rather than probing raw argv.
+// Probing argv would only prove that some syntax works, while leaving
+// ExecRunner free to use a different one — which is precisely the gap that let
+// #1392 ship. What needs testing is the function the daemon actually calls.
+//
+// probeCandidates below survives for the one case that still needs it: #1390's
+// test has to produce an Incus-level snapshot across Incus versions without
+// depending on the runner it is investigating.
 
 // incusRun runs the incus CLI and returns combined output plus whether it
 // succeeded, without failing the test — a non-zero exit is data here.
@@ -68,11 +74,12 @@ func firstLine(s string) string {
 	return s
 }
 
-// TestIntegrationIncus_MigrationRunnerCLISurface establishes the syntax for
-// every command pkg/core/incus/migration.go shells out to.
+// TestIntegrationIncus_MigrationRunnerCLISurface exercises every command
+// pkg/core/incus/migration.go shells out to, against a real Incus.
 //
-// Deliberately NOT a fix: this PR establishes facts. The fix to ExecRunner is
-// its own change, designed against what this records.
+// This is the test #1392 needed and did not have. It fails if a future Incus
+// changes any of these commands under the runner, instead of that surfacing as
+// a migration failing in production.
 func TestIntegrationIncus_MigrationRunnerCLISurface(t *testing.T) {
 	s, _, _ := encTestEnv(t)
 
@@ -97,42 +104,42 @@ func TestIntegrationIncus_MigrationRunnerCLISurface(t *testing.T) {
 	}
 
 	const snap = "probe-snap"
+	runner := &incus.ExecRunner{}
 
-	// 1. Snapshot — the one already known to be wrong.
-	snapArgv := probeCandidates(t, "snapshot", [][]string{
-		{"snapshot", instance, snap},           // what ExecRunner.Snapshot does today
-		{"snapshot", "create", instance, snap}, // Incus 6.x command group
-	})
-	if snapArgv == nil {
-		t.Fatal("no candidate creates a snapshot — the migration runner cannot work at all, and " +
-			"the fix needs a syntax this test does not know about")
+	// The production methods, called directly. Probing raw argv would prove
+	// that SOME syntax works while leaving ExecRunner free to use another —
+	// which is exactly the gap that let #1392 ship. What needs testing is the
+	// function the daemon actually calls.
+	if err := runner.Snapshot(instance, snap); err != nil {
+		t.Fatalf("ExecRunner.Snapshot against a real Incus: %v\n\n"+
+			"This is MoveContainer's FIRST call, so migration is broken end to end on this "+
+			"version. Re-run the raw-syntax probe below to find the form this Incus accepts.", err)
 	}
-	if snapArgv[0] == "snapshot" && len(snapArgv) == 3 {
-		t.Log("ExecRunner.Snapshot's current syntax works on this Incus; the failure seen in " +
-			"#1390's test came from somewhere else and needs re-examining")
-	} else {
-		t.Errorf("DEFECT: ExecRunner.Snapshot shells out to `incus snapshot <c> <n>`, which this "+
-			"Incus rejects. The working form is `incus %s`. MoveContainer fails at phase 1 on "+
-			"this version, and no test caught it because every move test uses a fake runner",
-			strings.Join(snapArgv, " "))
-	}
+	t.Log("FACT: ExecRunner.Snapshot works against this Incus")
 
-	// 2. DeleteSnapshot — `incus delete <c>/<snap>`.
-	delArgv := probeCandidates(t, "delete-snapshot", [][]string{
-		{"delete", instance + "/" + snap},      // what ExecRunner.DeleteSnapshot does today
-		{"snapshot", "delete", instance, snap}, // the command-group form
-	})
-	if delArgv == nil {
-		t.Error("DEFECT: no candidate deletes a snapshot — a migration would leave its sync " +
-			"snapshots behind on every run")
+	// Idempotency is matched on the CLI's message text, so it breaks silently
+	// whenever the CLI is corrected under it — as it just was. A retry after a
+	// partial failure re-snapshots the same name and must not error.
+	if err := runner.Snapshot(instance, snap); err != nil {
+		t.Errorf("re-snapshotting an existing name failed: %v — MoveContainer retries after a "+
+			"partial failure, and this is the swallow that makes that safe", err)
 	}
 
-	// 3/4. Stop and Start, used either side of the cutover.
-	if argv := probeCandidates(t, "stop", [][]string{{"stop", instance}}); argv == nil {
-		t.Error("DEFECT: `incus stop` failed — the migration cutover cannot stop the source")
+	if err := runner.DeleteSnapshot(instance, snap); err != nil {
+		t.Errorf("ExecRunner.DeleteSnapshot against a real Incus: %v — every migration would "+
+			"leave its sync snapshots behind, pinning disk on both hosts", err)
 	}
-	if argv := probeCandidates(t, "start", [][]string{{"start", instance}}); argv == nil {
-		t.Error("DEFECT: `incus start` failed — a rolled-back migration cannot restart the source")
+	// And deleting one that is already gone must stay a no-op, same reasoning.
+	if err := runner.DeleteSnapshot(instance, snap); err != nil {
+		t.Errorf("deleting an absent snapshot returned %v, want nil — a cleanup that already "+
+			"ran must not fail the migration", err)
+	}
+
+	if err := runner.Stop(instance); err != nil {
+		t.Errorf("ExecRunner.Stop: %v — the migration cutover cannot stop the source", err)
+	}
+	if err := runner.Start(instance); err != nil {
+		t.Errorf("ExecRunner.Start: %v — a rolled-back migration cannot restart the source", err)
 	}
 
 	// 5/6. Copy. Not run for real (it needs a second daemon), so only the

--- a/pkg/core/incus/migration.go
+++ b/pkg/core/incus/migration.go
@@ -89,12 +89,20 @@ func (e *ExecRunner) incus(args ...string) error {
 	return nil
 }
 
-// Snapshot — `incus snapshot <container> <snapshot>`. If the snapshot
-// already exists (rerun after partial failure), the underlying CLI
-// errors with "snapshot already exists" — we swallow that to keep
-// retry idempotent.
+// Snapshot — `incus snapshot create <container> <snapshot>` (#1392).
+//
+// `incus snapshot` is a command GROUP in Incus 6.x, not a verb. This used to
+// call `incus snapshot <container> <snapshot>`, which that version rejects
+// with `unknown command "<container>" for "incus snapshot"` — so MoveContainer
+// failed on its very first call, before any copy. No test caught it because
+// every move test substitutes a fake MigrationRunner and the real ExecRunner
+// is wired only in production; the migration logic was covered, the CLI
+// surface under it was not covered at all.
+//
+// If the snapshot already exists (rerun after a partial failure) the CLI errors
+// with "already exists" — swallowed to keep retry idempotent.
 func (e *ExecRunner) Snapshot(container, snapshot string) error {
-	err := e.incus("snapshot", container, snapshot)
+	err := e.incus("snapshot", "create", container, snapshot)
 	if err == nil {
 		return nil
 	}
@@ -104,8 +112,15 @@ func (e *ExecRunner) Snapshot(container, snapshot string) error {
 	return err
 }
 
+// DeleteSnapshot — `incus snapshot delete <container> <snapshot>` (#1392).
+//
+// This used to call `incus delete <container>/<snapshot>`, which Incus 6.x
+// rejects with `Invalid instance name`. That message matches neither of the
+// absent-snapshot strings below, so a failed cleanup surfaced as a hard error
+// rather than being swallowed — and every migration left its sync snapshots
+// behind, pinning disk on both hosts.
 func (e *ExecRunner) DeleteSnapshot(container, snapshot string) error {
-	err := e.incus("delete", container+"/"+snapshot)
+	err := e.incus("snapshot", "delete", container, snapshot)
 	if err == nil {
 		return nil
 	}


### PR DESCRIPTION
Started as "establish the fact #1390's fix needs, before designing the fix". The lane answered that — and on the way it found that **`containarium move` is broken in production**.

## 1. The fact #1390 needed

Incus names its own ZFS snapshots with a **`snapshot-` prefix**. From the lane, after one `incus snapshot` and one `CreateContainerSnapshot` on the same container:

```
FACT for #1390: ZFS snapshots on <pool>/containers/<c>:
  [<...>@snapshot-containarium-move-sync0  <...>@tenant-taken]
FACT for #1390: ListContainerSnapshots reports
  [snapshot-containarium-move-sync0  tenant-taken]
```

**Reproduced.** The tenant snapshot API reports Incus's own snapshot. During a migration those are live sync points, and a tenant deleting an unfamiliar row destroys one. The prefix is distinguishable, so #1390's fix is a **prefix filter plus a refusal-by-name on delete** — now decided on evidence rather than on a guess.

That test is a **characterization test**: it asserts today's defective behaviour, so it passes now and fails the moment the leak is fixed, telling whoever fixed it to convert it into the positive assertion. Asserting the correct behaviour instead would leave a red lane on main until someone got to it, and a permanently-red lane teaches everyone to ignore the lane.

## 2. What it found on the way: migration cannot work on Incus 6.0.0

#1390's first draft called `incus snapshot <c> <name>` — copied from `pkg/core/incus/migration.go`, the **production** migration runner. Incus 6.0.0:

```
Error: unknown command "reg19801-container" for "incus snapshot"
```

So I probed all six commands the runner uses:

| `ExecRunner` method | Was | Result |
|---|---|---|
| `Snapshot` | `incus snapshot <c> <n>` | ❌ `unknown command` |
| `DeleteSnapshot` | `incus delete <c>/<snap>` | ❌ `Invalid instance name` |
| `Stop` / `Start` | `incus stop` / `incus start` | ✅ |
| `CopyInitial` / `CopyRefresh` | `incus copy …` | flags present |

`incus snapshot` is a command **group** in Incus 6.x. Fixed to `incus snapshot create` / `incus snapshot delete` — **filed as #1392, closed by this PR.**

**Impact:** `MoveContainer` calls `Snapshot` *first*, so migration failed immediately, before any copy, on every attempt. With that fixed, `DeleteSnapshot` failing would have left every migration's sync snapshots behind on both hosts — and `Invalid instance name` matches neither absent-snapshot string it swallows, so it surfaced as a hard error rather than being absorbed.

**Why nothing caught it:** every `MoveContainer` test substitutes a fake `MigrationRunner`, and `dual_server.go:2089` wires the real `ExecRunner` **only in production**. The migration *logic* was well covered; the CLI surface underneath it was not covered at all. A fake at a process boundary tests the orchestration and nothing about whether the command exists.

## 3. The probe calls the production methods

The regression test exercises `runner.Snapshot(...)`, `runner.DeleteSnapshot(...)`, `Stop`, `Start` **directly**, not raw argv. Probing argv would only prove that *some* syntax works while leaving `ExecRunner` free to use another — exactly the gap that let #1392 ship.

It also asserts both **idempotency swallows** still work (re-snapshotting an existing name, deleting an absent one). Those are matched on the CLI's *message text*, so they break silently whenever the CLI is corrected under them — as it just was.

## Evidence

Incus lane, [run 31951712418](https://github.com/FootprintAI/Containarium/actions/runs/31951712418/job/95176062696) — pass, 11m44s:

```
--- PASS: TestIntegrationIncus_TenantSnapshotAPISeesIncusOwnSnapshots (28.39s)
    FACT: ExecRunner.Snapshot works against this Incus
--- PASS: TestIntegrationIncus_MigrationRunnerCLISurface (29.56s)
```

Two earlier runs on this branch failed — [the discovery](https://github.com/FootprintAI/Containarium/actions/runs/31950139781/job/95172241779) and [the probe reporting both defects](https://github.com/FootprintAI/Containarium/actions/runs/31950918740/job/95174126047) — which is the guard demonstrating it can fail before being trusted.

`go vet` clean under all five build tags.

Closes #1392. Refs #1390 (fact established; the fix is a separate change).
