### PR TITLE
feat(cluster): VM node pools, bootstrap, and the reconciler

### DIFF
--- a/internal/cmd/cluster.go
+++ b/internal/cmd/cluster.go
@@ -8,6 +8,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/footprintai/containarium/internal/client"
+	clusterstore "github.com/footprintai/containarium/internal/cluster"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 	"github.com/spf13/cobra"
 )
@@ -36,7 +37,11 @@ cluster is READY.
   containarium cluster delete demo --server <host>`,
 }
 
-var clusterOwner string
+var (
+	clusterOwner    string
+	clusterNodesMin int32
+	clusterNodesMax int32
+)
 
 var clusterCreateCmd = &cobra.Command{
 	Use:   "create <name>",
@@ -92,6 +97,8 @@ func init() {
 	rootCmd.AddCommand(clusterCmd)
 	clusterCmd.AddCommand(clusterCreateCmd, clusterListCmd, clusterGetCmd, clusterDeleteCmd, clusterKubeconfigCmd, clusterNodePoolCmd)
 	clusterCmd.PersistentFlags().StringVar(&clusterOwner, "owner", "", "owning tenant (admin only; default: the authenticated user)")
+	clusterCreateCmd.Flags().Int32Var(&clusterNodesMin, "nodes-min", -1, "small size class's minimum worker count (default: platform preset)")
+	clusterCreateCmd.Flags().Int32Var(&clusterNodesMax, "nodes-max", -1, "small size class's maximum worker count (default: platform preset)")
 	clusterNodePoolCmd.Flags().StringArrayVar(&clusterGroups, "group", nil,
 		"node group as name=<g>,cpu=<n>,memory=<x>GB,disk=<x>GB,min=<n>,max=<n> (repeatable, required)")
 }
@@ -116,6 +123,35 @@ func newClusterClient() (clusterAPI, error) {
 		return client.NewHTTPClient(serverAddr, authToken)
 	}
 	return client.NewGRPCClient(serverAddr, certsDir, insecure)
+}
+
+// createNodeGroups applies --nodes-min/--nodes-max to the platform
+// presets' small class (other classes keep their preset bounds; use
+// `cluster node-pool` for full control). Returns nil when neither flag
+// is set, so the server applies its presets untouched.
+func createNodeGroups(cmd *cobra.Command) ([]*pb.NodeGroup, error) {
+	if !cmd.Flags().Changed("nodes-min") && !cmd.Flags().Changed("nodes-max") {
+		return nil, nil
+	}
+	var out []*pb.NodeGroup
+	for _, g := range clusterstore.DefaultNodeGroups() {
+		g := g
+		if g.Name == "small" {
+			if cmd.Flags().Changed("nodes-min") {
+				g.MinNodes = clusterNodesMin
+			}
+			if cmd.Flags().Changed("nodes-max") {
+				g.MaxNodes = clusterNodesMax
+			}
+		}
+		out = append(out, &pb.NodeGroup{
+			Name:     g.Name,
+			Size:     &pb.ResourceLimits{Cpu: g.Size.CPU, Memory: g.Size.Memory, Disk: g.Size.Disk},
+			MinNodes: g.MinNodes,
+			MaxNodes: g.MaxNodes,
+		})
+	}
+	return out, nil
 }
 
 // parseNodeGroup parses one --group flag value into a typed NodeGroup.
@@ -199,7 +235,13 @@ func runClusterCreate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer func() { _ = c.Close() }()
-	resp, err := c.CreateCluster(&pb.CreateClusterRequest{Name: args[0], Owner: clusterOwner})
+	req := &pb.CreateClusterRequest{Name: args[0], Owner: clusterOwner}
+	if groups, gerr := createNodeGroups(cmd); gerr != nil {
+		return gerr
+	} else if groups != nil {
+		req.NodeGroups = groups
+	}
+	resp, err := c.CreateCluster(req)
 	if err != nil {
 		return err
 	}

--- a/internal/server/cluster_reconciler.go
+++ b/internal/server/cluster_reconciler.go
@@ -1,0 +1,379 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"strconv"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/footprintai/containarium/internal/auth"
+	clusterstore "github.com/footprintai/containarium/internal/cluster"
+	clustercore "github.com/footprintai/containarium/pkg/core/cluster"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// ClusterReconciler converges managed-cluster records (#1414): it
+// reads desired state from the store, observes VMs on the host, and
+// executes whatever the pure clustercore.Decide returns. All policy
+// lives in Decide; this loop is plumbing plus bookkeeping (node rows,
+// scale events, state transitions).
+//
+// One pass is idempotent and crash-safe: nothing here holds state
+// between ticks, so a daemon restart resumes wherever the store and
+// the host actually are.
+type ClusterReconciler struct {
+	store clusterstore.Store
+	mgr   *clustercore.Manager
+
+	// admit is the CPU-admission seam (nil = no gate, unit tests).
+	// Refusals are recorded as events, never silent.
+	admit func(owner, cpu string) error
+
+	// publish allocates/records the external API endpoint for a
+	// cluster whose control plane is up; unpublish reverses it.
+	// Seamed for tests; production wires the passthrough route.
+	publish   func(ctx context.Context, c *clusterstore.Cluster, cpIP string) (string, error)
+	unpublish func(ctx context.Context, c *clusterstore.Cluster) error
+
+	interval time.Duration
+}
+
+// NewClusterReconciler wires the loop. publish/unpublish may be nil
+// (endpoint stays the CP IP; nothing to reverse).
+func NewClusterReconciler(store clusterstore.Store, mgr *clustercore.Manager) *ClusterReconciler {
+	return &ClusterReconciler{store: store, mgr: mgr, interval: 15 * time.Second}
+}
+
+// SetAdmission wires the CPU-admission gate.
+func (r *ClusterReconciler) SetAdmission(f func(owner, cpu string) error) { r.admit = f }
+
+// SetEndpointPublisher wires endpoint publish/unpublish.
+func (r *ClusterReconciler) SetEndpointPublisher(
+	publish func(ctx context.Context, c *clusterstore.Cluster, cpIP string) (string, error),
+	unpublish func(ctx context.Context, c *clusterstore.Cluster) error,
+) {
+	r.publish, r.unpublish = publish, unpublish
+}
+
+// ReadKubeconfig implements the ClusterServer's KubeconfigReader seam:
+// read on demand from the CP VM, rewritten to the published endpoint,
+// never persisted.
+func (r *ClusterReconciler) ReadKubeconfig(ctx context.Context, c *clusterstore.Cluster) (string, error) {
+	return r.mgr.Kubeconfig(c.Owner, c.Name, c.APIEndpoint)
+}
+
+// VMCapable is the create-time capability probe.
+func (r *ClusterReconciler) VMCapable() error { return r.mgr.VMCapable() }
+
+// Run ticks until ctx ends.
+func (r *ClusterReconciler) Run(ctx context.Context) {
+	log.Printf("[cluster] reconciler running (interval %v)", r.interval)
+	t := time.NewTicker(r.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			r.ReconcileOnce(ctx)
+		}
+	}
+}
+
+// ReconcileOnce runs one pass over every cluster.
+func (r *ClusterReconciler) ReconcileOnce(ctx context.Context) {
+	clusters, err := r.store.List(ctx, "")
+	if err != nil {
+		log.Printf("[cluster] reconcile: list: %v", err)
+		return
+	}
+	for _, c := range clusters {
+		if err := r.reconcileCluster(ctx, c); err != nil {
+			log.Printf("[cluster] reconcile %s/%s: %v", c.Owner, c.Name, err)
+			// Provisioning failures surface on the record; the next
+			// pass retries (interval = natural backoff).
+			_ = r.store.SetState(ctx, c.Owner, c.Name, clusterstore.StateError, err.Error())
+		}
+	}
+}
+
+func desiredFrom(c *clusterstore.Cluster) clustercore.Desired {
+	d := clustercore.Desired{
+		Tenant:   c.Owner,
+		Cluster:  c.Name,
+		Deleting: c.State == clusterstore.StateDeleting,
+	}
+	for _, g := range c.NodeGroups {
+		d.Groups = append(d.Groups, clustercore.DesiredGroup{
+			Name: g.Name, Min: int(g.MinNodes), Max: int(g.MaxNodes),
+			CPU: g.Size.CPU, Memory: g.Size.Memory, Disk: g.Size.Disk,
+		})
+	}
+	return d
+}
+
+// cpSize is the control-plane VM's fixed size — platform overhead,
+// deliberately not part of any tenant node group.
+var cpSize = clustercore.DesiredGroup{CPU: "2", Memory: "4GB", Disk: "40GB"}
+
+func (r *ClusterReconciler) reconcileCluster(ctx context.Context, c *clusterstore.Cluster) error {
+	desired := desiredFrom(c)
+	observed, err := r.mgr.Observe(c.Owner, c.Name)
+	if err != nil {
+		return fmt.Errorf("observe: %w", err)
+	}
+	actions := clustercore.Decide(desired, observed)
+
+	groupByName := make(map[string]clustercore.DesiredGroup, len(desired.Groups))
+	for _, g := range desired.Groups {
+		groupByName[g.Name] = g
+	}
+
+	for _, act := range actions {
+		switch act.Kind {
+		case clustercore.ActionCreateCP:
+			if err := r.admitSize(c, cpSize, "control-plane"); err != nil {
+				return nil // refusal recorded; retry next pass
+			}
+			cpIP, err := r.mgr.ProvisionCP(c.Owner, c.Name, cpSize, nil)
+			if err != nil {
+				return fmt.Errorf("provision control plane: %w", err)
+			}
+			_ = r.store.UpsertNode(ctx, &clusterstore.Node{
+				Owner: c.Owner, Cluster: c.Name, VMName: act.Name,
+				Role: clusterstore.RoleControlPlane, State: clusterstore.NodeStateReady,
+				CreatedAt: time.Now().UTC(),
+			})
+			log.Printf("[cluster] %s/%s: control plane up at %s", c.Owner, c.Name, cpIP)
+
+		case clustercore.ActionCreateWorker:
+			g := groupByName[act.Group]
+			if err := r.admitSize(c, g, act.Group); err != nil {
+				return nil // refusal recorded; retry next pass
+			}
+			cpIP, err := r.mgr.CPIP(c.Owner, c.Name)
+			if err != nil {
+				return fmt.Errorf("control-plane IP: %w", err)
+			}
+			if err := r.mgr.ProvisionWorker(c.Owner, c.Name, g, act.Name, cpIP); err != nil {
+				return fmt.Errorf("provision worker %s: %w", act.Name, err)
+			}
+			_ = r.store.UpsertNode(ctx, &clusterstore.Node{
+				Owner: c.Owner, Cluster: c.Name, VMName: act.Name,
+				Role: clusterstore.RoleWorker, Group: act.Group,
+				State: clusterstore.NodeStateProvisioning, CreatedAt: time.Now().UTC(),
+			})
+			_ = r.store.AppendEvent(ctx, c.Owner, c.Name, clusterstore.Event{
+				At: time.Now().UTC(), Kind: clusterstore.EventScaleUp,
+				Group: act.Group, Reason: "reconciler: group below min_nodes",
+			})
+
+		case clustercore.ActionStartVM:
+			if err := r.mgr.StartVM(act.Name); err != nil {
+				return fmt.Errorf("start %s: %w", act.Name, err)
+			}
+
+		case clustercore.ActionDeleteVM:
+			if err := r.mgr.DeleteVM(act.Name); err != nil {
+				return fmt.Errorf("delete %s: %w", act.Name, err)
+			}
+			_ = r.store.DeleteNode(ctx, c.Owner, c.Name, act.Name)
+		}
+	}
+
+	if desired.Deleting {
+		// Torn down when nothing is left on the host: drop the
+		// endpoint and the rows — the name becomes reusable and a
+		// re-created cluster starts empty.
+		observed, err := r.mgr.Observe(c.Owner, c.Name)
+		if err != nil {
+			return fmt.Errorf("observe after teardown: %w", err)
+		}
+		if observed.CP == nil && len(observed.Workers) == 0 {
+			if r.unpublish != nil {
+				if err := r.unpublish(ctx, c); err != nil {
+					return fmt.Errorf("unpublish endpoint: %w", err)
+				}
+			}
+			if err := r.store.Delete(ctx, c.Owner, c.Name); err != nil {
+				return fmt.Errorf("delete record: %w", err)
+			}
+			log.Printf("[cluster] %s/%s: deleted", c.Owner, c.Name)
+		}
+		return nil
+	}
+
+	return r.settleState(ctx, c)
+}
+
+// admitSize runs the CPU-admission gate for one VM-sized request; a
+// refusal is recorded as a REFUSED scale event (loud, never clamped).
+func (r *ClusterReconciler) admitSize(c *clusterstore.Cluster, g clustercore.DesiredGroup, what string) error {
+	if r.admit == nil {
+		return nil
+	}
+	if err := r.admit(c.Owner, g.CPU); err != nil {
+		_ = r.store.AppendEvent(context.Background(), c.Owner, c.Name, clusterstore.Event{
+			At: time.Now().UTC(), Kind: clusterstore.EventRefused,
+			Group: what, Reason: fmt.Sprintf("admission refused %s cpu=%s: %v", what, g.CPU, err),
+		})
+		return err
+	}
+	return nil
+}
+
+// settleState publishes the endpoint once the CP is up and flips the
+// record to READY when the cluster's own API reports every expected
+// node Ready.
+func (r *ClusterReconciler) settleState(ctx context.Context, c *clusterstore.Cluster) error {
+	observed, err := r.mgr.Observe(c.Owner, c.Name)
+	if err != nil {
+		return fmt.Errorf("observe: %w", err)
+	}
+	if observed.CP == nil || !observed.CP.Running {
+		return nil // still converging; nothing to settle
+	}
+
+	if c.APIEndpoint == "" {
+		cpIP, err := r.mgr.CPIP(c.Owner, c.Name)
+		if err != nil {
+			return fmt.Errorf("control-plane IP: %w", err)
+		}
+		endpoint := cpIP + ":6443"
+		if r.publish != nil {
+			endpoint, err = r.publish(ctx, c, cpIP)
+			if err != nil {
+				return fmt.Errorf("publish endpoint: %w", err)
+			}
+		}
+		if err := r.store.SetEndpoint(ctx, c.Owner, c.Name, endpoint); err != nil {
+			return fmt.Errorf("record endpoint: %w", err)
+		}
+		c.APIEndpoint = endpoint
+	}
+
+	expected := 1 // control plane
+	for _, g := range c.NodeGroups {
+		expected += int(g.MinNodes)
+	}
+	ready, err := r.mgr.ReadyNodes(c.Owner, c.Name)
+	if err != nil {
+		return nil // API not up yet; try next pass
+	}
+	if ready >= expected && c.State != clusterstore.StateReady {
+		if err := r.store.SetState(ctx, c.Owner, c.Name, clusterstore.StateReady, ""); err != nil {
+			return err
+		}
+		// Worker rows ride along: the cluster API says they joined.
+		nodes, _ := r.store.ListNodes(ctx, c.Owner, c.Name)
+		for _, n := range nodes {
+			if n.State != clusterstore.NodeStateReady {
+				n.State = clusterstore.NodeStateReady
+				_ = r.store.UpsertNode(ctx, n)
+			}
+		}
+		log.Printf("[cluster] %s/%s: READY (%d nodes)", c.Owner, c.Name, ready)
+	} else if ready < expected && c.State == clusterstore.StateReady {
+		if err := r.store.SetState(ctx, c.Owner, c.Name, clusterstore.StateDegraded,
+			fmt.Sprintf("%d of %d expected nodes Ready", ready, expected)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// --- endpoint publishing over the passthrough surface ------------------
+
+// WireEndpointPublisher connects the reconciler to the durable
+// passthrough surface (design: create flow step 3): allocate an
+// external port from portRange, DNAT it to <cp>:6443, and record
+// <advertiseAddr>:<port> as the cluster's API endpoint. Invoked with
+// the _system identity — this is a daemon-internal reconciler path.
+func (r *ClusterReconciler) WireEndpointPublisher(network *NetworkServer, advertiseAddr, portRange string) error {
+	lo, hi, err := parsePortRange(portRange)
+	if err != nil {
+		return err
+	}
+	r.publish = func(ctx context.Context, c *clusterstore.Cluster, cpIP string) (string, error) {
+		port, err := r.freeClusterPort(ctx, lo, hi)
+		if err != nil {
+			return "", err
+		}
+		sysCtx := auth.ContextWithSystemIdentity(ctx)
+		if _, err := network.AddPassthroughRoute(sysCtx, &pb.AddPassthroughRouteRequest{
+			ExternalPort:  int32(port),
+			TargetIp:      cpIP,
+			TargetPort:    6443,
+			Protocol:      pb.RouteProtocol_ROUTE_PROTOCOL_TCP,
+			ContainerName: clustercore.CPName(c.Owner, c.Name),
+		}); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%s:%d", advertiseAddr, port), nil
+	}
+	r.unpublish = func(ctx context.Context, c *clusterstore.Cluster) error {
+		port := portFromEndpoint(c.APIEndpoint)
+		if port == 0 {
+			return nil // never published
+		}
+		sysCtx := auth.ContextWithSystemIdentity(ctx)
+		_, err := network.DeletePassthroughRoute(sysCtx, &pb.DeletePassthroughRouteRequest{
+			ExternalPort: int32(port),
+			Protocol:     pb.RouteProtocol_ROUTE_PROTOCOL_TCP,
+		})
+		if err != nil && status.Code(err) == codes.NotFound {
+			return nil // already gone — teardown is idempotent
+		}
+		return err
+	}
+	return nil
+}
+
+func parsePortRange(s string) (int, int, error) {
+	var lo, hi int
+	if _, err := fmt.Sscanf(s, "%d-%d", &lo, &hi); err != nil {
+		return 0, 0, fmt.Errorf("invalid port range %q (want e.g. 36443-36542): %w", s, err)
+	}
+	if lo < 1024 || hi > 65535 || hi < lo {
+		return 0, 0, fmt.Errorf("invalid port range %q", s)
+	}
+	return lo, hi, nil
+}
+
+// freeClusterPort picks the first port in [lo,hi] not already recorded
+// on some cluster's endpoint.
+func (r *ClusterReconciler) freeClusterPort(ctx context.Context, lo, hi int) (int, error) {
+	clusters, err := r.store.List(ctx, "")
+	if err != nil {
+		return 0, err
+	}
+	used := make(map[int]bool, len(clusters))
+	for _, c := range clusters {
+		if p := portFromEndpoint(c.APIEndpoint); p != 0 {
+			used[p] = true
+		}
+	}
+	for p := lo; p <= hi; p++ {
+		if !used[p] {
+			return p, nil
+		}
+	}
+	return 0, fmt.Errorf("cluster API port range %d-%d exhausted", lo, hi)
+}
+
+func portFromEndpoint(endpoint string) int {
+	_, portStr, err := net.SplitHostPort(endpoint)
+	if err != nil {
+		return 0
+	}
+	p, err := strconv.Atoi(portStr)
+	if err != nil {
+		return 0
+	}
+	return p
+}

--- a/internal/server/cluster_reconciler.go
+++ b/internal/server/cluster_reconciler.go
@@ -306,7 +306,7 @@ func (r *ClusterReconciler) WireEndpointPublisher(network *NetworkServer, advert
 		}
 		sysCtx := auth.ContextWithSystemIdentity(ctx)
 		if _, err := network.AddPassthroughRoute(sysCtx, &pb.AddPassthroughRouteRequest{
-			ExternalPort:  int32(port),
+			ExternalPort:  int32(port), //nolint:gosec // freeClusterPort draws from parsePortRange's validated [1024,65535]
 			TargetIp:      cpIP,
 			TargetPort:    6443,
 			Protocol:      pb.RouteProtocol_ROUTE_PROTOCOL_TCP,
@@ -323,7 +323,7 @@ func (r *ClusterReconciler) WireEndpointPublisher(network *NetworkServer, advert
 		}
 		sysCtx := auth.ContextWithSystemIdentity(ctx)
 		_, err := network.DeletePassthroughRoute(sysCtx, &pb.DeletePassthroughRouteRequest{
-			ExternalPort: int32(port),
+			ExternalPort: int32(port), //nolint:gosec // portFromEndpoint rejects values outside [1,65535]
 			Protocol:     pb.RouteProtocol_ROUTE_PROTOCOL_TCP,
 		})
 		if err != nil && status.Code(err) == codes.NotFound {
@@ -372,7 +372,7 @@ func portFromEndpoint(endpoint string) int {
 		return 0
 	}
 	p, err := strconv.Atoi(portStr)
-	if err != nil {
+	if err != nil || p < 1 || p > 65535 {
 		return 0
 	}
 	return p

--- a/internal/server/cluster_reconciler_test.go
+++ b/internal/server/cluster_reconciler_test.go
@@ -1,0 +1,302 @@
+package server
+
+// Reconciler coverage (#1414): the REAL Manager and MemStore drive a
+// stateful fake host, entered through the real ClusterServer handlers —
+// so these tests pin the whole daemon-side loop except Incus itself
+// (which the gated KVM e2e lane #1418 owns).
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	clustercore "github.com/footprintai/containarium/pkg/core/cluster"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// stateHost is a stateful VMHost fake: created VMs exist and run,
+// pushed files persist, and the in-cluster kubectl reports every
+// existing VM as a Ready node.
+type stateHost struct {
+	mu     sync.Mutex
+	vms    map[string]*stateVM
+	files  map[string][]byte
+	capErr error
+}
+
+type stateVM struct {
+	labels  map[string]string
+	running bool
+}
+
+func newStateHost() *stateHost {
+	return &stateHost{vms: map[string]*stateVM{}, files: map[string][]byte{}}
+}
+
+func (h *stateHost) VMCapable() error { return h.capErr }
+
+func (h *stateHost) CreateVM(spec clustercore.NodeSpec) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if _, ok := h.vms[spec.Name]; ok {
+		return fmt.Errorf("vm %s already exists", spec.Name)
+	}
+	h.vms[spec.Name] = &stateVM{labels: spec.Labels, running: true}
+	// A booted CP "writes" its own kubeconfig and join token.
+	if spec.Labels[clustercore.LabelClusterRole] == clustercore.RoleControlPlane {
+		h.files[spec.Name+":"+clustercore.KubeconfigPath] = []byte("clusters:\n- cluster:\n    server: https://127.0.0.1:6443\n")
+		h.files[spec.Name+":"+clustercore.NodeTokenPath] = []byte("K10::join-token")
+	}
+	return nil
+}
+
+func (h *stateHost) Start(name string) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	vm, ok := h.vms[name]
+	if !ok {
+		return fmt.Errorf("no vm %s", name)
+	}
+	vm.running = true
+	return nil
+}
+
+func (h *stateHost) Delete(name string) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if _, ok := h.vms[name]; !ok {
+		return fmt.Errorf("no vm %s", name)
+	}
+	delete(h.vms, name)
+	return nil
+}
+
+func (h *stateHost) WaitReady(name string, _ time.Duration) (string, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if _, ok := h.vms[name]; !ok {
+		return "", fmt.Errorf("no vm %s", name)
+	}
+	return "10.166.11.5", nil
+}
+
+func (h *stateHost) Push(name, path string, content []byte, mode string) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.files[name+":"+path] = content
+	return nil
+}
+
+func (h *stateHost) Read(name, path string) ([]byte, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if c, ok := h.files[name+":"+path]; ok {
+		return c, nil
+	}
+	return nil, errors.New("no such file")
+}
+
+func (h *stateHost) Exec(name string, cmd []string) (string, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if len(cmd) >= 2 && cmd[1] == "kubectl" {
+		var b strings.Builder
+		for vm := range h.vms {
+			fmt.Fprintf(&b, "%s   Ready   <none>   1m   v-test\n", vm)
+		}
+		return b.String(), nil
+	}
+	return "", nil
+}
+
+func (h *stateHost) ClusterVMs(tenant, clusterName string) (clustercore.Observed, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	obs := clustercore.Observed{Workers: map[string][]clustercore.ObservedVM{}}
+	for name, vm := range h.vms {
+		if vm.labels[clustercore.LabelCluster] != clusterName || vm.labels[clustercore.LabelClusterOwner] != tenant {
+			continue
+		}
+		o := clustercore.ObservedVM{Name: name, Running: vm.running}
+		switch vm.labels[clustercore.LabelClusterRole] {
+		case clustercore.RoleControlPlane:
+			cp := o
+			obs.CP = &cp
+		case clustercore.RoleWorker:
+			g := vm.labels[clustercore.LabelNodeGroup]
+			obs.Workers[g] = append(obs.Workers[g], o)
+		}
+	}
+	return obs, nil
+}
+
+func testReconcilerRig(t *testing.T) (*ClusterServer, *ClusterReconciler, *stateHost) {
+	t.Helper()
+	host := newStateHost()
+	mgr := clustercore.NewManagerWithLoader(host, func() ([]byte, error) { return []byte("k3s-bin"), nil })
+	srv := clusterTestServer()
+	rec := NewClusterReconciler(srv.Store(), mgr)
+	srv.SetReconciler(rec)
+	return srv, rec, host
+}
+
+func TestReconciler_ProvisionsToReady(t *testing.T) {
+	srv, rec, host := testReconcilerRig(t)
+	ctx := context.Background()
+	mustCreate(t, srv, tenantCtx("alice"), "demo") // default presets: small min=1
+
+	// Pass 1: control plane first, no workers yet.
+	rec.ReconcileOnce(ctx)
+	if _, ok := host.vms["alice-k8s-demo-cp"]; !ok {
+		t.Fatalf("pass 1 did not create the control plane; vms=%v", vmNames(host))
+	}
+	if len(host.vms) != 1 {
+		t.Fatalf("pass 1 created workers before the CP was observed running: %v", vmNames(host))
+	}
+
+	// Pass 2: worker to min, endpoint recorded, cluster READY (the
+	// fake cluster API reports both nodes Ready).
+	rec.ReconcileOnce(ctx)
+	if _, ok := host.vms["alice-k8s-demo-small-1"]; !ok {
+		t.Fatalf("pass 2 did not create the small worker: %v", vmNames(host))
+	}
+	// Worker got the binary, the 0600 token, and a join script.
+	if string(host.files["alice-k8s-demo-small-1:"+clustercore.AgentTokenPath]) != "K10::join-token" {
+		t.Fatal("worker did not receive the CP's join token")
+	}
+
+	rec.ReconcileOnce(ctx) // settle
+	got, err := srv.GetCluster(tenantCtx("alice"), &pb.GetClusterRequest{Name: "demo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Cluster.State != pb.ClusterState_CLUSTER_STATE_READY {
+		t.Fatalf("state = %v, want READY (reason %q)", got.Cluster.State, got.Cluster.StateReason)
+	}
+	if got.Cluster.ApiEndpoint != "10.166.11.5:6443" {
+		t.Fatalf("endpoint = %q (publish seam nil → CP IP)", got.Cluster.ApiEndpoint)
+	}
+
+	// Kubeconfig now flows through the reconciler's reader, rewritten
+	// to the recorded endpoint.
+	kc, err := srv.GetClusterKubeconfig(tenantCtx("alice"), &pb.GetClusterKubeconfigRequest{Name: "demo"})
+	if err != nil {
+		t.Fatalf("kubeconfig: %v", err)
+	}
+	if !strings.Contains(kc.Kubeconfig, "server: https://10.166.11.5:6443") {
+		t.Fatalf("kubeconfig not rewritten:\n%s", kc.Kubeconfig)
+	}
+
+	// Status shows the worker row and per-group counts.
+	st, err := srv.GetClusterStatus(tenantCtx("alice"), &pb.GetClusterStatusRequest{Name: "demo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(st.Nodes) != 2 {
+		t.Fatalf("status nodes = %d, want cp+worker", len(st.Nodes))
+	}
+}
+
+func TestReconciler_ReplacesLostWorker(t *testing.T) {
+	srv, rec, host := testReconcilerRig(t)
+	ctx := context.Background()
+	mustCreate(t, srv, tenantCtx("alice"), "demo")
+	rec.ReconcileOnce(ctx)
+	rec.ReconcileOnce(ctx)
+	rec.ReconcileOnce(ctx)
+
+	// Kill the worker out-of-band.
+	delete(host.vms, "alice-k8s-demo-small-1")
+
+	rec.ReconcileOnce(ctx)
+	if _, ok := host.vms["alice-k8s-demo-small-1"]; !ok {
+		t.Fatalf("lost worker not replaced: %v", vmNames(host))
+	}
+	// The replacement is on the scale-event record.
+	st, err := srv.GetClusterStatus(tenantCtx("alice"), &pb.GetClusterStatusRequest{Name: "demo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(st.Events) == 0 {
+		t.Fatal("no scale events recorded for the replacement")
+	}
+}
+
+func TestReconciler_AsyncDeleteDrainsEverything(t *testing.T) {
+	srv, rec, host := testReconcilerRig(t)
+	ctx := context.Background()
+	mustCreate(t, srv, tenantCtx("alice"), "demo")
+	rec.ReconcileOnce(ctx)
+	rec.ReconcileOnce(ctx)
+
+	resp, err := srv.DeleteCluster(tenantCtx("alice"), &pb.DeleteClusterRequest{Name: "demo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(resp.Message, "in progress") {
+		t.Fatalf("async delete message = %q", resp.Message)
+	}
+	// Record still present (DELETING) until the reconciler drains it.
+	if _, err := srv.GetCluster(tenantCtx("alice"), &pb.GetClusterRequest{Name: "demo"}); err != nil {
+		t.Fatalf("record vanished before the reconciler ran: %v", err)
+	}
+
+	rec.ReconcileOnce(ctx) // deletes VMs
+	rec.ReconcileOnce(ctx) // observes empty, drops rows
+	if len(host.vms) != 0 {
+		t.Fatalf("VMs survived deletion: %v", vmNames(host))
+	}
+	_, err = srv.GetCluster(tenantCtx("alice"), &pb.GetClusterRequest{Name: "demo"})
+	if status.Code(err) != codes.NotFound {
+		t.Fatalf("record after drain = %v, want NotFound", err)
+	}
+	// Name immediately reusable.
+	mustCreate(t, srv, tenantCtx("alice"), "demo")
+}
+
+func TestReconciler_AdmissionRefusalIsLoud(t *testing.T) {
+	srv, rec, host := testReconcilerRig(t)
+	ctx := context.Background()
+	rec.SetAdmission(func(owner, cpu string) error { return errors.New("host at capacity") })
+	mustCreate(t, srv, tenantCtx("alice"), "demo")
+
+	rec.ReconcileOnce(ctx)
+	if len(host.vms) != 0 {
+		t.Fatalf("VM created despite admission refusal: %v", vmNames(host))
+	}
+	st, err := srv.GetClusterStatus(tenantCtx("alice"), &pb.GetClusterStatusRequest{Name: "demo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(st.Events) == 0 || st.Events[0].Kind != pb.ScaleEventKind_SCALE_EVENT_KIND_REFUSED {
+		t.Fatalf("refusal not recorded as a REFUSED event: %+v", st.Events)
+	}
+}
+
+func TestReconciler_VMCapabilityGatesCreate(t *testing.T) {
+	srv, _, host := testReconcilerRig(t)
+	host.capErr = clustercore.ErrVMsUnsupported
+
+	_, err := srv.CreateCluster(tenantCtx("alice"), &pb.CreateClusterRequest{Name: "demo"})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("create on a VM-incapable host = %v, want FailedPrecondition", err)
+	}
+	if !strings.Contains(err.Error(), "virtual machines") {
+		t.Fatalf("error does not explain the capability gap: %v", err)
+	}
+}
+
+func vmNames(h *stateHost) []string {
+	var out []string
+	for n := range h.vms {
+		out = append(out, n)
+	}
+	return out
+}

--- a/internal/server/cluster_server.go
+++ b/internal/server/cluster_server.go
@@ -29,13 +29,21 @@ type KubeconfigReader interface {
 // record desired state and the reconciler (#1414) converges VMs — so
 // this server stays thin: authz, validation, store transitions.
 //
-// Until the reconciler lands, DeleteCluster removes rows directly
-// (nothing has provisioned VMs yet) and GetClusterKubeconfig answers
-// Unimplemented on a READY cluster; #1414 replaces both seams.
+// Without a reconciler wired (SetReconciler), DeleteCluster removes
+// rows directly (nothing can have provisioned VMs) and
+// GetClusterKubeconfig answers Unimplemented on a READY cluster.
 type ClusterServer struct {
 	pb.UnimplementedClusterServiceServer
 	store      cluster.Store
 	kubeconfig KubeconfigReader
+	// vmCapable is the create-time capability probe (#1414): a host
+	// that cannot run VMs refuses cluster creation with a typed
+	// error instead of provisioning doomed records.
+	vmCapable func() error
+	// asyncDelete marks the reconciler as wired: DeleteCluster flips
+	// records to DELETING for the reconciler to drain instead of
+	// dropping rows that may have live VMs behind them.
+	asyncDelete bool
 }
 
 // NewClusterServer builds the server on a Store (in-memory at startup;
@@ -51,6 +59,17 @@ func (s *ClusterServer) SetStore(store cluster.Store) { s.store = store }
 
 // SetKubeconfigReader wires the provisioner-backed kubeconfig path (#1414).
 func (s *ClusterServer) SetKubeconfigReader(r KubeconfigReader) { s.kubeconfig = r }
+
+// Store exposes the backing store so the reconciler shares it.
+func (s *ClusterServer) Store() cluster.Store { return s.store }
+
+// SetReconciler wires the #1414 reconciler: kubeconfig reads, the VM
+// capability probe, and reconciler-drained deletes.
+func (s *ClusterServer) SetReconciler(r *ClusterReconciler) {
+	s.kubeconfig = r
+	s.vmCapable = r.VMCapable
+	s.asyncDelete = true
+}
 
 // resolveOwner defaults an empty request owner to the authenticated
 // subject and enforces tenant isolation for the resolved value.
@@ -181,6 +200,11 @@ func (s *ClusterServer) CreateCluster(ctx context.Context, req *pb.CreateCluster
 	if err := cluster.ValidateName(req.Name); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if s.vmCapable != nil {
+		if err := s.vmCapable(); err != nil {
+			return nil, status.Errorf(codes.FailedPrecondition, "%v", err)
+		}
+	}
 	groups, err := groupsFromProto(req.NodeGroups)
 	if err != nil {
 		return nil, err
@@ -265,9 +289,20 @@ func (s *ClusterServer) DeleteCluster(ctx context.Context, req *pb.DeleteCluster
 	if err != nil {
 		return nil, err
 	}
-	// Until the reconciler (#1414) exists nothing has provisioned VMs,
-	// so removing rows IS the whole teardown. #1414 turns this into a
-	// DELETING transition the reconciler drains.
+	if s.asyncDelete {
+		// The reconciler owns teardown: flip to DELETING and let it
+		// drain VMs, the endpoint, and finally the rows.
+		if _, err := s.store.Get(ctx, owner, req.Name); err != nil {
+			return nil, storeErr(err)
+		}
+		if err := s.store.SetState(ctx, owner, req.Name, cluster.StateDeleting, ""); err != nil {
+			return nil, storeErr(err)
+		}
+		log.Printf("[cluster] deletion requested owner=%s name=%s", owner, req.Name)
+		return &pb.DeleteClusterResponse{Message: "cluster deletion in progress: " + req.Name}, nil
+	}
+	// No reconciler wired → nothing can have provisioned VMs, so
+	// removing rows IS the whole teardown.
 	if err := s.store.Delete(ctx, owner, req.Name); err != nil {
 		return nil, storeErr(err)
 	}

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -42,6 +42,7 @@ import (
 	zapscanner "github.com/footprintai/containarium/internal/zap"
 	"github.com/footprintai/containarium/pkg/core/box"
 	"github.com/footprintai/containarium/pkg/core/catalogsig"
+	clustercore "github.com/footprintai/containarium/pkg/core/cluster"
 	"github.com/footprintai/containarium/pkg/core/container"
 	"github.com/footprintai/containarium/pkg/core/crews"
 	"github.com/footprintai/containarium/pkg/core/incus"
@@ -1197,6 +1198,35 @@ skipAppHosting:
 					log.Printf("Agent task-queue persistence enabled (Postgres store)")
 				}
 			}
+		}
+	}
+
+	// Managed-cluster reconciler (#1414): converges cluster records into
+	// control-plane + worker VMs (pure Decide policy in
+	// pkg/core/cluster). Wired AFTER the Postgres store swap so it
+	// shares whichever store the cluster server ended up on. Set
+	// CONTAINARIUM_CLUSTER_RECONCILER=false to disable.
+	if os.Getenv("CONTAINARIUM_CLUSTER_RECONCILER") != "false" {
+		if clusterIncus, cErr := incus.New(); cErr != nil {
+			log.Printf("[cluster] reconciler disabled: incus unavailable: %v", cErr)
+		} else {
+			clusterMgr := clustercore.NewManager(clustercore.NewIncusHost(clusterIncus), clustercore.DefaultArtifactBase)
+			clusterReconciler := NewClusterReconciler(clusterServer.Store(), clusterMgr)
+			clusterReconciler.SetAdmission(containerServer.admitCPUCapacity)
+			if adv := os.Getenv("CONTAINARIUM_CLUSTER_ADVERTISE_ADDR"); adv != "" && networkServer != nil {
+				portRange := os.Getenv("CONTAINARIUM_CLUSTER_PORT_RANGE")
+				if portRange == "" {
+					portRange = "36443-36542"
+				}
+				if pErr := clusterReconciler.WireEndpointPublisher(networkServer, adv, portRange); pErr != nil {
+					log.Printf("[cluster] endpoint publisher disabled: %v", pErr)
+				}
+			} else {
+				log.Printf("[cluster] CONTAINARIUM_CLUSTER_ADVERTISE_ADDR unset; cluster API endpoints use VM IPs (host-local reach only)")
+			}
+			clusterServer.SetReconciler(clusterReconciler)
+			go clusterReconciler.Run(context.Background())
+			log.Printf("Managed-cluster reconciler enabled")
 		}
 	}
 

--- a/pkg/core/cluster/artifacts.go
+++ b/pkg/core/cluster/artifacts.go
@@ -81,13 +81,13 @@ func fetchVerified(ctx context.Context, srcURL, path, want string) error {
 	if err != nil {
 		return err
 	}
-	defer os.Remove(tmp.Name())
+	defer func() { _ = os.Remove(tmp.Name()) }()
 	if _, err := io.Copy(tmp, resp.Body); err != nil {
-		tmp.Close()
+		_ = tmp.Close()
 		return err
 	}
 	if err := tmp.Chmod(0o755); err != nil {
-		tmp.Close()
+		_ = tmp.Close()
 		return err
 	}
 	if err := tmp.Close(); err != nil {
@@ -105,7 +105,7 @@ func verifySHA256(path, want string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	h := sha256.New()
 	if _, err := io.Copy(h, f); err != nil {
 		return err

--- a/pkg/core/cluster/artifacts.go
+++ b/pkg/core/cluster/artifacts.go
@@ -1,0 +1,117 @@
+package cluster
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Pinned artifacts. THIS FILE IS THE REVIEWABLE SURFACE: what a release
+// ships into tenant clusters is exactly what is pinned here, golden-
+// tested so a bump is a visible one-line diff (same rule as the
+// metrics-export allowlist). Checksums are the upstream-published
+// sha256sum-amd64.txt values for the release.
+//
+// Artifacts are fetched onto the HOST cache and pushed into VMs over
+// the Incus API — a cluster VM never downloads anything at bootstrap.
+// The airgap image preload is a later cold-start optimization (design:
+// "What has to change at 10x").
+const (
+	// K3sVersion is the k3s release every managed cluster runs.
+	K3sVersion = "v1.33.4+k3s1"
+	// K3sSHA256 is the sha256 of the linux-amd64 `k3s` binary.
+	K3sSHA256 = "10da34c350ab8a02e4513a6021046db9e9afecc31bae77419bc6444cbd7b1400"
+)
+
+// DefaultArtifactBase is the host-side artifact cache root.
+const DefaultArtifactBase = "/var/lib/containarium/artifacts"
+
+func k3sDownloadURL() string {
+	return "https://github.com/k3s-io/k3s/releases/download/" + url.PathEscape(K3sVersion) + "/k3s"
+}
+
+// K3sPath is where EnsureK3s caches the verified binary.
+func K3sPath(base string) string {
+	return filepath.Join(base, "k8s", K3sVersion, "k3s")
+}
+
+// EnsureK3s returns the path to the pinned, checksum-verified k3s
+// binary in the host cache, downloading it first if absent. The
+// checksum is verified on EVERY call — a corrupted or tampered cache
+// entry fails closed rather than being pushed into a tenant's cluster.
+func EnsureK3s(ctx context.Context, base string) (string, error) {
+	path := K3sPath(base)
+	if err := verifySHA256(path, K3sSHA256); err == nil {
+		return path, nil
+	}
+	if err := fetchVerified(ctx, k3sDownloadURL(), path, K3sSHA256); err != nil {
+		return "", fmt.Errorf("fetch k3s %s: %w", K3sVersion, err)
+	}
+	return path, nil
+}
+
+// fetchVerified downloads url into path atomically (tmp file + rename),
+// accepting the result only if its sha256 matches want.
+func fetchVerified(ctx context.Context, srcURL, path, want string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srcURL, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("GET %s: status %d", srcURL, resp.StatusCode)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".fetch-*")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := io.Copy(tmp, resp.Body); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(0o755); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := verifySHA256(tmp.Name(), want); err != nil {
+		return err
+	}
+	return os.Rename(tmp.Name(), path)
+}
+
+// verifySHA256 errors unless path exists and hashes to want.
+func verifySHA256(path, want string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return err
+	}
+	if got := hex.EncodeToString(h.Sum(nil)); got != want {
+		return fmt.Errorf("sha256 mismatch for %s: got %s, want %s", path, got, want)
+	}
+	return nil
+}

--- a/pkg/core/cluster/artifacts_test.go
+++ b/pkg/core/cluster/artifacts_test.go
@@ -1,0 +1,97 @@
+package cluster
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestPinnedArtifacts is the golden pin: what a release ships into
+// tenant clusters is reviewable as this one diff. Bumping k3s means
+// changing BOTH constants and this test, on purpose.
+func TestPinnedArtifacts(t *testing.T) {
+	if K3sVersion != "v1.33.4+k3s1" {
+		t.Fatalf("K3sVersion pin changed to %q — update the golden and re-verify the checksum against the upstream release", K3sVersion)
+	}
+	if K3sSHA256 != "10da34c350ab8a02e4513a6021046db9e9afecc31bae77419bc6444cbd7b1400" {
+		t.Fatalf("K3sSHA256 pin changed — update the golden from the upstream sha256sum-amd64.txt")
+	}
+	// "+" is a legal literal in a URL path segment (only query strings
+	// read it as a space), so PathEscape leaves it alone.
+	if got := k3sDownloadURL(); got != "https://github.com/k3s-io/k3s/releases/download/v1.33.4+k3s1/k3s" {
+		t.Fatalf("download URL = %q", got)
+	}
+}
+
+func TestVerifySHA256(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "artifact")
+	content := []byte("managed-cluster test artifact")
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(content)
+	want := hex.EncodeToString(sum[:])
+
+	if err := verifySHA256(path, want); err != nil {
+		t.Fatalf("matching checksum rejected: %v", err)
+	}
+	if err := verifySHA256(path, "deadbeef"); err == nil {
+		t.Fatal("wrong checksum accepted")
+	}
+	if err := verifySHA256(filepath.Join(dir, "missing"), want); err == nil {
+		t.Fatal("missing file accepted")
+	}
+}
+
+func TestFetchVerified(t *testing.T) {
+	good := []byte("the pinned artifact bytes")
+	sum := sha256.Sum256(good)
+	goodSHA := hex.EncodeToString(sum[:])
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/good":
+			_, _ = w.Write(good)
+		case "/tampered":
+			_, _ = w.Write([]byte("something else entirely"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+
+	// Happy path: fetched, verified, executable, atomic.
+	dst := filepath.Join(dir, "k3s")
+	if err := fetchVerified(context.Background(), srv.URL+"/good", dst, goodSHA); err != nil {
+		t.Fatalf("fetchVerified: %v", err)
+	}
+	st, err := os.Stat(dst)
+	if err != nil {
+		t.Fatalf("stat fetched artifact: %v", err)
+	}
+	if st.Mode().Perm() != 0o755 {
+		t.Fatalf("fetched artifact mode = %v, want 0755", st.Mode().Perm())
+	}
+
+	// Tampered payload fails closed and leaves nothing at the target.
+	dst2 := filepath.Join(dir, "k3s2")
+	if err := fetchVerified(context.Background(), srv.URL+"/tampered", dst2, goodSHA); err == nil {
+		t.Fatal("tampered artifact accepted")
+	}
+	if _, err := os.Stat(dst2); !os.IsNotExist(err) {
+		t.Fatalf("tampered fetch left a file behind: %v", err)
+	}
+
+	// HTTP error fails.
+	if err := fetchVerified(context.Background(), srv.URL+"/missing", dst2, goodSHA); err == nil {
+		t.Fatal("404 accepted")
+	}
+}

--- a/pkg/core/cluster/bootstrap.go
+++ b/pkg/core/cluster/bootstrap.go
@@ -1,0 +1,139 @@
+package cluster
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Bootstrap renderers — pure functions producing the shell that runs
+// inside a freshly created VM over `incus exec`. Rendered output is
+// golden-tested (testdata/*.golden): a change to what executes inside
+// a tenant's cluster VM must show up as a reviewable golden diff.
+//
+// Both scripts assume the pinned k3s binary was already pushed to
+// K3sBinaryPath by the manager — bootstrap never downloads anything.
+
+const (
+	// K3sBinaryPath is where the manager pushes the pinned binary.
+	K3sBinaryPath = "/usr/local/bin/k3s"
+	// AgentTokenPath is where the manager pushes the join token (0600).
+	AgentTokenPath = "/etc/containarium/k3s-agent-token"
+	// KubeconfigPath is where k3s server writes the admin kubeconfig.
+	KubeconfigPath = "/etc/rancher/k3s/k3s.yaml"
+	// NodeTokenPath is where k3s server writes the agent join token.
+	NodeTokenPath = "/var/lib/rancher/k3s/server/node-token"
+)
+
+// ServerBootstrap parameterizes the control-plane script.
+type ServerBootstrap struct {
+	// TLSSANs are extra subject-alt-names for the API server cert —
+	// the external endpoint and the VM IP, so the rewritten
+	// kubeconfig verifies.
+	TLSSANs []string
+}
+
+// RenderServerScript renders the control-plane first-boot script: a
+// systemd unit for `k3s server`, tainted so tenant pods never schedule
+// onto the platform-owned VM, traefik disabled (ingress is a later
+// phase riding the platform's own routing).
+func RenderServerScript(b ServerBootstrap) string {
+	sans := append([]string(nil), b.TLSSANs...)
+	sort.Strings(sans)
+	var sanFlags strings.Builder
+	for _, s := range sans {
+		fmt.Fprintf(&sanFlags, " --tls-san %s", s)
+	}
+	return fmt.Sprintf(`#!/bin/sh
+# containarium managed-cluster control-plane bootstrap (#1414).
+# The k3s binary is pre-pushed; this script only wires and starts it.
+set -eu
+
+chmod 0755 %[1]s
+
+cat > /etc/systemd/system/k3s.service <<'UNIT'
+[Unit]
+Description=containarium managed k3s server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=notify
+ExecStart=%[1]s server --disable traefik --node-taint node-role.kubernetes.io/control-plane=:NoSchedule --write-kubeconfig-mode 0600%[2]s
+Restart=always
+RestartSec=5
+LimitNOFILE=1048576
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+systemctl daemon-reload
+systemctl enable --now k3s.service
+
+# Bootstrap is done when the admin kubeconfig and the join token exist.
+i=0
+until [ -s %[3]s ] && [ -s %[4]s ]; do
+  i=$((i+1))
+  [ "$i" -gt 120 ] && { echo "k3s server did not come up" >&2; exit 1; }
+  sleep 2
+done
+`, K3sBinaryPath, sanFlags.String(), KubeconfigPath, NodeTokenPath)
+}
+
+// AgentBootstrap parameterizes a worker script.
+type AgentBootstrap struct {
+	// ServerURL is the control-plane's in-host API URL
+	// (https://<cp-ip>:6443) — workers join over the private bridge,
+	// not the published endpoint.
+	ServerURL string
+}
+
+// RenderAgentScript renders a worker first-boot script: a systemd unit
+// for `k3s agent` joining via the pre-pushed token file.
+func RenderAgentScript(b AgentBootstrap) string {
+	return fmt.Sprintf(`#!/bin/sh
+# containarium managed-cluster worker bootstrap (#1414).
+# The k3s binary and the join token are pre-pushed.
+set -eu
+
+chmod 0755 %[1]s
+chmod 0600 %[2]s
+
+cat > /etc/systemd/system/k3s-agent.service <<'UNIT'
+[Unit]
+Description=containarium managed k3s agent
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=notify
+ExecStart=%[1]s agent --server %[3]s --token-file %[2]s
+Restart=always
+RestartSec=5
+LimitNOFILE=1048576
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+systemctl daemon-reload
+systemctl enable --now k3s-agent.service
+`, K3sBinaryPath, AgentTokenPath, b.ServerURL)
+}
+
+// RewriteKubeconfigServer replaces the server URL in a k3s admin
+// kubeconfig with the published external endpoint. Pure string surgery
+// on the one line k3s emits (`server: https://127.0.0.1:6443`), so it
+// needs no YAML dependency.
+func RewriteKubeconfigServer(kubeconfig, endpoint string) string {
+	lines := strings.Split(kubeconfig, "\n")
+	for i, l := range lines {
+		trimmed := strings.TrimSpace(l)
+		if strings.HasPrefix(trimmed, "server:") {
+			indent := l[:len(l)-len(strings.TrimLeft(l, " \t"))]
+			lines[i] = indent + "server: https://" + endpoint
+		}
+	}
+	return strings.Join(lines, "\n")
+}

