### PR TITLE
docs(cluster): accept the container node pools design

### DIFF
--- a/docs/architecture/cluster-container-node-pools.md
+++ b/docs/architecture/cluster-container-node-pools.md
@@ -1,7 +1,7 @@
 # Design: container node pools for managed Kubernetes clusters
 
 **Date:** 2026-08-18
-**Status:** proposed
+**Status:** accepted
 **Stack:** protobuf/gRPC (grpc-gateway) + the existing host daemon; Go 1.26 throughout (no new languages)
 **Extends:** `docs/architecture/managed-k8s-clusters.md` (the VM-only design this
 document adds a second isolation class to — everything not named here is


### PR DESCRIPTION
Flips `docs/architecture/cluster-container-node-pools.md` from **proposed** to **accepted** — sign-off given by the product owner on the #1426 design. Scoping into implementation issues follows via sprint planning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)