### PR TITLE
feat(cluster): container node runtime — CreateNode seam, container profile, capability probe (#1429)

### DIFF
--- a/internal/server/cluster_reconciler.go
+++ b/internal/server/cluster_reconciler.go
@@ -88,8 +88,25 @@ func (r *ClusterReconciler) ReadKubeconfig(ctx context.Context, c *clusterstore.
 	return r.mgr.Kubeconfig(c.Owner, c.Name, c.APIEndpoint)
 }
 
-// VMCapable is the create-time capability probe.
-func (r *ClusterReconciler) VMCapable() error { return r.mgr.VMCapable() }
+// NodeCapable is the create-time capability probe for one isolation
+// class (#1429): the seam carries the class and the probe dispatches
+// on it — a VM cluster needs VM capability, a container cluster needs
+// the container-node preconditions, never both.
+func (r *ClusterReconciler) NodeCapable(iso clusterstore.Isolation) error {
+	if coreIsolation(iso) == clustercore.IsolationContainer {
+		return r.mgr.ContainerNodeCapable()
+	}
+	return r.mgr.VMCapable()
+}
+
+// coreIsolation maps the stored class onto the provisioning seam's.
+// Anything that is not the explicit weaker class provisions VMs.
+func coreIsolation(i clusterstore.Isolation) clustercore.Isolation {
+	if i.OrDefault() == clusterstore.IsolationContainer {
+		return clustercore.IsolationContainer
+	}
+	return clustercore.IsolationVM
+}
 
 // Run ticks until ctx ends.
 func (r *ClusterReconciler) Run(ctx context.Context) {
@@ -148,6 +165,7 @@ var cpSize = clustercore.DesiredGroup{CPU: "2", Memory: "4GB", Disk: "40GB"}
 
 func (r *ClusterReconciler) reconcileCluster(ctx context.Context, c *clusterstore.Cluster) error {
 	desired := desiredFrom(c)
+	iso := coreIsolation(c.NodeIsolation)
 	observed, err := r.mgr.Observe(c.Owner, c.Name)
 	if err != nil {
 		return fmt.Errorf("observe: %w", err)
@@ -165,7 +183,7 @@ func (r *ClusterReconciler) reconcileCluster(ctx context.Context, c *clusterstor
 			if err := r.admitSize(c, cpSize, "control-plane"); err != nil {
 				return nil // refusal recorded; retry next pass
 			}
-			cpIP, err := r.mgr.ProvisionCP(c.Owner, c.Name, cpSize, nil)
+			cpIP, err := r.mgr.ProvisionCP(c.Owner, c.Name, iso, cpSize, nil)
 			if err != nil {
 				return fmt.Errorf("provision control plane: %w", err)
 			}
@@ -185,7 +203,7 @@ func (r *ClusterReconciler) reconcileCluster(ctx context.Context, c *clusterstor
 			if err != nil {
 				return fmt.Errorf("control-plane IP: %w", err)
 			}
-			if err := r.mgr.ProvisionWorker(c.Owner, c.Name, g, act.Name, cpIP); err != nil {
+			if err := r.mgr.ProvisionWorker(c.Owner, c.Name, iso, g, act.Name, cpIP); err != nil {
 				return fmt.Errorf("provision worker %s: %w", act.Name, err)
 			}
 			_ = r.store.UpsertNode(ctx, &clusterstore.Node{

--- a/internal/server/cluster_reconciler_test.go
+++ b/internal/server/cluster_reconciler_test.go
@@ -25,10 +25,13 @@ import (
 // pushed files persist, and the in-cluster kubectl reports every
 // existing VM as a Ready node.
 type stateHost struct {
-	mu     sync.Mutex
-	vms    map[string]*stateVM
-	files  map[string][]byte
-	capErr error
+	mu              sync.Mutex
+	vms             map[string]*stateVM
+	files           map[string][]byte
+	capErr          error
+	containerCapErr error
+	// isolations records the class each node was created with (#1429).
+	isolations map[string]clustercore.Isolation
 }
 
 type stateVM struct {
@@ -37,18 +40,20 @@ type stateVM struct {
 }
 
 func newStateHost() *stateHost {
-	return &stateHost{vms: map[string]*stateVM{}, files: map[string][]byte{}}
+	return &stateHost{vms: map[string]*stateVM{}, files: map[string][]byte{}, isolations: map[string]clustercore.Isolation{}}
 }
 
-func (h *stateHost) VMCapable() error { return h.capErr }
+func (h *stateHost) VMCapable() error            { return h.capErr }
+func (h *stateHost) ContainerNodeCapable() error { return h.containerCapErr }
 
-func (h *stateHost) CreateVM(spec clustercore.NodeSpec) error {
+func (h *stateHost) CreateNode(spec clustercore.NodeSpec, isolation clustercore.Isolation) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if _, ok := h.vms[spec.Name]; ok {
 		return fmt.Errorf("vm %s already exists", spec.Name)
 	}
 	h.vms[spec.Name] = &stateVM{labels: spec.Labels, running: true}
+	h.isolations[spec.Name] = isolation
 	// A booted CP "writes" its own kubeconfig and join token.
 	if spec.Labels[clustercore.LabelClusterRole] == clustercore.RoleControlPlane {
 		h.files[spec.Name+":"+clustercore.KubeconfigPath] = []byte("clusters:\n- cluster:\n    server: https://127.0.0.1:6443\n")
@@ -299,4 +304,79 @@ func vmNames(h *stateHost) []string {
 		out = append(out, n)
 	}
 	return out
+}
+
+// The create-time capability probe dispatches on the cluster's
+// isolation class (#1429): a VM cluster is gated by VMCapable only, a
+// container cluster by ContainerNodeCapable only.
+func TestReconciler_CapabilityProbeMatchesIsolation(t *testing.T) {
+	vmErr := clustercore.ErrVMsUnsupported
+	containerErr := fmt.Errorf("%w: br_netfilter: kernel module not present", clustercore.ErrContainerNodesUnsupported)
+
+	cases := []struct {
+		name            string
+		isolation       pb.NodeIsolation
+		vmCapErr        error
+		containerCapErr error
+		wantCode        codes.Code // OK = create allowed
+		wantIn          string
+	}{
+		{"vm cluster gated by the VM probe", pb.NodeIsolation_NODE_ISOLATION_VM, vmErr, nil, codes.FailedPrecondition, "virtual machines"},
+		{"vm cluster ignores the container probe", pb.NodeIsolation_NODE_ISOLATION_VM, nil, containerErr, codes.OK, ""},
+		{"container cluster gated by the container probe, refusal names the precondition", pb.NodeIsolation_NODE_ISOLATION_CONTAINER, nil, containerErr, codes.FailedPrecondition, "br_netfilter"},
+		{"container cluster does not require VM capability", pb.NodeIsolation_NODE_ISOLATION_CONTAINER, vmErr, nil, codes.OK, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, _, host := testReconcilerRig(t)
+			srv.SetIsolationGateFromEnv("true")
+			host.capErr, host.containerCapErr = tc.vmCapErr, tc.containerCapErr
+
+			_, err := srv.CreateCluster(tenantCtx("alice"), &pb.CreateClusterRequest{
+				Name: "demo", NodeIsolation: tc.isolation,
+			})
+			if status.Code(err) != tc.wantCode {
+				t.Fatalf("CreateCluster = %v, want code %v", err, tc.wantCode)
+			}
+			if tc.wantIn != "" && !strings.Contains(err.Error(), tc.wantIn) {
+				t.Fatalf("refusal %q does not name %q", err, tc.wantIn)
+			}
+		})
+	}
+}
+
+// A container cluster's nodes are provisioned as container nodes all
+// the way down the seam; a default cluster's stay VM (#1429).
+func TestReconciler_ProvisionIsolationMatchesCluster(t *testing.T) {
+	cases := []struct {
+		name      string
+		isolation pb.NodeIsolation
+		want      clustercore.Isolation
+	}{
+		{"default cluster provisions VM nodes", pb.NodeIsolation_NODE_ISOLATION_UNSPECIFIED, clustercore.IsolationVM},
+		{"container cluster provisions container nodes", pb.NodeIsolation_NODE_ISOLATION_CONTAINER, clustercore.IsolationContainer},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, rec, host := testReconcilerRig(t)
+			srv.SetIsolationGateFromEnv("true")
+			ctx := context.Background()
+			if _, err := srv.CreateCluster(tenantCtx("alice"), &pb.CreateClusterRequest{
+				Name: "demo", NodeIsolation: tc.isolation,
+			}); err != nil {
+				t.Fatalf("CreateCluster: %v", err)
+			}
+
+			rec.ReconcileOnce(ctx) // control plane
+			rec.ReconcileOnce(ctx) // workers to min
+			if len(host.vms) < 2 {
+				t.Fatalf("expected CP + worker, got %v", vmNames(host))
+			}
+			for name := range host.vms {
+				if got := host.isolations[name]; got != tc.want {
+					t.Fatalf("node %s created with isolation %q, want %q", name, got, tc.want)
+				}
+			}
+		})
+	}
 }

--- a/internal/server/cluster_server.go
+++ b/internal/server/cluster_server.go
@@ -36,10 +36,12 @@ type ClusterServer struct {
 	pb.UnimplementedClusterServiceServer
 	store      cluster.Store
 	kubeconfig KubeconfigReader
-	// vmCapable is the create-time capability probe (#1414): a host
-	// that cannot run VMs refuses cluster creation with a typed
-	// error instead of provisioning doomed records.
-	vmCapable func() error
+	// nodeCapable is the create-time capability probe (#1414, #1429):
+	// dispatched on the requested isolation class, it refuses cluster
+	// creation with a typed error instead of provisioning doomed
+	// records — a VM cluster on a KVM-less host, a container cluster
+	// on a host missing the container-node preconditions.
+	nodeCapable func(cluster.Isolation) error
 	// asyncDelete marks the reconciler as wired: DeleteCluster flips
 	// records to DELETING for the reconciler to drain instead of
 	// dropping rows that may have live VMs behind them.
@@ -73,7 +75,7 @@ func (s *ClusterServer) Store() cluster.Store { return s.store }
 // capability probe, and reconciler-drained deletes.
 func (s *ClusterServer) SetReconciler(r *ClusterReconciler) {
 	s.kubeconfig = r
-	s.vmCapable = r.VMCapable
+	s.nodeCapable = r.NodeCapable
 	s.asyncDelete = true
 }
 
@@ -216,8 +218,8 @@ func (s *ClusterServer) CreateCluster(ctx context.Context, req *pb.CreateCluster
 	if err != nil {
 		return nil, err
 	}
-	if s.vmCapable != nil {
-		if err := s.vmCapable(); err != nil {
+	if s.nodeCapable != nil {
+		if err := s.nodeCapable(isolation); err != nil {
 			return nil, status.Errorf(codes.FailedPrecondition, "%v", err)
 		}
 	}

--- a/pkg/core/cluster/bootstrap.go
+++ b/pkg/core/cluster/bootstrap.go
@@ -31,6 +31,11 @@ type ServerBootstrap struct {
 	// the external endpoint and the VM IP, so the rewritten
 	// kubeconfig verifies.
 	TLSSANs []string
+	// Isolation selects the node runtime variant: the container path
+	// prepends the boot-time /dev/kmsg shim into the unit (#1429);
+	// the zero value renders the VM script byte-identically to
+	// pre-#1429.
+	Isolation Isolation
 }
 
 // RenderServerScript renders the control-plane first-boot script: a
@@ -59,7 +64,7 @@ Wants=network-online.target
 
 [Service]
 Type=notify
-ExecStart=%[1]s server --disable traefik --node-taint node-role.kubernetes.io/control-plane=:NoSchedule --write-kubeconfig-mode 0600%[2]s
+%[5]sExecStart=%[1]s server --disable traefik --node-taint node-role.kubernetes.io/control-plane=:NoSchedule --write-kubeconfig-mode 0600%[2]s
 Restart=always
 RestartSec=5
 LimitNOFILE=1048576
@@ -78,7 +83,7 @@ until [ -s %[3]s ] && [ -s %[4]s ]; do
   [ "$i" -gt 120 ] && { echo "k3s server did not come up" >&2; exit 1; }
   sleep 2
 done
-`, K3sBinaryPath, sanFlags.String(), KubeconfigPath, NodeTokenPath)
+`, K3sBinaryPath, sanFlags.String(), KubeconfigPath, NodeTokenPath, kmsgShimUnitLine(b.Isolation))
 }
 
 // AgentBootstrap parameterizes a worker script.
@@ -87,6 +92,8 @@ type AgentBootstrap struct {
 	// (https://<cp-ip>:6443) — workers join over the private bridge,
 	// not the published endpoint.
 	ServerURL string
+	// Isolation selects the node runtime variant; see ServerBootstrap.
+	Isolation Isolation
 }
 
 // RenderAgentScript renders a worker first-boot script: a systemd unit
@@ -108,7 +115,7 @@ Wants=network-online.target
 
 [Service]
 Type=notify
-ExecStart=%[1]s agent --server %[3]s --token-file %[2]s
+%[4]sExecStart=%[1]s agent --server %[3]s --token-file %[2]s
 Restart=always
 RestartSec=5
 LimitNOFILE=1048576
@@ -119,7 +126,7 @@ UNIT
 
 systemctl daemon-reload
 systemctl enable --now k3s-agent.service
-`, K3sBinaryPath, AgentTokenPath, b.ServerURL)
+`, K3sBinaryPath, AgentTokenPath, b.ServerURL, kmsgShimUnitLine(b.Isolation))
 }
 
 // RewriteKubeconfigServer replaces the server URL in a k3s admin

--- a/pkg/core/cluster/bootstrap_test.go
+++ b/pkg/core/cluster/bootstrap_test.go
@@ -114,3 +114,52 @@ func TestRenderCACloudConfig(t *testing.T) {
 		}
 	}
 }
+
+// --- container-variant renders (#1429) --------------------------------
+//
+// The container path prepends the boot-time /dev/kmsg shim into the
+// systemd unit; the VM path stays byte-identical to its pre-#1429
+// golden (pinned above by TestRenderServerScript/TestRenderAgentScript).
+
+func TestRenderServerScriptContainerVariant(t *testing.T) {
+	got := RenderServerScript(ServerBootstrap{
+		TLSSANs:   []string{"203.0.113.10", "10.166.11.5"},
+		Isolation: IsolationContainer,
+	})
+	golden(t, "server-container.sh.golden", got)
+
+	// The shim runs inside the unit, before k3s, so it re-applies on
+	// every boot (/dev is a fresh tmpfs each start).
+	if !strings.Contains(got, "ln -s /dev/console /dev/kmsg") {
+		t.Fatal("container server unit is missing the /dev/kmsg shim")
+	}
+	if !strings.Contains(got, "ExecStartPre="+KmsgShimCommand+"\nExecStart=") {
+		t.Fatal("kmsg shim is not rendered into the unit before k3s starts")
+	}
+	if strings.Contains(got, "security.privileged") {
+		t.Fatal("bootstrap must not touch security.privileged")
+	}
+
+	// The zero-value (VM) render carries no shim.
+	vm := RenderServerScript(ServerBootstrap{TLSSANs: []string{"203.0.113.10", "10.166.11.5"}})
+	if strings.Contains(vm, "kmsg") {
+		t.Fatal("VM server script grew a kmsg shim")
+	}
+}
+
+func TestRenderAgentScriptContainerVariant(t *testing.T) {
+	got := RenderAgentScript(AgentBootstrap{
+		ServerURL: "https://10.166.11.5:6443",
+		Isolation: IsolationContainer,
+	})
+	golden(t, "agent-container.sh.golden", got)
+
+	if !strings.Contains(got, "ExecStartPre="+KmsgShimCommand+"\nExecStart=") {
+		t.Fatal("kmsg shim is not rendered into the agent unit before k3s starts")
+	}
+
+	vm := RenderAgentScript(AgentBootstrap{ServerURL: "https://10.166.11.5:6443"})
+	if strings.Contains(vm, "kmsg") {
+		t.Fatal("VM agent script grew a kmsg shim")
+	}
+}

--- a/pkg/core/cluster/containerprofile.go
+++ b/pkg/core/cluster/containerprofile.go
@@ -1,0 +1,207 @@
+package cluster
+
+// Container node profile and capability probe (#1429): THE one place
+// holding the "k3s node inside an Incus system container" knowledge.
+// Design: docs/architecture/cluster-container-node-pools.md
+// ("The container node profile").
+//
+// The profile is deliberately three facts and a hard line:
+//
+//   - security.nesting=true — containerd runs pods inside the node.
+//   - cgroup v2 delegation — Incus's default for system containers;
+//     nothing to set here, the host-side requirement (a unified
+//     cgroup v2 hierarchy) is asserted by ContainerNodeCapable.
+//   - a boot-time /dev/kmsg shim rendered into the bootstrap unit
+//     (KmsgShimCommand below).
+//   - NO security.privileged — if a future k8s feature turns out to
+//     need it, that is a new design conversation, not a config tweak.
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ContainerNodeConfig returns the Incus instance config applied to a
+// k3s node container by CreateNode on the container path. Golden-
+// pinned (testdata/container-node-config.golden): what a tenant's node
+// container is granted changes only as a reviewable golden diff.
+func ContainerNodeConfig() map[string]string {
+	return map[string]string{
+		// containerd runs pods inside the node container.
+		"security.nesting": "true",
+	}
+}
+
+// KmsgShimCommand is the boot-time /dev/kmsg shim: k3s's kubelet wants
+// /dev/kmsg, which an unprivileged container does not get — the
+// k3d-proven workaround links it to the console. It renders into the
+// k3s systemd unit as an ExecStartPre so it re-applies on every boot
+// (/dev is a fresh tmpfs each start), rather than being mounted from
+// the host, whose own /dev/kmsg may not exist (nested case).
+const KmsgShimCommand = `/bin/sh -c '[ -e /dev/kmsg ] || ln -s /dev/console /dev/kmsg'`
+
+// kmsgShimUnitLine renders the shim into a unit's [Service] section:
+// one ExecStartPre line on the container path, nothing on the VM path
+// — VM units stay byte-identical to their pre-#1429 goldens.
+func kmsgShimUnitLine(iso Isolation) string {
+	if iso != IsolationContainer {
+		return ""
+	}
+	return "ExecStartPre=" + KmsgShimCommand + "\n"
+}
+
+// --- capability probe -------------------------------------------------
+
+// ErrContainerNodesUnsupported heads every ContainerNodeCapable
+// refusal — the container-class counterpart of ErrVMsUnsupported.
+var ErrContainerNodesUnsupported = errors.New("this backend cannot run container nodes")
+
+// ProbeState is one precondition's observed state.
+type ProbeState int
+
+const (
+	// ProbeOK: the precondition was verified present.
+	ProbeOK ProbeState = iota
+	// ProbeMissing: the precondition was verified absent.
+	ProbeMissing
+	// ProbeUnknown: the precondition could not be observed. Never
+	// treated as OK — an unverified boundary requirement refuses,
+	// with the refusal saying what could not be checked and why.
+	ProbeUnknown
+)
+
+// Probe is one precondition's observation: its state plus, for
+// anything other than OK, the incusenv "which step, which error"
+// detail an operator needs to act on it.
+type Probe struct {
+	State  ProbeState
+	Detail string
+}
+
+// ContainerNodeFacts is everything ContainerNodeCapable observes about
+// the host, one Probe per design-named precondition. Split from the
+// verdict (CheckContainerNodeFacts) so the fold is a pure,
+// table-testable function.
+type ContainerNodeFacts struct {
+	// Nesting: the Incus server can create system containers (lxc
+	// driver present) — the carrier for security.nesting. On a nested
+	// host, a responding Incus is itself the evidence that nesting was
+	// granted to this environment.
+	Nesting Probe
+	// CgroupV2: the (shared) kernel exposes a unified cgroup v2
+	// hierarchy, which Incus delegates to system containers.
+	CgroupV2 Probe
+	// BrNetfilter / Overlay: kernel modules k3s networking and
+	// containerd's snapshotter need, present on the shared kernel.
+	BrNetfilter Probe
+	Overlay     Probe
+}
+
+// CheckContainerNodeFacts folds the observations into the create-time
+// verdict: nil only when every precondition was VERIFIED present.
+// Missing and unprobeable preconditions both refuse — each named with
+// its own detail, an unprobeable one explicitly as "could not be
+// verified" rather than assumed green.
+func CheckContainerNodeFacts(f ContainerNodeFacts) error {
+	items := []struct {
+		name string
+		p    Probe
+	}{
+		{"nesting", f.Nesting},
+		{"cgroup v2", f.CgroupV2},
+		{"br_netfilter", f.BrNetfilter},
+		{"overlay", f.Overlay},
+	}
+	var problems []string
+	for _, it := range items {
+		switch it.p.State {
+		case ProbeOK:
+		case ProbeMissing:
+			problems = append(problems, fmt.Sprintf("%s: %s", it.name, it.p.Detail))
+		default: // ProbeUnknown and anything unrecognized fail closed
+			problems = append(problems, fmt.Sprintf("%s: could not be verified (%s)", it.name, it.p.Detail))
+		}
+	}
+	if len(problems) == 0 {
+		return nil
+	}
+	return fmt.Errorf("%w: %s", ErrContainerNodesUnsupported, strings.Join(problems, "; "))
+}
+
+// GatherContainerNodeFacts probes the daemon host. sysRoot is the host
+// filesystem root ("/" in production, a fixture in tests); driver
+// reports the Incus server's instance drivers (IncusHost wires
+// GetServerInfo). Every probe distinguishes verified-absent from
+// could-not-observe.
+func GatherContainerNodeFacts(sysRoot string, driver func() (string, error)) ContainerNodeFacts {
+	nested := hostIsContainer(sysRoot)
+	return ContainerNodeFacts{
+		Nesting:     probeNesting(driver),
+		CgroupV2:    probeCgroupV2(sysRoot),
+		BrNetfilter: probeModule(sysRoot, "br_netfilter", nested),
+		Overlay:     probeModule(sysRoot, "overlay", nested),
+	}
+}
+
+// hostIsContainer reports whether the daemon host is itself a
+// container (the nested rung): systemd writes /run/systemd/container
+// in any container it boots in.
+func hostIsContainer(sysRoot string) bool {
+	_, err := os.Stat(filepath.Join(sysRoot, "run/systemd/container"))
+	return err == nil
+}
+
+func probeNesting(driver func() (string, error)) Probe {
+	d, err := driver()
+	if err != nil {
+		return Probe{State: ProbeUnknown, Detail: fmt.Sprintf("query incus server drivers: %v", err)}
+	}
+	if !strings.Contains(d, "lxc") {
+		return Probe{State: ProbeMissing, Detail: fmt.Sprintf("incus reports no system-container (lxc) driver, only %q", d)}
+	}
+	// lxc driver present: system containers can be created and
+	// security.nesting is per-instance config this server applies. On
+	// a nested host, this very answer is the transitive evidence that
+	// nesting was granted — the outer instance's config cannot be
+	// read from in here.
+	return Probe{State: ProbeOK}
+}
+
+func probeCgroupV2(sysRoot string) Probe {
+	p := filepath.Join(sysRoot, "sys/fs/cgroup/cgroup.controllers")
+	_, err := os.Stat(p)
+	switch {
+	case err == nil:
+		return Probe{State: ProbeOK}
+	case os.IsNotExist(err):
+		return Probe{State: ProbeMissing,
+			Detail: fmt.Sprintf("host cgroup hierarchy is not unified cgroup v2 (%s not found); k3s-in-container needs cgroup v2 delegation", p)}
+	default:
+		return Probe{State: ProbeUnknown, Detail: fmt.Sprintf("stat %s: %v", p, err)}
+	}
+}
+
+func probeModule(sysRoot, module string, nested bool) Probe {
+	p := filepath.Join(sysRoot, "sys/module", module)
+	_, err := os.Stat(p)
+	switch {
+	case err == nil:
+		return Probe{State: ProbeOK}
+	case os.IsNotExist(err):
+		detail := fmt.Sprintf("kernel module %s not present (%s not found)", module, p)
+		if nested {
+			// The shared kernel belongs to the outer host; a nested
+			// daemon can neither load the module nor probe beyond
+			// /sys — say so instead of guessing.
+			detail += "; this host is itself a container sharing the outer kernel — the module cannot be loaded from here, load it on the physical host"
+		} else {
+			detail += "; load it (modprobe " + module + ")"
+		}
+		return Probe{State: ProbeMissing, Detail: detail}
+	default:
+		return Probe{State: ProbeUnknown, Detail: fmt.Sprintf("stat %s: %v", p, err)}
+	}
+}

--- a/pkg/core/cluster/containerprofile_test.go
+++ b/pkg/core/cluster/containerprofile_test.go
@@ -1,0 +1,262 @@
+package cluster
+
+// Container node runtime (#1429): the profile (the ONE place holding
+// the k3s-in-container knowledge) and the ContainerNodeCapable probe.
+// Design: docs/architecture/cluster-container-node-pools.md.
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// --- the profile ------------------------------------------------------
+
+// The applied Incus config set is golden-pinned: what a tenant's node
+// container is granted changes only as a reviewable golden diff.
+func TestContainerNodeConfigGolden(t *testing.T) {
+	cfg := ContainerNodeConfig()
+	keys := make([]string, 0, len(cfg))
+	for k := range cfg {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for _, k := range keys {
+		fmt.Fprintf(&b, "%s=%s\n", k, cfg[k])
+	}
+	golden(t, "container-node-config.golden", b.String())
+}
+
+func TestContainerNodeConfigHardLines(t *testing.T) {
+	cfg := ContainerNodeConfig()
+	if cfg["security.nesting"] != "true" {
+		t.Fatalf("security.nesting = %q, want \"true\" (containerd runs pods inside the node)", cfg["security.nesting"])
+	}
+	// The design's hard line: NO security.privileged, ever. A future
+	// k8s feature that seems to need it is a new design conversation,
+	// not a config tweak — this test is the tripwire.
+	if v, ok := cfg["security.privileged"]; ok {
+		t.Fatalf("container node profile sets security.privileged=%q — forbidden by design", v)
+	}
+}
+
+// --- probe verdict: CheckContainerNodeFacts ---------------------------
+
+func greenFacts() ContainerNodeFacts {
+	return ContainerNodeFacts{
+		Nesting:     Probe{State: ProbeOK},
+		CgroupV2:    Probe{State: ProbeOK},
+		BrNetfilter: Probe{State: ProbeOK},
+		Overlay:     Probe{State: ProbeOK},
+	}
+}
+
+func TestCheckContainerNodeFacts(t *testing.T) {
+	cases := []struct {
+		name    string
+		mutate  func(*ContainerNodeFacts)
+		wantErr []string // substrings the refusal must name; nil = capable
+	}{
+		{
+			name:   "all preconditions verified",
+			mutate: func(*ContainerNodeFacts) {},
+		},
+		{
+			name: "missing nesting is named",
+			mutate: func(f *ContainerNodeFacts) {
+				f.Nesting = Probe{State: ProbeMissing, Detail: "incus reports no system-container (lxc) driver"}
+			},
+			wantErr: []string{"nesting", "lxc"},
+		},
+		{
+			name: "missing cgroup v2 is named",
+			mutate: func(f *ContainerNodeFacts) {
+				f.CgroupV2 = Probe{State: ProbeMissing, Detail: "/sys/fs/cgroup/cgroup.controllers not found"}
+			},
+			wantErr: []string{"cgroup v2", "cgroup.controllers"},
+		},
+		{
+			name: "missing br_netfilter is named",
+			mutate: func(f *ContainerNodeFacts) {
+				f.BrNetfilter = Probe{State: ProbeMissing, Detail: "kernel module br_netfilter not present; load it (modprobe br_netfilter)"}
+			},
+			wantErr: []string{"br_netfilter", "modprobe"},
+		},
+		{
+			name: "missing overlay is named",
+			mutate: func(f *ContainerNodeFacts) {
+				f.Overlay = Probe{State: ProbeMissing, Detail: "kernel module overlay not present"}
+			},
+			wantErr: []string{"overlay"},
+		},
+		{
+			name: "unprobeable precondition refuses as unverified, never assumed green",
+			mutate: func(f *ContainerNodeFacts) {
+				f.BrNetfilter = Probe{State: ProbeUnknown, Detail: "stat /sys/module/br_netfilter: permission denied"}
+			},
+			wantErr: []string{"br_netfilter", "could not be verified", "permission denied"},
+		},
+		{
+			name: "every problem is named, not just the first",
+			mutate: func(f *ContainerNodeFacts) {
+				f.CgroupV2 = Probe{State: ProbeMissing, Detail: "host cgroup hierarchy is not cgroup v2"}
+				f.Overlay = Probe{State: ProbeUnknown, Detail: "stat /sys/module/overlay: permission denied"}
+			},
+			wantErr: []string{"cgroup v2", "overlay", "could not be verified"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := greenFacts()
+			tc.mutate(&f)
+			err := CheckContainerNodeFacts(f)
+			if len(tc.wantErr) == 0 {
+				if err != nil {
+					t.Fatalf("CheckContainerNodeFacts = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("CheckContainerNodeFacts = nil, want a refusal")
+			}
+			if !errors.Is(err, ErrContainerNodesUnsupported) {
+				t.Fatalf("refusal is not ErrContainerNodesUnsupported: %v", err)
+			}
+			for _, want := range tc.wantErr {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("refusal %q does not name %q", err, want)
+				}
+			}
+		})
+	}
+}
+
+// --- fact gathering from a host filesystem ----------------------------
+
+func lxcDriver() (string, error)  { return "lxc | qemu", nil }
+func qemuDriver() (string, error) { return "qemu", nil }
+
+// writeLayout materializes a fake sysroot: entries ending in "/" are
+// directories, the rest empty files.
+func writeLayout(t *testing.T, root string, entries []string) {
+	t.Helper()
+	for _, e := range entries {
+		p := filepath.Join(root, e)
+		if strings.HasSuffix(e, "/") {
+			if err := os.MkdirAll(p, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+var fullLayout = []string{
+	"sys/fs/cgroup/cgroup.controllers",
+	"sys/module/br_netfilter/",
+	"sys/module/overlay/",
+}
+
+func TestGatherContainerNodeFacts(t *testing.T) {
+	cases := []struct {
+		name   string
+		layout []string
+		driver func() (string, error)
+		check  func(t *testing.T, f ContainerNodeFacts)
+	}{
+		{
+			name:   "everything present verifies green",
+			layout: fullLayout,
+			driver: lxcDriver,
+			check: func(t *testing.T, f ContainerNodeFacts) {
+				if err := CheckContainerNodeFacts(f); err != nil {
+					t.Fatalf("green host refused: %v", err)
+				}
+			},
+		},
+		{
+			name:   "cgroup v1 host is missing, with the probed path named",
+			layout: []string{"sys/module/br_netfilter/", "sys/module/overlay/"},
+			driver: lxcDriver,
+			check: func(t *testing.T, f ContainerNodeFacts) {
+				if f.CgroupV2.State != ProbeMissing {
+					t.Fatalf("CgroupV2 = %+v, want ProbeMissing", f.CgroupV2)
+				}
+				if !strings.Contains(f.CgroupV2.Detail, "cgroup.controllers") {
+					t.Fatalf("detail %q does not name the probed path", f.CgroupV2.Detail)
+				}
+			},
+		},
+		{
+			name:   "module missing on a plain host says how to load it",
+			layout: []string{"sys/fs/cgroup/cgroup.controllers", "sys/module/overlay/"},
+			driver: lxcDriver,
+			check: func(t *testing.T, f ContainerNodeFacts) {
+				if f.BrNetfilter.State != ProbeMissing {
+					t.Fatalf("BrNetfilter = %+v, want ProbeMissing", f.BrNetfilter)
+				}
+				if !strings.Contains(f.BrNetfilter.Detail, "modprobe br_netfilter") {
+					t.Fatalf("detail %q does not say how to fix it", f.BrNetfilter.Detail)
+				}
+			},
+		},
+		{
+			name: "module missing on a NESTED host reports it cannot be fixed from here",
+			layout: []string{
+				"sys/fs/cgroup/cgroup.controllers",
+				"sys/module/overlay/",
+				"run/systemd/container", // nested marker
+			},
+			driver: lxcDriver,
+			check: func(t *testing.T, f ContainerNodeFacts) {
+				if f.BrNetfilter.State != ProbeMissing {
+					t.Fatalf("BrNetfilter = %+v, want ProbeMissing", f.BrNetfilter)
+				}
+				if !strings.Contains(f.BrNetfilter.Detail, "cannot be loaded from here") {
+					t.Fatalf("nested detail %q does not report the nested limitation", f.BrNetfilter.Detail)
+				}
+			},
+		},
+		{
+			name:   "unreachable incus is unknown, not green",
+			layout: fullLayout,
+			driver: func() (string, error) { return "", errors.New("connection refused") },
+			check: func(t *testing.T, f ContainerNodeFacts) {
+				if f.Nesting.State != ProbeUnknown {
+					t.Fatalf("Nesting = %+v, want ProbeUnknown", f.Nesting)
+				}
+				if err := CheckContainerNodeFacts(f); err == nil {
+					t.Fatal("unverifiable nesting still passed the probe")
+				}
+			},
+		},
+		{
+			name:   "no lxc driver is missing",
+			layout: fullLayout,
+			driver: qemuDriver,
+			check: func(t *testing.T, f ContainerNodeFacts) {
+				if f.Nesting.State != ProbeMissing {
+					t.Fatalf("Nesting = %+v, want ProbeMissing", f.Nesting)
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeLayout(t, root, tc.layout)
+			tc.check(t, GatherContainerNodeFacts(root, tc.driver))
+		})
+	}
+}

--- a/pkg/core/cluster/incushost.go
+++ b/pkg/core/cluster/incushost.go
@@ -38,7 +38,21 @@ func (h *IncusHost) VMCapable() error {
 	return nil
 }
 
-func (h *IncusHost) CreateVM(spec NodeSpec) error {
+// ContainerNodeCapable probes the container-node preconditions on the
+// real host (#1429): the observation lives in GatherContainerNodeFacts
+// and the verdict in CheckContainerNodeFacts, both in
+// containerprofile.go — the one place holding this knowledge.
+func (h *IncusHost) ContainerNodeCapable() error {
+	return CheckContainerNodeFacts(GatherContainerNodeFacts("/", func() (string, error) {
+		info, err := h.client.GetServerInfo()
+		if err != nil {
+			return "", err
+		}
+		return info.Environment.Driver, nil
+	}))
+}
+
+func (h *IncusHost) CreateNode(spec NodeSpec, isolation Isolation) error {
 	cfg := incus.ContainerConfig{
 		Name:         spec.Name,
 		Image:        "images:ubuntu/24.04", // the nodevm default; VM image bake is a later phase
@@ -46,6 +60,14 @@ func (h *IncusHost) CreateVM(spec NodeSpec) error {
 		Memory:       spec.Memory,
 		InstanceType: api.InstanceTypeVM,
 		AutoStart:    true,
+	}
+	if isolation == IsolationContainer {
+		// The container node profile — nesting, no privileged — comes
+		// from ContainerNodeConfig; anything that is not the explicit
+		// weaker class provisions a VM (never default to the weaker
+		// boundary).
+		cfg.InstanceType = api.InstanceTypeContainer
+		cfg.ExtraConfig = ContainerNodeConfig()
 	}
 	if spec.Disk != "" {
 		cfg.Disk = &incus.DiskDevice{Size: spec.Disk}

--- a/pkg/core/cluster/manager.go
+++ b/pkg/core/cluster/manager.go
@@ -16,7 +16,14 @@ type VMHost interface {
 	// user-facing error when it cannot (the design's hard create-time
 	// requirement).
 	VMCapable() error
-	CreateVM(spec NodeSpec) error
+	// ContainerNodeCapable is the container-class counterpart
+	// (#1429): nil when the host can run k3s node containers, or a
+	// refusal naming every missing (or unverifiable) precondition.
+	ContainerNodeCapable() error
+	// CreateNode creates one cluster node backed by the instance type
+	// the isolation class selects: an Incus VM, or a system container
+	// carrying the container node profile (#1429).
+	CreateNode(spec NodeSpec, isolation Isolation) error
 	Start(name string) error
 	Delete(name string) error
 	// WaitReady blocks until the guest agent is up and networked,
@@ -68,6 +75,9 @@ func NewManagerWithLoader(host VMHost, loader func() ([]byte, error)) *Manager {
 // VMCapable surfaces the host's VM capability probe.
 func (m *Manager) VMCapable() error { return m.host.VMCapable() }
 
+// ContainerNodeCapable surfaces the host's container-node probe (#1429).
+func (m *Manager) ContainerNodeCapable() error { return m.host.ContainerNodeCapable() }
+
 // Observe returns the host's view of a cluster's VMs.
 func (m *Manager) Observe(tenant, clusterName string) (Observed, error) {
 	return m.host.ClusterVMs(tenant, clusterName)
@@ -85,14 +95,14 @@ const bootstrapScriptPath = "/root/containarium-bootstrap.sh"
 // start → wait → push pinned binary + rendered script → exec. Returns
 // the VM's IP (workers join over it). cpSize is the smallest preset —
 // the control plane is platform overhead, not tenant capacity.
-func (m *Manager) ProvisionCP(tenant, clusterName string, cpSize DesiredGroup, tlsSANs []string) (string, error) {
+func (m *Manager) ProvisionCP(tenant, clusterName string, iso Isolation, cpSize DesiredGroup, tlsSANs []string) (string, error) {
 	name := CPName(tenant, clusterName)
 	spec := NodeSpec{
 		Name: name, CPU: cpSize.CPU, Memory: cpSize.Memory, Disk: cpSize.Disk,
 		Labels: VMLabels(tenant, clusterName, RoleControlPlane, ""),
 	}
-	if err := m.host.CreateVM(spec); err != nil {
-		return "", fmt.Errorf("create control-plane VM: %w", err)
+	if err := m.host.CreateNode(spec, iso); err != nil {
+		return "", fmt.Errorf("create control-plane node: %w", err)
 	}
 	ip, err := m.host.WaitReady(name, m.waitReadyTimeout)
 	if err != nil {
@@ -105,7 +115,7 @@ func (m *Manager) ProvisionCP(tenant, clusterName string, cpSize DesiredGroup, t
 	if err := m.host.Push(name, K3sBinaryPath, bin, "0755"); err != nil {
 		return "", fmt.Errorf("push k3s binary: %w", err)
 	}
-	script := RenderServerScript(ServerBootstrap{TLSSANs: append([]string{ip}, tlsSANs...)})
+	script := RenderServerScript(ServerBootstrap{TLSSANs: append([]string{ip}, tlsSANs...), Isolation: iso})
 	if err := m.host.Push(name, bootstrapScriptPath, []byte(script), "0755"); err != nil {
 		return "", fmt.Errorf("push bootstrap script: %w", err)
 	}
@@ -118,7 +128,7 @@ func (m *Manager) ProvisionCP(tenant, clusterName string, cpSize DesiredGroup, t
 // ProvisionWorker creates and joins one worker VM to a running control
 // plane. The join token is read from the CP and pushed 0600 — it never
 // leaves the host or lands in a store.
-func (m *Manager) ProvisionWorker(tenant, clusterName string, g DesiredGroup, vmName, cpIP string) error {
+func (m *Manager) ProvisionWorker(tenant, clusterName string, iso Isolation, g DesiredGroup, vmName, cpIP string) error {
 	cp := CPName(tenant, clusterName)
 	token, err := m.host.Read(cp, NodeTokenPath)
 	if err != nil {
@@ -128,8 +138,8 @@ func (m *Manager) ProvisionWorker(tenant, clusterName string, g DesiredGroup, vm
 		Name: vmName, CPU: g.CPU, Memory: g.Memory, Disk: g.Disk,
 		Labels: VMLabels(tenant, clusterName, RoleWorker, g.Name),
 	}
-	if err := m.host.CreateVM(spec); err != nil {
-		return fmt.Errorf("create worker VM: %w", err)
+	if err := m.host.CreateNode(spec, iso); err != nil {
+		return fmt.Errorf("create worker node: %w", err)
 	}
 	if _, err := m.host.WaitReady(vmName, m.waitReadyTimeout); err != nil {
 		return fmt.Errorf("worker VM %s not ready: %w", vmName, err)
@@ -144,7 +154,7 @@ func (m *Manager) ProvisionWorker(tenant, clusterName string, g DesiredGroup, vm
 	if err := m.host.Push(vmName, AgentTokenPath, token, "0600"); err != nil {
 		return fmt.Errorf("push join token: %w", err)
 	}
-	script := RenderAgentScript(AgentBootstrap{ServerURL: "https://" + cpIP + ":6443"})
+	script := RenderAgentScript(AgentBootstrap{ServerURL: "https://" + cpIP + ":6443", Isolation: iso})
 	if err := m.host.Push(vmName, bootstrapScriptPath, []byte(script), "0755"); err != nil {
 		return fmt.Errorf("push bootstrap script: %w", err)
 	}

--- a/pkg/core/cluster/manager_test.go
+++ b/pkg/core/cluster/manager_test.go
@@ -11,24 +11,31 @@ import (
 // fakeHost records every VMHost call so tests assert the exact
 // orchestration sequence — the part of the manager that matters.
 type fakeHost struct {
-	calls    []string
-	files    map[string][]byte // "<vm>:<path>" → content
-	execOut  map[string]string // "<vm>:<argv0...>" → stdout
-	readErr  error
-	capError error
+	calls             []string
+	files             map[string][]byte // "<vm>:<path>" → content
+	execOut           map[string]string // "<vm>:<argv0...>" → stdout
+	readErr           error
+	capError          error
+	containerCapError error
+	// isolations records the isolation class CreateNode was called
+	// with, per node name (#1429 acceptance: the fake records the
+	// isolation per call).
+	isolations map[string]Isolation
 }
 
 func newFakeHost() *fakeHost {
-	return &fakeHost{files: map[string][]byte{}, execOut: map[string]string{}}
+	return &fakeHost{files: map[string][]byte{}, execOut: map[string]string{}, isolations: map[string]Isolation{}}
 }
 
 func (f *fakeHost) record(format string, a ...any) {
 	f.calls = append(f.calls, fmt.Sprintf(format, a...))
 }
 
-func (f *fakeHost) VMCapable() error { return f.capError }
-func (f *fakeHost) CreateVM(spec NodeSpec) error {
+func (f *fakeHost) VMCapable() error            { return f.capError }
+func (f *fakeHost) ContainerNodeCapable() error { return f.containerCapError }
+func (f *fakeHost) CreateNode(spec NodeSpec, isolation Isolation) error {
 	f.record("create %s cpu=%s mem=%s disk=%s role=%s", spec.Name, spec.CPU, spec.Memory, spec.Disk, spec.Labels[LabelClusterRole])
+	f.isolations[spec.Name] = isolation
 	return nil
 }
 func (f *fakeHost) Start(name string) error  { f.record("start %s", name); return nil }
@@ -72,7 +79,7 @@ func TestProvisionCPSequence(t *testing.T) {
 	f := newFakeHost()
 	m := testManager(f)
 
-	ip, err := m.ProvisionCP("alice", "demo", DesiredGroup{CPU: "2", Memory: "4GB", Disk: "40GB"}, []string{"203.0.113.10"})
+	ip, err := m.ProvisionCP("alice", "demo", IsolationVM, DesiredGroup{CPU: "2", Memory: "4GB", Disk: "40GB"}, []string{"203.0.113.10"})
 	if err != nil {
 		t.Fatalf("ProvisionCP: %v", err)
 	}
@@ -102,7 +109,7 @@ func TestProvisionWorkerSequence(t *testing.T) {
 	f.files["alice-k8s-demo-cp:"+NodeTokenPath] = []byte("K10secret::token")
 	m := testManager(f)
 
-	err := m.ProvisionWorker("alice", "demo",
+	err := m.ProvisionWorker("alice", "demo", IsolationVM,
 		DesiredGroup{Name: "small", CPU: "2", Memory: "4GB", Disk: "40GB"},
 		"alice-k8s-demo-small-1", "10.166.11.5")
 	if err != nil {
@@ -130,7 +137,7 @@ func TestProvisionWorkerSequence(t *testing.T) {
 	// A CP whose token can't be read must fail BEFORE creating a VM.
 	f2 := newFakeHost()
 	f2.readErr = errors.New("no such file")
-	if err := testManager(f2).ProvisionWorker("alice", "demo", DesiredGroup{Name: "small"}, "alice-k8s-demo-small-1", "10.0.0.1"); err == nil {
+	if err := testManager(f2).ProvisionWorker("alice", "demo", IsolationVM, DesiredGroup{Name: "small"}, "alice-k8s-demo-small-1", "10.0.0.1"); err == nil {
 		t.Fatal("worker provisioned without a join token")
 	}
 	for _, c := range f2.calls {
@@ -179,5 +186,51 @@ func assertCalls(t *testing.T, got, want []string) {
 		if got[i] != want[i] {
 			t.Fatalf("call %d:\n  got  %q\n  want %q", i, got[i], want[i])
 		}
+	}
+}
+
+// The seam carries the isolation class end to end (#1429): CreateNode
+// receives it verbatim, and the bootstrap script the node executes is
+// the matching variant (kmsg shim only on the container path).
+func TestProvisionCarriesIsolationThroughTheSeam(t *testing.T) {
+	cases := []struct {
+		name     string
+		iso      Isolation
+		wantShim bool
+	}{
+		{"vm nodes", IsolationVM, false},
+		{"container nodes", IsolationContainer, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFakeHost()
+			m := testManager(f)
+
+			if _, err := m.ProvisionCP("alice", "demo", tc.iso, DesiredGroup{CPU: "2", Memory: "4GB", Disk: "40GB"}, nil); err != nil {
+				t.Fatalf("ProvisionCP: %v", err)
+			}
+			if got := f.isolations["alice-k8s-demo-cp"]; got != tc.iso {
+				t.Fatalf("CP CreateNode isolation = %q, want %q", got, tc.iso)
+			}
+			cpScript := string(f.files["alice-k8s-demo-cp:"+bootstrapScriptPath])
+			if strings.Contains(cpScript, "kmsg") != tc.wantShim {
+				t.Fatalf("CP script kmsg shim = %v, want %v:\n%s", !tc.wantShim, tc.wantShim, cpScript)
+			}
+
+			f.files["alice-k8s-demo-cp:"+NodeTokenPath] = []byte("K10secret::token")
+			err := m.ProvisionWorker("alice", "demo", tc.iso,
+				DesiredGroup{Name: "small", CPU: "2", Memory: "4GB", Disk: "40GB"},
+				"alice-k8s-demo-small-1", "10.166.11.5")
+			if err != nil {
+				t.Fatalf("ProvisionWorker: %v", err)
+			}
+			if got := f.isolations["alice-k8s-demo-small-1"]; got != tc.iso {
+				t.Fatalf("worker CreateNode isolation = %q, want %q", got, tc.iso)
+			}
+			wScript := string(f.files["alice-k8s-demo-small-1:"+bootstrapScriptPath])
+			if strings.Contains(wScript, "kmsg") != tc.wantShim {
+				t.Fatalf("worker script kmsg shim = %v, want %v:\n%s", !tc.wantShim, tc.wantShim, wScript)
+			}
+		})
 	}
 }

--- a/pkg/core/cluster/spec.go
+++ b/pkg/core/cluster/spec.go
@@ -61,6 +61,27 @@ func VMLabels(tenant, clusterName, role, group string) map[string]string {
 	return l
 }
 
+// Isolation is a cluster's node isolation class as the provisioning
+// seam carries it (#1429): which Incus instance type backs a node and
+// which capability probe must pass before creating it. Mirrors
+// internal/cluster.Isolation / pb.NodeIsolation without importing
+// either — this package depends on neither the store nor the wire
+// contract.
+type Isolation string
+
+const (
+	// IsolationVM backs each node with an Incus VM (its own kernel) —
+	// the default class. Everywhere the seam branches, any value
+	// other than IsolationContainer takes the VM path: an unknown
+	// class must never resolve to the weaker boundary.
+	IsolationVM Isolation = "vm"
+	// IsolationContainer backs each node with an Incus system
+	// container sharing the host kernel. Operator-gated upstream
+	// (#1428); down here it selects the container profile and the
+	// kmsg-shimmed bootstrap variant.
+	IsolationContainer Isolation = "container"
+)
+
 // NodeSpec is everything the host needs to create one cluster VM.
 type NodeSpec struct {
 	Name   string

--- a/pkg/core/cluster/testdata/agent-container.sh.golden
+++ b/pkg/core/cluster/testdata/agent-container.sh.golden
@@ -1,0 +1,28 @@
+#!/bin/sh
+# containarium managed-cluster worker bootstrap (#1414).
+# The k3s binary and the join token are pre-pushed.
+set -eu
+
+chmod 0755 /usr/local/bin/k3s
+chmod 0600 /etc/containarium/k3s-agent-token
+
+cat > /etc/systemd/system/k3s-agent.service <<'UNIT'
+[Unit]
+Description=containarium managed k3s agent
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=notify
+ExecStartPre=/bin/sh -c '[ -e /dev/kmsg ] || ln -s /dev/console /dev/kmsg'
+ExecStart=/usr/local/bin/k3s agent --server https://10.166.11.5:6443 --token-file /etc/containarium/k3s-agent-token
+Restart=always
+RestartSec=5
+LimitNOFILE=1048576
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+systemctl daemon-reload
+systemctl enable --now k3s-agent.service

--- a/pkg/core/cluster/testdata/container-node-config.golden
+++ b/pkg/core/cluster/testdata/container-node-config.golden
@@ -1,0 +1,1 @@
+security.nesting=true

--- a/pkg/core/cluster/testdata/server-container.sh.golden
+++ b/pkg/core/cluster/testdata/server-container.sh.golden
@@ -1,0 +1,35 @@
+#!/bin/sh
+# containarium managed-cluster control-plane bootstrap (#1414).
+# The k3s binary is pre-pushed; this script only wires and starts it.
+set -eu
+
+chmod 0755 /usr/local/bin/k3s
+
+cat > /etc/systemd/system/k3s.service <<'UNIT'
+[Unit]
+Description=containarium managed k3s server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=notify
+ExecStartPre=/bin/sh -c '[ -e /dev/kmsg ] || ln -s /dev/console /dev/kmsg'
+ExecStart=/usr/local/bin/k3s server --disable traefik --node-taint node-role.kubernetes.io/control-plane=:NoSchedule --write-kubeconfig-mode 0600 --tls-san 10.166.11.5 --tls-san 203.0.113.10
+Restart=always
+RestartSec=5
+LimitNOFILE=1048576
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+systemctl daemon-reload
+systemctl enable --now k3s.service
+
+# Bootstrap is done when the admin kubeconfig and the join token exist.
+i=0
+until [ -s /etc/rancher/k3s/k3s.yaml ] && [ -s /var/lib/rancher/k3s/server/node-token ]; do
+  i=$((i+1))
+  [ "$i" -gt 120 ] && { echo "k3s server did not come up" >&2; exit 1; }
+  sleep 2
+done

--- a/pkg/core/incus/client.go
+++ b/pkg/core/incus/client.go
@@ -376,6 +376,12 @@ type ContainerConfig struct {
 	EnablePodmanPrivileged bool // Full Docker support (requires privileged container + AppArmor disabled)
 	AutoStart              bool
 
+	// ExtraConfig is applied verbatim as Incus instance config keys,
+	// after the fields above. Used by the cluster container-node
+	// profile (#1429: security.nesting for k3s node containers);
+	// callers own the keys they set.
+	ExtraConfig map[string]string
+
 	// Env is a map of environment variables to set inside the
 	// container, equivalent to `incus config set <name>
 	// environment.<KEY> <value>`. Visible to every shell session and
@@ -796,6 +802,11 @@ func (c *Client) CreateContainer(config ContainerConfig) error {
 	// Auto-start on boot
 	if config.AutoStart {
 		req.Config["boot.autostart"] = "true"
+	}
+
+	// Caller-owned instance config (see ExtraConfig).
+	for k, v := range config.ExtraConfig {
+		req.Config[k] = v
 	}
 
 	// Environment variables — Incus stores these as `environment.<KEY>`


### PR DESCRIPTION
Closes #1429

Story 2 of `docs/architecture/cluster-container-node-pools.md` (accepted): the runtime layer for container node pools, riding the #1428 NodeIsolation contract.

## What changed

- **CreateNode seam** — `VMHost.CreateVM(spec)` widens to `CreateNode(spec, isolation)`; `ContainerNodeCapable()` joins `VMCapable()` on the interface. Reconciler and manager orchestration are unchanged above the seam: the isolation class flows from the stored cluster row through `ProvisionCP`/`ProvisionWorker` into `CreateNode`, and the fake hosts record the isolation per call.
- **Probe dispatch on the create path** — where `CreateCluster` previously ran the VM probe for every cluster, the probe now matches the cluster's isolation class: VM cluster → `VMCapable`, CONTAINER cluster → `ContainerNodeCapable` (`ClusterReconciler.NodeCapable(iso)`).
- **`pkg/core/cluster/containerprofile.go`** — the ONE place holding the k3s-in-container knowledge: `security.nesting=true` (golden-pinned config set), cgroup v2 delegation (Incus default for system containers, asserted host-side by the probe), the boot-time `/dev/kmsg` shim (`ln -s /dev/console /dev/kmsg`) rendered into the bootstrap unit as an `ExecStartPre` so it re-applies every boot, and **no `security.privileged`** — with a tripwire test.
- **`ContainerNodeCapable()`** — probes nesting (lxc driver present; on a nested host a responding Incus is itself the evidence nesting was granted), cgroup v2 (`cgroup.controllers`), and `br_netfilter`/`overlay` (`/sys/module`). Refusals name every missing precondition; a precondition that could not be observed refuses as "could not be verified (…)" instead of being assumed green, and a module missing on a nested host says it cannot be loaded from there.
- **`incus.ContainerConfig.ExtraConfig`** — typed carrier for the profile's instance config keys.

## VM path unchanged

Existing goldens (`server.sh.golden`, `agent.sh.golden`, CA goldens) and the manager call-sequence expectations are byte-untouched — the VM bootstrap renders identically (the shim slot renders empty), and `git status` on `testdata/` shows only the three new golden files.

## Test evidence

| Acceptance criterion | Tests |
| --- | --- |
| (a) seam widens; fake hosts record isolation per call | `TestProvisionCarriesIsolationThroughTheSeam` (pkg/core/cluster), `TestReconciler_ProvisionIsolationMatchesCluster` (internal/server) |
| (b) container profile in one place, golden-tested, no privileged | `TestContainerNodeConfigGolden`, `TestContainerNodeConfigHardLines`, `TestRenderServerScriptContainerVariant`, `TestRenderAgentScriptContainerVariant` |
| (c) probe names the missing precondition; unprobeable ≠ green | `TestCheckContainerNodeFacts` (incl. "unprobeable precondition refuses as unverified, never assumed green"), `TestGatherContainerNodeFacts` (incl. nested-host wording) |
| (d) probe dispatches on isolation; VM path unchanged | `TestReconciler_CapabilityProbeMatchesIsolation`; existing `TestReconciler_VMCapabilityGatesCreate`, `TestProvisionCPSequence`, `TestProvisionWorkerSequence`, `TestRenderServerScript`, `TestRenderAgentScript` all green untouched |

Local: `go test ./pkg/core/cluster/ ./internal/server/ ./internal/cluster/` green, `go vet` + `go build ./...` clean. CI run link to follow on this PR's checks.

## Reviewer notes

- Start with `pkg/core/cluster/containerprofile.go` — everything container-node lives there.
- Design deviation: none. One judgment call worth a look: "nesting permitted" is probed as *lxc driver present*, with the nested case treated as transitively evidenced (a responding nested Incus required outer `security.nesting=true` to exist); Incus project-level nesting restrictions are not readable through our current client, so a restricted project would surface at create time with Incus's own error rather than at probe time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