--- a/pkg/core/cluster/bootstrap_test.go
+++ b/pkg/core/cluster/bootstrap_test.go
@@ -1,0 +1,88 @@
+package cluster
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+var update = flag.Bool("update", false, "rewrite golden files")
+
+// golden compares rendered bootstrap output against testdata — what
+// executes inside a tenant's cluster VM changes only as a reviewable
+// golden diff (`go test ./pkg/core/cluster/ -update` to regenerate).
+func golden(t *testing.T, name, got string) {
+	t.Helper()
+	path := filepath.Join("testdata", name)
+	if *update {
+		if err := os.MkdirAll("testdata", 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(got), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read golden %s (run with -update to create): %v", path, err)
+	}
+	if got != string(want) {
+		t.Fatalf("rendered output diverges from %s.\n--- got ---\n%s\n--- want ---\n%s", path, got, want)
+	}
+}
+
+func TestRenderServerScript(t *testing.T) {
+	got := RenderServerScript(ServerBootstrap{TLSSANs: []string{"203.0.113.10", "10.166.11.5"}})
+	golden(t, "server.sh.golden", got)
+
+	// Behavioral pins independent of the golden bytes.
+	for _, must := range []string{
+		"--disable traefik",
+		"--node-taint node-role.kubernetes.io/control-plane=:NoSchedule",
+		"--write-kubeconfig-mode 0600",
+		"--tls-san 10.166.11.5",
+		"--tls-san 203.0.113.10",
+	} {
+		if !strings.Contains(got, must) {
+			t.Fatalf("server script missing %q", must)
+		}
+	}
+	if strings.Contains(got, "curl") || strings.Contains(got, "wget") {
+		t.Fatal("bootstrap must not download anything in-guest")
+	}
+}
+
+func TestRenderAgentScript(t *testing.T) {
+	got := RenderAgentScript(AgentBootstrap{ServerURL: "https://10.166.11.5:6443"})
+	golden(t, "agent.sh.golden", got)
+
+	for _, must := range []string{
+		"k3s agent --server https://10.166.11.5:6443",
+		"--token-file " + AgentTokenPath,
+		"chmod 0600 " + AgentTokenPath,
+	} {
+		if !strings.Contains(got, must) {
+			t.Fatalf("agent script missing %q", must)
+		}
+	}
+	if strings.Contains(got, "curl") || strings.Contains(got, "wget") {
+		t.Fatal("bootstrap must not download anything in-guest")
+	}
+}
+
+func TestRewriteKubeconfigServer(t *testing.T) {
+	in := "apiVersion: v1\nclusters:\n- cluster:\n    server: https://127.0.0.1:6443\n  name: default\n"
+	got := RewriteKubeconfigServer(in, "203.0.113.10:30443")
+	if !strings.Contains(got, "    server: https://203.0.113.10:30443\n") {
+		t.Fatalf("server line not rewritten:\n%s", got)
+	}
+	if strings.Contains(got, "127.0.0.1") {
+		t.Fatalf("old server survived rewrite:\n%s", got)
+	}
+	// Indentation is preserved so the YAML stays valid.
+	if !strings.Contains(got, "\n    server:") {
+		t.Fatalf("indentation lost:\n%s", got)
+	}
+}

--- a/pkg/core/cluster/incushost.go
+++ b/pkg/core/cluster/incushost.go
@@ -1,0 +1,107 @@
+package cluster
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/lxc/incus/v6/shared/api"
+
+	"github.com/footprintai/containarium/pkg/core/incus"
+)
+
+// ErrVMsUnsupported is the typed create-time refusal for hosts that
+// cannot run Incus VMs (the design's hard requirement — no silent
+// degrade to shared-kernel containers).
+var ErrVMsUnsupported = errors.New("this backend cannot run virtual machines (KVM/qemu unavailable); managed clusters require VM capability")
+
+// IncusHost adapts pkg/core/incus.Client to the VMHost seam. Thin by
+// design: every method is one client call plus shaping; the sequences
+// that matter are in Manager and tested against a fake.
+type IncusHost struct {
+	client *incus.Client
+}
+
+// NewIncusHost wraps an incus client.
+func NewIncusHost(c *incus.Client) *IncusHost { return &IncusHost{client: c} }
+
+func (h *IncusHost) VMCapable() error {
+	info, err := h.client.GetServerInfo()
+	if err != nil {
+		return fmt.Errorf("query incus server: %w", err)
+	}
+	// Incus reports VM support by listing "qemu" among its drivers.
+	if !strings.Contains(info.Environment.Driver, "qemu") {
+		return ErrVMsUnsupported
+	}
+	return nil
+}
+
+func (h *IncusHost) CreateVM(spec NodeSpec) error {
+	cfg := incus.ContainerConfig{
+		Name:         spec.Name,
+		Image:        "images:ubuntu/24.04", // the nodevm default; VM image bake is a later phase
+		CPU:          spec.CPU,
+		Memory:       spec.Memory,
+		InstanceType: api.InstanceTypeVM,
+		AutoStart:    true,
+	}
+	if spec.Disk != "" {
+		cfg.Disk = &incus.DiskDevice{Size: spec.Disk}
+	}
+	if err := h.client.CreateContainer(cfg); err != nil {
+		return err
+	}
+	if err := h.client.SetLabels(spec.Name, spec.Labels); err != nil {
+		return fmt.Errorf("label %s: %w", spec.Name, err)
+	}
+	return h.client.StartContainer(spec.Name)
+}
+
+func (h *IncusHost) Start(name string) error  { return h.client.StartContainer(name) }
+func (h *IncusHost) Delete(name string) error { return h.client.DeleteContainer(name) }
+
+func (h *IncusHost) WaitReady(name string, timeout time.Duration) (string, error) {
+	return h.client.WaitForNetwork(name, timeout)
+}
+
+func (h *IncusHost) Push(name, path string, content []byte, mode string) error {
+	return h.client.WriteFile(name, path, content, mode)
+}
+
+func (h *IncusHost) Read(name, path string) ([]byte, error) {
+	return h.client.ReadFile(name, path)
+}
+
+func (h *IncusHost) Exec(name string, cmd []string) (string, error) {
+	stdout, stderr, err := h.client.ExecWithOutput(name, cmd)
+	if err != nil {
+		return stdout, fmt.Errorf("%w (stderr: %s)", err, strings.TrimSpace(stderr))
+	}
+	return stdout, nil
+}
+
+func (h *IncusHost) ClusterVMs(tenant, clusterName string) (Observed, error) {
+	all, err := h.client.ListContainers()
+	if err != nil {
+		return Observed{}, err
+	}
+	obs := Observed{Workers: map[string][]ObservedVM{}}
+	for i := range all {
+		c := &all[i]
+		if c.Labels[LabelCluster] != clusterName || c.Labels[LabelClusterOwner] != tenant {
+			continue
+		}
+		vm := ObservedVM{Name: c.Name, Running: strings.EqualFold(c.State, "running")}
+		switch c.Labels[LabelClusterRole] {
+		case RoleControlPlane:
+			cp := vm
+			obs.CP = &cp
+		case RoleWorker:
+			g := c.Labels[LabelNodeGroup]
+			obs.Workers[g] = append(obs.Workers[g], vm)
+		}
+	}
+	return obs, nil
+}

