### PR TITLE
ci(cluster): gated KVM e2e lane for managed clusters

### DIFF
--- a/.github/workflows/cluster-e2e.yml
+++ b/.github/workflows/cluster-e2e.yml
@@ -1,0 +1,109 @@
+name: Managed clusters KVM e2e
+
+# The definition-of-done lane for the managed-Kubernetes-clusters MVP
+# (#1418): the six-step tenant journey from the design's "End-to-end"
+# section, run with real everything — Incus VMs, k3s, cluster-autoscaler,
+# VPA — by scripts/cluster-e2e.sh + test/e2e/cluster/.
+#
+# Cadence per the design's CI-gates section: NIGHTLY + RELEASE-BLOCKING
+# (tag push), not per-PR — a full run provisions VMs for over an hour.
+# Pull requests touching the lane get only the cheap job: compile the
+# gated package and run its untagged unit tests, so the lane's own logic
+# cannot rot unnoticed between nightlies.
+#
+# Runner contract (the provisioning half of #1418): a SELF-HOSTED runner
+# labeled `incus` + `kvm`, with Incus and its unix socket, /dev/kvm,
+# a Go toolchain, passwordless sudo, docker or podman (throwaway
+# Postgres), and egress to github.com + registry.k8s.io. Details in the
+# header of scripts/cluster-e2e.sh.
+#
+# Prove-the-lane-can-fail (#1418 guardrail): dispatch with
+# sabotage=join-token. The script corrupts worker join tokens so no node
+# can register; the JOB goes green only if the SUITE goes red. Run it
+# once when the runner first comes up, and after any change to the
+# lane's assertions — a green lane that has never failed proves nothing.
+
+on:
+  schedule:
+    # Nightly, off-peak for the self-hosted host.
+    - cron: '30 2 * * *'
+  push:
+    tags:
+      - 'v*'   # release-blocking: docs/RELEASE-PROCESS.md gates publishing on this run
+  workflow_dispatch:
+    inputs:
+      sabotage:
+        description: 'Deliberate breakage; join-token proves the lane can fail'
+        type: choice
+        options: ['none', 'join-token']
+        default: 'none'
+  pull_request:
+    paths:
+      - 'test/e2e/cluster/**'
+      - 'scripts/cluster-e2e.sh'
+      - '.github/workflows/cluster-e2e.yml'
+
+permissions:
+  contents: read
+
+# One run at a time regardless of ref: every run owns the runner's Incus
+# (VM capacity, the fixed CA-provider port, the sweep of e2etenant VMs).
+concurrency:
+  group: cluster-e2e-kvm
+  cancel-in-progress: false
+
+jobs:
+  build-unit:
+    name: compile lane + helper unit tests
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version: '1.26.6'
+      - name: Compile the gated e2e package
+        run: go vet -tags 'incus cluster_e2e' ./test/e2e/cluster/
+      - name: Helper unit tests (pure, no Incus)
+        # This is the only invocation list carrying this package's unit
+        # tests — no repo-wide `go test ./...` lane exists to catch it.
+        run: go test -race -count=1 -v ./test/e2e/cluster/
+      - name: Lane script syntax
+        run: bash -n scripts/cluster-e2e.sh
+
+  kvm-e2e:
+    name: six-step journey (real VMs)
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' && inputs.sabotage == 'none')
+    runs-on: [self-hosted, incus, kvm]
+    timeout-minutes: 150
+    steps:
+      - uses: actions/checkout@v7
+      - name: Run the lane
+        # No pipes around the go test inside — its exit status is the
+        # script's, and the script's is the job's.
+        run: bash scripts/cluster-e2e.sh
+
+  prove-lane-can-fail:
+    name: sabotage run (suite must go red)
+    if: github.event_name == 'workflow_dispatch' && inputs.sabotage == 'join-token'
+    runs-on: [self-hosted, incus, kvm]
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+      - name: Corrupt join tokens and expect the suite to fail
+        # Inversion is explicit and lives only in this dispatch-only
+        # job: green here means the lane DETECTED the sabotage.
+        env:
+          CONTAINARIUM_E2E_SABOTAGE: join-token
+          # Sabotaged workers can never register; don't wait the full
+          # production bound to learn what we broke on purpose.
+          CONTAINARIUM_E2E_READY_TIMEOUT: 12m
+        run: |
+          if bash scripts/cluster-e2e.sh; then
+            echo "::error::lane stayed GREEN under join-token sabotage — it cannot fail, so its green proves nothing"
+            exit 1
+          fi
+          echo "lane went red under sabotage: it can fail, and its green is evidence."

--- a/docs/RELEASE-PROCESS.md
+++ b/docs/RELEASE-PROCESS.md
@@ -70,6 +70,12 @@ anyway; it's the only thing a non-release build has to go on.
    artifacts and `SHA256SUMS.txt`, that `containarium version` on a
    freshly downloaded binary reports the new tag, and that the image
    and PyPI publishes succeeded.
