### PR TITLE
feat(cluster): pod vertical autoscaling — pinned VPA into every cluster

### DIFF
--- a/internal/server/cluster_reconciler.go
+++ b/internal/server/cluster_reconciler.go
@@ -40,6 +40,10 @@ type ClusterReconciler struct {
 	publish   func(ctx context.Context, c *clusterstore.Cluster, cpIP string) (string, error)
 	unpublish func(ctx context.Context, c *clusterstore.Cluster) error
 
+	// vpaDisabled turns off VPA deployment (CONTAINARIUM_CLUSTER_VPA=false);
+	// default is on — pod vertical autoscaling is a P0 story (#1416).
+	vpaDisabled bool
+
 	interval time.Duration
 }
 
@@ -51,6 +55,9 @@ func NewClusterReconciler(store clusterstore.Store, mgr *clustercore.Manager) *C
 
 // SetAdmission wires the CPU-admission gate.
 func (r *ClusterReconciler) SetAdmission(f func(owner, cpu string) error) { r.admit = f }
+
+// SetVPADisabled turns off VPA deployment into new clusters.
+func (r *ClusterReconciler) SetVPADisabled(v bool) { r.vpaDisabled = v }
 
 // SetEndpointPublisher wires endpoint publish/unpublish.
 func (r *ClusterReconciler) SetEndpointPublisher(
@@ -255,6 +262,15 @@ func (r *ClusterReconciler) settleState(ctx context.Context, c *clusterstore.Clu
 			return fmt.Errorf("record endpoint: %w", err)
 		}
 		c.APIEndpoint = endpoint
+	}
+
+	// VPA rides the settle path: a transient deploy failure retries
+	// every pass until READY; DeployVPA is idempotent and never
+	// rotates a deployed webhook secret.
+	if !r.vpaDisabled && c.State != clusterstore.StateReady {
+		if err := r.mgr.DeployVPA(c.Owner, c.Name); err != nil {
+			return fmt.Errorf("deploy VPA: %w", err)
+		}
 	}
 
 	expected := 1 // control plane

--- a/internal/server/cluster_vpa_test.go
+++ b/internal/server/cluster_vpa_test.go
@@ -1,0 +1,47 @@
+package server
+
+// VPA deployment through the reconciler (#1416): the pinned bundle and
+// a per-cluster webhook secret land on the CP via the k3s auto-apply
+// dir, exactly once.
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	clustercore "github.com/footprintai/containarium/pkg/core/cluster"
+)
+
+func TestReconciler_DeploysVPAOntoCP(t *testing.T) {
+	srv, rec, host := testReconcilerRig(t)
+	mustCreate(t, srv, tenantCtx("alice"), "demo")
+	ctx := context.Background()
+	rec.ReconcileOnce(ctx)
+	rec.ReconcileOnce(ctx)
+	rec.ReconcileOnce(ctx)
+
+	cp := "alice-k8s-demo-cp"
+	manifests := string(host.files[cp+":"+clustercore.VPAManifestPath])
+	if !strings.Contains(manifests, "vpa-recommender") || !strings.Contains(manifests, "@sha256:") {
+		t.Fatal("digest-pinned VPA manifests not deployed to the CP")
+	}
+	secretA := string(host.files[cp+":"+clustercore.VPACertsPath])
+	if !strings.Contains(secretA, "vpa-tls-certs") {
+		t.Fatal("VPA webhook secret not deployed")
+	}
+	// Further passes never rotate the webhook secret.
+	rec.ReconcileOnce(ctx)
+	if string(host.files[cp+":"+clustercore.VPACertsPath]) != secretA {
+		t.Fatal("reconciler pass rotated the deployed VPA webhook secret")
+	}
+
+	// Disabled reconcilers deploy no VPA.
+	srv2, rec2, host2 := testReconcilerRig(t)
+	rec2.SetVPADisabled(true)
+	mustCreate(t, srv2, tenantCtx("alice"), "demo")
+	rec2.ReconcileOnce(ctx)
+	rec2.ReconcileOnce(ctx)
+	if _, ok := host2.files["alice-k8s-demo-cp:"+clustercore.VPAManifestPath]; ok {
+		t.Fatal("VPA deployed despite being disabled")
+	}
+}

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -1224,6 +1224,10 @@ skipAppHosting:
 			} else {
 				log.Printf("[cluster] CONTAINARIUM_CLUSTER_ADVERTISE_ADDR unset; cluster API endpoints use VM IPs (host-local reach only)")
 			}
+			if os.Getenv("CONTAINARIUM_CLUSTER_VPA") == "false" {
+				clusterReconciler.SetVPADisabled(true)
+				log.Printf("[cluster] VPA deployment disabled by CONTAINARIUM_CLUSTER_VPA=false")
+			}
 			clusterServer.SetReconciler(clusterReconciler)
 			go clusterReconciler.Run(context.Background())
 			log.Printf("Managed-cluster reconciler enabled")

