### PR TITLE
feat(cluster): cluster status CLI + server-side caps

### DIFF
--- a/internal/cmd/cluster.go
+++ b/internal/cmd/cluster.go
@@ -78,7 +78,17 @@ var clusterKubeconfigCmd = &cobra.Command{
 	RunE:  runClusterKubeconfig,
 }
 
-var clusterGroups []string
+var (
+	clusterGroups      []string
+	clusterEventsLimit int32
+)
+
+var clusterStatusCmd = &cobra.Command{
+	Use:   "status <name>",
+	Short: "Show a cluster's nodes, per-group counts, and scale history",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runClusterStatus,
+}
 
 var clusterNodePoolCmd = &cobra.Command{
 	Use:   "node-pool <name>",
@@ -95,7 +105,8 @@ key=value pairs; the set you pass REPLACES the current set.
 
 func init() {
 	rootCmd.AddCommand(clusterCmd)
-	clusterCmd.AddCommand(clusterCreateCmd, clusterListCmd, clusterGetCmd, clusterDeleteCmd, clusterKubeconfigCmd, clusterNodePoolCmd)
+	clusterCmd.AddCommand(clusterCreateCmd, clusterListCmd, clusterGetCmd, clusterDeleteCmd, clusterKubeconfigCmd, clusterNodePoolCmd, clusterStatusCmd)
+	clusterStatusCmd.Flags().Int32Var(&clusterEventsLimit, "events", 10, "scale events to show, newest first")
 	clusterCmd.PersistentFlags().StringVar(&clusterOwner, "owner", "", "owning tenant (admin only; default: the authenticated user)")
 	clusterCreateCmd.Flags().Int32Var(&clusterNodesMin, "nodes-min", -1, "small size class's minimum worker count (default: platform preset)")
 	clusterCreateCmd.Flags().Int32Var(&clusterNodesMax, "nodes-max", -1, "small size class's maximum worker count (default: platform preset)")
@@ -111,6 +122,7 @@ type clusterAPI interface {
 	GetCluster(name, owner string) (*pb.GetClusterResponse, error)
 	DeleteCluster(name, owner string) (*pb.DeleteClusterResponse, error)
 	GetClusterKubeconfig(name, owner string) (*pb.GetClusterKubeconfigResponse, error)
+	GetClusterStatus(name, owner string, eventsLimit int32) (*pb.GetClusterStatusResponse, error)
 	UpdateClusterNodePool(req *pb.UpdateClusterNodePoolRequest) (*pb.UpdateClusterNodePoolResponse, error)
 	Close() error
 }
@@ -344,4 +356,71 @@ func runClusterNodePool(cmd *cobra.Command, args []string) error {
 	fmt.Println(resp.Message)
 	printCluster(resp.Cluster)
 	return nil
+}
+
+func clusterNodeStateString(s pb.ClusterNodeState) string {
+	switch s {
+	case pb.ClusterNodeState_CLUSTER_NODE_STATE_PROVISIONING:
+		return "provisioning"
+	case pb.ClusterNodeState_CLUSTER_NODE_STATE_READY:
+		return "ready"
+	case pb.ClusterNodeState_CLUSTER_NODE_STATE_DRAINING:
+		return "draining"
+	default:
+		return "unknown"
+	}
+}
+
+func scaleEventKindString(k pb.ScaleEventKind) string {
+	switch k {
+	case pb.ScaleEventKind_SCALE_EVENT_KIND_SCALE_UP:
+		return "scale-up"
+	case pb.ScaleEventKind_SCALE_EVENT_KIND_SCALE_DOWN:
+		return "scale-down"
+	case pb.ScaleEventKind_SCALE_EVENT_KIND_REFUSED:
+		return "REFUSED"
+	case pb.ScaleEventKind_SCALE_EVENT_KIND_NODE_REPLACED:
+		return "node-replaced"
+	default:
+		return "unknown"
+	}
+}
+
+func runClusterStatus(cmd *cobra.Command, args []string) error {
+	c, err := newClusterClient()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = c.Close() }()
+	st, err := c.GetClusterStatus(args[0], clusterOwner, clusterEventsLimit)
+	if err != nil {
+		return err
+	}
+	printCluster(st.Cluster)
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
+	fmt.Fprintln(w, "\nGROUP\tSIZE\tNODES\tBOUNDS")
+	for _, g := range st.Groups {
+		fmt.Fprintf(w, "%s\tcpu=%s mem=%s disk=%s\t%d\t%d..%d\n",
+			g.Group.Name, g.Group.Size.Cpu, g.Group.Size.Memory, g.Group.Size.Disk,
+			g.CurrentNodes, g.Group.MinNodes, g.Group.MaxNodes)
+	}
+	if len(st.Nodes) > 0 {
+		fmt.Fprintln(w, "\nNODE\tROLE\tGROUP\tSTATE")
+		for _, n := range st.Nodes {
+			role := "worker"
+			if n.Role == pb.ClusterNodeRole_CLUSTER_NODE_ROLE_CONTROL_PLANE {
+				role = "control-plane"
+			}
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", n.VmName, role, n.NodeGroup, clusterNodeStateString(n.State))
+		}
+	}
+	if len(st.Events) > 0 {
+		fmt.Fprintln(w, "\nWHEN\tEVENT\tGROUP\tREASON")
+		for _, e := range st.Events {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+				e.At.AsTime().Format("2006-01-02 15:04:05"), scaleEventKindString(e.Kind), e.NodeGroup, e.Reason)
+		}
+	}
+	return w.Flush()
 }