+6. **Wait for the managed-clusters KVM e2e lane to go green on the
+   tag** (`.github/workflows/cluster-e2e.yml`, also runs nightly). It
+   is release-blocking (#1418): a red or missing run means the release
+   is not announced or deployed anywhere until the lane passes on that
+   tag — the publish workflows above don't wait for it, so this gate
+   is yours to enforce.
 
 ## What a tag push actually publishes
 

--- a/scripts/cluster-e2e.sh
+++ b/scripts/cluster-e2e.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+#
+# cluster-e2e.sh — the gated KVM e2e lane for managed Kubernetes
+# clusters (#1418). Builds the CLI+daemon from this tree, starts a real
+# daemon against a real Postgres on a VM-capable Incus host, and runs
+# the six-step MVP journey in test/e2e/cluster/ against it.
+#
+# Local use:   sudo -v && bash scripts/cluster-e2e.sh
+# Sabotage:    CONTAINARIUM_E2E_SABOTAGE=join-token bash scripts/cluster-e2e.sh
+#              (expected to exit non-zero — that is the point; the
+#              workflow's prove-can-fail job asserts it)
+# CI:          .github/workflows/cluster-e2e.yml on the self-hosted
+#              incus+kvm runner (nightly + release tags, not per-PR).
+#
+# Host requirements (the runner-provisioning half of #1418):
+#   - Incus with a usable storage pool at /var/lib/incus/unix.socket
+#   - KVM (/dev/kvm) — cluster nodes are VMs, not containers
+#   - Go toolchain, passwordless sudo for the invoking user
+#   - Postgres reachable via CONTAINARIUM_POSTGRES_URL, or Docker/Podman
+#     available so the script can start a throwaway one
+#   - Egress to github.com (k3s binary) and registry.k8s.io (CA, images)
+#
+# The Go test's exit status is the script's exit status — nothing here
+# pipes it away (a green lane must be evidence the test ran).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+GRPC_PORT="${CONTAINARIUM_E2E_GRPC_PORT:-15051}"
+HTTP_PORT="${CONTAINARIUM_E2E_HTTP_PORT:-18080}"
+WORKDIR="$(mktemp -d)"
+BIN="$WORKDIR/containarium"
+DAEMON_LOG="$WORKDIR/daemon.log"
+PG_CONTAINER=""
+DAEMON_PID=""
+
+# The tenant/cluster names the Go test uses; the sweep below must match.
+VM_PREFIX="e2etenant-k8s-lane-"
+
+log() { echo "==> $*"; }
+
+fail() { echo "FATAL: $*" >&2; exit 1; }
+
+# --- pre-flight: fail loudly, never skip silently -----------------------
+[ -e /dev/kvm ] || fail "no /dev/kvm — this lane needs a KVM-capable host (nested virt on a VM runner)"
+[ -S /var/lib/incus/unix.socket ] || fail "no Incus socket at /var/lib/incus/unix.socket"
+command -v go >/dev/null || fail "no Go toolchain"
+sudo -n true 2>/dev/null || fail "needs passwordless sudo (daemon and Incus operations run as root)"
+
+cleanup() {
+  status=$?
+  set +e
+  if [ -n "$DAEMON_PID" ]; then
+    log "stopping daemon (pid $DAEMON_PID)"
+    sudo kill "$DAEMON_PID" 2>/dev/null
+    sleep 2
+    sudo kill -9 "$DAEMON_PID" 2>/dev/null
+  fi
+  # Sweep any VMs a red run left behind, so the next nightly starts clean.
+  for vm in $(sudo incus list --format csv --columns n 2>/dev/null | grep "^${VM_PREFIX}" || true); do
+    log "sweeping leftover VM $vm"
+    sudo incus delete --force "$vm" 2>/dev/null
+  done
+  if [ -n "$PG_CONTAINER" ]; then
+    log "stopping throwaway postgres"
+    "$CONTAINER_RUNTIME" rm -f "$PG_CONTAINER" >/dev/null 2>&1
+  fi
+  if [ $status -ne 0 ] && [ -f "$DAEMON_LOG" ]; then
+    echo "---- daemon log (last 100 lines) ----"
+    tail -100 "$DAEMON_LOG"
+  fi
+  rm -rf "$WORKDIR"
+  exit $status
+}
+trap cleanup EXIT
+
+# --- postgres: real, per the design's real-vs-faked table ---------------
+if [ -z "${CONTAINARIUM_POSTGRES_URL:-}" ]; then
+  CONTAINER_RUNTIME="$(command -v docker || command -v podman || true)"
+  [ -n "$CONTAINER_RUNTIME" ] || fail "set CONTAINARIUM_POSTGRES_URL or install docker/podman for a throwaway postgres"
+  PG_PORT="$(( (RANDOM % 1000) + 15432 ))"
+  PG_CONTAINER="cluster-e2e-pg-$$"
+  log "starting throwaway postgres on :$PG_PORT"
+  "$CONTAINER_RUNTIME" run -d --name "$PG_CONTAINER" \
+    -e POSTGRES_USER=containarium -e POSTGRES_PASSWORD=e2e -e POSTGRES_DB=containarium \
+    -p "127.0.0.1:${PG_PORT}:5432" postgres:16-alpine >/dev/null
+  export CONTAINARIUM_POSTGRES_URL="postgres://containarium:e2e@127.0.0.1:${PG_PORT}/containarium?sslmode=disable"
+  for _ in $(seq 1 30); do
+    "$CONTAINER_RUNTIME" exec "$PG_CONTAINER" pg_isready -U containarium >/dev/null 2>&1 && break
+    sleep 1
+  done
+  "$CONTAINER_RUNTIME" exec "$PG_CONTAINER" pg_isready -U containarium >/dev/null 2>&1 \
+    || fail "postgres did not become ready"
+else
+  CONTAINER_RUNTIME=""
+fi
+
+# --- build the system under test ----------------------------------------
+log "building containarium"
+go build -o "$BIN" ./cmd/containarium
+
+# --- daemon environment --------------------------------------------------
+JWT_SECRET="${CONTAINARIUM_JWT_SECRET:-$(head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n')}"
+ADVERTISE_HOST="${CONTAINARIUM_E2E_ADVERTISE_HOST:-$(ip -4 route get 1.1.1.1 | sed -n 's/.*src \([0-9.]*\).*/\1/p')}"
+[ -n "$ADVERTISE_HOST" ] || fail "could not determine the host's advertise address; set CONTAINARIUM_E2E_ADVERTISE_HOST"
+
+log "starting daemon (grpc :$GRPC_PORT http :$HTTP_PORT advertise $ADVERTISE_HOST)"
+sudo env \
+  CONTAINARIUM_JWT_SECRET="$JWT_SECRET" \
+  CONTAINARIUM_POSTGRES_URL="$CONTAINARIUM_POSTGRES_URL" \
+  CONTAINARIUM_CLUSTER_ADVERTISE_ADDR="$ADVERTISE_HOST" \
+  CONTAINARIUM_CLUSTER_CA_ADVERTISE="$ADVERTISE_HOST:36442" \
+  CONTAINARIUM_CLUSTER_CA_PKI_DIR="$WORKDIR/cluster-ca" \
+  "$BIN" daemon --port "$GRPC_PORT" --http-port "$HTTP_PORT" \
+  >"$DAEMON_LOG" 2>&1 &
+DAEMON_PID=$!
+
+# Readiness: any HTTP answer on the gateway port means the REST surface
+# is up. Authenticated calls are the Go test's job — it mints its own
+# tenant token from the same secret.
+log "waiting for the daemon's HTTP gateway"
+for i in $(seq 1 60); do
+  if ! sudo kill -0 "$DAEMON_PID" 2>/dev/null; then
+    fail "daemon exited during startup"
+  fi
+  if curl -s -o /dev/null "http://127.0.0.1:$HTTP_PORT/v1/clusters"; then
+    break
+  fi
+  [ "$i" = 60 ] && fail "daemon HTTP gateway not answering after 120s"
+  sleep 2
+done
+
+# --- run the lane --------------------------------------------------------
+log "running the six-step journey (sabotage: ${CONTAINARIUM_E2E_SABOTAGE:-none})"
+sudo env \
+  PATH="$PATH" HOME="$HOME" GOFLAGS="${GOFLAGS:-}" GOCACHE="$(go env GOCACHE)" GOMODCACHE="$(go env GOMODCACHE)" \
+  CONTAINARIUM_REQUIRE_INCUS=1 \
+  CONTAINARIUM_E2E_CLI="$BIN" \
+  CONTAINARIUM_E2E_SERVER="127.0.0.1:$HTTP_PORT" \
+  CONTAINARIUM_E2E_ADVERTISE_HOST="$ADVERTISE_HOST" \
+  CONTAINARIUM_JWT_SECRET="$JWT_SECRET" \
+  CONTAINARIUM_E2E_SABOTAGE="${CONTAINARIUM_E2E_SABOTAGE:-}" \
+  go test -tags 'incus cluster_e2e' -count=1 -timeout 110m -v ./test/e2e/cluster/

--- a/scripts/cluster-e2e.sh
+++ b/scripts/cluster-e2e.sh
@@ -13,6 +13,11 @@
 #              incus+kvm runner (nightly + release tags, not per-PR).
 #
 # Host requirements (the runner-provisioning half of #1418):
+#   - Capacity for the journey's worst case: ~16 vCPU (CP 2 + up to
+#     3×small 2 + one large 8), ~32 GB RAM, ~500 GB free in the Incus
+#     pool. On a smaller host the daemon's CPU-admission gate will
+#     correctly REFUSE the larger-class scale-up and the lane goes red
+#     for an environmental reason that looks like a product bug.
 #   - Incus with a usable storage pool at /var/lib/incus/unix.socket
 #   - KVM (/dev/kvm) — cluster nodes are VMs, not containers
 #   - Go toolchain, passwordless sudo for the invoking user

--- a/test/e2e/cluster/e2e_test.go
+++ b/test/e2e/cluster/e2e_test.go
@@ -1,0 +1,663 @@
+//go:build incus && cluster_e2e
+
+package clustere2e
+
+// The gated KVM e2e lane (#1418): the managed-clusters MVP journey run
+// against real everything — real Incus VMs, real k3s, real
+// cluster-autoscaler, real VPA — on a VM-capable host. Design:
+// docs/architecture/managed-k8s-clusters.md, "End-to-end".
+//
+// Every assertion is against observed cluster or Incus state (the k8s
+// API through the tenant kubeconfig, the Incus API, TCP reachability),
+// never against the daemon's own SQL or logs. Rows are asserted through
+// the product API (`cluster get` NotFound), which is the tenant-visible
+// meaning of "no rows".
+//
+// Driven CLI-first: every platform action goes through the
+// `containarium` binary the lane built, exactly as a tenant would run
+// it — no agent-only escape hatches (CLAUDE.md).
+//
+// Steps are strictly sequential; each builds on the previous one, so a
+// failed step aborts the rest instead of cascading noise.
+//
+// Environment contract (set by scripts/cluster-e2e.sh):
+//
+//	CONTAINARIUM_E2E_CLI            path to the built containarium binary
+//	CONTAINARIUM_E2E_SERVER         daemon HTTP address, e.g. 127.0.0.1:8080
+//	CONTAINARIUM_JWT_SECRET         daemon's JWT secret; the lane mints its tenant token
+//	CONTAINARIUM_E2E_ADVERTISE_HOST host the kubeconfig must point at ("outside" reach)
+//	CONTAINARIUM_E2E_SABOTAGE       "" or "join-token" (prove-the-lane-can-fail runs)
+//	CONTAINARIUM_REQUIRE_INCUS      "1" in the lane: a missing environment fails, not skips
+//
+// Timeouts (durations, optional): CONTAINARIUM_E2E_READY_TIMEOUT
+// (default 15m; PRD documents create→kubectl under 10 minutes),
+// _SCALEUP_TIMEOUT (12m), _VPA_TIMEOUT (15m), _SCALEDOWN_TIMEOUT (30m —
+// stock CA scale-down: 10m delay-after-add + 10m unneeded),
+// _DELETE_TIMEOUT (10m).
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/internal/testsupport/incusenv"
+	clusterpkg "github.com/footprintai/containarium/pkg/core/cluster"
+	"github.com/footprintai/containarium/pkg/core/incus"
+)
+
+const (
+	tenant      = "e2etenant"
+	clusterName = "lane"
+
+	// burnImage runs both the pause-style sleepers and the CPU burner.
+	// registry.k8s.io is the same registry the pinned CA image comes
+	// from, and it is not rate-limited the way docker.io is.
+	burnImage = "registry.k8s.io/e2e-test-images/busybox:1.36.1-1"
+)
+
+// vmPrefix is the Incus name prefix every VM of the lane cluster
+// carries (spec.go's naming scheme).
+var vmPrefix = tenant + "-k8s-" + clusterName + "-"
+
+type lane struct {
+	t             *testing.T
+	cli           string
+	server        string
+	token         string
+	advertiseHost string
+	incus         *incus.Client
+
+	cs  *kubernetes.Clientset
+	dyn dynamic.Interface
+
+	kubeconfig    []byte
+	baselineNodes []string
+	baselineVMs   []string
+}
+
+func env(t *testing.T, key string) string {
+	t.Helper()
+	v := os.Getenv(key)
+	if v == "" {
+		msg := fmt.Sprintf("%s is not set; the cluster e2e needs the lane script's environment", key)
+		if incusenv.DispositionFor(os.Getenv(incusenv.RequireEnv)) == incusenv.Fail {
+			t.Fatalf("%s (%s is set, so this is a failure and not a skip)", msg, incusenv.RequireEnv)
+		}
+		t.Skipf("%s (set %s=1 to make this a failure instead)", msg, incusenv.RequireEnv)
+	}
+	return v
+}
+
+func timeoutEnv(key string, def time.Duration) time.Duration {
+	if v := os.Getenv(key); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+	}
+	return def
+}
+
+func TestManagedClusterJourney(t *testing.T) {
+	if testing.Short() {
+		t.Skip("gated KVM lane; not a -short test")
+	}
+
+	l := &lane{
+		t:             t,
+		cli:           env(t, "CONTAINARIUM_E2E_CLI"),
+		server:        env(t, "CONTAINARIUM_E2E_SERVER"),
+		advertiseHost: env(t, "CONTAINARIUM_E2E_ADVERTISE_HOST"),
+		incus:         incusenv.Require(t),
+	}
+
+	secret := env(t, "CONTAINARIUM_JWT_SECRET")
+	tm, err := auth.NewTokenManager(secret, "containarium")
+	if err != nil {
+		t.Fatalf("token manager: %v", err)
+	}
+	// The tenant's own least-privilege token — the journey is the
+	// tenant's, not an admin's.
+	l.token, err = tm.GenerateAccessToken(tenant, []string{"user"}, 4*time.Hour,
+		auth.ScopeClustersRead, auth.ScopeClustersWrite)
+	if err != nil {
+		t.Fatalf("mint tenant token: %v", err)
+	}
+
+	sabotage, err := ParseSabotage(os.Getenv("CONTAINARIUM_E2E_SABOTAGE"))
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	if sabotage == SabotageJoinToken {
+		stop := make(chan struct{})
+		defer close(stop)
+		go l.sabotageJoinTokens(stop)
+		t.Log("SABOTAGE ACTIVE: corrupting worker join tokens — this run is expected to go red")
+	}
+
+	// Whatever happens, tear the cluster down so a red run does not
+	// leak VMs into the next nightly. Errors are logged, not fatal —
+	// the script's sweep is the backstop.
+	defer func() {
+		out, err := l.runCLI("cluster", "delete", clusterName)
+		l.t.Logf("teardown delete: %v %s", err, strings.TrimSpace(out))
+	}()
+
+	steps := []struct {
+		name string
+		fn   func() error
+	}{
+		{"1_create_kubeconfig_from_outside", l.stepCreate},
+		{"2_overflow_scales_up_via_new_ready_node", l.stepOverflowScaleUp},
+		{"3_big_pod_lands_on_larger_class_node", l.stepLargerClass},
+		{"4_vpa_raises_requests_without_restart_loop", l.stepVPA},
+		{"5_scale_to_zero_drains_and_deletes_vm", l.stepScaleToZero},
+		{"6_delete_leaves_nothing", l.stepDelete},
+	}
+	for _, s := range steps {
+		if !t.Run(s.name, func(t *testing.T) {
+			if err := s.fn(); err != nil {
+				l.dumpDiagnostics()
+				t.Fatal(err)
+			}
+		}) {
+			t.Fatalf("step %s failed; aborting the journey (later steps depend on it)", s.name)
+		}
+	}
+}
+
+// --- CLI ----------------------------------------------------------------
+
+func (l *lane) runCLI(args ...string) (string, error) {
+	full := append([]string{"--http", "--server", l.server, "--token", l.token}, args...)
+	cmd := exec.Command(l.cli, full...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// --- step 1: create → kubeconfig works from outside ---------------------
+
+func (l *lane) stepCreate() error {
+	readyTimeout := timeoutEnv("CONTAINARIUM_E2E_READY_TIMEOUT", 15*time.Minute)
+
+	if out, err := l.runCLI("cluster", "create", clusterName); err != nil {
+		return fmt.Errorf("cluster create: %v\n%s", err, out)
+	}
+
+	// The kubeconfig RPC is FailedPrecondition until the cluster is
+	// READY, then returns the credential: polling it IS the readiness
+	// probe, through the same door a tenant uses.
+	err := l.waitFor("cluster READY and kubeconfig served", readyTimeout, 10*time.Second, func() (bool, string) {
+		out, err := l.runCLI("cluster", "kubeconfig", clusterName)
+		if err != nil {
+			return false, strings.TrimSpace(out)
+		}
+		l.kubeconfig = []byte(out)
+		return true, "kubeconfig fetched"
+	})
+	if err != nil {
+		return err
+	}
+
+	// "From outside": the credential must point at the advertised host
+	// (the passthrough route), not at a VM address only the host can
+	// reach.
+	host, err := KubeconfigServerHost(l.kubeconfig)
+	if err != nil {
+		return err
+	}
+	if got, _, splitErr := net.SplitHostPort(host); splitErr != nil || got != l.advertiseHost {
+		return fmt.Errorf("kubeconfig points at %q, want the advertised host %q — that is not reachable from outside", host, l.advertiseHost)
+	}
+
+	restCfg, err := clientcmd.RESTConfigFromKubeConfig(l.kubeconfig)
+	if err != nil {
+		return fmt.Errorf("kubeconfig rest config: %w", err)
+	}
+	if l.cs, err = kubernetes.NewForConfig(restCfg); err != nil {
+		return fmt.Errorf("clientset: %w", err)
+	}
+	if l.dyn, err = dynamic.NewForConfig(restCfg); err != nil {
+		return fmt.Errorf("dynamic client: %w", err)
+	}
+
+	// The small group's min worker must register and go Ready — a
+	// kubeconfig against an empty cluster is not a working cluster.
+	err = l.waitFor("min worker Ready via kubeconfig", readyTimeout, 10*time.Second, func() (bool, string) {
+		ready, status := l.readyNodes()
+		workers := 0
+		for name := range ready {
+			if strings.Contains(name, "-small-") && ready[name] {
+				workers++
+			}
+		}
+		return workers >= 1, status
+	})
+	if err != nil {
+		return err
+	}
+
+	ready, _ := l.readyNodes()
+	l.baselineNodes = nil
+	for name := range ready {
+		l.baselineNodes = append(l.baselineNodes, name)
+	}
+	l.baselineVMs = l.clusterVMs()
+	l.t.Logf("baseline nodes: %v, VMs: %v", l.baselineNodes, l.baselineVMs)
+	return nil
+}
+
+// --- step 2: overflow → Pending→Running via a new Ready node ------------
+
+func (l *lane) stepOverflowScaleUp() error {
+	scaleupTimeout := timeoutEnv("CONTAINARIUM_E2E_SCALEUP_TIMEOUT", 12*time.Minute)
+	ctx := context.Background()
+
+	// Two sleepers at 1500m each: one fills the initial small worker
+	// (2 CPU), the second cannot fit anywhere and must force a new
+	// node. Requests, not load — the autoscaler's currency (design:
+	// "Measured utilization triggers no scale-up anywhere").
+	replicas := int32(2)
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "overflow"},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "overflow"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "overflow"}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:    "sleep",
+						Image:   burnImage,
+						Command: []string{"sh", "-c", "sleep infinity"},
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("1500m"),
+								corev1.ResourceMemory: resource.MustParse("128Mi"),
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+	if _, err := l.cs.AppsV1().Deployments("default").Create(ctx, dep, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("create overflow deployment: %w", err)
+	}
+
+	return l.waitFor("overflow Running on a new Ready node", scaleupTimeout, 10*time.Second, func() (bool, string) {
+		ready, status := l.readyNodes()
+		newNodes := NewReadyNodes(l.baselineNodes, ready)
+		pods, err := l.cs.CoreV1().Pods("default").List(ctx, metav1.ListOptions{LabelSelector: "app=overflow"})
+		if err != nil {
+			return false, err.Error()
+		}
+		running := 0
+		onNew := false
+		for _, p := range pods.Items {
+			if p.Status.Phase == corev1.PodRunning {
+				running++
+				for _, n := range newNodes {
+					if p.Spec.NodeName == n {
+						onNew = true
+					}
+				}
+			}
+		}
+		return running == int(replicas) && onNew,
+			fmt.Sprintf("running=%d/%d newReadyNodes=%v onNew=%v (%s)", running, replicas, newNodes, onNew, status)
+	})
+}
+
+// --- step 3: a pod too big for the small template -----------------------
+
+func (l *lane) stepLargerClass() error {
+	scaleupTimeout := timeoutEnv("CONTAINARIUM_E2E_SCALEUP_TIMEOUT", 12*time.Minute)
+	ctx := context.Background()
+
+	// 3 CPU cannot fit the small template (2 CPU): the autoscaler's fit
+	// simulation must pick a larger size class, not add another small.
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "big"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:    "sleep",
+				Image:   burnImage,
+				Command: []string{"sh", "-c", "sleep infinity"},
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("3"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+				},
+			}},
+		},
+	}
+	if _, err := l.cs.CoreV1().Pods("default").Create(ctx, pod, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("create big pod: %w", err)
+	}
+
+	return l.waitFor("big pod Running on a larger-class node", scaleupTimeout, 10*time.Second, func() (bool, string) {
+		p, err := l.cs.CoreV1().Pods("default").Get(ctx, "big", metav1.GetOptions{})
+		if err != nil {
+			return false, err.Error()
+		}
+		if p.Status.Phase != corev1.PodRunning {
+			return false, fmt.Sprintf("phase=%s node=%s", p.Status.Phase, p.Spec.NodeName)
+		}
+		larger := strings.Contains(p.Spec.NodeName, "-medium-") || strings.Contains(p.Spec.NodeName, "-large-")
+		return larger, fmt.Sprintf("running on %s (larger-class=%v)", p.Spec.NodeName, larger)
+	})
+}
+
+// --- step 4: VPA raises requests without restart-looping ----------------
+
+var vpaGVR = schema.GroupVersionResource{Group: "autoscaling.k8s.io", Version: "v1", Resource: "verticalpodautoscalers"}
+
+func (l *lane) stepVPA() error {
+	vpaTimeout := timeoutEnv("CONTAINARIUM_E2E_VPA_TIMEOUT", 15*time.Minute)
+	ctx := context.Background()
+
+	// A burner that actually uses CPU while requesting almost none —
+	// VPA is the single component licensed to turn usage into requests.
+	replicas := int32(2)
+	burn := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "burner"},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "burner"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "burner"}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:    "burn",
+						Image:   burnImage,
+						Command: []string{"sh", "-c", "while :; do :; done"},
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("100m"),
+								corev1.ResourceMemory: resource.MustParse("64Mi"),
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+	if _, err := l.cs.AppsV1().Deployments("default").Create(ctx, burn, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("create burner: %w", err)
+	}
+
+	// Tenant opt-in, exactly as #1416 documents it: a VPA object with
+	// updateMode InPlaceOrRecreate (stock VPA 1.7 on k8s 1.33).
+	vpa := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "autoscaling.k8s.io/v1",
+		"kind":       "VerticalPodAutoscaler",
+		"metadata":   map[string]interface{}{"name": "burner"},
+		"spec": map[string]interface{}{
+			"targetRef": map[string]interface{}{
+				"apiVersion": "apps/v1", "kind": "Deployment", "name": "burner",
+			},
+			"updatePolicy": map[string]interface{}{
+				"updateMode":  "InPlaceOrRecreate",
+				"minReplicas": int64(1),
+			},
+		},
+	}}
+	if _, err := l.dyn.Resource(vpaGVR).Namespace("default").Create(ctx, vpa, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("create VPA object (is the VPA bundle deployed?): %w", err)
+	}
+
+	before, err := l.restartCounts(ctx, "app=burner")
+	if err != nil {
+		return err
+	}
+	origCPU := resource.MustParse("100m")
+
+	var loopErr error
+	waitErr := l.waitFor("burner request raised, no restart loop", vpaTimeout, 15*time.Second, func() (bool, string) {
+		pods, err := l.cs.CoreV1().Pods("default").List(ctx, metav1.ListOptions{LabelSelector: "app=burner"})
+		if err != nil {
+			return false, err.Error()
+		}
+		raised := false
+		var seen []string
+		for _, p := range pods.Items {
+			for _, c := range p.Spec.Containers {
+				req := c.Resources.Requests[corev1.ResourceCPU]
+				seen = append(seen, fmt.Sprintf("%s=%s", p.Name, req.String()))
+				if req.Cmp(origCPU) > 0 {
+					raised = true
+				}
+			}
+		}
+		after, err := l.restartCounts(ctx, "app=burner")
+		if err != nil {
+			return false, err.Error()
+		}
+		delta := MaxRestartDelta(before, after)
+		if delta > 1 {
+			// Abort the wait with a real error: a raised request via
+			// crash-looping is precisely the failure under test.
+			loopErr = fmt.Errorf("burner restart-looping: max restart delta %d (requests: %s)", delta, strings.Join(seen, " "))
+			return true, "restart loop detected"
+		}
+		return raised, fmt.Sprintf("requests: %s (restart delta %d)", strings.Join(seen, " "), delta)
+	})
+	if loopErr != nil {
+		return loopErr
+	}
+	return waitErr
+}
+
+// --- step 5: scale to zero → drained node, deleted VM -------------------
+
+func (l *lane) stepScaleToZero() error {
+	scaledownTimeout := timeoutEnv("CONTAINARIUM_E2E_SCALEDOWN_TIMEOUT", 30*time.Minute)
+	ctx := context.Background()
+
+	// Remove all tenant load. The surplus nodes must drain and their
+	// VMs disappear, back to the baseline shape (small group at min=1).
+	if err := l.cs.CoreV1().Pods("default").Delete(ctx, "big", metav1.DeleteOptions{}); err != nil {
+		return fmt.Errorf("delete big pod: %w", err)
+	}
+	if err := l.dyn.Resource(vpaGVR).Namespace("default").Delete(ctx, "burner", metav1.DeleteOptions{}); err != nil {
+		return fmt.Errorf("delete VPA: %w", err)
+	}
+	for _, name := range []string{"burner", "overflow"} {
+		if err := l.cs.AppsV1().Deployments("default").Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+			return fmt.Errorf("delete %s: %w", name, err)
+		}
+	}
+
+	baseline := map[string]bool{}
+	for _, v := range l.baselineVMs {
+		baseline[v] = true
+	}
+
+	return l.waitFor("surplus nodes drained and VMs deleted", scaledownTimeout, 20*time.Second, func() (bool, string) {
+		// Observed k8s state: the node objects are gone (a drained,
+		// deleted node deregisters; a merely cordoned one would linger).
+		ready, _ := l.readyNodes()
+		surplusNodes := NewReadyNodes(l.baselineNodes, ready)
+
+		// Observed Incus state: no VM beyond the baseline set.
+		var surplusVMs []string
+		for _, vm := range l.clusterVMs() {
+			if !baseline[vm] {
+				surplusVMs = append(surplusVMs, vm)
+			}
+		}
+		return len(surplusNodes) == 0 && len(surplusVMs) == 0,
+			fmt.Sprintf("surplus nodes=%v surplus VMs=%v", surplusNodes, surplusVMs)
+	})
+}
+
+// --- step 6: delete leaves nothing --------------------------------------
+
+func (l *lane) stepDelete() error {
+	deleteTimeout := timeoutEnv("CONTAINARIUM_E2E_DELETE_TIMEOUT", 10*time.Minute)
+
+	apiHost, err := KubeconfigServerHost(l.kubeconfig)
+	if err != nil {
+		return err
+	}
+
+	if out, err := l.runCLI("cluster", "delete", clusterName); err != nil {
+		return fmt.Errorf("cluster delete: %v\n%s", err, out)
+	}
+
+	return l.waitFor("no rows, no VMs, no passthrough", deleteTimeout, 10*time.Second, func() (bool, string) {
+		// No rows, observed through the product API.
+		out, err := l.runCLI("cluster", "get", clusterName)
+		if err == nil {
+			return false, "cluster get still succeeds"
+		}
+		if !strings.Contains(strings.ToLower(out), "not") {
+			return false, fmt.Sprintf("cluster get: %s", strings.TrimSpace(out))
+		}
+
+		// No VMs, observed through Incus.
+		if vms := l.clusterVMs(); len(vms) > 0 {
+			return false, fmt.Sprintf("VMs remain: %v", vms)
+		}
+
+		// No passthrough rule: the published API endpoint stopped
+		// accepting connections.
+		conn, dialErr := net.DialTimeout("tcp", apiHost, 3*time.Second)
+		if dialErr == nil {
+			_ = conn.Close()
+			return false, fmt.Sprintf("%s still accepts connections", apiHost)
+		}
+		return true, "gone"
+	})
+}
+
+// --- sabotage ------------------------------------------------------------
+
+// sabotageJoinTokens continuously corrupts the pre-pushed join token on
+// every worker VM and kills any running agent, so no worker can ever
+// register: the lane MUST go red. This is the #1418 guardrail — a lane
+// that stays green under this cannot fail, and proves nothing.
+func (l *lane) sabotageJoinTokens(stop <-chan struct{}) {
+	for {
+		select {
+		case <-stop:
+			return
+		case <-time.After(3 * time.Second):
+		}
+		for _, vm := range l.clusterVMs() {
+			if strings.HasSuffix(vm, "-cp") {
+				continue
+			}
+			_, _, _ = l.incus.ExecWithOutput(vm, []string{"sh", "-c",
+				"echo sabotaged > " + clusterpkg.AgentTokenPath + "; pkill -f 'k3s agent' || true"})
+		}
+	}
+}
+
+// --- observation helpers -------------------------------------------------
+
+// readyNodes returns node name → Ready as observed through the tenant
+// kubeconfig, plus a status line for logs.
+func (l *lane) readyNodes() (map[string]bool, string) {
+	nodes, err := l.cs.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err.Error()
+	}
+	out := map[string]bool{}
+	var parts []string
+	for _, n := range nodes.Items {
+		ready := false
+		for _, c := range n.Status.Conditions {
+			if c.Type == corev1.NodeReady && c.Status == corev1.ConditionTrue {
+				ready = true
+			}
+		}
+		out[n.Name] = ready
+		parts = append(parts, fmt.Sprintf("%s ready=%v", n.Name, ready))
+	}
+	return out, strings.Join(parts, ", ")
+}
+
+// clusterVMs lists the lane cluster's VMs as Incus sees them.
+func (l *lane) clusterVMs() []string {
+	all, err := l.incus.ListContainers()
+	if err != nil {
+		l.t.Logf("incus list: %v", err)
+		return nil
+	}
+	var vms []string
+	for _, c := range all {
+		if strings.HasPrefix(c.Name, vmPrefix) {
+			vms = append(vms, c.Name)
+		}
+	}
+	return vms
+}
+
+func (l *lane) restartCounts(ctx context.Context, selector string) (map[string]int32, error) {
+	pods, err := l.cs.CoreV1().Pods("default").List(ctx, metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]int32{}
+	for _, p := range pods.Items {
+		for _, cs := range p.Status.ContainerStatuses {
+			out[p.Name+"/"+cs.Name] = cs.RestartCount
+		}
+	}
+	return out, nil
+}
+
+func (l *lane) waitFor(what string, timeout, interval time.Duration, probe func() (bool, string)) error {
+	deadline := time.Now().Add(timeout)
+	last := ""
+	for {
+		ok, status := probe()
+		if ok {
+			l.t.Logf("%s: %s", what, status)
+			return nil
+		}
+		if status != last {
+			l.t.Logf("waiting for %s: %s", what, status)
+			last = status
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out after %s waiting for %s (last: %s)", timeout, what, status)
+		}
+		time.Sleep(interval)
+	}
+}
+
+// dumpDiagnostics prints what the platform and Incus believe on
+// failure — the operator's first three commands, run for them.
+func (l *lane) dumpDiagnostics() {
+	out, err := l.runCLI("cluster", "status", clusterName)
+	l.t.Logf("cluster status (err=%v):\n%s", err, out)
+	l.t.Logf("incus VMs with prefix %s: %v", vmPrefix, l.clusterVMs())
+	if l.cs != nil {
+		if evs, err := l.cs.CoreV1().Events("default").List(context.Background(), metav1.ListOptions{Limit: 30}); err == nil {
+			var lines []string
+			for _, e := range evs.Items {
+				lines = append(lines, fmt.Sprintf("%s %s/%s: %s", e.Reason, e.InvolvedObject.Kind, e.InvolvedObject.Name, e.Message))
+			}
+			l.t.Logf("recent k8s events:\n%s", strings.Join(lines, "\n"))
+		}
+	}
+}