--- a/pkg/core/cluster/vpa.go
+++ b/pkg/core/cluster/vpa.go
@@ -1,0 +1,163 @@
+package cluster
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	_ "embed"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"time"
+)
+
+// Vertical Pod Autoscaler (#1416): upstream VPA shipped into every
+// managed cluster via the k3s manifest auto-apply dir. Usage→requests
+// conversion happens ONLY here (design: "Who decides what"); tenants
+// opt workloads in with VPA objects (updateMode InPlaceOrRecreate for
+// in-place resizes, Recreate as the fallback — both stock VPA 1.7
+// behavior, no bespoke resizing loop).
+const (
+	// VPAVersion is the pinned upstream release.
+	VPAVersion = "1.7.1"
+	// VPAManifestSHA256 pins the embedded, digest-pinned manifest
+	// bundle — the reviewable surface (golden-tested like the k3s
+	// binary pin): what runs inside tenant clusters changes only as
+	// a visible re-vendor diff.
+	VPAManifestSHA256 = "6804cbac5efe0b4f258ed6d8a61477ccf304aff9c7f37e6b4bef0a9a94e8518b"
+)
+
+//go:embed vpa/manifests.yaml
+var vpaManifests []byte
+
+// VPAManifests returns the vendored bundle after re-verifying it
+// against the pin — a tampered or drifted embed fails closed instead
+// of being applied into a tenant's cluster.
+func VPAManifests() ([]byte, error) {
+	sum := sha256.Sum256(vpaManifests)
+	if got := hex.EncodeToString(sum[:]); got != VPAManifestSHA256 {
+		return nil, fmt.Errorf("embedded VPA manifests hash %s does not match the pin %s", got, VPAManifestSHA256)
+	}
+	return vpaManifests, nil
+}
+
+// K3s manifest auto-apply paths for the VPA deployment.
+const (
+	VPAManifestPath = "/var/lib/rancher/k3s/server/manifests/containarium-vpa.yaml"
+	VPACertsPath    = "/var/lib/rancher/k3s/server/manifests/containarium-vpa-certs.yaml"
+)
+
+// vpaWebhookDNS is the admission webhook's in-cluster service name —
+// the SAN its serving cert must carry.
+const vpaWebhookDNS = "vpa-webhook.kube-system.svc"
+
+// GenerateVPAWebhookSecret generates a fresh per-cluster CA + serving
+// cert for the VPA admission webhook and renders the vpa-tls-certs
+// Secret (key names are the admission-controller's flag defaults).
+// Per-cluster generation, never shared, never persisted by the
+// platform — the Secret lives only inside the tenant's cluster.
+func GenerateVPAWebhookSecret() ([]byte, error) {
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	caTmpl := &x509.Certificate{
+		SerialNumber:          vpaSerial(),
+		Subject:               pkix.Name{CommonName: "containarium vpa-webhook CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().AddDate(10, 0, 0),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		return nil, err
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		return nil, err
+	}
+
+	srvKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	srvTmpl := &x509.Certificate{
+		SerialNumber: vpaSerial(),
+		Subject:      pkix.Name{CommonName: vpaWebhookDNS},
+		DNSNames:     []string{vpaWebhookDNS, vpaWebhookDNS + ".cluster.local"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().AddDate(10, 0, 0),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	srvDER, err := x509.CreateCertificate(rand.Reader, srvTmpl, caCert, &srvKey.PublicKey, caKey)
+	if err != nil {
+		return nil, err
+	}
+	srvKeyDER, err := x509.MarshalPKCS8PrivateKey(srvKey)
+	if err != nil {
+		return nil, err
+	}
+
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+	srvPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: srvDER})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: srvKeyDER})
+
+	b64 := base64.StdEncoding.EncodeToString
+	secret := fmt.Sprintf(`# Generated per cluster by containarium (#1416). The admission
+# webhook's serving certs — never shared across clusters.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vpa-tls-certs
+  namespace: kube-system
+type: Opaque
+data:
+  caCert.pem: %s
+  serverCert.pem: %s
+  serverKey.pem: %s
+`, b64(caPEM), b64(srvPEM), b64(keyPEM))
+	return []byte(secret), nil
+}
+
+func vpaSerial() *big.Int {
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		panic(err) // rand.Reader failing is unrecoverable
+	}
+	return serial
+}
+
+// DeployVPA installs the pinned VPA bundle onto a provisioned control
+// plane via the k3s auto-apply dir. Idempotent by presence check: the
+// per-cluster webhook Secret is generated exactly once — re-pushing it
+// every pass would rotate the webhook's certs under the running
+// admission controller.
+func (m *Manager) DeployVPA(tenant, clusterName string) error {
+	cp := CPName(tenant, clusterName)
+	if _, err := m.host.Read(cp, VPACertsPath); err == nil {
+		return nil // already deployed
+	}
+	manifests, err := VPAManifests()
+	if err != nil {
+		return err
+	}
+	secret, err := GenerateVPAWebhookSecret()
+	if err != nil {
+		return fmt.Errorf("generate VPA webhook certs: %w", err)
+	}
+	if err := m.host.Push(cp, VPACertsPath, secret, "0600"); err != nil {
+		return fmt.Errorf("push VPA certs manifest: %w", err)
+	}
+	if err := m.host.Push(cp, VPAManifestPath, manifests, "0644"); err != nil {
+		return fmt.Errorf("push VPA manifests: %w", err)
+	}
+	return nil
+}