--- a/pkg/core/cluster/manager.go
+++ b/pkg/core/cluster/manager.go
@@ -1,0 +1,193 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+// VMHost is the narrow host surface the manager drives — implemented
+// by IncusHost in production and by a fake in tests, so orchestration
+// sequences are unit-testable (the nodevm Runner-seam precedent).
+type VMHost interface {
+	// VMCapable returns nil when the host can run VMs, or a typed,
+	// user-facing error when it cannot (the design's hard create-time
+	// requirement).
+	VMCapable() error
+	CreateVM(spec NodeSpec) error
+	Start(name string) error
+	Delete(name string) error
+	// WaitReady blocks until the guest agent is up and networked,
+	// returning the VM's primary IP.
+	WaitReady(name string, timeout time.Duration) (string, error)
+	Push(name, path string, content []byte, mode string) error
+	Read(name, path string) ([]byte, error)
+	Exec(name string, cmd []string) (string, error)
+	// ClusterVMs lists this cluster's VMs by label, bucketed as the
+	// reconciler's Observed shape.
+	ClusterVMs(tenant, clusterName string) (Observed, error)
+}
+
+// Manager provisions cluster VMs. It is stateless: every method takes
+// what it needs, and persistence stays with the caller.
+type Manager struct {
+	host VMHost
+	// k3sBinary loads the host-cached, checksum-verified binary
+	// (EnsureK3s). A loader keeps ~70MB out of memory until a
+	// provision actually happens.
+	k3sBinary func() ([]byte, error)
+	// waitReadyTimeout is how long a fresh VM gets to boot + network.
+	waitReadyTimeout time.Duration
+}
+
+// NewManager builds a Manager on a host. artifactBase is the host
+// cache root (DefaultArtifactBase in production).
+func NewManager(host VMHost, artifactBase string) *Manager {
+	return &Manager{
+		host: host,
+		k3sBinary: func() ([]byte, error) {
+			path, err := EnsureK3s(context.Background(), artifactBase)
+			if err != nil {
+				return nil, err
+			}
+			return os.ReadFile(path)
+		},
+		waitReadyTimeout: 3 * time.Minute,
+	}
+}
+
+// NewManagerWithLoader builds a Manager with an explicit binary
+// loader — the seam tests (and callers with pre-staged artifacts) use
+// instead of the EnsureK3s download path.
+func NewManagerWithLoader(host VMHost, loader func() ([]byte, error)) *Manager {
+	return &Manager{host: host, k3sBinary: loader, waitReadyTimeout: 3 * time.Minute}
+}
+
+// VMCapable surfaces the host's VM capability probe.
+func (m *Manager) VMCapable() error { return m.host.VMCapable() }
+
+// Observe returns the host's view of a cluster's VMs.
+func (m *Manager) Observe(tenant, clusterName string) (Observed, error) {
+	return m.host.ClusterVMs(tenant, clusterName)
+}
+
+// StartVM restarts a stopped cluster VM.
+func (m *Manager) StartVM(name string) error { return m.host.Start(name) }
+
+// DeleteVM force-removes a cluster VM.
+func (m *Manager) DeleteVM(name string) error { return m.host.Delete(name) }
+
+const bootstrapScriptPath = "/root/containarium-bootstrap.sh"
+
+// ProvisionCP creates and bootstraps the control-plane VM: create →
+// start → wait → push pinned binary + rendered script → exec. Returns
+// the VM's IP (workers join over it). cpSize is the smallest preset —
+// the control plane is platform overhead, not tenant capacity.
+func (m *Manager) ProvisionCP(tenant, clusterName string, cpSize DesiredGroup, tlsSANs []string) (string, error) {
+	name := CPName(tenant, clusterName)
+	spec := NodeSpec{
+		Name: name, CPU: cpSize.CPU, Memory: cpSize.Memory, Disk: cpSize.Disk,
+		Labels: VMLabels(tenant, clusterName, RoleControlPlane, ""),
+	}
+	if err := m.host.CreateVM(spec); err != nil {
+		return "", fmt.Errorf("create control-plane VM: %w", err)
+	}
+	ip, err := m.host.WaitReady(name, m.waitReadyTimeout)
+	if err != nil {
+		return "", fmt.Errorf("control-plane VM %s not ready: %w", name, err)
+	}
+	bin, err := m.k3sBinary()
+	if err != nil {
+		return "", err
+	}
+	if err := m.host.Push(name, K3sBinaryPath, bin, "0755"); err != nil {
+		return "", fmt.Errorf("push k3s binary: %w", err)
+	}
+	script := RenderServerScript(ServerBootstrap{TLSSANs: append([]string{ip}, tlsSANs...)})
+	if err := m.host.Push(name, bootstrapScriptPath, []byte(script), "0755"); err != nil {
+		return "", fmt.Errorf("push bootstrap script: %w", err)
+	}
+	if _, err := m.host.Exec(name, []string{"sh", bootstrapScriptPath}); err != nil {
+		return "", fmt.Errorf("control-plane bootstrap: %w", err)
+	}
+	return ip, nil
+}
+
+// ProvisionWorker creates and joins one worker VM to a running control
+// plane. The join token is read from the CP and pushed 0600 — it never
+// leaves the host or lands in a store.
+func (m *Manager) ProvisionWorker(tenant, clusterName string, g DesiredGroup, vmName, cpIP string) error {
+	cp := CPName(tenant, clusterName)
+	token, err := m.host.Read(cp, NodeTokenPath)
+	if err != nil {
+		return fmt.Errorf("read join token from %s: %w", cp, err)
+	}
+	spec := NodeSpec{
+		Name: vmName, CPU: g.CPU, Memory: g.Memory, Disk: g.Disk,
+		Labels: VMLabels(tenant, clusterName, RoleWorker, g.Name),
+	}
+	if err := m.host.CreateVM(spec); err != nil {
+		return fmt.Errorf("create worker VM: %w", err)
+	}
+	if _, err := m.host.WaitReady(vmName, m.waitReadyTimeout); err != nil {
+		return fmt.Errorf("worker VM %s not ready: %w", vmName, err)
+	}
+	bin, err := m.k3sBinary()
+	if err != nil {
+		return err
+	}
+	if err := m.host.Push(vmName, K3sBinaryPath, bin, "0755"); err != nil {
+		return fmt.Errorf("push k3s binary: %w", err)
+	}
+	if err := m.host.Push(vmName, AgentTokenPath, token, "0600"); err != nil {
+		return fmt.Errorf("push join token: %w", err)
+	}
+	script := RenderAgentScript(AgentBootstrap{ServerURL: "https://" + cpIP + ":6443"})
+	if err := m.host.Push(vmName, bootstrapScriptPath, []byte(script), "0755"); err != nil {
+		return fmt.Errorf("push bootstrap script: %w", err)
+	}
+	if _, err := m.host.Exec(vmName, []string{"sh", bootstrapScriptPath}); err != nil {
+		return fmt.Errorf("worker bootstrap: %w", err)
+	}
+	return nil
+}
+
+// Kubeconfig reads the CP's admin kubeconfig on demand and rewrites
+// its server URL to the published endpoint. Never persisted.
+func (m *Manager) Kubeconfig(tenant, clusterName, endpoint string) (string, error) {
+	raw, err := m.host.Read(CPName(tenant, clusterName), KubeconfigPath)
+	if err != nil {
+		return "", fmt.Errorf("read kubeconfig: %w", err)
+	}
+	kc := string(raw)
+	if endpoint != "" {
+		kc = RewriteKubeconfigServer(kc, endpoint)
+	}
+	return kc, nil
+}
+
+// CPIP returns the control-plane VM's current IP.
+func (m *Manager) CPIP(tenant, clusterName string) (string, error) {
+	return m.host.WaitReady(CPName(tenant, clusterName), 30*time.Second)
+}
+
+// ReadyNodes counts Ready nodes as the cluster's own API reports them,
+// via `k3s kubectl` on the CP — observed state from the cluster, not
+// from our rows.
+func (m *Manager) ReadyNodes(tenant, clusterName string) (int, error) {
+	out, err := m.host.Exec(CPName(tenant, clusterName),
+		[]string{K3sBinaryPath, "kubectl", "get", "nodes", "--no-headers"})
+	if err != nil {
+		return 0, fmt.Errorf("kubectl get nodes: %w", err)
+	}
+	ready := 0
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[1] == "Ready" {
+			ready++
+		}
+	}
+	return ready, nil
+}