--- a/internal/server/cluster_caps.go
+++ b/internal/server/cluster_caps.go
@@ -1,0 +1,169 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	clusterstore "github.com/footprintai/containarium/internal/cluster"
+)
+
+// clusterCaps is the operator's hard ceiling on what any tenant may
+// configure a managed cluster to consume (#1417, PRD story 5). Zero
+// values mean unlimited. Enforced server-side at create and node-pool
+// update; a refused request is a typed error (and a REFUSED scale
+// event on updates) — never a silent clamp.
+type clusterCaps struct {
+	// configErr poisons the caps: every check fails with it. Set when
+	// the operator's cap configuration cannot be parsed — a typo must
+	// fail closed, not silently leave the gate open.
+	configErr error
+	// maxNodes bounds the SUM of max_nodes across a cluster's groups
+	// — the worst-case VM count a tenant's autoscaler may reach.
+	maxNodes int32
+	// Per-node size ceilings.
+	maxCPU         int
+	maxMemoryBytes int64
+	maxDiskBytes   int64
+}
+
+// SetCaps installs the caps (SetCapsFromEnv in production; direct in
+// tests).
+func (s *ClusterServer) SetCaps(c clusterCaps) { s.caps = c }
+
+// SetCapsFromEnv parses CONTAINARIUM_CLUSTER_MAX_NODES and
+// CONTAINARIUM_CLUSTER_MAX_NODE_SIZE ("cpu=8,memory=16GB,disk=200GB").
+// A malformed value is a startup error — a typo must not silently
+// leave the gate open.
+func (s *ClusterServer) SetCapsFromEnv(maxNodes, maxNodeSize string) error {
+	caps, err := parseClusterCaps(maxNodes, maxNodeSize)
+	if err != nil {
+		return err
+	}
+	s.caps = caps
+	return nil
+}
+
+var sizeBytesRE = regexp.MustCompile(`^([1-9][0-9]*)(MB|GB|TB)$`)
+
+// sizeToBytes parses the house size format ("16GB") into bytes
+// (decimal units, matching the format ValidateNodeGroups accepts).
+func sizeToBytes(s string) (int64, error) {
+	m := sizeBytesRE.FindStringSubmatch(s)
+	if m == nil {
+		return 0, fmt.Errorf("invalid size %q (want e.g. 16GB)", s)
+	}
+	n, err := strconv.ParseInt(m[1], 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	switch m[2] {
+	case "MB":
+		return n * 1_000_000, nil
+	case "GB":
+		return n * 1_000_000_000, nil
+	default: // TB
+		return n * 1_000_000_000_000, nil
+	}
+}
+
+func parseClusterCaps(maxNodes, maxNodeSize string) (clusterCaps, error) {
+	var caps clusterCaps
+	if maxNodes != "" {
+		n, err := strconv.ParseInt(maxNodes, 10, 32)
+		if err != nil || n < 1 {
+			return caps, fmt.Errorf("CONTAINARIUM_CLUSTER_MAX_NODES %q: want a positive integer", maxNodes)
+		}
+		caps.maxNodes = int32(n)
+	}
+	if maxNodeSize == "" {
+		return caps, nil
+	}
+	for _, kv := range strings.Split(maxNodeSize, ",") {
+		k, v, ok := strings.Cut(strings.TrimSpace(kv), "=")
+		if !ok {
+			return caps, fmt.Errorf("CONTAINARIUM_CLUSTER_MAX_NODE_SIZE: %q is not key=value", kv)
+		}
+		switch k {
+		case "cpu":
+			n, err := strconv.Atoi(v)
+			if err != nil || n < 1 {
+				return caps, fmt.Errorf("CONTAINARIUM_CLUSTER_MAX_NODE_SIZE cpu %q: want a positive integer", v)
+			}
+			caps.maxCPU = n
+		case "memory":
+			b, err := sizeToBytes(v)
+			if err != nil {
+				return caps, fmt.Errorf("CONTAINARIUM_CLUSTER_MAX_NODE_SIZE memory: %w", err)
+			}
+			caps.maxMemoryBytes = b
+		case "disk":
+			b, err := sizeToBytes(v)
+			if err != nil {
+				return caps, fmt.Errorf("CONTAINARIUM_CLUSTER_MAX_NODE_SIZE disk: %w", err)
+			}
+			caps.maxDiskBytes = b
+		default:
+			return caps, fmt.Errorf("CONTAINARIUM_CLUSTER_MAX_NODE_SIZE: unknown key %q (want cpu/memory/disk)", k)
+		}
+	}
+	return caps, nil
+}
+
+// check validates a replacement group set against the caps. Groups are
+// assumed already structurally valid (ValidateNodeGroups).
+func (c clusterCaps) check(groups []clusterstore.NodeGroup) error {
+	if c.configErr != nil {
+		return fmt.Errorf("cluster caps misconfigured (%v); refusing until fixed", c.configErr)
+	}
+	if c.maxNodes > 0 {
+		var total int32
+		for _, g := range groups {
+			total += g.MaxNodes
+		}
+		if total > c.maxNodes {
+			return fmt.Errorf("total max_nodes %d exceeds the platform cap of %d", total, c.maxNodes)
+		}
+	}
+	for _, g := range groups {
+		if c.maxCPU > 0 {
+			if cpu, _ := strconv.Atoi(g.Size.CPU); cpu > c.maxCPU {
+				return fmt.Errorf("node group %q: cpu %s exceeds the platform cap of %d", g.Name, g.Size.CPU, c.maxCPU)
+			}
+		}
+		if c.maxMemoryBytes > 0 {
+			if b, err := sizeToBytes(g.Size.Memory); err == nil && b > c.maxMemoryBytes {
+				return fmt.Errorf("node group %q: memory %s exceeds the platform cap", g.Name, g.Size.Memory)
+			}
+		}
+		if c.maxDiskBytes > 0 {
+			if b, err := sizeToBytes(g.Size.Disk); err == nil && b > c.maxDiskBytes {
+				return fmt.Errorf("node group %q: disk %s exceeds the platform cap", g.Name, g.Size.Disk)
+			}
+		}
+	}
+	return nil
+}
+
+// enforceCaps turns a cap violation into the typed refusal; when a
+// cluster record exists (updates), the refusal also lands on its scale
+// history so `cluster status` shows WHY the pool stopped growing.
+func (s *ClusterServer) enforceCaps(ctx context.Context, owner, name string, groups []clusterstore.NodeGroup, recordEvent bool) error {
+	err := s.caps.check(groups)
+	if err == nil {
+		return nil
+	}
+	if recordEvent {
+		_ = s.store.AppendEvent(ctx, owner, name, clusterstore.Event{
+			At: time.Now().UTC(), Kind: clusterstore.EventRefused,
+			Reason: err.Error(),
+		})
+	}
+	return status.Errorf(codes.InvalidArgument, "%v", err)
+}

--- a/internal/server/cluster_caps_test.go
+++ b/internal/server/cluster_caps_test.go
@@ -1,0 +1,124 @@
+package server
+
+// Server-side caps (#1417): the operator's hard ceiling on what any
+// tenant may configure a cluster to consume. Refusals are typed errors
+// (and REFUSED events on updates) — never silent clamps.
+
+import (
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+func group(name, cpu, mem, disk string, min, max int32) *pb.NodeGroup {
+	return &pb.NodeGroup{
+		Name: name, Size: &pb.ResourceLimits{Cpu: cpu, Memory: mem, Disk: disk},
+		MinNodes: min, MaxNodes: max,
+	}
+}
+
+func TestClusterCaps_ParseEnv(t *testing.T) {
+	caps, err := parseClusterCaps("10", "cpu=8,memory=16GB,disk=200GB")
+	if err != nil {
+		t.Fatalf("parseClusterCaps: %v", err)
+	}
+	if caps.maxNodes != 10 || caps.maxCPU != 8 || caps.maxMemoryBytes != 16_000_000_000 || caps.maxDiskBytes != 200_000_000_000 {
+		t.Fatalf("caps = %+v", caps)
+	}
+	// Unset means unlimited, not zero.
+	caps, err = parseClusterCaps("", "")
+	if err != nil || caps.maxNodes != 0 || caps.maxCPU != 0 {
+		t.Fatalf("empty caps = %+v (%v), want unlimited", caps, err)
+	}
+	// Garbage is a startup error, not a silently-open gate.
+	if _, err := parseClusterCaps("ten", ""); err == nil {
+		t.Fatal("bad max-nodes accepted")
+	}
+	if _, err := parseClusterCaps("", "cpu=lots"); err == nil {
+		t.Fatal("bad node-size accepted")
+	}
+	if _, err := parseClusterCaps("", "flavor=big"); err == nil {
+		t.Fatal("unknown size key accepted")
+	}
+}
+
+func TestClusterCaps_EnforcedOnCreate(t *testing.T) {
+	s := clusterTestServer()
+	s.SetCaps(clusterCaps{maxNodes: 4, maxCPU: 4, maxMemoryBytes: 8_000_000_000, maxDiskBytes: 100_000_000_000})
+	ctx := tenantCtx("alice")
+
+	cases := []struct {
+		name   string
+		groups []*pb.NodeGroup
+		frag   string
+	}{
+		{"total max_nodes over cap", []*pb.NodeGroup{
+			group("small", "2", "4GB", "40GB", 1, 3),
+			group("medium", "4", "8GB", "80GB", 0, 2),
+		}, "max_nodes"},
+		{"cpu over cap", []*pb.NodeGroup{group("big", "8", "8GB", "80GB", 0, 1)}, "cpu"},
+		{"memory over cap", []*pb.NodeGroup{group("big", "4", "16GB", "80GB", 0, 1)}, "memory"},
+		{"disk over cap", []*pb.NodeGroup{group("big", "4", "8GB", "200GB", 0, 1)}, "disk"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := s.CreateCluster(ctx, &pb.CreateClusterRequest{Name: "demo", NodeGroups: tc.groups})
+			wantCode(t, err, codes.InvalidArgument)
+			if !strings.Contains(err.Error(), tc.frag) {
+				t.Fatalf("error %q does not name the exceeded cap %q", err, tc.frag)
+			}
+		})
+	}
+
+	// Within caps still works.
+	if _, err := s.CreateCluster(ctx, &pb.CreateClusterRequest{Name: "demo", NodeGroups: []*pb.NodeGroup{
+		group("small", "2", "4GB", "40GB", 1, 4),
+	}}); err != nil {
+		t.Fatalf("within-caps create refused: %v", err)
+	}
+
+	// The platform presets must also fit whatever caps the operator
+	// sets — otherwise a flagless create breaks confusingly.
+	s2 := clusterTestServer()
+	s2.SetCaps(clusterCaps{maxNodes: 2})
+	_, err := s2.CreateCluster(ctx, &pb.CreateClusterRequest{Name: "demo"})
+	wantCode(t, err, codes.InvalidArgument)
+}
+
+func TestClusterCaps_UpdateRefusalIsRecorded(t *testing.T) {
+	s := clusterTestServer()
+	s.SetCaps(clusterCaps{maxNodes: 4})
+	ctx := tenantCtx("alice")
+	if _, err := s.CreateCluster(ctx, &pb.CreateClusterRequest{Name: "demo", NodeGroups: []*pb.NodeGroup{
+		group("small", "2", "4GB", "40GB", 1, 3),
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := s.UpdateClusterNodePool(ctx, &pb.UpdateClusterNodePoolRequest{Name: "demo", NodeGroups: []*pb.NodeGroup{
+		group("small", "2", "4GB", "40GB", 1, 5),
+	}})
+	wantCode(t, err, codes.InvalidArgument)
+
+	// The refusal is on the record — visible in `cluster status`, not
+	// silently clamped (the PRD's Story 5 requirement).
+	st, err := s.GetClusterStatus(ctx, &pb.GetClusterStatusRequest{Name: "demo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(st.Events) == 0 || st.Events[0].Kind != pb.ScaleEventKind_SCALE_EVENT_KIND_REFUSED {
+		t.Fatalf("cap refusal not recorded as REFUSED event: %+v", st.Events)
+	}
+	if !strings.Contains(st.Events[0].Reason, "max_nodes") {
+		t.Fatalf("refusal reason does not name the cap: %q", st.Events[0].Reason)
+	}
+
+	// The pool is unchanged after the refusal.
+	got, _ := s.GetCluster(ctx, &pb.GetClusterRequest{Name: "demo"})
+	if got.Cluster.NodeGroups[0].MaxNodes != 3 {
+		t.Fatalf("pool changed despite refusal: %+v", got.Cluster.NodeGroups)
+	}
+}

--- a/internal/server/cluster_server.go
+++ b/internal/server/cluster_server.go
@@ -44,6 +44,9 @@ type ClusterServer struct {
 	// records to DELETING for the reconciler to drain instead of
 	// dropping rows that may have live VMs behind them.
 	asyncDelete bool
+	// caps is the operator ceiling on configurable cluster size
+	// (#1417); zero values = unlimited.
+	caps clusterCaps
 }
 
 // NewClusterServer builds the server on a Store (in-memory at startup;
@@ -214,6 +217,9 @@ func (s *ClusterServer) CreateCluster(ctx context.Context, req *pb.CreateCluster
 	}
 	if err := cluster.ValidateNodeGroups(groups); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := s.enforceCaps(ctx, owner, req.Name, groups, false); err != nil {
+		return nil, err
 	}
 
 	now := time.Now().UTC()
@@ -416,6 +422,9 @@ func (s *ClusterServer) UpdateClusterNodePool(ctx context.Context, req *pb.Updat
 	}
 	if err := cluster.ValidateNodeGroups(groups); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := s.enforceCaps(ctx, owner, req.Name, groups, true); err != nil {
+		return nil, err
 	}
 	if err := s.store.UpdateNodeGroups(ctx, owner, req.Name, groups); err != nil {
 		return nil, storeErr(err)

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -530,6 +530,13 @@ func NewDualServer(config *DualServerConfig) (*DualServer, error) {
 	// below once the pool is up (same degrade posture as the network
 	// policy and crew-run stores).
 	clusterServer := NewClusterServer(clusterstore.NewMemStore())
+	if capsErr := clusterServer.SetCapsFromEnv(
+		os.Getenv("CONTAINARIUM_CLUSTER_MAX_NODES"),
+		os.Getenv("CONTAINARIUM_CLUSTER_MAX_NODE_SIZE")); capsErr != nil {
+		// Fail closed: a typo'd cap must not become an unlimited one.
+		clusterServer.SetCaps(clusterCaps{configErr: capsErr})
+		log.Printf("ERROR: %v — cluster creates/updates will be refused until the caps are fixed", capsErr)
+	}
 	pb.RegisterClusterServiceServer(grpcServer, clusterServer)
 	log.Printf("Cluster service enabled (in-memory store; Postgres swap below)")
 


### PR DESCRIPTION
Closes #1417. Part of sprint umbrella #1419 · Design: `docs/architecture/managed-k8s-clusters.md`. Independent of #1422 (branches off main).

## What changed

- **Server-side caps** (`internal/server/cluster_caps.go`): `CONTAINARIUM_CLUSTER_MAX_NODES` bounds the sum of `max_nodes` across a cluster's groups — the worst-case VM count a tenant's autoscaler may ever reach; `CONTAINARIUM_CLUSTER_MAX_NODE_SIZE` (`cpu=8,memory=16GB,disk=200GB`) caps per-node size. Enforced at create and node-pool update: typed `InvalidArgument` naming the exceeded cap, a **REFUSED scale event on updates** (so `cluster status` shows *why* the pool stopped growing — never a silent clamp), and the pool stays unchanged. **Misconfigured caps fail closed**: a typo'd env refuses every create/update with the parse error rather than silently becoming "unlimited".
- **`containarium cluster status <name> [--events N]`**: cluster summary, per-group current-vs-bounds table, node table with typed states, scale history newest-first (REFUSED rendered in caps for visibility).

## Test evidence

| Acceptance criterion | Test |
|---|---|
| Caps parse (garbage = startup error, unset = unlimited) | `TestClusterCaps_ParseEnv` |
| Enforced per cap on create, typed + named | `TestClusterCaps_EnforcedOnCreate` (4-case table + presets-vs-caps interaction) |
| Update refusal recorded as REFUSED event, pool unchanged | `TestClusterCaps_UpdateRefusalIsRecorded` |
| Status shows nodes/groups/events | covered by `TestClusterServer_StatusAndNodePool` (#1413) + the new CLI rendering |

## Verify on dev (batched pass — queue row on #1419)

1. With `CONTAINARIUM_CLUSTER_MAX_NODES=4`: `cluster create demo` (presets total max 6) → refused with a message naming `max_nodes`; `cluster create demo --nodes-max 2` → succeeds.
2. `cluster node-pool demo --group name=small,cpu=2,memory=4GB,disk=40GB,min=1,max=9` → refused; `cluster status demo` shows a REFUSED event with the cap in the reason; bounds unchanged.
3. `cluster status demo` renders groups (current vs min..max), nodes with states, and events newest-first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)