### PR TITLE
feat(cluster): NodeIsolation contract — proto enum, store, operator-gated create, CLI (#1428)

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -7612,6 +7612,10 @@
         "createdAt": {
           "type": "string",
           "format": "date-time"
+        },
+        "nodeIsolation": {
+          "$ref": "#/definitions/NodeIsolation",
+          "description": "Isolation class of this cluster's nodes. Always populated on read\n(never UNSPECIFIED) so an auditor can answer \"which clusters share\na kernel with this host\" from any cluster read."
         }
       },
       "description": "Cluster is a managed Kubernetes cluster."
@@ -8271,6 +8275,10 @@
             "$ref": "#/definitions/NodeGroup"
           },
           "description": "Worker size classes. Empty = the platform's default presets."
+        },
+        "nodeIsolation": {
+          "$ref": "#/definitions/NodeIsolation",
+          "description": "Requested node isolation class. Unspecified = VM. CONTAINER is\nrefused with FailedPrecondition unless the host carries the\noperator opt-in."
         }
       }
     },
@@ -10901,6 +10909,16 @@
         }
       },
       "description": "NodeGroupStatus is a group's observed count against its bounds."
+    },
+    "NodeIsolation": {
+      "type": "string",
+      "enum": [
+        "NODE_ISOLATION_UNSPECIFIED",
+        "NODE_ISOLATION_VM",
+        "NODE_ISOLATION_CONTAINER"
+      ],
+      "default": "NODE_ISOLATION_UNSPECIFIED",
+      "description": "NodeIsolation is the isolation class of a cluster's nodes: the\nboundary that contains a tenant kernel exploit. Cluster-level and\nimmutable after create.\n\nVM is the default and the only class safe on a shared multi-tenant\nhost. CONTAINER runs each node as an Incus system container sharing\nthe host kernel — weaker by construction, so it is operator-gated:\nthe daemon permits it only where the operator has declared the host\na single trust domain. UNSPECIFIED resolves to VM server-side; the\nweaker class is never reached by omission.\n\nDesign: docs/architecture/cluster-container-node-pools.md.\n\n - NODE_ISOLATION_VM: Each node is an Incus VM — hardware-virtualized kernel boundary.\n - NODE_ISOLATION_CONTAINER: Each node is an Incus system container sharing the host kernel.\nRequires the operator opt-in on the target host."
     },
     "OSType": {
       "type": "string",

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -52,6 +52,32 @@ const (
 	RoleWorker       = "worker"
 )
 
+// Isolation is a cluster's node isolation class — the boundary that
+// contains a tenant kernel exploit. Mirrors pb.NodeIsolation; the
+// string form is what the store persists.
+//
+// Design: docs/architecture/cluster-container-node-pools.md.
+type Isolation string
+
+const (
+	// IsolationVM gives every node its own kernel (Incus VM). The
+	// default, and the only class safe on a shared multi-tenant host.
+	IsolationVM Isolation = "vm"
+	// IsolationContainer runs nodes as Incus system containers sharing
+	// the host kernel — operator-gated, single-trust-domain hosts only.
+	IsolationContainer Isolation = "container"
+)
+
+// OrDefault resolves an unset class to the strong one. The weaker
+// class is only ever reached by an explicit request; omitting the
+// field can never downgrade a boundary.
+func (i Isolation) OrDefault() Isolation {
+	if i == "" {
+		return IsolationVM
+	}
+	return i
+}
+
 // NodeState is a node's coarse lifecycle state. Mirrors
 // pb.ClusterNodeState; typed so the reconciler cannot persist a value
 // the API cannot express.
@@ -110,8 +136,12 @@ type Cluster struct {
 	K3sVersion  string
 	APIEndpoint string
 	NodeGroups  []NodeGroup
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
+	// NodeIsolation is the cluster's isolation class, fixed at create
+	// and never rewritten. Stores resolve an unset value to
+	// IsolationVM, so a read never has to guess.
+	NodeIsolation Isolation
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
 }
 
 // Node is one VM belonging to a cluster.

--- a/internal/cluster/isolation_test.go
+++ b/internal/cluster/isolation_test.go
@@ -1,0 +1,60 @@
+package cluster
+
+// Isolation defaulting (#1428). The both-impls round-trip lives in the
+// tagged store_integration_test.go; this is the untagged half so the
+// fast lane also fails when the safe default stops being the default.
+
+import (
+	"context"
+	"testing"
+)
+
+func TestIsolation_OrDefault(t *testing.T) {
+	cases := []struct {
+		name string
+		in   Isolation
+		want Isolation
+	}{
+		{"unset resolves to the strong class", "", IsolationVM},
+		{"vm stays vm", IsolationVM, IsolationVM},
+		{"container is never silently upgraded away", IsolationContainer, IsolationContainer},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.in.OrDefault(); got != tc.want {
+				t.Fatalf("Isolation(%q).OrDefault() = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMemStore_NodeIsolationRoundTrips(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemStore()
+	for _, tc := range []struct {
+		name string
+		in   Isolation
+		want Isolation
+	}{
+		{"unset", "", IsolationVM},
+		{"vm", IsolationVM, IsolationVM},
+		{"container", IsolationContainer, IsolationContainer},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := s.Create(ctx, &Cluster{
+				ID: tc.name, Owner: "alice", Name: tc.name,
+				State: StateProvisioning, NodeIsolation: tc.in,
+				NodeGroups: DefaultNodeGroups(),
+			}); err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+			got, err := s.Get(ctx, "alice", tc.name)
+			if err != nil {
+				t.Fatalf("Get: %v", err)
+			}
+			if got.NodeIsolation != tc.want {
+				t.Fatalf("isolation = %q, want %q", got.NodeIsolation, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cluster/memstore.go
+++ b/internal/cluster/memstore.go
@@ -43,7 +43,11 @@ func (m *MemStore) Create(ctx context.Context, c *Cluster) error {
 	if _, ok := m.clusters[k]; ok {
 		return ErrAlreadyExists
 	}
-	m.clusters[k] = copyCluster(c)
+	stored := copyCluster(c)
+	// Same resolution the Postgres column DEFAULT performs, so a read
+	// never returns an unset isolation class from either impl (#1428).
+	stored.NodeIsolation = stored.NodeIsolation.OrDefault()
+	m.clusters[k] = stored
 	return nil
 }
 

--- a/internal/cluster/store.go
+++ b/internal/cluster/store.go
@@ -69,11 +69,16 @@ func (s *PGStore) initSchema(ctx context.Context) error {
 			k3s_version TEXT NOT NULL DEFAULT '',
 			api_endpoint TEXT NOT NULL DEFAULT '',
 			node_groups JSONB NOT NULL,
+			node_isolation TEXT NOT NULL DEFAULT 'vm',
 			created_at TIMESTAMPTZ NOT NULL,
 			updated_at TIMESTAMPTZ NOT NULL,
 			UNIQUE(owner, name)
 		);
 		CREATE INDEX IF NOT EXISTS idx_k8s_clusters_owner ON k8s_clusters(owner);
+		-- #1428: clusters recorded before the isolation class existed
+		-- were all VMs; the DEFAULT states that for the existing rows
+		-- rather than leaving their boundary unknown.
+		ALTER TABLE k8s_clusters ADD COLUMN IF NOT EXISTS node_isolation TEXT NOT NULL DEFAULT 'vm';
 
 		CREATE TABLE IF NOT EXISTS k8s_cluster_nodes (
 			vm_name TEXT PRIMARY KEY,
@@ -115,9 +120,10 @@ func (s *PGStore) Create(ctx context.Context, c *Cluster) error {
 		return fmt.Errorf("marshal node groups: %w", err)
 	}
 	_, err = s.pool.Exec(ctx, `
-		INSERT INTO k8s_clusters (id, owner, name, state, state_reason, k3s_version, api_endpoint, node_groups, created_at, updated_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
-		c.ID, c.Owner, c.Name, string(c.State), c.StateReason, c.K3sVersion, c.APIEndpoint, groups, c.CreatedAt, c.UpdatedAt)
+		INSERT INTO k8s_clusters (id, owner, name, state, state_reason, k3s_version, api_endpoint, node_groups, node_isolation, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+		c.ID, c.Owner, c.Name, string(c.State), c.StateReason, c.K3sVersion, c.APIEndpoint, groups,
+		string(c.NodeIsolation.OrDefault()), c.CreatedAt, c.UpdatedAt)
 	var pgErr *pgconn.PgError
 	if errors.As(err, &pgErr) && pgErr.Code == "23505" { // unique_violation
 		return ErrAlreadyExists
@@ -127,9 +133,9 @@ func (s *PGStore) Create(ctx context.Context, c *Cluster) error {
 
 func scanCluster(row pgx.Row) (*Cluster, error) {
 	var c Cluster
-	var state string
+	var state, isolation string
 	var groups []byte
-	err := row.Scan(&c.ID, &c.Owner, &c.Name, &state, &c.StateReason, &c.K3sVersion, &c.APIEndpoint, &groups, &c.CreatedAt, &c.UpdatedAt)
+	err := row.Scan(&c.ID, &c.Owner, &c.Name, &state, &c.StateReason, &c.K3sVersion, &c.APIEndpoint, &groups, &isolation, &c.CreatedAt, &c.UpdatedAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, ErrNotFound
 	}
@@ -137,13 +143,14 @@ func scanCluster(row pgx.Row) (*Cluster, error) {
 		return nil, err
 	}
 	c.State = State(state)
+	c.NodeIsolation = Isolation(isolation).OrDefault()
 	if err := json.Unmarshal(groups, &c.NodeGroups); err != nil {
 		return nil, fmt.Errorf("unmarshal node groups: %w", err)
 	}
 	return &c, nil
 }
 
-const clusterCols = `id, owner, name, state, state_reason, k3s_version, api_endpoint, node_groups, created_at, updated_at`
+const clusterCols = `id, owner, name, state, state_reason, k3s_version, api_endpoint, node_groups, node_isolation, created_at, updated_at`
 
 func (s *PGStore) Get(ctx context.Context, owner, name string) (*Cluster, error) {
 	return scanCluster(s.pool.QueryRow(ctx,

--- a/internal/cluster/store_integration_test.go
+++ b/internal/cluster/store_integration_test.go
@@ -224,3 +224,107 @@ func TestClusterStore_ContractHoldsForBothImpls(t *testing.T) {
 		})
 	}
 }
+
+// The isolation class is part of the cluster row, not a server-side
+// afterthought: both impls must round-trip it, and both must resolve an
+// unset value to the safe class (#1428). A store that quietly persisted
+// "" would make "which clusters share a kernel with this host"
+// unanswerable from the data.
+func TestClusterStore_NodeIsolationRoundTrips(t *testing.T) {
+	ctx := context.Background()
+	for impl, s := range stores(t) {
+		t.Run(impl, func(t *testing.T) {
+			// Explicit container isolation round-trips verbatim.
+			cc := mkCluster("alice", "shared-kernel")
+			cc.NodeIsolation = IsolationContainer
+			if err := s.Create(ctx, cc); err != nil {
+				t.Fatalf("Create container cluster: %v", err)
+			}
+			// Explicit vm isolation round-trips verbatim.
+			cv := mkCluster("alice", "hw-isolated")
+			cv.NodeIsolation = IsolationVM
+			if err := s.Create(ctx, cv); err != nil {
+				t.Fatalf("Create vm cluster: %v", err)
+			}
+			// An unset class is persisted as the safe default, not as "".
+			cu := mkCluster("alice", "unset")
+			if err := s.Create(ctx, cu); err != nil {
+				t.Fatalf("Create unset cluster: %v", err)
+			}
+
+			for name, want := range map[string]Isolation{
+				"shared-kernel": IsolationContainer,
+				"hw-isolated":   IsolationVM,
+				"unset":         IsolationVM,
+			} {
+				got, err := s.Get(ctx, "alice", name)
+				if err != nil {
+					t.Fatalf("Get %s: %v", name, err)
+				}
+				if got.NodeIsolation != want {
+					t.Fatalf("Get %s isolation = %q, want %q", name, got.NodeIsolation, want)
+				}
+			}
+
+			// List carries it too — the auditor's query is a list, not a
+			// walk of individual gets.
+			all, err := s.List(ctx, "alice")
+			if err != nil || len(all) != 3 {
+				t.Fatalf("List = %d clusters (%v), want 3", len(all), err)
+			}
+			for _, c := range all {
+				if c.NodeIsolation != IsolationVM && c.NodeIsolation != IsolationContainer {
+					t.Fatalf("List %s isolation = %q, want a resolved class", c.Name, c.NodeIsolation)
+				}
+			}
+		})
+	}
+}
+
+// Rows written before this column existed must read back as VM, never
+// as "" — the migration decides the class of every legacy cluster, and
+// the only safe answer is the strong one. Postgres-only: MemStore has
+// no on-disk history to migrate.
+func TestClusterStore_LegacyRowsDefaultToVM(t *testing.T) {
+	ctx := context.Background()
+	pool := testPool(t)
+	freshSchema(t, pool)
+
+	// The pre-#1428 k8s_clusters shape, and a row inside it.
+	if _, err := pool.Exec(ctx, `
+		CREATE TABLE k8s_clusters (
+			id UUID PRIMARY KEY,
+			owner TEXT NOT NULL,
+			name TEXT NOT NULL,
+			state TEXT NOT NULL,
+			state_reason TEXT NOT NULL DEFAULT '',
+			k3s_version TEXT NOT NULL DEFAULT '',
+			api_endpoint TEXT NOT NULL DEFAULT '',
+			node_groups JSONB NOT NULL,
+			created_at TIMESTAMPTZ NOT NULL,
+			updated_at TIMESTAMPTZ NOT NULL,
+			UNIQUE(owner, name)
+		)`); err != nil {
+		t.Fatalf("create legacy schema: %v", err)
+	}
+	now := time.Now().UTC()
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO k8s_clusters (id, owner, name, state, node_groups, created_at, updated_at)
+		VALUES ($1, 'alice', 'legacy', 'ready', '[]'::jsonb, $2, $2)`,
+		uuid.NewString(), now); err != nil {
+		t.Fatalf("insert legacy row: %v", err)
+	}
+
+	// The constructor migrates in place; the legacy row keeps its data.
+	s, err := NewPGStore(ctx, pool)
+	if err != nil {
+		t.Fatalf("NewPGStore over legacy schema: %v", err)
+	}
+	got, err := s.Get(ctx, "alice", "legacy")
+	if err != nil {
+		t.Fatalf("Get legacy row: %v", err)
+	}
+	if got.NodeIsolation != IsolationVM {
+		t.Fatalf("legacy row isolation = %q, want %q", got.NodeIsolation, IsolationVM)
+	}
+}

--- a/internal/cmd/cluster.go
+++ b/internal/cmd/cluster.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -38,10 +39,48 @@ cluster is READY.
 }
 
 var (
-	clusterOwner    string
-	clusterNodesMin int32
-	clusterNodesMax int32
+	clusterOwner     string
+	clusterNodesMin  int32
+	clusterNodesMax  int32
+	clusterIsolation isolationFlag
 )
+
+// isolationFlag is the enum-backed --isolation flag (#1428). Cobra
+// rejects anything that is not a NodeIsolation value at parse time, so
+// a typo is a CLI error rather than a request that silently falls back
+// to the default class on the daemon.
+type isolationFlag struct{ value pb.NodeIsolation }
+
+func (f *isolationFlag) String() string { return nodeIsolationString(f.value) }
+
+func (f *isolationFlag) Type() string { return "isolation" }
+
+func (f *isolationFlag) Set(s string) error {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "vm":
+		f.value = pb.NodeIsolation_NODE_ISOLATION_VM
+	case "container":
+		f.value = pb.NodeIsolation_NODE_ISOLATION_CONTAINER
+	default:
+		f.value = pb.NodeIsolation_NODE_ISOLATION_UNSPECIFIED
+		return fmt.Errorf("invalid isolation %q (expected vm or container)", s)
+	}
+	return nil
+}
+
+// nodeIsolationString renders the class for humans. An unrecognized
+// value reads as "unknown", never as "vm": a boundary the CLI cannot
+// name must not look like the strong one.
+func nodeIsolationString(i pb.NodeIsolation) string {
+	switch i {
+	case pb.NodeIsolation_NODE_ISOLATION_VM:
+		return "vm"
+	case pb.NodeIsolation_NODE_ISOLATION_CONTAINER:
+		return "container"
+	default:
+		return "unknown"
+	}
+}
 
 var clusterCreateCmd = &cobra.Command{
 	Use:   "create <name>",
@@ -110,6 +149,9 @@ func init() {
 	clusterCmd.PersistentFlags().StringVar(&clusterOwner, "owner", "", "owning tenant (admin only; default: the authenticated user)")
 	clusterCreateCmd.Flags().Int32Var(&clusterNodesMin, "nodes-min", -1, "small size class's minimum worker count (default: platform preset)")
 	clusterCreateCmd.Flags().Int32Var(&clusterNodesMax, "nodes-max", -1, "small size class's maximum worker count (default: platform preset)")
+	clusterCreateCmd.Flags().Var(&clusterIsolation, "isolation",
+		"node isolation class: vm (default) or container. Container nodes share the host kernel and are only "+
+			"accepted where the operator has opted the host in; the daemon refuses them otherwise")
 	clusterNodePoolCmd.Flags().StringArrayVar(&clusterGroups, "group", nil,
 		"node group as name=<g>,cpu=<n>,memory=<x>GB,disk=<x>GB,min=<n>,max=<n> (repeatable, required)")
 }
@@ -202,11 +244,18 @@ func parseNodeGroup(spec string) (*pb.NodeGroup, error) {
 	return g, nil
 }
 
-func printCluster(c *pb.Cluster) {
-	w := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
+func printCluster(c *pb.Cluster) { printClusterTo(os.Stdout, c) }
+
+// printClusterTo renders one cluster's metadata. Used by `cluster get`
+// and `cluster status`, so the isolation class shows up on every
+// cluster read — "which clusters share a kernel with this host" is
+// answerable without querying the daemon's config.
+func printClusterTo(out io.Writer, c *pb.Cluster) {
+	w := tabwriter.NewWriter(out, 0, 2, 2, ' ', 0)
 	fmt.Fprintf(w, "Name:\t%s\n", c.Name)
 	fmt.Fprintf(w, "Owner:\t%s\n", c.Owner)
 	fmt.Fprintf(w, "State:\t%s\n", clusterStateString(c.State))
+	fmt.Fprintf(w, "Isolation:\t%s\n", nodeIsolationString(c.NodeIsolation))
 	if c.StateReason != "" {
 		fmt.Fprintf(w, "Reason:\t%s\n", c.StateReason)
 	}
@@ -247,7 +296,13 @@ func runClusterCreate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer func() { _ = c.Close() }()
-	req := &pb.CreateClusterRequest{Name: args[0], Owner: clusterOwner}
+	req := &pb.CreateClusterRequest{
+		Name: args[0], Owner: clusterOwner,
+		// Unset stays UNSPECIFIED on the wire and resolves to VM
+		// server-side — the CLI does not pick a class the caller
+		// did not ask for.
+		NodeIsolation: clusterIsolation.value,
+	}
 	if groups, gerr := createNodeGroups(cmd); gerr != nil {
 		return gerr
 	} else if groups != nil {
@@ -276,11 +331,20 @@ func runClusterList(cmd *cobra.Command, args []string) error {
 		fmt.Println("No clusters.")
 		return nil
 	}
-	w := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
-	fmt.Fprintln(w, "NAME\tOWNER\tSTATE\tGROUPS\tAPI ENDPOINT")
-	for _, cl := range resp.Clusters {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%s\n",
-			cl.Name, cl.Owner, clusterStateString(cl.State), len(cl.NodeGroups), cl.ApiEndpoint)
+	return writeClusterList(os.Stdout, resp.Clusters)
+}
+
+// writeClusterList renders the `cluster list` table. ISOLATION is a
+// first-class column, not a detail behind `cluster get`: an auditor
+// scanning the fleet needs the weak-boundary clusters to stand out in
+// the list itself.
+func writeClusterList(out io.Writer, clusters []*pb.Cluster) error {
+	w := tabwriter.NewWriter(out, 0, 2, 2, ' ', 0)
+	fmt.Fprintln(w, "NAME\tOWNER\tSTATE\tISOLATION\tGROUPS\tAPI ENDPOINT")
+	for _, cl := range clusters {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%s\n",
+			cl.Name, cl.Owner, clusterStateString(cl.State), nodeIsolationString(cl.NodeIsolation),
+			len(cl.NodeGroups), cl.ApiEndpoint)
 	}
 	return w.Flush()
 }

--- a/internal/cmd/cluster_isolation_test.go
+++ b/internal/cmd/cluster_isolation_test.go
@@ -1,0 +1,99 @@
+package cmd
+
+// CLI half of the node isolation contract (#1428): --isolation is an
+// enum-backed flag (a typo is rejected at parse time, never sent to the
+// daemon as a silent default), and every cluster read surface prints
+// the class an operator would be audited on.
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+func TestIsolationFlag_ParsesEnumValuesOnly(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    pb.NodeIsolation
+		wantErr bool
+	}{
+		{"vm", "vm", pb.NodeIsolation_NODE_ISOLATION_VM, false},
+		{"container", "container", pb.NodeIsolation_NODE_ISOLATION_CONTAINER, false},
+		{"case insensitive", "CONTAINER", pb.NodeIsolation_NODE_ISOLATION_CONTAINER, false},
+		{"typo is refused, not defaulted", "containr", pb.NodeIsolation_NODE_ISOLATION_UNSPECIFIED, true},
+		{"the wire spelling is not the flag spelling", "NODE_ISOLATION_VM", pb.NodeIsolation_NODE_ISOLATION_UNSPECIFIED, true},
+		{"empty is refused", "", pb.NodeIsolation_NODE_ISOLATION_UNSPECIFIED, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var f isolationFlag
+			err := f.Set(tc.in)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("Set(%q) err = %v, wantErr %v", tc.in, err, tc.wantErr)
+			}
+			if f.value != tc.want {
+				t.Fatalf("Set(%q) = %v, want %v", tc.in, f.value, tc.want)
+			}
+			if tc.wantErr && !strings.Contains(err.Error(), "container") {
+				t.Fatalf("error %q does not list the accepted values", err)
+			}
+		})
+	}
+}
+
+// `cluster get` and `cluster status` both render through printClusterTo:
+// the isolation class is visible on every cluster read, so "which
+// clusters share a kernel with this host" is answerable from the CLI.
+func TestPrintClusterTo_ShowsIsolation(t *testing.T) {
+	cases := []struct {
+		name string
+		in   pb.NodeIsolation
+		want string
+	}{
+		{"vm", pb.NodeIsolation_NODE_ISOLATION_VM, "Isolation:  vm"},
+		{"container", pb.NodeIsolation_NODE_ISOLATION_CONTAINER, "Isolation:  container"},
+		// A daemon too old to know the field must not render as a VM
+		// cluster — an unknown boundary is not a strong boundary.
+		{"unspecified", pb.NodeIsolation_NODE_ISOLATION_UNSPECIFIED, "Isolation:  unknown"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			printClusterTo(&buf, &pb.Cluster{
+				Name: "demo", Owner: "alice", NodeIsolation: tc.in,
+				State: pb.ClusterState_CLUSTER_STATE_READY,
+				NodeGroups: []*pb.NodeGroup{{
+					Name: "small", MinNodes: 1, MaxNodes: 3,
+					Size: &pb.ResourceLimits{Cpu: "2", Memory: "4GB", Disk: "40GB"},
+				}},
+			})
+			if !strings.Contains(buf.String(), tc.want) {
+				t.Fatalf("printClusterTo output missing %q:\n%s", tc.want, buf.String())
+			}
+		})
+	}
+}
+
+func TestWriteClusterList_ShowsIsolationColumn(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeClusterList(&buf, []*pb.Cluster{
+		{Name: "hw", Owner: "alice", State: pb.ClusterState_CLUSTER_STATE_READY,
+			NodeIsolation: pb.NodeIsolation_NODE_ISOLATION_VM},
+		{Name: "shared", Owner: "alice", State: pb.ClusterState_CLUSTER_STATE_READY,
+			NodeIsolation: pb.NodeIsolation_NODE_ISOLATION_CONTAINER},
+	}); err != nil {
+		t.Fatalf("writeClusterList: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "ISOLATION") {
+		t.Fatalf("list header has no ISOLATION column:\n%s", out)
+	}
+	for _, want := range []string{"hw", "vm", "shared", "container"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("list output missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/internal/server/cluster_isolation.go
+++ b/internal/server/cluster_isolation.go
@@ -1,0 +1,123 @@
+package server
+
+// Node isolation gate (#1428). A cluster's isolation class decides what
+// contains a tenant kernel exploit: a VM node keeps it inside the
+// tenant's own kernel, a container node does not. The weaker class is
+// therefore not tenant-selectable — the tenant *requests* it and the
+// operator *permits* it, per host, with an env opt-in.
+//
+// Design: docs/architecture/cluster-container-node-pools.md.
+
+import (
+	"fmt"
+	"strconv"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/footprintai/containarium/internal/cluster"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// allowContainerNodesEnv is the operator's per-host assertion that
+// everything on this host already shares one trust domain (a dev rung,
+// a dedicated single-tenant machine, the operator's own CI). Unset on
+// a shared multi-tenant host, container clusters are impossible there,
+// so a tenant can never downgrade the boundary protecting another
+// tenant.
+const allowContainerNodesEnv = "CONTAINARIUM_CLUSTER_ALLOW_CONTAINER_NODES"
+
+// isolationGate holds the parsed opt-in. Same fail-closed shape as
+// clusterCaps: a configuration that cannot be parsed poisons the gate
+// with configErr rather than leaving it open.
+type isolationGate struct {
+	allowContainer bool
+	configErr      error
+}
+
+// parseIsolationGate reads the opt-in env. Unset is "not permitted"
+// with no error (the default posture, not a misconfiguration); a value
+// that is not a boolean is "not permitted AND say so", because a typo
+// must refuse container creates rather than silently allow them.
+func parseIsolationGate(v string) (isolationGate, error) {
+	if v == "" {
+		return isolationGate{}, nil
+	}
+	allow, err := strconv.ParseBool(v)
+	if err != nil {
+		return isolationGate{}, fmt.Errorf("%s %q: want true or false", allowContainerNodesEnv, v)
+	}
+	return isolationGate{allowContainer: allow}, nil
+}
+
+// SetIsolationGateFromEnv installs the gate from the operator's env
+// value. A parse failure is recorded on the gate rather than returned:
+// a typo must not open the gate, and must not stop the daemon serving
+// VM clusters either.
+func (s *ClusterServer) SetIsolationGateFromEnv(v string) {
+	g, err := parseIsolationGate(v)
+	if err != nil {
+		s.isolation = isolationGate{configErr: err}
+		return
+	}
+	s.isolation = g
+}
+
+// isolationFromProto maps a requested class onto the stored one.
+// UNSPECIFIED resolves to VM — the safe default cannot be reached by
+// omission of config. An unrecognized value is refused rather than
+// defaulted: a caller who asked for something specific is never told
+// "fine" and given something else.
+func isolationFromProto(in pb.NodeIsolation) (cluster.Isolation, error) {
+	switch in {
+	case pb.NodeIsolation_NODE_ISOLATION_UNSPECIFIED, pb.NodeIsolation_NODE_ISOLATION_VM:
+		return cluster.IsolationVM, nil
+	case pb.NodeIsolation_NODE_ISOLATION_CONTAINER:
+		return cluster.IsolationContainer, nil
+	default:
+		return "", status.Errorf(codes.InvalidArgument,
+			"unknown node_isolation %v (want vm or container)", int32(in))
+	}
+}
+
+// isolationToProto is the read direction. An isolation the API cannot
+// express surfaces as UNSPECIFIED rather than as a silently-defaulted
+// VM — an unknown boundary must not read as a strong one.
+var isolationToProto = map[cluster.Isolation]pb.NodeIsolation{
+	cluster.IsolationVM:        pb.NodeIsolation_NODE_ISOLATION_VM,
+	cluster.IsolationContainer: pb.NodeIsolation_NODE_ISOLATION_CONTAINER,
+}
+
+// check admits an isolation class on this host. Only the weak class is
+// gated; VM is always permitted (the gate's misconfiguration must not
+// take the default class down with it).
+func (g isolationGate) check(iso cluster.Isolation) error {
+	if iso != cluster.IsolationContainer {
+		return nil
+	}
+	if g.configErr != nil {
+		return fmt.Errorf("container node isolation is gated by %s, which is misconfigured (%v); refusing until it is fixed",
+			allowContainerNodesEnv, g.configErr)
+	}
+	if !g.allowContainer {
+		return fmt.Errorf("container node isolation is not permitted on this host: the operator has not set %s=true. "+
+			"Container nodes share the host kernel, so the opt-in is the operator asserting the host is a single trust domain",
+			allowContainerNodesEnv)
+	}
+	return nil
+}
+
+// enforceIsolation resolves the requested class and admits it, or
+// refuses with the typed error. FailedPrecondition, like the VM
+// capability probe: the request is well-formed, the host will not
+// serve it.
+func (s *ClusterServer) enforceIsolation(req pb.NodeIsolation) (cluster.Isolation, error) {
+	iso, err := isolationFromProto(req)
+	if err != nil {
+		return "", err
+	}
+	if err := s.isolation.check(iso); err != nil {
+		return "", status.Errorf(codes.FailedPrecondition, "%v", err)
+	}
+	return iso, nil
+}

--- a/internal/server/cluster_isolation_test.go
+++ b/internal/server/cluster_isolation_test.go
@@ -1,0 +1,165 @@
+package server
+
+// Node isolation contract (#1428): a cluster's isolation class is the
+// boundary that contains a tenant kernel exploit. The weaker class
+// (CONTAINER) is operator-gated and must be unreachable by omission or
+// by a typo — both directions fail closed.
+//
+// Design: docs/architecture/cluster-container-node-pools.md.
+
+import (
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/footprintai/containarium/internal/cluster"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// A cluster created without asking for an isolation class must come
+// back — and be stored — as VM. The safe default is not reachable by
+// omission of config; it IS the omission of config.
+func TestClusterIsolation_UnspecifiedResolvesToVM(t *testing.T) {
+	s := clusterTestServer()
+	ctx := tenantCtx("alice")
+
+	resp, err := s.CreateCluster(ctx, &pb.CreateClusterRequest{Name: "demo"})
+	if err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+	if got := resp.Cluster.NodeIsolation; got != pb.NodeIsolation_NODE_ISOLATION_VM {
+		t.Fatalf("create response isolation = %v, want VM", got)
+	}
+
+	// The store holds the resolved class, not the unset one.
+	rec, err := s.store.Get(ctx, "alice", "demo")
+	if err != nil {
+		t.Fatalf("store Get: %v", err)
+	}
+	if rec.NodeIsolation != cluster.IsolationVM {
+		t.Fatalf("stored isolation = %q, want %q", rec.NodeIsolation, cluster.IsolationVM)
+	}
+
+	// And every read surface says so.
+	got, err := s.GetCluster(ctx, &pb.GetClusterRequest{Name: "demo"})
+	if err != nil {
+		t.Fatalf("GetCluster: %v", err)
+	}
+	if got.Cluster.NodeIsolation != pb.NodeIsolation_NODE_ISOLATION_VM {
+		t.Fatalf("GetCluster isolation = %v, want VM", got.Cluster.NodeIsolation)
+	}
+	st, err := s.GetClusterStatus(ctx, &pb.GetClusterStatusRequest{Name: "demo"})
+	if err != nil {
+		t.Fatalf("GetClusterStatus: %v", err)
+	}
+	if st.Cluster.NodeIsolation != pb.NodeIsolation_NODE_ISOLATION_VM {
+		t.Fatalf("GetClusterStatus isolation = %v, want VM", st.Cluster.NodeIsolation)
+	}
+	list, err := s.ListClusters(ctx, &pb.ListClustersRequest{})
+	if err != nil || len(list.Clusters) != 1 {
+		t.Fatalf("ListClusters = %+v (%v)", list, err)
+	}
+	if list.Clusters[0].NodeIsolation != pb.NodeIsolation_NODE_ISOLATION_VM {
+		t.Fatalf("ListClusters isolation = %v, want VM", list.Clusters[0].NodeIsolation)
+	}
+}
+
+// The operator opt-in is parsed by the same fail-closed rule as the
+// caps envs (cluster_caps.go): unset means "not permitted", a typo
+// means "not permitted AND say so", never "permitted".
+func TestParseIsolationGate(t *testing.T) {
+	cases := []struct {
+		name         string
+		env          string
+		wantAllow    bool
+		wantParseErr bool
+	}{
+		{"unset is closed", "", false, false},
+		{"explicit true opens", "true", true, false},
+		{"explicit false is closed", "false", false, false},
+		{"garbage is a config error, not an open gate", "yes-please", false, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g, err := parseIsolationGate(tc.env)
+			if (err != nil) != tc.wantParseErr {
+				t.Fatalf("parseIsolationGate(%q) err = %v, wantErr %v", tc.env, err, tc.wantParseErr)
+			}
+			if err != nil && !strings.Contains(err.Error(), allowContainerNodesEnv) {
+				t.Fatalf("parse error %q does not name %s", err, allowContainerNodesEnv)
+			}
+			if g.allowContainer != tc.wantAllow {
+				t.Fatalf("allowContainer = %v, want %v", g.allowContainer, tc.wantAllow)
+			}
+		})
+	}
+}
+
+// The create-path gate: a CONTAINER request is admitted only where the
+// operator set the flag. Refusals are FailedPrecondition and name the
+// flag, so an operator reading the error knows exactly what to set.
+func TestClusterIsolation_CreateGate(t *testing.T) {
+	cases := []struct {
+		name       string
+		env        string
+		requested  pb.NodeIsolation
+		wantAllow  bool
+		wantStored cluster.Isolation
+	}{
+		{"container refused when the flag is unset", "", pb.NodeIsolation_NODE_ISOLATION_CONTAINER, false, ""},
+		{"container allowed when the flag is true", "true", pb.NodeIsolation_NODE_ISOLATION_CONTAINER, true, cluster.IsolationContainer},
+		{"container refused when the flag is garbage", "not-a-bool", pb.NodeIsolation_NODE_ISOLATION_CONTAINER, false, ""},
+		{"container refused when the flag says false", "false", pb.NodeIsolation_NODE_ISOLATION_CONTAINER, false, ""},
+		{"vm is never gated: flag unset", "", pb.NodeIsolation_NODE_ISOLATION_VM, true, cluster.IsolationVM},
+		{"vm is never gated: flag garbage", "not-a-bool", pb.NodeIsolation_NODE_ISOLATION_VM, true, cluster.IsolationVM},
+		{"unspecified is never gated: flag garbage", "not-a-bool", pb.NodeIsolation_NODE_ISOLATION_UNSPECIFIED, true, cluster.IsolationVM},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := clusterTestServer()
+			s.SetIsolationGateFromEnv(tc.env)
+			ctx := tenantCtx("alice")
+
+			resp, err := s.CreateCluster(ctx, &pb.CreateClusterRequest{
+				Name: "demo", NodeIsolation: tc.requested,
+			})
+			if !tc.wantAllow {
+				wantCode(t, err, codes.FailedPrecondition)
+				if !strings.Contains(err.Error(), allowContainerNodesEnv) {
+					t.Fatalf("refusal %q does not name %s", err, allowContainerNodesEnv)
+				}
+				// Fail closed means nothing was recorded either.
+				if _, gerr := s.store.Get(ctx, "alice", "demo"); gerr == nil {
+					t.Fatal("refused create still wrote a cluster row")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("CreateCluster: %v", err)
+			}
+			rec, gerr := s.store.Get(ctx, "alice", "demo")
+			if gerr != nil {
+				t.Fatalf("store Get: %v", gerr)
+			}
+			if rec.NodeIsolation != tc.wantStored {
+				t.Fatalf("stored isolation = %q, want %q", rec.NodeIsolation, tc.wantStored)
+			}
+			if resp.Cluster.NodeIsolation != isolationToProto[tc.wantStored] {
+				t.Fatalf("response isolation = %v, want %v", resp.Cluster.NodeIsolation, isolationToProto[tc.wantStored])
+			}
+		})
+	}
+}
+
+// An isolation value the server does not know (a newer client, or a
+// hand-rolled request) is refused rather than silently defaulted to
+// the safe class — a caller who asked for something specific must
+// never be told "fine" and given something else.
+func TestClusterIsolation_UnknownValueRefused(t *testing.T) {
+	s := clusterTestServer()
+	_, err := s.CreateCluster(tenantCtx("alice"), &pb.CreateClusterRequest{
+		Name: "demo", NodeIsolation: pb.NodeIsolation(99),
+	})
+	wantCode(t, err, codes.InvalidArgument)
+}

--- a/internal/server/cluster_server.go
+++ b/internal/server/cluster_server.go
@@ -47,6 +47,9 @@ type ClusterServer struct {
 	// caps is the operator ceiling on configurable cluster size
 	// (#1417); zero values = unlimited.
 	caps clusterCaps
+	// isolation is the operator's per-host opt-in for the weaker node
+	// isolation class (#1428). Zero value = container nodes refused.
+	isolation isolationGate
 }
 
 // NewClusterServer builds the server on a Store (in-memory at startup;
@@ -160,7 +163,10 @@ func clusterToProto(c *cluster.Cluster) *pb.Cluster {
 		StateReason: c.StateReason,
 		K3SVersion:  c.K3sVersion,
 		ApiEndpoint: c.APIEndpoint,
-		CreatedAt:   timestamppb.New(c.CreatedAt),
+		// Resolved on the way out too, so a row written before the
+		// column existed still reads as a definite class (#1428).
+		NodeIsolation: isolationToProto[c.NodeIsolation.OrDefault()],
+		CreatedAt:     timestamppb.New(c.CreatedAt),
 	}
 	for _, g := range c.NodeGroups {
 		out.NodeGroups = append(out.NodeGroups, groupToProto(g))
@@ -203,6 +209,13 @@ func (s *ClusterServer) CreateCluster(ctx context.Context, req *pb.CreateCluster
 	if err := cluster.ValidateName(req.Name); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	// Isolation is decided before anything is recorded: a refused class
+	// leaves no row behind, and the refusal names the flag the operator
+	// would have to set.
+	isolation, err := s.enforceIsolation(req.NodeIsolation)
+	if err != nil {
+		return nil, err
+	}
 	if s.vmCapable != nil {
 		if err := s.vmCapable(); err != nil {
 			return nil, status.Errorf(codes.FailedPrecondition, "%v", err)
@@ -224,18 +237,19 @@ func (s *ClusterServer) CreateCluster(ctx context.Context, req *pb.CreateCluster
 
 	now := time.Now().UTC()
 	c := &cluster.Cluster{
-		ID:         uuid.NewString(),
-		Owner:      owner,
-		Name:       req.Name,
-		State:      cluster.StateProvisioning,
-		NodeGroups: groups,
-		CreatedAt:  now,
-		UpdatedAt:  now,
+		ID:            uuid.NewString(),
+		Owner:         owner,
+		Name:          req.Name,
+		State:         cluster.StateProvisioning,
+		NodeGroups:    groups,
+		NodeIsolation: isolation,
+		CreatedAt:     now,
+		UpdatedAt:     now,
 	}
 	if err := s.store.Create(ctx, c); err != nil {
 		return nil, storeErr(err)
 	}
-	log.Printf("[cluster] created owner=%s name=%s groups=%d", owner, req.Name, len(groups))
+	log.Printf("[cluster] created owner=%s name=%s groups=%d isolation=%s", owner, req.Name, len(groups), isolation)
 	return &pb.CreateClusterResponse{
 		Cluster: clusterToProto(c),
 		Message: "cluster recorded; provisioning runs asynchronously",

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -537,6 +537,10 @@ func NewDualServer(config *DualServerConfig) (*DualServer, error) {
 		clusterServer.SetCaps(clusterCaps{configErr: capsErr})
 		log.Printf("ERROR: %v — cluster creates/updates will be refused until the caps are fixed", capsErr)
 	}
+	// Node isolation opt-in (#1428): unset means container node pools
+	// are refused on this host, which is the right default for a shared
+	// multi-tenant one. A typo'd value refuses them too, loudly.
+	clusterServer.SetIsolationGateFromEnv(os.Getenv("CONTAINARIUM_CLUSTER_ALLOW_CONTAINER_NODES"))
 	pb.RegisterClusterServiceServer(grpcServer, clusterServer)
 	log.Printf("Cluster service enabled (in-memory store; Postgres swap below)")
 

--- a/pkg/pb/containarium/v1/cluster.pb.go
+++ b/pkg/pb/containarium/v1/cluster.pb.go
@@ -252,6 +252,70 @@ func (ScaleEventKind) EnumDescriptor() ([]byte, []int) {
 	return file_containarium_v1_cluster_proto_rawDescGZIP(), []int{3}
 }
 
+// NodeIsolation is the isolation class of a cluster's nodes: the
+// boundary that contains a tenant kernel exploit. Cluster-level and
+// immutable after create.
+//
+// VM is the default and the only class safe on a shared multi-tenant
+// host. CONTAINER runs each node as an Incus system container sharing
+// the host kernel — weaker by construction, so it is operator-gated:
+// the daemon permits it only where the operator has declared the host
+// a single trust domain. UNSPECIFIED resolves to VM server-side; the
+// weaker class is never reached by omission.
+//
+// Design: docs/architecture/cluster-container-node-pools.md.
+type NodeIsolation int32
+
+const (
+	NodeIsolation_NODE_ISOLATION_UNSPECIFIED NodeIsolation = 0
+	// Each node is an Incus VM — hardware-virtualized kernel boundary.
+	NodeIsolation_NODE_ISOLATION_VM NodeIsolation = 1
+	// Each node is an Incus system container sharing the host kernel.
+	// Requires the operator opt-in on the target host.
+	NodeIsolation_NODE_ISOLATION_CONTAINER NodeIsolation = 2
+)
+
+// Enum value maps for NodeIsolation.
+var (
+	NodeIsolation_name = map[int32]string{
+		0: "NODE_ISOLATION_UNSPECIFIED",
+		1: "NODE_ISOLATION_VM",
+		2: "NODE_ISOLATION_CONTAINER",
+	}
+	NodeIsolation_value = map[string]int32{
+		"NODE_ISOLATION_UNSPECIFIED": 0,
+		"NODE_ISOLATION_VM":          1,
+		"NODE_ISOLATION_CONTAINER":   2,
+	}
+)
+
+func (x NodeIsolation) Enum() *NodeIsolation {
+	p := new(NodeIsolation)
+	*p = x
+	return p
+}
+
+func (x NodeIsolation) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (NodeIsolation) Descriptor() protoreflect.EnumDescriptor {
+	return file_containarium_v1_cluster_proto_enumTypes[4].Descriptor()
+}
+
+func (NodeIsolation) Type() protoreflect.EnumType {
+	return &file_containarium_v1_cluster_proto_enumTypes[4]
+}
+
+func (x NodeIsolation) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use NodeIsolation.Descriptor instead.
+func (NodeIsolation) EnumDescriptor() ([]byte, []int) {
+	return file_containarium_v1_cluster_proto_rawDescGZIP(), []int{4}
+}
+
 // NodeGroup is a typed worker size class. The autoscaler advertises one
 // node group per class and picks the class whose template fits pending
 // pods; the template it advertises MUST equal `size` (truthfulness the
@@ -496,8 +560,12 @@ type Cluster struct {
 	// Worker size classes.
 	NodeGroups []*NodeGroup `protobuf:"bytes,6,rep,name=node_groups,json=nodeGroups,proto3" json:"node_groups,omitempty"`
 	// External API endpoint (host:port), set once published.
-	ApiEndpoint   string                 `protobuf:"bytes,7,opt,name=api_endpoint,json=apiEndpoint,proto3" json:"api_endpoint,omitempty"`
-	CreatedAt     *timestamppb.Timestamp `protobuf:"bytes,8,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	ApiEndpoint string                 `protobuf:"bytes,7,opt,name=api_endpoint,json=apiEndpoint,proto3" json:"api_endpoint,omitempty"`
+	CreatedAt   *timestamppb.Timestamp `protobuf:"bytes,8,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	// Isolation class of this cluster's nodes. Always populated on read
+	// (never UNSPECIFIED) so an auditor can answer "which clusters share
+	// a kernel with this host" from any cluster read.
+	NodeIsolation NodeIsolation `protobuf:"varint,9,opt,name=node_isolation,json=nodeIsolation,proto3,enum=containarium.v1.NodeIsolation" json:"node_isolation,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -588,6 +656,13 @@ func (x *Cluster) GetCreatedAt() *timestamppb.Timestamp {
 	return nil
 }
 
+func (x *Cluster) GetNodeIsolation() NodeIsolation {
+	if x != nil {
+		return x.NodeIsolation
+	}
+	return NodeIsolation_NODE_ISOLATION_UNSPECIFIED
+}
+
 type CreateClusterRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Cluster name (DNS-label syntax).
@@ -596,7 +671,11 @@ type CreateClusterRequest struct {
 	// tenant requires the admin role.
 	Owner string `protobuf:"bytes,2,opt,name=owner,proto3" json:"owner,omitempty"`
 	// Worker size classes. Empty = the platform's default presets.
-	NodeGroups    []*NodeGroup `protobuf:"bytes,3,rep,name=node_groups,json=nodeGroups,proto3" json:"node_groups,omitempty"`
+	NodeGroups []*NodeGroup `protobuf:"bytes,3,rep,name=node_groups,json=nodeGroups,proto3" json:"node_groups,omitempty"`
+	// Requested node isolation class. Unspecified = VM. CONTAINER is
+	// refused with FailedPrecondition unless the host carries the
+	// operator opt-in.
+	NodeIsolation NodeIsolation `protobuf:"varint,4,opt,name=node_isolation,json=nodeIsolation,proto3,enum=containarium.v1.NodeIsolation" json:"node_isolation,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -650,6 +729,13 @@ func (x *CreateClusterRequest) GetNodeGroups() []*NodeGroup {
 		return x.NodeGroups
 	}
 	return nil
+}
+
+func (x *CreateClusterRequest) GetNodeIsolation() NodeIsolation {
+	if x != nil {
+		return x.NodeIsolation
+	}
+	return NodeIsolation_NODE_ISOLATION_UNSPECIFIED
 }
 
 type CreateClusterResponse struct {
@@ -1408,7 +1494,7 @@ const file_containarium_v1_cluster_proto_rawDesc = "" +
 	"\x04kind\x18\x02 \x01(\x0e2\x1f.containarium.v1.ScaleEventKindR\x04kind\x12\x1d\n" +
 	"\n" +
 	"node_group\x18\x03 \x01(\tR\tnodeGroup\x12\x16\n" +
-	"\x06reason\x18\x04 \x01(\tR\x06reason\"\xc7\x02\n" +
+	"\x06reason\x18\x04 \x01(\tR\x06reason\"\x8e\x03\n" +
 	"\aCluster\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
 	"\x05owner\x18\x02 \x01(\tR\x05owner\x123\n" +
@@ -1420,12 +1506,14 @@ const file_containarium_v1_cluster_proto_rawDesc = "" +
 	"nodeGroups\x12!\n" +
 	"\fapi_endpoint\x18\a \x01(\tR\vapiEndpoint\x129\n" +
 	"\n" +
-	"created_at\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\"}\n" +
+	"created_at\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x12E\n" +
+	"\x0enode_isolation\x18\t \x01(\x0e2\x1e.containarium.v1.NodeIsolationR\rnodeIsolation\"\xc4\x01\n" +
 	"\x14CreateClusterRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
 	"\x05owner\x18\x02 \x01(\tR\x05owner\x12;\n" +
 	"\vnode_groups\x18\x03 \x03(\v2\x1a.containarium.v1.NodeGroupR\n" +
-	"nodeGroups\"e\n" +
+	"nodeGroups\x12E\n" +
+	"\x0enode_isolation\x18\x04 \x01(\x0e2\x1e.containarium.v1.NodeIsolationR\rnodeIsolation\"e\n" +
 	"\x15CreateClusterResponse\x122\n" +
 	"\acluster\x18\x01 \x01(\v2\x18.containarium.v1.ClusterR\acluster\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\"+\n" +
@@ -1491,7 +1579,11 @@ const file_containarium_v1_cluster_proto_rawDesc = "" +
 	"\x19SCALE_EVENT_KIND_SCALE_UP\x10\x01\x12\x1f\n" +
 	"\x1bSCALE_EVENT_KIND_SCALE_DOWN\x10\x02\x12\x1c\n" +
 	"\x18SCALE_EVENT_KIND_REFUSED\x10\x03\x12\"\n" +
-	"\x1eSCALE_EVENT_KIND_NODE_REPLACED\x10\x042\xa5\x0e\n" +
+	"\x1eSCALE_EVENT_KIND_NODE_REPLACED\x10\x04*d\n" +
+	"\rNodeIsolation\x12\x1e\n" +
+	"\x1aNODE_ISOLATION_UNSPECIFIED\x10\x00\x12\x15\n" +
+	"\x11NODE_ISOLATION_VM\x10\x01\x12\x1c\n" +
+	"\x18NODE_ISOLATION_CONTAINER\x10\x022\xa5\x0e\n" +
 	"\x0eClusterService\x12\xe2\x02\n" +
 	"\rCreateCluster\x12%.containarium.v1.CreateClusterRequest\x1a&.containarium.v1.CreateClusterResponse\"\x81\x02\x92A\xe6\x01\n" +
 	"\bClusters\x12#Create a managed Kubernetes cluster\x1a\xb4\x01Records the cluster and returns immediately in state PROVISIONING; a reconciler provisions the control-plane and worker VMs asynchronously. Fails fast on hosts that cannot run VMs.\x82\xd3\xe4\x93\x02\x11:\x01*\"\f/v1/clusters\x12\x95\x01\n" +
@@ -1521,75 +1613,78 @@ func file_containarium_v1_cluster_proto_rawDescGZIP() []byte {
 	return file_containarium_v1_cluster_proto_rawDescData
 }
 
-var file_containarium_v1_cluster_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
+var file_containarium_v1_cluster_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
 var file_containarium_v1_cluster_proto_msgTypes = make([]protoimpl.MessageInfo, 19)
 var file_containarium_v1_cluster_proto_goTypes = []any{
 	(ClusterState)(0),                     // 0: containarium.v1.ClusterState
 	(ClusterNodeRole)(0),                  // 1: containarium.v1.ClusterNodeRole
 	(ClusterNodeState)(0),                 // 2: containarium.v1.ClusterNodeState
 	(ScaleEventKind)(0),                   // 3: containarium.v1.ScaleEventKind
-	(*NodeGroup)(nil),                     // 4: containarium.v1.NodeGroup
-	(*ClusterNode)(nil),                   // 5: containarium.v1.ClusterNode
-	(*ScaleEvent)(nil),                    // 6: containarium.v1.ScaleEvent
-	(*Cluster)(nil),                       // 7: containarium.v1.Cluster
-	(*CreateClusterRequest)(nil),          // 8: containarium.v1.CreateClusterRequest
-	(*CreateClusterResponse)(nil),         // 9: containarium.v1.CreateClusterResponse
-	(*ListClustersRequest)(nil),           // 10: containarium.v1.ListClustersRequest
-	(*ListClustersResponse)(nil),          // 11: containarium.v1.ListClustersResponse
-	(*GetClusterRequest)(nil),             // 12: containarium.v1.GetClusterRequest
-	(*GetClusterResponse)(nil),            // 13: containarium.v1.GetClusterResponse
-	(*DeleteClusterRequest)(nil),          // 14: containarium.v1.DeleteClusterRequest
-	(*DeleteClusterResponse)(nil),         // 15: containarium.v1.DeleteClusterResponse
-	(*GetClusterKubeconfigRequest)(nil),   // 16: containarium.v1.GetClusterKubeconfigRequest
-	(*GetClusterKubeconfigResponse)(nil),  // 17: containarium.v1.GetClusterKubeconfigResponse
-	(*GetClusterStatusRequest)(nil),       // 18: containarium.v1.GetClusterStatusRequest
-	(*NodeGroupStatus)(nil),               // 19: containarium.v1.NodeGroupStatus
-	(*GetClusterStatusResponse)(nil),      // 20: containarium.v1.GetClusterStatusResponse
-	(*UpdateClusterNodePoolRequest)(nil),  // 21: containarium.v1.UpdateClusterNodePoolRequest
-	(*UpdateClusterNodePoolResponse)(nil), // 22: containarium.v1.UpdateClusterNodePoolResponse
-	(*ResourceLimits)(nil),                // 23: containarium.v1.ResourceLimits
-	(*timestamppb.Timestamp)(nil),         // 24: google.protobuf.Timestamp
+	(NodeIsolation)(0),                    // 4: containarium.v1.NodeIsolation
+	(*NodeGroup)(nil),                     // 5: containarium.v1.NodeGroup
+	(*ClusterNode)(nil),                   // 6: containarium.v1.ClusterNode
+	(*ScaleEvent)(nil),                    // 7: containarium.v1.ScaleEvent
+	(*Cluster)(nil),                       // 8: containarium.v1.Cluster
+	(*CreateClusterRequest)(nil),          // 9: containarium.v1.CreateClusterRequest
+	(*CreateClusterResponse)(nil),         // 10: containarium.v1.CreateClusterResponse
+	(*ListClustersRequest)(nil),           // 11: containarium.v1.ListClustersRequest
+	(*ListClustersResponse)(nil),          // 12: containarium.v1.ListClustersResponse
+	(*GetClusterRequest)(nil),             // 13: containarium.v1.GetClusterRequest
+	(*GetClusterResponse)(nil),            // 14: containarium.v1.GetClusterResponse
+	(*DeleteClusterRequest)(nil),          // 15: containarium.v1.DeleteClusterRequest
+	(*DeleteClusterResponse)(nil),         // 16: containarium.v1.DeleteClusterResponse
+	(*GetClusterKubeconfigRequest)(nil),   // 17: containarium.v1.GetClusterKubeconfigRequest
+	(*GetClusterKubeconfigResponse)(nil),  // 18: containarium.v1.GetClusterKubeconfigResponse
+	(*GetClusterStatusRequest)(nil),       // 19: containarium.v1.GetClusterStatusRequest
+	(*NodeGroupStatus)(nil),               // 20: containarium.v1.NodeGroupStatus
+	(*GetClusterStatusResponse)(nil),      // 21: containarium.v1.GetClusterStatusResponse
+	(*UpdateClusterNodePoolRequest)(nil),  // 22: containarium.v1.UpdateClusterNodePoolRequest
+	(*UpdateClusterNodePoolResponse)(nil), // 23: containarium.v1.UpdateClusterNodePoolResponse
+	(*ResourceLimits)(nil),                // 24: containarium.v1.ResourceLimits
+	(*timestamppb.Timestamp)(nil),         // 25: google.protobuf.Timestamp
 }
 var file_containarium_v1_cluster_proto_depIdxs = []int32{
-	23, // 0: containarium.v1.NodeGroup.size:type_name -> containarium.v1.ResourceLimits
+	24, // 0: containarium.v1.NodeGroup.size:type_name -> containarium.v1.ResourceLimits
 	1,  // 1: containarium.v1.ClusterNode.role:type_name -> containarium.v1.ClusterNodeRole
 	2,  // 2: containarium.v1.ClusterNode.state:type_name -> containarium.v1.ClusterNodeState
-	24, // 3: containarium.v1.ClusterNode.created_at:type_name -> google.protobuf.Timestamp
-	24, // 4: containarium.v1.ScaleEvent.at:type_name -> google.protobuf.Timestamp
+	25, // 3: containarium.v1.ClusterNode.created_at:type_name -> google.protobuf.Timestamp
+	25, // 4: containarium.v1.ScaleEvent.at:type_name -> google.protobuf.Timestamp
 	3,  // 5: containarium.v1.ScaleEvent.kind:type_name -> containarium.v1.ScaleEventKind
 	0,  // 6: containarium.v1.Cluster.state:type_name -> containarium.v1.ClusterState
-	4,  // 7: containarium.v1.Cluster.node_groups:type_name -> containarium.v1.NodeGroup
-	24, // 8: containarium.v1.Cluster.created_at:type_name -> google.protobuf.Timestamp
-	4,  // 9: containarium.v1.CreateClusterRequest.node_groups:type_name -> containarium.v1.NodeGroup
-	7,  // 10: containarium.v1.CreateClusterResponse.cluster:type_name -> containarium.v1.Cluster
-	7,  // 11: containarium.v1.ListClustersResponse.clusters:type_name -> containarium.v1.Cluster
-	7,  // 12: containarium.v1.GetClusterResponse.cluster:type_name -> containarium.v1.Cluster
-	4,  // 13: containarium.v1.NodeGroupStatus.group:type_name -> containarium.v1.NodeGroup
-	7,  // 14: containarium.v1.GetClusterStatusResponse.cluster:type_name -> containarium.v1.Cluster
-	5,  // 15: containarium.v1.GetClusterStatusResponse.nodes:type_name -> containarium.v1.ClusterNode
-	19, // 16: containarium.v1.GetClusterStatusResponse.groups:type_name -> containarium.v1.NodeGroupStatus
-	6,  // 17: containarium.v1.GetClusterStatusResponse.events:type_name -> containarium.v1.ScaleEvent
-	4,  // 18: containarium.v1.UpdateClusterNodePoolRequest.node_groups:type_name -> containarium.v1.NodeGroup
-	7,  // 19: containarium.v1.UpdateClusterNodePoolResponse.cluster:type_name -> containarium.v1.Cluster
-	8,  // 20: containarium.v1.ClusterService.CreateCluster:input_type -> containarium.v1.CreateClusterRequest
-	10, // 21: containarium.v1.ClusterService.ListClusters:input_type -> containarium.v1.ListClustersRequest
-	12, // 22: containarium.v1.ClusterService.GetCluster:input_type -> containarium.v1.GetClusterRequest
-	14, // 23: containarium.v1.ClusterService.DeleteCluster:input_type -> containarium.v1.DeleteClusterRequest
-	16, // 24: containarium.v1.ClusterService.GetClusterKubeconfig:input_type -> containarium.v1.GetClusterKubeconfigRequest
-	18, // 25: containarium.v1.ClusterService.GetClusterStatus:input_type -> containarium.v1.GetClusterStatusRequest
-	21, // 26: containarium.v1.ClusterService.UpdateClusterNodePool:input_type -> containarium.v1.UpdateClusterNodePoolRequest
-	9,  // 27: containarium.v1.ClusterService.CreateCluster:output_type -> containarium.v1.CreateClusterResponse
-	11, // 28: containarium.v1.ClusterService.ListClusters:output_type -> containarium.v1.ListClustersResponse
-	13, // 29: containarium.v1.ClusterService.GetCluster:output_type -> containarium.v1.GetClusterResponse
-	15, // 30: containarium.v1.ClusterService.DeleteCluster:output_type -> containarium.v1.DeleteClusterResponse
-	17, // 31: containarium.v1.ClusterService.GetClusterKubeconfig:output_type -> containarium.v1.GetClusterKubeconfigResponse
-	20, // 32: containarium.v1.ClusterService.GetClusterStatus:output_type -> containarium.v1.GetClusterStatusResponse
-	22, // 33: containarium.v1.ClusterService.UpdateClusterNodePool:output_type -> containarium.v1.UpdateClusterNodePoolResponse
-	27, // [27:34] is the sub-list for method output_type
-	20, // [20:27] is the sub-list for method input_type
-	20, // [20:20] is the sub-list for extension type_name
-	20, // [20:20] is the sub-list for extension extendee
-	0,  // [0:20] is the sub-list for field type_name
+	5,  // 7: containarium.v1.Cluster.node_groups:type_name -> containarium.v1.NodeGroup
+	25, // 8: containarium.v1.Cluster.created_at:type_name -> google.protobuf.Timestamp
+	4,  // 9: containarium.v1.Cluster.node_isolation:type_name -> containarium.v1.NodeIsolation
+	5,  // 10: containarium.v1.CreateClusterRequest.node_groups:type_name -> containarium.v1.NodeGroup
+	4,  // 11: containarium.v1.CreateClusterRequest.node_isolation:type_name -> containarium.v1.NodeIsolation
+	8,  // 12: containarium.v1.CreateClusterResponse.cluster:type_name -> containarium.v1.Cluster
+	8,  // 13: containarium.v1.ListClustersResponse.clusters:type_name -> containarium.v1.Cluster
+	8,  // 14: containarium.v1.GetClusterResponse.cluster:type_name -> containarium.v1.Cluster
+	5,  // 15: containarium.v1.NodeGroupStatus.group:type_name -> containarium.v1.NodeGroup
+	8,  // 16: containarium.v1.GetClusterStatusResponse.cluster:type_name -> containarium.v1.Cluster
+	6,  // 17: containarium.v1.GetClusterStatusResponse.nodes:type_name -> containarium.v1.ClusterNode
+	20, // 18: containarium.v1.GetClusterStatusResponse.groups:type_name -> containarium.v1.NodeGroupStatus
+	7,  // 19: containarium.v1.GetClusterStatusResponse.events:type_name -> containarium.v1.ScaleEvent
+	5,  // 20: containarium.v1.UpdateClusterNodePoolRequest.node_groups:type_name -> containarium.v1.NodeGroup
+	8,  // 21: containarium.v1.UpdateClusterNodePoolResponse.cluster:type_name -> containarium.v1.Cluster
+	9,  // 22: containarium.v1.ClusterService.CreateCluster:input_type -> containarium.v1.CreateClusterRequest
+	11, // 23: containarium.v1.ClusterService.ListClusters:input_type -> containarium.v1.ListClustersRequest
+	13, // 24: containarium.v1.ClusterService.GetCluster:input_type -> containarium.v1.GetClusterRequest
+	15, // 25: containarium.v1.ClusterService.DeleteCluster:input_type -> containarium.v1.DeleteClusterRequest
+	17, // 26: containarium.v1.ClusterService.GetClusterKubeconfig:input_type -> containarium.v1.GetClusterKubeconfigRequest
+	19, // 27: containarium.v1.ClusterService.GetClusterStatus:input_type -> containarium.v1.GetClusterStatusRequest
+	22, // 28: containarium.v1.ClusterService.UpdateClusterNodePool:input_type -> containarium.v1.UpdateClusterNodePoolRequest
+	10, // 29: containarium.v1.ClusterService.CreateCluster:output_type -> containarium.v1.CreateClusterResponse
+	12, // 30: containarium.v1.ClusterService.ListClusters:output_type -> containarium.v1.ListClustersResponse
+	14, // 31: containarium.v1.ClusterService.GetCluster:output_type -> containarium.v1.GetClusterResponse
+	16, // 32: containarium.v1.ClusterService.DeleteCluster:output_type -> containarium.v1.DeleteClusterResponse
+	18, // 33: containarium.v1.ClusterService.GetClusterKubeconfig:output_type -> containarium.v1.GetClusterKubeconfigResponse
+	21, // 34: containarium.v1.ClusterService.GetClusterStatus:output_type -> containarium.v1.GetClusterStatusResponse
+	23, // 35: containarium.v1.ClusterService.UpdateClusterNodePool:output_type -> containarium.v1.UpdateClusterNodePoolResponse
+	29, // [29:36] is the sub-list for method output_type
+	22, // [22:29] is the sub-list for method input_type
+	22, // [22:22] is the sub-list for extension type_name
+	22, // [22:22] is the sub-list for extension extendee
+	0,  // [0:22] is the sub-list for field type_name
 }
 
 func init() { file_containarium_v1_cluster_proto_init() }
@@ -1603,7 +1698,7 @@ func file_containarium_v1_cluster_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_v1_cluster_proto_rawDesc), len(file_containarium_v1_cluster_proto_rawDesc)),
-			NumEnums:      4,
+			NumEnums:      5,
 			NumMessages:   19,
 			NumExtensions: 0,
 			NumServices:   1,

--- a/proto/containarium/v1/cluster.proto
+++ b/proto/containarium/v1/cluster.proto
@@ -159,6 +159,27 @@ enum ScaleEventKind {
   SCALE_EVENT_KIND_NODE_REPLACED = 4;
 }
 
+// NodeIsolation is the isolation class of a cluster's nodes: the
+// boundary that contains a tenant kernel exploit. Cluster-level and
+// immutable after create.
+//
+// VM is the default and the only class safe on a shared multi-tenant
+// host. CONTAINER runs each node as an Incus system container sharing
+// the host kernel — weaker by construction, so it is operator-gated:
+// the daemon permits it only where the operator has declared the host
+// a single trust domain. UNSPECIFIED resolves to VM server-side; the
+// weaker class is never reached by omission.
+//
+// Design: docs/architecture/cluster-container-node-pools.md.
+enum NodeIsolation {
+  NODE_ISOLATION_UNSPECIFIED = 0;
+  // Each node is an Incus VM — hardware-virtualized kernel boundary.
+  NODE_ISOLATION_VM = 1;
+  // Each node is an Incus system container sharing the host kernel.
+  // Requires the operator opt-in on the target host.
+  NODE_ISOLATION_CONTAINER = 2;
+}
+
 // NodeGroup is a typed worker size class. The autoscaler advertises one
 // node group per class and picks the class whose template fits pending
 // pods; the template it advertises MUST equal `size` (truthfulness the
@@ -214,6 +235,10 @@ message Cluster {
   // External API endpoint (host:port), set once published.
   string api_endpoint = 7;
   google.protobuf.Timestamp created_at = 8;
+  // Isolation class of this cluster's nodes. Always populated on read
+  // (never UNSPECIFIED) so an auditor can answer "which clusters share
+  // a kernel with this host" from any cluster read.
+  NodeIsolation node_isolation = 9;
 }
 
 message CreateClusterRequest {
@@ -224,6 +249,10 @@ message CreateClusterRequest {
   string owner = 2;
   // Worker size classes. Empty = the platform's default presets.
   repeated NodeGroup node_groups = 3;
+  // Requested node isolation class. Unspecified = VM. CONTAINER is
+  // refused with FailedPrecondition unless the host carries the
+  // operator opt-in.
+  NodeIsolation node_isolation = 4;
 }
 
 message CreateClusterResponse {


### PR DESCRIPTION
Closes #1428

Story 1 of `docs/architecture/cluster-container-node-pools.md` (Status: accepted) — the contract layer for container node pools. A cluster's nodes now carry an explicit isolation class, decided at create time and visible on every read. The weaker class is chosen on the record, never reached as a silent fallback.

## What changed

- **proto (the contract source).** `NodeIsolation` enum (`UNSPECIFIED/VM/CONTAINER`) in `proto/containarium/v1/cluster.proto`, field **4** on `CreateClusterRequest` and field **9** on `Cluster` — both the next free number in their message, pinned deliberately. Regenerated with `make proto`; `pkg/pb/` and `api/swagger/` are generated output, not hand edits.
- **store.** `node_isolation` on the cluster row in both impls. Postgres gets `ADD COLUMN IF NOT EXISTS node_isolation TEXT NOT NULL DEFAULT 'vm'` alongside the `CREATE TABLE`, so clusters recorded before the column existed read back as VM rather than as an unknown boundary. `MemStore` performs the same resolution, so the two impls do not diverge.
- **server.** Create-path gate: `CONTAINER` requires `CONTAINARIUM_CLUSTER_ALLOW_CONTAINER_NODES=true` on the host, else `FailedPrecondition` naming the flag. Fail closed **both ways**, mirroring `cluster_caps.go`: unset refuses, and a value that will not parse poisons the gate with a `configErr` and refuses too rather than leaving it open. `UNSPECIFIED` resolves to `VM`; an unrecognized enum value is `InvalidArgument` rather than a silent downgrade to the default. A refused create writes no row.
- **CLI.** `cluster create --isolation vm|container` as an enum-backed `pflag.Value` — a typo is a parse error, not a request that quietly falls back to a class the caller never asked for. The class prints in `cluster get`, `cluster list` (new `ISOLATION` column), and `cluster status`.

## Reviewer, start here

- `internal/server/cluster_isolation.go` — the whole gate, including which direction each failure mode falls. `parseIsolationGate("")` is *not* an error (unset is the default posture); `parseIsolationGate("garbage")` is, and both refuse container creates.
- `internal/cluster/store.go` — the migration line, and `scanCluster`'s `.OrDefault()` on the read path (belt and braces: the column default covers legacy rows, the read-path resolution covers anything that predates or bypasses it).

## Test evidence

Written before the implementation; each was confirmed red first (undefined symbols at the contract boundary), and two were re-confirmed by deliberate mutation after going green — the gate test fails when `!g.allowContainer` is neutered, and the migration test fails when the `ALTER TABLE` is removed (`column "node_isolation" does not exist`).

| Acceptance criterion | Test |
|---|---|
| (a) `UNSPECIFIED` resolves to VM server-side | `TestClusterIsolation_UnspecifiedResolvesToVM` (asserts create response, store row, `GetCluster`, `GetClusterStatus`, `ListClusters`); `TestIsolation_OrDefault` |
| (b) store round-trips `node_isolation` in mem + Postgres, `'vm'` default for existing rows | `TestClusterStore_NodeIsolationRoundTrips` (both impls, tagged `integration`); `TestClusterStore_LegacyRowsDefaultToVM` (builds the pre-#1428 schema, inserts a row, runs the constructor, asserts VM); `TestMemStore_NodeIsolationRoundTrips` (untagged, so the fast lane covers it too) |
| (c) create-path gate table: CONTAINER x {unset, true, garbage} -> {refuse, allow, refuse}, `FailedPrecondition` naming the flag | `TestClusterIsolation_CreateGate` (7 rows: the three above plus `false`, and VM/UNSPECIFIED ungated even when the flag is garbage; asserts the code, that the message names `CONTAINARIUM_CLUSTER_ALLOW_CONTAINER_NODES`, and that a refusal leaves no row); `TestParseIsolationGate` (4 rows); `TestClusterIsolation_UnknownValueRefused` |
| (d) isolation printed by `cluster get`/`list`/`status` | `TestPrintClusterTo_ShowsIsolation` (3 rows — `get` and `status` share this renderer); `TestWriteClusterList_ShowsIsolationColumn`; `TestIsolationFlag_ParsesEnumValuesOnly` (6 rows) |

`internal/cluster/` was already in the `store-integration` lane's package list (`.github/workflows/store-integration.yml`), so the two new tagged tests are picked up with no workflow change.

CI run linked in a comment below once the checks report.

## Deviation flagged

None from the design — but a **story boundary** worth stating: the design's component table assigns `ContainerNodeCapable()` and the `CreateVM` -> `CreateNode(spec, isolation)` seam to `pkg/core/cluster`, which is not this story. Until that lands, the existing VM capability probe still runs on every create, so a `CONTAINER` cluster additionally requires a VM-capable host. The contract, the gate, and the persistence are correct and complete; the capability probe becomes isolation-aware in the follow-on story. Noted in the commit message too.