--- a/pkg/core/cluster/manager_test.go
+++ b/pkg/core/cluster/manager_test.go
@@ -1,0 +1,183 @@
+package cluster
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeHost records every VMHost call so tests assert the exact
+// orchestration sequence — the part of the manager that matters.
+type fakeHost struct {
+	calls    []string
+	files    map[string][]byte // "<vm>:<path>" → content
+	execOut  map[string]string // "<vm>:<argv0...>" → stdout
+	readErr  error
+	capError error
+}
+
+func newFakeHost() *fakeHost {
+	return &fakeHost{files: map[string][]byte{}, execOut: map[string]string{}}
+}
+
+func (f *fakeHost) record(format string, a ...any) {
+	f.calls = append(f.calls, fmt.Sprintf(format, a...))
+}
+
+func (f *fakeHost) VMCapable() error { return f.capError }
+func (f *fakeHost) CreateVM(spec NodeSpec) error {
+	f.record("create %s cpu=%s mem=%s disk=%s role=%s", spec.Name, spec.CPU, spec.Memory, spec.Disk, spec.Labels[LabelClusterRole])
+	return nil
+}
+func (f *fakeHost) Start(name string) error  { f.record("start %s", name); return nil }
+func (f *fakeHost) Delete(name string) error { f.record("delete %s", name); return nil }
+func (f *fakeHost) WaitReady(name string, _ time.Duration) (string, error) {
+	f.record("wait %s", name)
+	return "10.166.11.5", nil
+}
+func (f *fakeHost) Push(name, path string, content []byte, mode string) error {
+	f.record("push %s:%s mode=%s", name, path, mode)
+	f.files[name+":"+path] = content
+	return nil
+}
+func (f *fakeHost) Read(name, path string) ([]byte, error) {
+	if f.readErr != nil {
+		return nil, f.readErr
+	}
+	f.record("read %s:%s", name, path)
+	if c, ok := f.files[name+":"+path]; ok {
+		return c, nil
+	}
+	return []byte("stored-content"), nil
+}
+func (f *fakeHost) Exec(name string, cmd []string) (string, error) {
+	f.record("exec %s:%s", name, strings.Join(cmd, " "))
+	return f.execOut[name+":"+cmd[0]], nil
+}
+func (f *fakeHost) ClusterVMs(tenant, clusterName string) (Observed, error) {
+	return Observed{}, nil
+}
+
+func testManager(f *fakeHost) *Manager {
+	return &Manager{
+		host:             f,
+		k3sBinary:        func() ([]byte, error) { return []byte("k3s-binary-bytes"), nil },
+		waitReadyTimeout: time.Second,
+	}
+}
+
+func TestProvisionCPSequence(t *testing.T) {
+	f := newFakeHost()
+	m := testManager(f)
+
+	ip, err := m.ProvisionCP("alice", "demo", DesiredGroup{CPU: "2", Memory: "4GB", Disk: "40GB"}, []string{"203.0.113.10"})
+	if err != nil {
+		t.Fatalf("ProvisionCP: %v", err)
+	}
+	if ip != "10.166.11.5" {
+		t.Fatalf("ip = %q", ip)
+	}
+	want := []string{
+		"create alice-k8s-demo-cp cpu=2 mem=4GB disk=40GB role=control-plane",
+		"wait alice-k8s-demo-cp",
+		"push alice-k8s-demo-cp:" + K3sBinaryPath + " mode=0755",
+		"push alice-k8s-demo-cp:" + bootstrapScriptPath + " mode=0755",
+		"exec alice-k8s-demo-cp:sh " + bootstrapScriptPath,
+	}
+	assertCalls(t, f.calls, want)
+
+	// The pushed script carries BOTH the VM IP and the external SAN.
+	script := string(f.files["alice-k8s-demo-cp:"+bootstrapScriptPath])
+	for _, san := range []string{"--tls-san 10.166.11.5", "--tls-san 203.0.113.10"} {
+		if !strings.Contains(script, san) {
+			t.Fatalf("server script missing %q", san)
+		}
+	}
+}
+
+func TestProvisionWorkerSequence(t *testing.T) {
+	f := newFakeHost()
+	f.files["alice-k8s-demo-cp:"+NodeTokenPath] = []byte("K10secret::token")
+	m := testManager(f)
+
+	err := m.ProvisionWorker("alice", "demo",
+		DesiredGroup{Name: "small", CPU: "2", Memory: "4GB", Disk: "40GB"},
+		"alice-k8s-demo-small-1", "10.166.11.5")
+	if err != nil {
+		t.Fatalf("ProvisionWorker: %v", err)
+	}
+	want := []string{
+		"read alice-k8s-demo-cp:" + NodeTokenPath,
+		"create alice-k8s-demo-small-1 cpu=2 mem=4GB disk=40GB role=worker",
+		"wait alice-k8s-demo-small-1",
+		"push alice-k8s-demo-small-1:" + K3sBinaryPath + " mode=0755",
+		"push alice-k8s-demo-small-1:" + AgentTokenPath + " mode=0600",
+		"push alice-k8s-demo-small-1:" + bootstrapScriptPath + " mode=0755",
+		"exec alice-k8s-demo-small-1:sh " + bootstrapScriptPath,
+	}
+	assertCalls(t, f.calls, want)
+
+	if got := string(f.files["alice-k8s-demo-small-1:"+AgentTokenPath]); got != "K10secret::token" {
+		t.Fatalf("token pushed = %q", got)
+	}
+	script := string(f.files["alice-k8s-demo-small-1:"+bootstrapScriptPath])
+	if !strings.Contains(script, "--server https://10.166.11.5:6443") {
+		t.Fatalf("agent script joins wrong server:\n%s", script)
+	}
+
+	// A CP whose token can't be read must fail BEFORE creating a VM.
+	f2 := newFakeHost()
+	f2.readErr = errors.New("no such file")
+	if err := testManager(f2).ProvisionWorker("alice", "demo", DesiredGroup{Name: "small"}, "alice-k8s-demo-small-1", "10.0.0.1"); err == nil {
+		t.Fatal("worker provisioned without a join token")
+	}
+	for _, c := range f2.calls {
+		if strings.HasPrefix(c, "create") {
+			t.Fatalf("VM created despite missing token: %v", f2.calls)
+		}
+	}
+}
+
+func TestKubeconfigRewrites(t *testing.T) {
+	f := newFakeHost()
+	f.files["alice-k8s-demo-cp:"+KubeconfigPath] = []byte("clusters:\n- cluster:\n    server: https://127.0.0.1:6443\n")
+	m := testManager(f)
+
+	kc, err := m.Kubeconfig("alice", "demo", "203.0.113.10:30443")
+	if err != nil {
+		t.Fatalf("Kubeconfig: %v", err)
+	}
+	if !strings.Contains(kc, "server: https://203.0.113.10:30443") || strings.Contains(kc, "127.0.0.1") {
+		t.Fatalf("kubeconfig not rewritten:\n%s", kc)
+	}
+}
+
+func TestReadyNodesParsesKubectl(t *testing.T) {
+	f := newFakeHost()
+	f.execOut["alice-k8s-demo-cp:"+K3sBinaryPath] = "" +
+		"alice-k8s-demo-cp        Ready    control-plane   5m    v1.33.4+k3s1\n" +
+		"alice-k8s-demo-small-1   Ready    <none>          2m    v1.33.4+k3s1\n" +
+		"alice-k8s-demo-small-2   NotReady <none>          10s   v1.33.4+k3s1\n"
+	m := testManager(f)
+	n, err := m.ReadyNodes("alice", "demo")
+	if err != nil {
+		t.Fatalf("ReadyNodes: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("ReadyNodes = %d, want 2", n)
+	}
+}
+
+func assertCalls(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("call sequence:\n  got  %q\n  want %q", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("call %d:\n  got  %q\n  want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/pkg/core/cluster/reconcile.go
+++ b/pkg/core/cluster/reconcile.go
@@ -1,0 +1,149 @@
+package cluster
+
+import (
+	"fmt"
+	"sort"
+)
+
+// The reconcile decision function — pure, exhaustively table-tested
+// (the autosleep decide.go house pattern). The daemon-side loop builds
+// Desired from the store record and Observed from the host, and
+// executes whatever Decide returns; all policy lives here.
+//
+// Deliberately NOT here: scale-down. Removing surplus workers is the
+// cluster-autoscaler's job (it drains first); the reconciler only
+// creates up to each group's Min, restarts stopped VMs, and tears down
+// deleting clusters. See the design's "Who decides what".
+
+// DesiredGroup is one node group's desired shape.
+type DesiredGroup struct {
+	Name     string
+	Min, Max int
+	CPU      string
+	Memory   string
+	Disk     string
+}
+
+// Desired is a cluster's desired state, derived from the store record.
+type Desired struct {
+	Tenant  string
+	Cluster string
+	// Deleting means the record is in state DELETING: every VM goes.
+	Deleting bool
+	Groups   []DesiredGroup
+}
+
+// ObservedVM is one cluster VM as the host reports it.
+type ObservedVM struct {
+	Name    string
+	Running bool
+}
+
+// Observed is the host's view of a cluster's VMs.
+type Observed struct {
+	CP *ObservedVM
+	// Workers by group name. Names follow WorkerName; the observer
+	// buckets them by the node_group label, not by parsing names.
+	Workers map[string][]ObservedVM
+}
+
+// ActionKind enumerates what the reconciler can do in one pass.
+type ActionKind int
+
+const (
+	ActionCreateCP ActionKind = iota
+	ActionStartVM
+	ActionCreateWorker
+	ActionDeleteVM
+)
+
+func (k ActionKind) String() string {
+	switch k {
+	case ActionCreateCP:
+		return "create-cp"
+	case ActionStartVM:
+		return "start-vm"
+	case ActionCreateWorker:
+		return "create-worker"
+	case ActionDeleteVM:
+		return "delete-vm"
+	default:
+		return fmt.Sprintf("actionkind(%d)", int(k))
+	}
+}
+
+// Action is one step the loop executes.
+type Action struct {
+	Kind  ActionKind
+	Group string // worker actions only
+	// Name is the VM the action targets (for creates, the name to
+	// create under).
+	Name string
+}
+
+// Decide computes the actions that move Observed toward Desired.
+// Invariants:
+//   - a deleting cluster tears down workers first, control plane last;
+//   - no worker is created before the control plane exists and runs
+//     (agents need a server to join);
+//   - stopped VMs are started, missing ones created — never both for
+//     the same name in one pass;
+//   - creation converges to each group's Min; anything between Min and
+//     Max is the autoscaler's territory and is left alone;
+//   - scale-down never happens here.
+func Decide(d Desired, o Observed) []Action {
+	if d.Deleting {
+		var acts []Action
+		groups := sortedKeys(o.Workers)
+		for _, g := range groups {
+			for _, w := range o.Workers[g] {
+				acts = append(acts, Action{Kind: ActionDeleteVM, Group: g, Name: w.Name})
+			}
+		}
+		if o.CP != nil {
+			acts = append(acts, Action{Kind: ActionDeleteVM, Name: o.CP.Name})
+		}
+		return acts
+	}
+
+	cpName := CPName(d.Tenant, d.Cluster)
+	if o.CP == nil {
+		return []Action{{Kind: ActionCreateCP, Name: cpName}}
+	}
+	if !o.CP.Running {
+		return []Action{{Kind: ActionStartVM, Name: o.CP.Name}}
+	}
+
+	var acts []Action
+	for _, g := range d.Groups {
+		observed := o.Workers[g.Name]
+		inUse := make(map[string]bool, len(observed))
+		alive := 0
+		for _, w := range observed {
+			inUse[w.Name] = true
+			if !w.Running {
+				acts = append(acts, Action{Kind: ActionStartVM, Group: g.Name, Name: w.Name})
+			}
+			alive++ // stopped VMs are being started, not replaced
+		}
+		for n := 1; alive < g.Min; n++ {
+			name := WorkerName(d.Tenant, d.Cluster, g.Name, n)
+			if inUse[name] {
+				continue
+			}
+			acts = append(acts, Action{Kind: ActionCreateWorker, Group: g.Name, Name: name})
+			inUse[name] = true
+			alive++
+		}
+	}
+	return acts
+}
+
+func sortedKeys(m map[string][]ObservedVM) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/pkg/core/cluster/reconcile_test.go
+++ b/pkg/core/cluster/reconcile_test.go
@@ -1,0 +1,133 @@
+package cluster
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDecide(t *testing.T) {
+	desired := Desired{
+		Tenant:  "alice",
+		Cluster: "demo",
+		Groups: []DesiredGroup{
+			{Name: "small", Min: 2, Max: 3},
+			{Name: "large", Min: 0, Max: 1},
+		},
+	}
+	cp := func(running bool) *ObservedVM {
+		return &ObservedVM{Name: "alice-k8s-demo-cp", Running: running}
+	}
+
+	cases := []struct {
+		name     string
+		desired  Desired
+		observed Observed
+		want     []Action
+	}{
+		{
+			"fresh cluster creates the control plane first, no workers yet",
+			desired,
+			Observed{},
+			[]Action{{Kind: ActionCreateCP, Name: "alice-k8s-demo-cp"}},
+		},
+		{
+			"stopped control plane is started, not replaced",
+			desired,
+			Observed{CP: cp(false)},
+			[]Action{{Kind: ActionStartVM, Name: "alice-k8s-demo-cp"}},
+		},
+		{
+			"running control plane converges each group to its min",
+			desired,
+			Observed{CP: cp(true)},
+			[]Action{
+				{Kind: ActionCreateWorker, Group: "small", Name: "alice-k8s-demo-small-1"},
+				{Kind: ActionCreateWorker, Group: "small", Name: "alice-k8s-demo-small-2"},
+			},
+		},
+		{
+			"lost worker is replaced under an unused index",
+			desired,
+			Observed{CP: cp(true), Workers: map[string][]ObservedVM{
+				"small": {{Name: "alice-k8s-demo-small-2", Running: true}},
+			}},
+			[]Action{
+				{Kind: ActionCreateWorker, Group: "small", Name: "alice-k8s-demo-small-1"},
+			},
+		},
+		{
+			"stopped worker is started, never started AND replaced in one pass",
+			desired,
+			Observed{CP: cp(true), Workers: map[string][]ObservedVM{
+				"small": {
+					{Name: "alice-k8s-demo-small-1", Running: false},
+					{Name: "alice-k8s-demo-small-2", Running: true},
+				},
+			}},
+			[]Action{
+				{Kind: ActionStartVM, Group: "small", Name: "alice-k8s-demo-small-1"},
+			},
+		},
+		{
+			"between min and max is the autoscaler's territory — no scale-down",
+			desired,
+			Observed{CP: cp(true), Workers: map[string][]ObservedVM{
+				"small": {
+					{Name: "alice-k8s-demo-small-1", Running: true},
+					{Name: "alice-k8s-demo-small-2", Running: true},
+					{Name: "alice-k8s-demo-small-3", Running: true},
+				},
+			}},
+			nil,
+		},
+		{
+			"deleting tears down workers first, control plane last",
+			Desired{Tenant: "alice", Cluster: "demo", Deleting: true},
+			Observed{CP: cp(true), Workers: map[string][]ObservedVM{
+				"small": {{Name: "alice-k8s-demo-small-1", Running: true}},
+			}},
+			[]Action{
+				{Kind: ActionDeleteVM, Group: "small", Name: "alice-k8s-demo-small-1"},
+				{Kind: ActionDeleteVM, Name: "alice-k8s-demo-cp"},
+			},
+		},
+		{
+			"deleting with nothing observed does nothing",
+			Desired{Tenant: "alice", Cluster: "demo", Deleting: true},
+			Observed{},
+			nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Decide(tc.desired, tc.observed)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("Decide() =\n  %+v\nwant\n  %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNamingAndLabels(t *testing.T) {
+	if got := CPName("alice", "demo"); got != "alice-k8s-demo-cp" {
+		t.Fatalf("CPName = %q", got)
+	}
+	if got := WorkerName("alice", "demo", "small", 3); got != "alice-k8s-demo-small-3" {
+		t.Fatalf("WorkerName = %q", got)
+	}
+	l := VMLabels("alice", "demo", RoleWorker, "small")
+	for k, want := range map[string]string{
+		LabelCluster:       "demo",
+		LabelClusterOwner:  "alice",
+		LabelClusterRole:   "worker",
+		LabelNodeGroup:     "small",
+		LabelWorkloadClass: "k8s-node",
+	} {
+		if l[k] != want {
+			t.Fatalf("label %s = %q, want %q", k, l[k], want)
+		}
+	}
+	if _, ok := VMLabels("alice", "demo", RoleControlPlane, "")[LabelNodeGroup]; ok {
+		t.Fatal("control-plane labels must not carry a node_group")
+	}
+}

--- a/pkg/core/cluster/spec.go
+++ b/pkg/core/cluster/spec.go
@@ -1,0 +1,71 @@
+// Package cluster provisions and reconciles managed-Kubernetes-cluster
+// VMs (#1414): a platform-owned k3s control-plane VM plus worker VMs in
+// typed size classes, driven over the Incus API.
+//
+// Design: docs/architecture/managed-k8s-clusters.md. The package is
+// deliberately split along testability seams: naming/labels (this
+// file), artifact pins (artifacts.go), bootstrap renderers
+// (bootstrap.go), and the reconcile decision function (reconcile.go)
+// are pure; only manager.go touches a host, and it does so through the
+// narrow VMHost interface so orchestration is unit-testable against a
+// fake. Persistence stays behind internal/cluster's Store — this
+// package never talks to Postgres.
+package cluster
+
+import "fmt"
+
+// VM-name scheme. The "-k8s-" infix marks cluster VMs apart from
+// tenant boxes ("<tenant>-container"); cluster and group names are
+// validated DNS labels (internal/cluster.ValidateName) so the scheme
+// stays inside Incus's 63-char instance-name limit.
+const nameInfix = "-k8s-"
+
+// CPName is the control-plane VM's name.
+func CPName(tenant, clusterName string) string {
+	return tenant + nameInfix + clusterName + "-cp"
+}
+
+// WorkerName is the n-th worker VM's name in a node group (1-based).
+func WorkerName(tenant, clusterName, group string, n int) string {
+	return fmt.Sprintf("%s%s%s-%s-%d", tenant, nameInfix, clusterName, group, n)
+}
+
+// Incus config labels stamped on every cluster VM, so the operator can
+// answer "what is this VM and why does it exist" and the capacity
+// policy can exclude cluster nodes by workload class.
+const (
+	LabelCluster       = "user.containarium.cluster"
+	LabelClusterOwner  = "user.containarium.cluster_owner"
+	LabelClusterRole   = "user.containarium.cluster_role"
+	LabelNodeGroup     = "user.containarium.node_group"
+	LabelWorkloadClass = "user.containarium.workload_class"
+
+	RoleControlPlane = "control-plane"
+	RoleWorker       = "worker"
+
+	WorkloadClassK8sNode = "k8s-node"
+)
+
+// VMLabels builds the label set for one cluster VM. group is empty for
+// the control plane.
+func VMLabels(tenant, clusterName, role, group string) map[string]string {
+	l := map[string]string{
+		LabelCluster:       clusterName,
+		LabelClusterOwner:  tenant,
+		LabelClusterRole:   role,
+		LabelWorkloadClass: WorkloadClassK8sNode,
+	}
+	if group != "" {
+		l[LabelNodeGroup] = group
+	}
+	return l
+}
+
+// NodeSpec is everything the host needs to create one cluster VM.
+type NodeSpec struct {
+	Name   string
+	CPU    string // e.g. "2"
+	Memory string // e.g. "4GB"
+	Disk   string // e.g. "40GB"
+	Labels map[string]string
+}

--- a/pkg/core/cluster/testdata/agent.sh.golden
+++ b/pkg/core/cluster/testdata/agent.sh.golden
@@ -1,0 +1,27 @@
+#!/bin/sh
+# containarium managed-cluster worker bootstrap (#1414).
+# The k3s binary and the join token are pre-pushed.
+set -eu
+
+chmod 0755 /usr/local/bin/k3s
+chmod 0600 /etc/containarium/k3s-agent-token
+
+cat > /etc/systemd/system/k3s-agent.service <<'UNIT'
+[Unit]
+Description=containarium managed k3s agent
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=notify
+ExecStart=/usr/local/bin/k3s agent --server https://10.166.11.5:6443 --token-file /etc/containarium/k3s-agent-token
+Restart=always
+RestartSec=5
+LimitNOFILE=1048576
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+systemctl daemon-reload
+systemctl enable --now k3s-agent.service

--- a/pkg/core/cluster/testdata/server.sh.golden
+++ b/pkg/core/cluster/testdata/server.sh.golden
@@ -1,0 +1,34 @@
+#!/bin/sh
+# containarium managed-cluster control-plane bootstrap (#1414).
+# The k3s binary is pre-pushed; this script only wires and starts it.
+set -eu
+
+chmod 0755 /usr/local/bin/k3s
+
+cat > /etc/systemd/system/k3s.service <<'UNIT'
+[Unit]
+Description=containarium managed k3s server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=notify
+ExecStart=/usr/local/bin/k3s server --disable traefik --node-taint node-role.kubernetes.io/control-plane=:NoSchedule --write-kubeconfig-mode 0600 --tls-san 10.166.11.5 --tls-san 203.0.113.10
+Restart=always
+RestartSec=5
+LimitNOFILE=1048576
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+systemctl daemon-reload
+systemctl enable --now k3s.service
+
+# Bootstrap is done when the admin kubeconfig and the join token exist.
+i=0
+until [ -s /etc/rancher/k3s/k3s.yaml ] && [ -s /var/lib/rancher/k3s/server/node-token ]; do
+  i=$((i+1))
+  [ "$i" -gt 120 ] && { echo "k3s server did not come up" >&2; exit 1; }
+  sleep 2
+done


### PR DESCRIPTION
Closes #1414. Part of sprint umbrella #1419 · Design: `docs/architecture/managed-k8s-clusters.md` · Builds on #1420.

## What changed

**`pkg/core/cluster`** — the core, split along testability seams:
- **Artifacts**: k3s `v1.33.4+k3s1` pinned by its upstream sha256, golden-tested (a version bump is a visible one-line diff); fetch-and-verify into the host cache with the checksum re-verified on *every* read. Cluster VMs never download anything — binary, token, and scripts are pushed over the Incus API.
- **Bootstrap renderers** (golden-tested): k3s server unit — control plane tainted so tenant pods never schedule there, traefik off, `--tls-san`s for the published endpoint — and the agent join unit. Tests assert no `curl`/`wget` in-guest.
- **`Decide(desired, observed)`** — all reconcile policy in one pure, table-tested function: CP first, workers to each group's min, start-don't-replace stopped VMs, teardown workers-then-CP, and deliberately **no scale-down** (the autoscaler owns it, per the design's "Who decides what").
- **Manager + IncusHost**: orchestration over a narrow `VMHost` seam (create→wait→push→exec; join token read from the CP and pushed 0600 — never persisted), typed `ErrVMsUnsupported` capability probe.

**Daemon wiring**:
- `ClusterReconciler`: idempotent per-tick convergence; node rows + scale events as bookkeeping; **CPU-admission refusals recorded as REFUSED events** (loud, never clamped); endpoint published through the durable passthrough surface (`CONTAINARIUM_CLUSTER_ADVERTISE_ADDR` + port range, `_system` identity) with CP-IP fallback; READY/DEGRADED settled from what the cluster's **own API** reports via `k3s kubectl`.
- `ClusterServer`: the three #1413 seams replaced — VM-capability gate on create (`FailedPrecondition` on hosts without qemu), reconciler-drained `DELETING` deletes, kubeconfig served read-on-demand and rewritten to the recorded endpoint.
- CLI: `cluster create --nodes-min/--nodes-max` (small class bounds; presets otherwise).

## Test evidence

| Acceptance criterion | Test |
|---|---|
| N workers from typed size classes reach Ready unattended | `TestReconciler_ProvisionsToReady` (real Manager + MemStore over a stateful fake host, through the real gRPC handlers; CP-first ordering asserted) |
| Failed worker detected and replaced (converges to min) | `TestReconciler_ReplacesLostWorker` (+ scale event recorded) |
| VM capability is a hard create-time requirement, typed error | `TestReconciler_VMCapabilityGatesCreate` |
| Delete drains VMs, endpoint, rows; name immediately reusable | `TestReconciler_AsyncDeleteDrainsEverything` |
| Admission refusal is loud | `TestReconciler_AdmissionRefusalIsLoud` (REFUSED event, no VM) |
| Reconcile policy invariants | `TestDecide` tables (8 scenarios) |
| Bootstrap content is reviewable | golden files + no-download assertions; `TestPinnedArtifacts`; `TestFetchVerified` tamper-rejection |
| Manager call sequences | `TestProvisionCPSequence` / `TestProvisionWorkerSequence` (token-before-create invariant included) |

Real-Incus behavior (actual VM boot, real k3s join) is deliberately left to the gated KVM e2e lane #1418 — kind can't exercise it and no fake should pretend to (#1234 lesson).

## Verify on dev (batched pass — queue row on #1419)

Requires a VM-capable (KVM) dev host with the daemon's reconciler enabled (default).
1. `containarium cluster create demo` → within ~5 min `cluster get demo` shows state `ready`, endpoint set.
2. `cluster kubeconfig demo > kc && KUBECONFIG=kc kubectl get nodes` → control-plane + 1 small worker, both `Ready` (CP carries the NoSchedule taint).
3. `incus delete --force <tenant>-k8s-demo-small-1` → within ~3 min the node is re-created and rejoins; `cluster status demo` shows a scale event.
4. On a non-KVM host: `cluster create` fails immediately with the "cannot run virtual machines" message.
5. `cluster delete demo` → VMs gone (`incus list`), passthrough rule gone, `cluster list` empty; re-create works immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)