--- a/test/e2e/cluster/e2e_test.go
+++ b/test/e2e/cluster/e2e_test.go
@@ -36,6 +36,7 @@ package clustere2e
 // _DELETE_TIMEOUT (10m).
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net"
@@ -183,11 +184,19 @@ func TestManagedClusterJourney(t *testing.T) {
 
 // --- CLI ----------------------------------------------------------------
 
+// runCLI returns stdout alone on success: `cluster kubeconfig` writes
+// the credential to stdout and a notice to stderr, and merging the two
+// would corrupt the YAML this test parses. On error the streams are
+// joined — cobra reports errors on stderr, and callers match on them.
 func (l *lane) runCLI(args ...string) (string, error) {
 	full := append([]string{"--http", "--server", l.server, "--token", l.token}, args...)
 	cmd := exec.Command(l.cli, full...)
-	out, err := cmd.CombinedOutput()
-	return string(out), err
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	if err := cmd.Run(); err != nil {
+		return strings.TrimSpace(stdout.String() + "\n" + stderr.String()), err
+	}
+	return stdout.String(), nil
 }
 
 // --- step 1: create → kubeconfig works from outside ---------------------
@@ -491,8 +500,10 @@ func (l *lane) stepScaleToZero() error {
 	}
 
 	return l.waitFor("surplus nodes drained and VMs deleted", scaledownTimeout, 20*time.Second, func() (bool, string) {
-		// Observed k8s state: the node objects are gone (a drained,
-		// deleted node deregisters; a merely cordoned one would linger).
+		// Observed k8s state: no surplus node is Ready anymore. (The
+		// Node *object* may linger NotReady after its VM dies — k3s
+		// has no cloud node-lifecycle controller to reap it — so
+		// Ready-ness plus the VM check below is the robust signal.)
 		ready, _ := l.readyNodes()
 		surplusNodes := NewReadyNodes(l.baselineNodes, ready)
 

--- a/test/e2e/cluster/helpers.go
+++ b/test/e2e/cluster/helpers.go
@@ -1,0 +1,105 @@
+// Package clustere2e is the gated KVM end-to-end lane for managed
+// Kubernetes clusters (#1418) — the definition-of-done check for the
+// managed-clusters MVP (design: docs/architecture/managed-k8s-clusters.md,
+// "End-to-end" section).
+//
+// This file carries no build tag on purpose, mirroring
+// internal/testsupport/incusenv: the pure decision logic the lane leans
+// on — which kubeconfig endpoint counts as "outside", which nodes count
+// as "new and Ready", what a sabotage value means — is testable, and
+// provably able to fail, in the ordinary unit suite on any machine. The
+// code that needs a real Incus + KVM host lives behind the
+// `incus && cluster_e2e` tags in e2e_test.go.
+package clustere2e
+
+import (
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// KubeconfigServerHost returns the host:port of the server URL the
+// kubeconfig's current context points at.
+func KubeconfigServerHost(kubeconfig []byte) (string, error) {
+	cfg, err := clientcmd.Load(kubeconfig)
+	if err != nil {
+		return "", fmt.Errorf("parse kubeconfig: %w", err)
+	}
+	ctx, ok := cfg.Contexts[cfg.CurrentContext]
+	if !ok {
+		return "", fmt.Errorf("kubeconfig has no context %q", cfg.CurrentContext)
+	}
+	cluster, ok := cfg.Clusters[ctx.Cluster]
+	if !ok {
+		return "", fmt.Errorf("kubeconfig context %q names missing cluster %q", cfg.CurrentContext, ctx.Cluster)
+	}
+	u, err := url.Parse(cluster.Server)
+	if err != nil {
+		return "", fmt.Errorf("kubeconfig server %q: %w", cluster.Server, err)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("kubeconfig server %q has no host", cluster.Server)
+	}
+	return u.Host, nil
+}
+
+// NewReadyNodes returns the names in current that are Ready and were
+// not present in baseline, sorted.
+func NewReadyNodes(baseline []string, current map[string]bool) []string {
+	known := make(map[string]bool, len(baseline))
+	for _, n := range baseline {
+		known[n] = true
+	}
+	var out []string
+	for name, ready := range current {
+		if ready && !known[name] {
+			out = append(out, name)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// SabotageMode is a deliberate breakage the lane injects to prove it
+// can fail (#1418 guardrail: a green lane is not evidence the test ran).
+type SabotageMode int
+
+const (
+	// SabotageNone runs the lane normally.
+	SabotageNone SabotageMode = iota
+	// SabotageJoinToken corrupts worker join tokens so nodes can never
+	// register; the lane must go red.
+	SabotageJoinToken
+)
+
+// ParseSabotage maps CONTAINARIUM_E2E_SABOTAGE onto a mode. Unknown
+// values are an error, not SabotageNone: a typo'd proof run silently
+// taking the normal green path would "prove" the lane can fail without
+// ever sabotaging anything.
+func ParseSabotage(value string) (SabotageMode, error) {
+	switch strings.TrimSpace(value) {
+	case "":
+		return SabotageNone, nil
+	case "join-token":
+		return SabotageJoinToken, nil
+	default:
+		return SabotageNone, fmt.Errorf("unknown CONTAINARIUM_E2E_SABOTAGE value %q (want empty or join-token)", value)
+	}
+}
+
+// MaxRestartDelta returns the largest restart-count increase across
+// containers between two observations keyed by pod/container name. A
+// container unseen before counts from zero; one gone in after (its pod
+// replaced) contributes nothing — a fresh pod is not a restart loop.
+func MaxRestartDelta(before, after map[string]int32) int32 {
+	var max int32
+	for key, count := range after {
+		if d := count - before[key]; d > max {
+			max = d
+		}
+	}
+	return max
+}

--- a/test/e2e/cluster/helpers_test.go
+++ b/test/e2e/cluster/helpers_test.go
@@ -1,0 +1,202 @@
+package clustere2e
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// A minimal but real kubeconfig shape — two clusters, so the test can
+// prove the helper follows current-context rather than "first cluster".
+const twoClusterKubeconfig = `apiVersion: v1
+kind: Config
+current-context: outside
+clusters:
+- name: inside
+  cluster:
+    server: https://10.166.42.7:6443
+- name: outside
+  cluster:
+    server: https://198.51.100.20:31843
+contexts:
+- name: inside
+  context:
+    cluster: inside
+    user: admin
+- name: outside
+  context:
+    cluster: outside
+    user: admin
+users:
+- name: admin
+  user:
+    token: unused
+`
+
+func TestKubeconfigServerHost(t *testing.T) {
+	tests := []struct {
+		name       string
+		kubeconfig string
+		want       string
+		wantErr    string
+	}{
+		{
+			name:       "follows current-context, not first cluster",
+			kubeconfig: twoClusterKubeconfig,
+			want:       "198.51.100.20:31843",
+		},
+		{
+			name: "no clusters is an error",
+			kubeconfig: `apiVersion: v1
+kind: Config
+current-context: gone
+`,
+			wantErr: "gone",
+		},
+		{
+			name:       "garbage is an error, not an empty host",
+			kubeconfig: "{{not yaml",
+			wantErr:    "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := KubeconfigServerHost([]byte(tt.kubeconfig))
+			if tt.wantErr != "" || tt.want == "" {
+				if err == nil {
+					t.Fatalf("want error, got host %q", got)
+				}
+				if tt.wantErr != "" && !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error %q does not mention %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("host = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewReadyNodes(t *testing.T) {
+	tests := []struct {
+		name     string
+		baseline []string
+		current  map[string]bool
+		want     []string
+	}{
+		{
+			name:     "new ready node is reported",
+			baseline: []string{"w-small-1"},
+			current:  map[string]bool{"w-small-1": true, "w-small-2": true},
+			want:     []string{"w-small-2"},
+		},
+		{
+			name:     "new but NotReady node does not count",
+			baseline: []string{"w-small-1"},
+			current:  map[string]bool{"w-small-1": true, "w-small-2": false},
+			want:     nil,
+		},
+		{
+			name:     "baseline node flapping back to Ready is not new",
+			baseline: []string{"w-small-1", "w-small-2"},
+			current:  map[string]bool{"w-small-1": true, "w-small-2": true},
+			want:     nil,
+		},
+		{
+			name:     "output is sorted for stable logs",
+			baseline: nil,
+			current:  map[string]bool{"w-b": true, "w-a": true},
+			want:     []string{"w-a", "w-b"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewReadyNodes(tt.baseline, tt.current)
+			if len(got) == 0 && len(tt.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("NewReadyNodes = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseSabotage(t *testing.T) {
+	tests := []struct {
+		value   string
+		want    SabotageMode
+		wantErr bool
+	}{
+		{value: "", want: SabotageNone},
+		{value: "join-token", want: SabotageJoinToken},
+		{value: "  join-token \n", want: SabotageJoinToken},
+		// Fail closed: a typo'd sabotage value silently running the
+		// normal green path would "prove" the lane can fail without
+		// ever sabotaging anything.
+		{value: "join_token", wantErr: true},
+		{value: "none", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run("value="+tt.value, func(t *testing.T) {
+			got, err := ParseSabotage(tt.value)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("want error for %q, got mode %v", tt.value, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("mode = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMaxRestartDelta(t *testing.T) {
+	tests := []struct {
+		name   string
+		before map[string]int32
+		after  map[string]int32
+		want   int32
+	}{
+		{
+			name:   "steady pods report zero",
+			before: map[string]int32{"p1/app": 0},
+			after:  map[string]int32{"p1/app": 0},
+			want:   0,
+		},
+		{
+			name:   "a restart-looping container dominates",
+			before: map[string]int32{"p1/app": 1, "p2/app": 0},
+			after:  map[string]int32{"p1/app": 1, "p2/app": 4},
+			want:   4,
+		},
+		{
+			name:   "a container unseen before counts from zero",
+			before: map[string]int32{},
+			after:  map[string]int32{"p3/app": 2},
+			want:   2,
+		},
+		{
+			name:   "a pod replaced by a fresh one is not a loop",
+			before: map[string]int32{"p1/app": 3},
+			after:  map[string]int32{"p9/app": 0},
+			want:   0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := MaxRestartDelta(tt.before, tt.after); got != tt.want {
+				t.Fatalf("MaxRestartDelta = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #1418

## What changed

- **`test/e2e/cluster/`** — the six-step MVP journey from the design's End-to-end section (`docs/architecture/managed-k8s-clusters.md`), gated behind `incus && cluster_e2e` build tags. Driven CLI-first (`containarium --http … cluster create/kubeconfig/status/delete` with a least-privilege tenant token minted from the daemon's JWT secret); every assertion observes cluster state (k8s API through the tenant kubeconfig), Incus state, or TCP reachability — never our own SQL or logs. "No rows" is asserted as `cluster get` → NotFound, the tenant-visible meaning.
- **Pure helpers untagged + unit-tested** (`helpers.go`, mirroring `incusenv`'s pattern): kubeconfig outside-endpoint parsing, new-Ready-node diffing, fail-closed sabotage parsing (an unknown sabotage value errors rather than silently running the green path), restart-loop delta. Written red-first; since no repo-wide `go test ./...` lane exists, the new workflow's PR job is their invocation list.
- **`scripts/cluster-e2e.sh`** — builds the tree, starts a real Postgres (given DSN or throwaway container) and the real daemon (`CONTAINARIUM_CLUSTER_ADVERTISE_ADDR`, `CONTAINARIUM_CLUSTER_CA_ADVERTISE`), runs the suite with its exit status unpiped, and sweeps leftover VMs on exit. Host requirements (the runner-provisioning half of #1418) are documented in its header.
- **`.github/workflows/cluster-e2e.yml`** — nightly + release-blocking (tag push), not per-PR, per the design's CI-gates section. PRs touching the lane get the cheap compile+unit job only. Single-flight concurrency (the runner's Incus is shared state).
- **`docs/RELEASE-PROCESS.md`** — step 6: a release is not announced/deployed until this lane is green on the tag.

## Guardrails from the issue

- **Prove the lane can fail**: `workflow_dispatch` with `sabotage=join-token` continuously corrupts `/etc/containarium/k3s-agent-token` on worker VMs and kills the agent so no node can register; the job goes green only if the suite goes red (inversion is explicit and lives only in that dispatch-only job).
- **Nightly + release-blocking, not per-PR**: cron + `v*` tag push; the KVM job is `if`-guarded off pull requests.
- **Exit codes not piped away**: the `go test` invocation is the last statement of the script, unpiped; the workflow runs the script bare.

## Test evidence

- `TestKubeconfigServerHost`, `TestNewReadyNodes`, `TestParseSabotage`, `TestMaxRestartDelta` — written failing first (zero-value stubs), then green: `ok github.com/footprintai/containarium/test/e2e/cluster`.
- `go vet -tags 'incus cluster_e2e' ./test/e2e/cluster/` compiles the gated journey.
- CI runs on this PR: the new `build-unit` job is the gate for the above; run link lands once checks report.
- The KVM journey itself **cannot run yet** — it needs the self-hosted `incus`+`kvm` runner that operator-side provisioning is standing up (flagged as the sprint's long pole on #1419). This is expected and is the reason the sabotage proof exists as a dispatchable job.

## Reviewer notes

- The 1.2k-line diff is all lane/test code plus docs; the ~400-line production-diff ceiling isn't in play.
- Step timeouts are env-tunable with defaults derived from stock component behavior (CA scale-down: 10m delay-after-add + 10m unneeded → 30m default for step 5; PRD documents create→kubectl under 10m → 15m ready default to absorb first-boot artifact pulls).
- Deviation callout: none from the design doc. The lane asserts "no passthrough rule" by observing the published API endpoint stop accepting connections — the tenant-observable form of the rule's absence.

## Verify on the KVM runner (once provisioned)

1. Register the runner with labels `self-hosted`, `incus`, `kvm`; check host requirements in `scripts/cluster-e2e.sh`'s header.
2. Dispatch **Managed clusters KVM e2e** with `sabotage=join-token` → the `prove-lane-can-fail` job must go green (i.e. the suite went red). This is the #1418 checkbox "prove the lane can fail once".
3. Dispatch again with `sabotage=none` (or wait for the nightly) → `kvm-e2e` green is the MVP definition-of-done demonstration; link that run on #1419.

🤖 Generated with [Claude Code](https://claude.com/claude-code)