--- a/pkg/core/cluster/vpa/manifests.yaml
+++ b/pkg/core/cluster/vpa/manifests.yaml
@@ -1,0 +1,1662 @@
+# VENDORED upstream Vertical Pod Autoscaler 1.7.1 (#1416), assembled
+# from kubernetes/autoscaler vertical-pod-autoscaler/deploy/ at tag
+# vertical-pod-autoscaler-1.7.1:
+#   vpa-v1-crd-gen.yaml + vpa-rbac.yaml + recommender-deployment.yaml
+#   + updater-deployment.yaml + admission-controller-deployment.yaml
+#   + admission-controller-service.yaml
+# Sole modification: component images pinned by registry.k8s.io
+# manifest-list digest. Do not edit except to re-vendor a newer pin —
+# the sha256 of this file is pinned in artifacts.go and golden-tested.
+# The vpa-tls-certs Secret is NOT here: it is generated per cluster at
+# deploy time (webhook serving certs must never be shared).
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes/kubernetes/pull/63797
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: verticalpodautoscalercheckpoints.autoscaling.k8s.io
+spec:
+  group: autoscaling.k8s.io
+  names:
+    kind: VerticalPodAutoscalerCheckpoint
+    listKind: VerticalPodAutoscalerCheckpointList
+    plural: verticalpodautoscalercheckpoints
+    shortNames:
+    - vpacheckpoint
+    singular: verticalpodautoscalercheckpoint
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VerticalPodAutoscalerCheckpoint is the checkpoint of the internal state of VPA that
+          is used for recovery after recommender's restart.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the checkpoint.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
+            properties:
+              containerName:
+                description: Name of the checkpointed container.
+                type: string
+              vpaObjectName:
+                description: Name of the VPA object that stored VerticalPodAutoscalerCheckpoint
+                  object.
+                type: string
+            type: object
+          status:
+            description: Data of the checkpoint.
+            properties:
+              cpuHistogram:
+                description: Checkpoint of histogram for consumption of CPU.
+                properties:
+                  bucketWeights:
+                    description: Map from bucket index to bucket weight.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  referenceTimestamp:
+                    description: Reference timestamp for samples collected within
+                      this histogram.
+                    format: date-time
+                    nullable: true
+                    type: string
+                  totalWeight:
+                    description: Sum of samples to be used as denominator for weights
+                      from BucketWeights.
+                    type: number
+                type: object
+              firstSampleStart:
+                description: Timestamp of the first sample from the histograms.
+                format: date-time
+                nullable: true
+                type: string
+              lastSampleStart:
+                description: Timestamp of the last sample from the histograms.
+                format: date-time
+                nullable: true
+                type: string
+              lastUpdateTime:
+                description: The time when the status was last refreshed.
+                format: date-time
+                nullable: true
+                type: string
+              memoryHistogram:
+                description: Checkpoint of histogram for consumption of memory.
+                properties:
+                  bucketWeights:
+                    description: Map from bucket index to bucket weight.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  referenceTimestamp:
+                    description: Reference timestamp for samples collected within
+                      this histogram.
+                    format: date-time
+                    nullable: true
+                    type: string
+                  totalWeight:
+                    description: Sum of samples to be used as denominator for weights
+                      from BucketWeights.
+                    type: number
+                type: object
+              totalSamplesCount:
+                description: Total number of samples in the histograms.
+                type: integer
+              version:
+                description: Version of the format of the stored data.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+  - name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VerticalPodAutoscalerCheckpoint is the checkpoint of the internal state of VPA that
+          is used for recovery after recommender's restart.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the checkpoint.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
+            properties:
+              containerName:
+                description: Name of the checkpointed container.
+                type: string
+              vpaObjectName:
+                description: Name of the VPA object that stored VerticalPodAutoscalerCheckpoint
+                  object.
+                type: string
+            type: object
+          status:
+            description: Data of the checkpoint.
+            properties:
+              cpuHistogram:
+                description: Checkpoint of histogram for consumption of CPU.
+                properties:
+                  bucketWeights:
+                    description: Map from bucket index to bucket weight.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  referenceTimestamp:
+                    description: Reference timestamp for samples collected within
+                      this histogram.
+                    format: date-time
+                    nullable: true
+                    type: string
+                  totalWeight:
+                    description: Sum of samples to be used as denominator for weights
+                      from BucketWeights.
+                    type: number
+                type: object
+              firstSampleStart:
+                description: Timestamp of the first sample from the histograms.
+                format: date-time
+                nullable: true
+                type: string
+              lastSampleStart:
+                description: Timestamp of the last sample from the histograms.
+                format: date-time
+                nullable: true
+                type: string
+              lastUpdateTime:
+                description: The time when the status was last refreshed.
+                format: date-time
+                nullable: true
+                type: string
+              memoryHistogram:
+                description: Checkpoint of histogram for consumption of memory.
+                properties:
+                  bucketWeights:
+                    description: Map from bucket index to bucket weight.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  referenceTimestamp:
+                    description: Reference timestamp for samples collected within
+                      this histogram.
+                    format: date-time
+                    nullable: true
+                    type: string
+                  totalWeight:
+                    description: Sum of samples to be used as denominator for weights
+                      from BucketWeights.
+                    type: number
+                type: object
+              totalSamplesCount:
+                description: Total number of samples in the histograms.
+                type: integer
+              version:
+                description: Version of the format of the stored data.
+                type: string
+            type: object
+        type: object
+    served: false
+    storage: false
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes/kubernetes/pull/63797
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: verticalpodautoscalers.autoscaling.k8s.io
+spec:
+  group: autoscaling.k8s.io
+  names:
+    kind: VerticalPodAutoscaler
+    listKind: VerticalPodAutoscalerList
+    plural: verticalpodautoscalers
+    shortNames:
+    - vpa
+    singular: verticalpodautoscaler
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.updatePolicy.updateMode
+      name: Mode
+      type: string
+    - jsonPath: .status.recommendation.containerRecommendations[0].target.cpu
+      name: CPU
+      type: string
+    - jsonPath: .status.recommendation.containerRecommendations[0].target.memory
+      name: Mem
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='RecommendationProvided')].status
+      name: Provided
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.updatePolicy.minReplicas
+      name: MinReplicas
+      priority: 1
+      type: integer
+    - jsonPath: .spec.updatePolicy.evictAfterOOMSeconds
+      name: OOMSeconds
+      priority: 1
+      type: integer
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VerticalPodAutoscaler is the configuration for a vertical pod
+          autoscaler, which automatically manages pod resources based on historical and
+          real time resource utilization.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the behavior of the autoscaler.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
+            properties:
+              recommenders:
+                description: |-
+                  Recommender responsible for generating recommendation for this object.
+                  List should be empty (then the default recommender will generate the
+                  recommendation) or contain exactly one recommender.
+                items:
+                  description: |-
+                    VerticalPodAutoscalerRecommenderSelector points to a specific Vertical Pod Autoscaler recommender.
+                    In the future it might pass parameters to the recommender.
+                  properties:
+                    name:
+                      description: Name of the recommender responsible for generating
+                        recommendation for this object.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              resourcePolicy:
+                description: |-
+                  Controls how the autoscaler computes recommended resources.
+                  The resource policy may be used to set constraints on the recommendations
+                  for individual containers.
+                  If any individual containers need to be excluded from getting the VPA recommendations, then
+                  it must be disabled explicitly by setting mode to "Off" under containerPolicies.
+                  If not specified, the autoscaler computes recommended resources for all containers in the pod,
+                  without additional constraints.
+                properties:
+                  containerPolicies:
+                    description: Per-container resource policies.
+                    items:
+                      description: |-
+                        ContainerResourcePolicy controls how autoscaler computes the recommended
+                        resources for a specific container.
+                      properties:
+                        containerName:
+                          description: |-
+                            Name of the container or DefaultContainerResourcePolicy, in which
+                            case the policy is used by the containers that don't have their own
+                            policy specified.
+                          type: string
+                        controlledResources:
+                          description: |-
+                            Specifies the type of recommendations that will be computed
+                            (and possibly applied) by VPA.
+                            If not specified, the default of [ResourceCPU, ResourceMemory] will be used.
+                          items:
+                            description: ResourceName is the name identifying various
+                              resources in a ResourceList.
+                            type: string
+                          type: array
+                        controlledValues:
+                          description: |-
+                            Specifies which resource values should be controlled.
+                            The default is "RequestsAndLimits".
+                          enum:
+                          - RequestsAndLimits
+                          - RequestsOnly
+                          type: string
+                        maxAllowed:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Specifies the maximum amount of resources that will be recommended
+                            for the container. The default is no maximum.
+                          type: object
+                        memoryAggregationIntervalCount:
+                          description: |-
+                            memoryAggregationIntervalCount is the number of consecutive
+                            memoryAggregationIntervals which make up the memory aggregation window.
+                            The total window length is:
+                            MemoryAggregationIntervalSeconds * MemoryAggregationIntervalCount.
+                          format: int64
+                          minimum: 1
+                          type: integer
+                        memoryAggregationIntervalSeconds:
+                          description: |-
+                            memoryAggregationIntervalSeconds is the length of a single interval
+                            (in seconds) for which the peak memory usage is computed.
+                            Memory usage peaks are aggregated in multiples of this interval.
+                            In other words, there is one memory usage sample per interval
+                            (the maximum usage over that interval).
+                          format: int32
+                          minimum: 1
+                          type: integer
+                        minAllowed:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Specifies the minimal amount of resources that will be recommended
+                            for the container. The default is no minimum.
+                          type: object
+                        mode:
+                          description: Whether autoscaler is enabled for the container.
+                            The default is "Auto".
+                          enum:
+                          - Auto
+                          - "Off"
+                          type: string
+                        oomBumpUpRatio:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: oomBumpUpRatio is the ratio to increase memory
+                            when OOM is detected.
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        oomMinBumpUp:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: oomMinBumpUp is the minimum increase in memory
+                            when OOM is detected.
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        startupBoost:
+                          description: |-
+                            startupBoost specifies the startup boost policy for the container.
+                            This overrides any pod-level startup boost policy.
+                            The startup boost policy takes precedence over the rest of the fields in
+                            this struct, except for ContainerName and ControlledValues.
+                          properties:
+                            cpu:
+                              description: |-
+                                cpu specifies the CPU startup boost policy.
+                                If this field is not set, no startup boost is applied.
+                              properties:
+                                durationSeconds:
+                                  description: |-
+                                    durationSeconds indicates for how long to keep the pod boosted after it goes to Ready.
+                                    Defaults to 0.
+                                  format: int32
+                                  type: integer
+                                factor:
+                                  description: |-
+                                    factor specifies the factor to apply to the resource request.
+                                    This field is required when Type is "Factor".
+                                  format: int32
+                                  type: integer
+                                quantity:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    quantity specifies the absolute resource quantity to be used as the
+                                    resource request and limit during the boost phase.
+                                    This field is required when Type is "Quantity".
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type:
+                                  description: |-
+                                    type specifies the kind of boost to apply.
+                                    Supported values are: "Factor", "Quantity".
+                                    No startupboost will be applied for unrecognized values.
+                                  enum:
+                                  - Factor
+                                  - Quantity
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                              x-kubernetes-validations:
+                              - message: factor is required when type is Factor and
+                                  forbidden otherwise
+                                rule: (self.type == 'Factor') == has(self.factor)
+                              - message: quantity is required when type is Quantity
+                                  and forbidden otherwise
+                                rule: (self.type == 'Quantity') == has(self.quantity)
+                          type: object
+                      type: object
+                    type: array
+                type: object
+              startupBoost:
+                description: startupBoost specifies the startup boost policy for the
+                  pod.
+                properties:
+                  cpu:
+                    description: |-
+                      cpu specifies the CPU startup boost policy.
+                      If this field is not set, no startup boost is applied.
+                    properties:
+                      durationSeconds:
+                        description: |-
+                          durationSeconds indicates for how long to keep the pod boosted after it goes to Ready.
+                          Defaults to 0.
+                        format: int32
+                        type: integer
+                      factor:
+                        description: |-
+                          factor specifies the factor to apply to the resource request.
+                          This field is required when Type is "Factor".
+                        format: int32
+                        type: integer
+                      quantity:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          quantity specifies the absolute resource quantity to be used as the
+                          resource request and limit during the boost phase.
+                          This field is required when Type is "Quantity".
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      type:
+                        description: |-
+                          type specifies the kind of boost to apply.
+                          Supported values are: "Factor", "Quantity".
+                          No startupboost will be applied for unrecognized values.
+                        enum:
+                        - Factor
+                        - Quantity
+                        type: string
+                    required:
+                    - type
+                    type: object
+                    x-kubernetes-validations:
+                    - message: factor is required when type is Factor and forbidden
+                        otherwise
+                      rule: (self.type == 'Factor') == has(self.factor)
+                    - message: quantity is required when type is Quantity and forbidden
+                        otherwise
+                      rule: (self.type == 'Quantity') == has(self.quantity)
+                type: object
+              targetRef:
+                description: |-
+                  TargetRef points to the controller managing the set of pods for the
+                  autoscaler to control - e.g. Deployment, StatefulSet. VerticalPodAutoscaler
+                  can be targeted at controller implementing scale subresource (the pod set is
+                  retrieved from the controller's ScaleStatus) or some well known controllers
+                  (e.g. for DaemonSet the pod set is read from the controller's spec).
+                  If VerticalPodAutoscaler cannot use specified target it will report
+                  ConfigUnsupported condition.
+                  Note that VerticalPodAutoscaler does not require full implementation
+                  of scale subresource - it will not use it to modify the replica count.
+                  The only thing retrieved is a label selector matching pods grouped by
+                  the target resource.
+                properties:
+                  apiVersion:
+                    description: apiVersion is the API version of the referent
+                    type: string
+                  kind:
+                    description: 'kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'name is the name of the referent; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              updatePolicy:
+                description: |-
+                  Describes the rules on how changes are applied to the pods.
+                  If not specified, all fields in the `PodUpdatePolicy` are set to their
+                  default values.
+                properties:
+                  evictAfterOOMSeconds:
+                    description: |-
+                      evictAfterOOMSeconds specifies the time in seconds to wait after an OOM event before
+                      considering the pod for eviction. Pods that have OOMed in less than this time
+                      since start will be evicted.
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  evictionRequirements:
+                    description: |-
+                      EvictionRequirements is a list of EvictionRequirements that need to
+                      evaluate to true in order for a Pod to be evicted. If more than one
+                      EvictionRequirement is specified, all of them need to be fulfilled to allow eviction.
+                    items:
+                      description: |-
+                        EvictionRequirement defines a single condition which needs to be true in
+                        order to evict a Pod
+                      properties:
+                        changeRequirement:
+                          description: EvictionChangeRequirement refers to the relationship
+                            between the new target recommendation for a Pod and its
+                            current requests, what kind of change is necessary for
+                            the Pod to be evicted
+                          enum:
+                          - TargetHigherThanRequests
+                          - TargetLowerThanRequests
+                          type: string
+                        resources:
+                          description: |-
+                            Resources is a list of one or more resources that the condition applies
+                            to. If more than one resource is given, the EvictionRequirement is fulfilled
+                            if at least one resource meets `changeRequirement`.
+                          items:
+                            description: ResourceName is the name identifying various
+                              resources in a ResourceList.
+                            type: string
+                          type: array
+                      required:
+                      - changeRequirement
+                      - resources
+                      type: object
+                    type: array
+                  minReplicas:
+                    description: |-
+                      Minimal number of replicas which need to be alive for Updater to attempt
+                      pod eviction (pending other checks like PDB). Only positive values are
+                      allowed. Overrides global '--min-replicas' flag.
+                    format: int32
+                    type: integer
+                  updateMode:
+                    description: |-
+                      Controls when autoscaler applies changes to the pod resources.
+                      The default is 'Recreate'.
+                    enum:
+                    - "Off"
+                    - Initial
+                    - Recreate
+                    - InPlaceOrRecreate
+                    - InPlace
+                    - Auto
+                    type: string
+                type: object
+            required:
+            - targetRef
+            type: object
+          status:
+            description: Current information about the autoscaler.
+            properties:
+              conditions:
+                description: |-
+                  Conditions is the set of conditions required for this autoscaler to scale its target,
+                  and indicates whether or not those conditions are met.
+                items:
+                  description: |-
+                    VerticalPodAutoscalerCondition describes the state of
+                    a VerticalPodAutoscaler at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from
+                        one status to another
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human-readable explanation containing details about
+                        the transition
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason is the reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: status is the status of the condition (True, False,
+                        Unknown)
+                      type: string
+                    type:
+                      description: type describes the current condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: observedGeneration is the most recent generation observed
+                  by this autoscaler.
+                format: int64
+                minimum: 0
+                type: integer
+              recommendation:
+                description: |-
+                  The most recently computed amount of resources recommended by the
+                  autoscaler for the controlled pods.
+                properties:
+                  containerRecommendations:
+                    description: Resources recommended by the autoscaler for each
+                      container.
+                    items:
+                      description: |-
+                        RecommendedContainerResources is the recommendation of resources computed by
+                        autoscaler for a specific container. Respects the container resource policy
+                        if present in the spec. In particular the recommendation is not produced for
+                        containers with `ContainerScalingMode` set to 'Off'.
+                      properties:
+                        containerName:
+                          description: Name of the container.
+                          type: string
+                        lowerBound:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Minimum recommended amount of resources. Observes ContainerResourcePolicy.
+                            This amount is not guaranteed to be sufficient for the application to operate in a stable way, however
+                            running with less resources is likely to have significant impact on performance/availability.
+                          type: object
+                        target:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: Recommended amount of resources. Observes ContainerResourcePolicy.
+                          type: object
+                        uncappedTarget:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            The most recent recommended resources target computed by the autoscaler
+                            for the controlled pods, based only on actual resource usage, not taking
+                            into account the ContainerResourcePolicy.
+                            May differ from the Recommendation if the actual resource usage causes
+                            the target to violate the ContainerResourcePolicy (lower than MinAllowed
+                            or higher that MaxAllowed).
+                            Used only as status indication, will not affect actual resource assignment.
+                          type: object
+                        upperBound:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Maximum recommended amount of resources. Observes ContainerResourcePolicy.
+                            Any resources allocated beyond this value are likely wasted. This value may be larger than the maximum
+                            amount of application is actually capable of consuming.
+                          type: object
+                      required:
+                      - target
+                      type: object
+                    type: array
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - deprecated: true
+    deprecationWarning: autoscaling.k8s.io/v1beta2 API is deprecated
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VerticalPodAutoscaler is the configuration for a vertical pod
+          autoscaler, which automatically manages pod resources based on historical and
+          real time resource utilization.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the behavior of the autoscaler.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
+            properties:
+              resourcePolicy:
+                description: |-
+                  Controls how the autoscaler computes recommended resources.
+                  The resource policy may be used to set constraints on the recommendations
+                  for individual containers. If not specified, the autoscaler computes recommended
+                  resources for all containers in the pod, without additional constraints.
+                properties:
+                  containerPolicies:
+                    description: Per-container resource policies.
+                    items:
+                      description: |-
+                        ContainerResourcePolicy controls how autoscaler computes the recommended
+                        resources for a specific container.
+                      properties:
+                        containerName:
+                          description: |-
+                            Name of the container or DefaultContainerResourcePolicy, in which
+                            case the policy is used by the containers that don't have their own
+                            policy specified.
+                          type: string
+                        maxAllowed:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Specifies the maximum amount of resources that will be recommended
+                            for the container. The default is no maximum.
+                          type: object
+                        minAllowed:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Specifies the minimal amount of resources that will be recommended
+                            for the container. The default is no minimum.
+                          type: object
+                        mode:
+                          description: Whether autoscaler is enabled for the container.
+                            The default is "Auto".
+                          enum:
+                          - Auto
+                          - "Off"
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: |-
+                  TargetRef points to the controller managing the set of pods for the
+                  autoscaler to control - e.g. Deployment, StatefulSet. VerticalPodAutoscaler
+                  can be targeted at controller implementing scale subresource (the pod set is
+                  retrieved from the controller's ScaleStatus) or some well known controllers
+                  (e.g. for DaemonSet the pod set is read from the controller's spec).
+                  If VerticalPodAutoscaler cannot use specified target it will report
+                  ConfigUnsupported condition.
+                  Note that VerticalPodAutoscaler does not require full implementation
+                  of scale subresource - it will not use it to modify the replica count.
+                  The only thing retrieved is a label selector matching pods grouped by
+                  the target resource.
+                properties:
+                  apiVersion:
+                    description: apiVersion is the API version of the referent
+                    type: string
+                  kind:
+                    description: 'kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'name is the name of the referent; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              updatePolicy:
+                description: |-
+                  Describes the rules on how changes are applied to the pods.
+                  If not specified, all fields in the `PodUpdatePolicy` are set to their
+                  default values.
+                properties:
+                  updateMode:
+                    description: |-
+                      Controls when autoscaler applies changes to the pod resources.
+                      The default is 'Auto'.
+                    enum:
+                    - "Off"
+                    - Initial
+                    - Recreate
+                    - Auto
+                    type: string
+                type: object
+            required:
+            - targetRef
+            type: object
+          status:
+            description: Current information about the autoscaler.
+            properties:
+              conditions:
+                description: |-
+                  Conditions is the set of conditions required for this autoscaler to scale its target,
+                  and indicates whether or not those conditions are met.
+                items:
+                  description: |-
+                    VerticalPodAutoscalerCondition describes the state of
+                    a VerticalPodAutoscaler at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from
+                        one status to another
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human-readable explanation containing details about
+                        the transition
+                      type: string
+                    reason:
+                      description: reason is the reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: status is the status of the condition (True, False,
+                        Unknown)
+                      type: string
+                    type:
+                      description: type describes the current condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              recommendation:
+                description: |-
+                  The most recently computed amount of resources recommended by the
+                  autoscaler for the controlled pods.
+                properties:
+                  containerRecommendations:
+                    description: Resources recommended by the autoscaler for each
+                      container.
+                    items:
+                      description: |-
+                        RecommendedContainerResources is the recommendation of resources computed by
+                        autoscaler for a specific container. Respects the container resource policy
+                        if present in the spec. In particular the recommendation is not produced for
+                        containers with `ContainerScalingMode` set to 'Off'.
+                      properties:
+                        containerName:
+                          description: Name of the container.
+                          type: string
+                        lowerBound:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Minimum recommended amount of resources. Observes ContainerResourcePolicy.
+                            This amount is not guaranteed to be sufficient for the application to operate in a stable way, however
+                            running with less resources is likely to have significant impact on performance/availability.
+                          type: object
+                        target:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: Recommended amount of resources. Observes ContainerResourcePolicy.
+                          type: object
+                        uncappedTarget:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            The most recent recommended resources target computed by the autoscaler
+                            for the controlled pods, based only on actual resource usage, not taking
+                            into account the ContainerResourcePolicy.
+                            May differ from the Recommendation if the actual resource usage causes
+                            the target to violate the ContainerResourcePolicy (lower than MinAllowed
+                            or higher that MaxAllowed).
+                            Used only as status indication, will not affect actual resource assignment.
+                          type: object
+                        upperBound:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Maximum recommended amount of resources. Observes ContainerResourcePolicy.
+                            Any resources allocated beyond this value are likely wasted. This value may be larger than the maximum
+                            amount of application is actually capable of consuming.
+                          type: object
+                      required:
+                      - target
+                      type: object
+                    type: array
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:metrics-reader
+rules:
+  - apiGroups:
+      - "metrics.k8s.io"
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:vpa-actor
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - nodes
+      - limitranges
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - patch
+      - update
+  - apiGroups:
+      - "poc.autoscaling.k8s.io"
+    resources:
+      - verticalpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "autoscaling.k8s.io"
+    resources:
+      - verticalpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:vpa-status-actor
+rules:
+  - apiGroups:
+      - "autoscaling.k8s.io"
+    resources:
+      - verticalpodautoscalers/status
+    verbs:
+      - get
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:vpa-checkpoint-actor
+rules:
+  - apiGroups:
+      - "poc.autoscaling.k8s.io"
+    resources:
+      - verticalpodautoscalercheckpoints
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+      - delete
+  - apiGroups:
+      - "autoscaling.k8s.io"
+    resources:
+      - verticalpodautoscalercheckpoints
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:evictioner
+rules:
+  - apiGroups:
+      - "apps"
+      - "extensions"
+    resources:
+      - replicasets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods/eviction
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:vpa-updater-in-place
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods/resize
+      - pods # required for patching vpaInPlaceUpdated annotations onto the pod
+    verbs:
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:vpa-updater-in-place-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:vpa-updater-in-place
+subjects:
+  - kind: ServiceAccount
+    name: vpa-updater
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:metrics-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:metrics-reader
+subjects:
+  - kind: ServiceAccount
+    name: vpa-recommender
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:vpa-actor
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:vpa-actor
+subjects:
+  - kind: ServiceAccount
+    name: vpa-recommender
+    namespace: kube-system
+  - kind: ServiceAccount
+    name: vpa-updater
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:vpa-status-actor
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:vpa-status-actor
+subjects:
+  - kind: ServiceAccount
+    name: vpa-recommender
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:vpa-checkpoint-actor
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:vpa-checkpoint-actor
+subjects:
+  - kind: ServiceAccount
+    name: vpa-recommender
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:vpa-target-reader
+rules:
+  - apiGroups:
+    - '*'
+    resources:
+    - '*/scale'
+    verbs:
+    - get
+    - watch
+  - apiGroups:
+      - ""
+    resources:
+      - replicationcontrollers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - deployments
+      - replicasets
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+      - cronjobs
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:vpa-target-reader-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:vpa-target-reader
+subjects:
+  - kind: ServiceAccount
+    name: vpa-recommender
+    namespace: kube-system
+  - kind: ServiceAccount
+    name: vpa-admission-controller
+    namespace: kube-system
+  - kind: ServiceAccount
+    name: vpa-updater
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:vpa-evictioner-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:evictioner
+subjects:
+  - kind: ServiceAccount
+    name: vpa-updater
+    namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vpa-admission-controller
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vpa-recommender
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vpa-updater
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:vpa-admission-controller
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - configmaps
+      - nodes
+      - limitranges
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "admissionregistration.k8s.io"
+    resources:
+      - mutatingwebhookconfigurations
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+  - apiGroups:
+      - "poc.autoscaling.k8s.io"
+    resources:
+      - verticalpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "autoscaling.k8s.io"
+    resources:
+      - verticalpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - create
+      - update
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:vpa-admission-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:vpa-admission-controller
+subjects:
+  - kind: ServiceAccount
+    name: vpa-admission-controller
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:vpa-status-reader
+rules:
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:vpa-status-reader-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:vpa-status-reader
+subjects:
+  - kind: ServiceAccount
+    name: vpa-updater
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: system:leader-locking-vpa-updater
+  namespace: kube-system
+rules:
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - create
+  - apiGroups:
+      - "coordination.k8s.io"
+    resourceNames:
+      - vpa-updater
+    resources:
+      - leases
+    verbs:
+      - get
+      - watch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:leader-locking-vpa-updater
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: system:leader-locking-vpa-updater
+subjects:
+  - kind: ServiceAccount
+    name: vpa-updater
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: system:leader-locking-vpa-recommender
+  namespace: kube-system
+rules:
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - create
+  - apiGroups:
+      - "coordination.k8s.io"
+    resourceNames:
+      # TODO: Clean vpa-recommender up once vpa-recommender-lease is used everywhere. See https://github.com/kubernetes/autoscaler/issues/7461.
+      - vpa-recommender
+      - vpa-recommender-lease
+    resources:
+      - leases
+    verbs:
+      - get
+      - watch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:leader-locking-vpa-recommender
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: system:leader-locking-vpa-recommender
+subjects:
+  - kind: ServiceAccount
+    name: vpa-recommender
+    namespace: kube-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vpa-recommender
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vpa-recommender
+  template:
+    metadata:
+      labels:
+        app: vpa-recommender
+        app.kubernetes.io/component: recommender
+        app.kubernetes.io/name: vertical-pod-autoscaler
+    spec:
+      serviceAccountName: vpa-recommender
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534 # nobody
+      containers:
+      - name: recommender
+        image: registry.k8s.io/autoscaling/vpa-recommender:1.7.1@sha256:89cea705535f9d8df6e62d5084916ec447e85d64369cfff2f7c6ac9d1cc5cd1e
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 200m
+            memory: 1000Mi
+          requests:
+            cpu: 50m
+            memory: 500Mi
+        ports:
+        - name: prometheus
+          containerPort: 8942
+        livenessProbe:
+          httpGet:
+            path: /health-check
+            port: prometheus
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /health-check
+            port: prometheus
+            scheme: HTTP
+          periodSeconds: 10
+          failureThreshold: 3
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vpa-updater
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vpa-updater
+  template:
+    metadata:
+      labels:
+        app: vpa-updater
+    spec:
+      serviceAccountName: vpa-updater
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534 # nobody
+      containers:
+        - name: updater
+          image: registry.k8s.io/autoscaling/vpa-updater:1.7.1@sha256:feb42a5269708d065d5a43c5379d0e4700c3eca333231723d6a7c24f222ab446
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          resources:
+            limits:
+              cpu: 200m
+              memory: 1000Mi
+            requests:
+              cpu: 50m
+              memory: 500Mi
+          ports:
+            - name: prometheus
+              containerPort: 8943
+          livenessProbe:
+            httpGet:
+              path: /health-check
+              port: prometheus
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health-check
+              port: prometheus
+              scheme: HTTP
+            periodSeconds: 10
+            failureThreshold: 3
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vpa-admission-controller
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vpa-admission-controller
+  template:
+    metadata:
+      labels:
+        app: vpa-admission-controller
+    spec:
+      serviceAccountName: vpa-admission-controller
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534 # nobody
+      containers:
+        - name: admission-controller
+          image: registry.k8s.io/autoscaling/vpa-admission-controller:1.7.1@sha256:be29624f7f12a0b6f7fe18e2e042195eb6e39ae37d4490000f2643a480873572
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          args: ["--v=4", "--stderrthreshold=info", "--reload-cert"]
+          volumeMounts:
+            - name: tls-certs
+              mountPath: "/etc/tls-certs"
+              readOnly: true
+          resources:
+            limits:
+              cpu: 200m
+              memory: 500Mi
+            requests:
+              cpu: 50m
+              memory: 200Mi
+          ports:
+            - containerPort: 8000
+            - name: prometheus
+              containerPort: 8944
+          livenessProbe:
+            httpGet:
+              path: /health-check
+              port: prometheus
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health-check
+              port: prometheus
+              scheme: HTTP
+            periodSeconds: 10
+            failureThreshold: 3
+      volumes:
+        - name: tls-certs
+          secret:
+            secretName: vpa-tls-certs
+apiVersion: v1
+kind: Service
+metadata:
+  name: vpa-webhook
+  namespace: kube-system
+spec:
+  ports:
+    - port: 443
+      targetPort: 8000
+  selector:
+    app: vpa-admission-controller

--- a/pkg/core/cluster/vpa_test.go
+++ b/pkg/core/cluster/vpa_test.go
@@ -1,0 +1,144 @@
+package cluster
+
+import (
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/pem"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestVPAPin is the golden pin for what runs inside tenant clusters:
+// bundle hash, version, and every image digest-pinned. Re-vendoring
+// means changing the bundle AND this test, on purpose.
+func TestVPAPin(t *testing.T) {
+	m, err := VPAManifests()
+	if err != nil {
+		t.Fatalf("VPAManifests: %v", err)
+	}
+	sum := sha256.Sum256(m)
+	if hex.EncodeToString(sum[:]) != VPAManifestSHA256 {
+		t.Fatal("embedded bundle does not match its pin")
+	}
+	if VPAVersion != "1.7.1" {
+		t.Fatalf("VPAVersion pin changed to %q — re-verify images and manifests against the upstream tag", VPAVersion)
+	}
+
+	text := string(m)
+	// Every component image is digest-pinned; no floating tags.
+	imageRE := regexp.MustCompile(`image:\s*(\S+)`)
+	images := imageRE.FindAllStringSubmatch(text, -1)
+	if len(images) != 3 {
+		t.Fatalf("expected 3 component images, found %d", len(images))
+	}
+	for _, im := range images {
+		if !strings.Contains(im[1], "@sha256:") {
+			t.Fatalf("image %q is not digest-pinned", im[1])
+		}
+	}
+	// The bundle carries the three components + the webhook service,
+	// and deliberately NOT the TLS secret (generated per cluster).
+	for _, must := range []string{"vpa-recommender", "vpa-updater", "vpa-admission-controller", "kind: Service"} {
+		if !strings.Contains(text, must) {
+			t.Fatalf("bundle missing %q", must)
+		}
+	}
+	if strings.Contains(text, "kind: Secret") {
+		t.Fatal("the bundle must not contain a shared TLS secret — it is generated per cluster")
+	}
+}
+
+func TestGenerateVPAWebhookSecret(t *testing.T) {
+	secret, err := GenerateVPAWebhookSecret()
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(secret)
+	for _, must := range []string{"name: vpa-tls-certs", "namespace: kube-system", "caCert.pem:", "serverCert.pem:", "serverKey.pem:"} {
+		if !strings.Contains(text, must) {
+			t.Fatalf("secret manifest missing %q", must)
+		}
+	}
+
+	// The serving cert verifies against the CA and carries the
+	// webhook service SAN — what the kube-apiserver will check.
+	field := func(key string) []byte {
+		re := regexp.MustCompile(key + `: (\S+)`)
+		m := re.FindStringSubmatch(text)
+		if m == nil {
+			t.Fatalf("missing %s", key)
+		}
+		raw, err := base64.StdEncoding.DecodeString(m[1])
+		if err != nil {
+			t.Fatalf("%s not base64: %v", key, err)
+		}
+		return raw
+	}
+	caBlock, _ := pem.Decode(field("caCert.pem"))
+	srvBlock, _ := pem.Decode(field("serverCert.pem"))
+	if caBlock == nil || srvBlock == nil {
+		t.Fatal("certs are not PEM")
+	}
+	ca, err := x509.ParseCertificate(caBlock.Bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv, err := x509.ParseCertificate(srvBlock.Bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := x509.NewCertPool()
+	pool.AddCert(ca)
+	if _, err := srv.Verify(x509.VerifyOptions{
+		Roots:     pool,
+		DNSName:   "vpa-webhook.kube-system.svc",
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}); err != nil {
+		t.Fatalf("serving cert does not verify for the webhook service: %v", err)
+	}
+
+	// Two clusters never share webhook certs.
+	secret2, err := GenerateVPAWebhookSecret()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(secret) == string(secret2) {
+		t.Fatal("webhook secrets are identical across generations")
+	}
+}
+
+func TestDeployVPA(t *testing.T) {
+	f := newFakeHost()
+	f.readErr = errNotDeployed{}
+	m := testManager(f)
+
+	if err := m.DeployVPA("alice", "demo"); err != nil {
+		t.Fatalf("DeployVPA: %v", err)
+	}
+	cp := "alice-k8s-demo-cp"
+	if _, ok := f.files[cp+":"+VPAManifestPath]; !ok {
+		t.Fatal("VPA manifests not pushed")
+	}
+	if _, ok := f.files[cp+":"+VPACertsPath]; !ok {
+		t.Fatal("VPA certs manifest not pushed")
+	}
+
+	// Idempotent: a second deploy must NOT regenerate the secret —
+	// that would rotate the webhook's certs under the running
+	// admission controller.
+	f.readErr = nil // certs file now readable
+	before := string(f.files[cp+":"+VPACertsPath])
+	if err := m.DeployVPA("alice", "demo"); err != nil {
+		t.Fatalf("second DeployVPA: %v", err)
+	}
+	if string(f.files[cp+":"+VPACertsPath]) != before {
+		t.Fatal("second deploy rotated the webhook secret")
+	}
+}
+
+type errNotDeployed struct{}
+
+func (errNotDeployed) Error() string { return "no such file" }


### PR DESCRIPTION
Closes #1416. Part of sprint umbrella #1419 · Design: `docs/architecture/managed-k8s-clusters.md`. Branches off main; touches the reconciler's settle path, so whichever of this and #1422 lands second gets a trivial rebase.

## What changed

- **Vendored, digest-pinned VPA 1.7.1 bundle** (`pkg/core/cluster/vpa/manifests.yaml`): upstream CRDs, RBAC, recommender/updater/admission-controller and the webhook service, with all three component images pinned by registry.k8s.io manifest digest. The bundle's sha256 is pinned in code and **re-verified on every load** — a tampered embed fails closed rather than being applied into a tenant's cluster.
- **Per-cluster webhook certs**: `GenerateVPAWebhookSecret` mints a fresh CA + serving cert (SAN `vpa-webhook.kube-system.svc`) per cluster, rendered as the `vpa-tls-certs` Secret at deploy time — never shared across clusters, never persisted by the platform, deliberately absent from the vendored bundle (asserted by test).
- **Deployment**: `Manager.DeployVPA` pushes both files into the k3s auto-apply dir; idempotent by presence check so a reconciler pass **never rotates the webhook secret** under the running admission controller. Rides the reconciler settle path until READY; `CONTAINARIUM_CLUSTER_VPA=false` opts a host out.
- Tenants opt workloads in with stock VPA objects — `updateMode: InPlaceOrRecreate` for in-place resizes with Recreate fallback (upstream 1.7 behavior; no bespoke resizing loop, per the design's "Who decides what": VPA is the only component licensed to turn usage into requests).

## Test evidence

| Claim | Test |
|---|---|
| Bundle pin + digest-pinned images + no shared secret | `TestVPAPin` |
| Webhook cert verifies for the service SAN; unique per cluster | `TestGenerateVPAWebhookSecret` |
| Deploy pushes both files; second deploy never rotates the secret | `TestDeployVPA` |
| Reconciler deploys before READY; disable flag honored; passes never rotate | `TestReconciler_DeploysVPAOntoCP` |

The runtime behaviors (request raised without restart-looping; resized pod that no longer fits triggers node scale-up) are #1418 e2e lane assertions — they cannot occur in any fake.

## Verify on dev (batched pass — queue row on #1419)

1. `cluster create demo` → once READY: `kubectl -n kube-system get pods` shows vpa-recommender/updater/admission-controller Running; `kubectl get crd verticalpodautoscalers.autoscaling.k8s.io` exists.
2. Apply a VPA object (`updateMode: InPlaceOrRecreate`) for a deployment under sustained load above its request → within the recommender window the pod's requests rise without a restart loop.
3. Push the resized workload past node capacity → Pending → node scale-up (composition with #1415).

🤖 Generated with [Claude Code](https://claude.com/claude-code)