### PR TITLE
ci(cluster): container-mode e2e lane on GitHub-hosted runners (#1430)

### DIFF
--- a/.github/workflows/cluster-container-e2e.yml
+++ b/.github/workflows/cluster-container-e2e.yml
@@ -1,0 +1,168 @@
+name: Managed clusters container-mode e2e
+
+# The container-node e2e lane (#1430): the same six-step tenant journey
+# as the KVM lane, run with cluster nodes provisioned as Incus SYSTEM
+# CONTAINERS (#1428/#1429) instead of VMs — which is why it needs no KVM
+# and fits on a plain GitHub-hosted `ubuntu-latest` runner. Design:
+# docs/architecture/cluster-container-node-pools.md, "Test strategy".
+#
+# THIS LANE IS NOT A SUBSTITUTE FOR THE KVM LANE (#1234 rule: a lane
+# tests only the mode it actually runs). `.github/workflows/cluster-e2e.yml`
+# remains the definition-of-done gate for VM-mode clusters — the default
+# and the only class with a hardware isolation boundary. Nothing here
+# exercises the qemu path, VM boot, or VM-sized capacity, and a green run
+# here says nothing about any of them. What it buys is the shared ~95% —
+# create, kubeconfig-from-outside, autoscaler scale-up, larger-class fit,
+# VPA, scale-down, delete — moved from "nightly on scarce self-hosted
+# hardware" to "cheap and frequent on every PR that touches the path".
+#
+# Runner contract: a stock `ubuntu-latest`, provisioned in-job following
+# the incus-create.yml precedent — Incus + dnsmasq, unprivileged-userns
+# AppArmor relaxed, iptables FORWARD reopened (Docker sets it to DROP),
+# subuid/subgid for root, and a ZFS pool named the way the daemon's own
+# storage detection probes for it. No /dev/kvm anywhere.
+#
+# Operator opt-in: the daemon refuses container-node creates unless
+# CONTAINARIUM_CLUSTER_ALLOW_CONTAINER_NODES=true. Set here because a
+# throwaway CI runner IS a single trust domain — the same assertion an
+# operator makes on a single-tenant host, never a product default.
+#
+# Prove-the-lane-can-fail (#1418 guardrail, reused): dispatch with
+# sabotage=join-token. Worker join tokens are corrupted so no node can
+# register; the JOB goes green only if the SUITE goes red. Run it once
+# after this lane first lands, and after any change to the journey's
+# assertions — a green lane that has never failed proves nothing.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'test/e2e/cluster/**'
+      - 'scripts/cluster-e2e.sh'
+      - 'scripts/ci-incus-container-host.sh'
+      - 'pkg/core/cluster/**'
+      - 'internal/cluster/**'
+      - 'internal/server/cluster_*.go'
+      - '.github/workflows/cluster-container-e2e.yml'
+  # No `branches:` filter — a base filter leaves stacked PRs with no
+  # checks at all, which looks the same as checks not having started
+  # (#1215). Duplicated rather than anchored: GitHub Actions does not
+  # expand YAML anchors.
+  pull_request:
+    paths:
+      - 'test/e2e/cluster/**'
+      - 'scripts/cluster-e2e.sh'
+      - 'scripts/ci-incus-container-host.sh'
+      - 'pkg/core/cluster/**'
+      - 'internal/cluster/**'
+      - 'internal/server/cluster_*.go'
+      - '.github/workflows/cluster-container-e2e.yml'
+  workflow_dispatch:
+    inputs:
+      sabotage:
+        description: 'Deliberate breakage; join-token proves the lane can fail'
+        type: choice
+        options: ['none', 'join-token']
+        default: 'none'
+
+permissions:
+  contents: read
+
+# One run at a time per ref: each run owns the runner's Incus and the
+# fixed CA-provider port. Runners are per-job here, so unlike the KVM
+# lane this does not have to serialize across refs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  container-e2e:
+    name: six-step journey (container nodes, no KVM)
+    if: github.event_name != 'workflow_dispatch' || inputs.sabotage == 'none'
+    runs-on: ubuntu-latest
+    # Budget: create ~8m + scale-up ~8m + larger class ~8m + VPA ~12m +
+    # scale-down ~30m (stock cluster-autoscaler: 10m delay-after-add +
+    # 10m unneeded — irreducible without retuning CA) + delete ~8m, plus
+    # ~10m of runner provisioning. Container nodes boot in seconds where
+    # VMs take minutes, which is why this fits well inside the KVM lane's
+    # 150m.
+    timeout-minutes: 100
+    env:
+      # The journey, in the class this lane exists to cover.
+      CONTAINARIUM_E2E_ISOLATION: container
+      # Operator opt-in (see header): a throwaway runner is one trust
+      # domain. Without this the daemon refuses the create, by design.
+      CONTAINARIUM_CLUSTER_ALLOW_CONTAINER_NODES: 'true'
+      # A missing/unusable Incus fails the lane instead of skipping it.
+      CONTAINARIUM_REQUIRE_INCUS: '1'
+      # Container nodes boot far faster than VMs, so the waits are
+      # tightened HERE rather than in the test's defaults — the KVM lane
+      # keeps its own bounds unchanged.
+      CONTAINARIUM_E2E_READY_TIMEOUT: 10m
+      CONTAINARIUM_E2E_SCALEUP_TIMEOUT: 10m
+      CONTAINARIUM_E2E_VPA_TIMEOUT: 12m
+      # Not tightened: this one is cluster-autoscaler's own schedule, not
+      # the node runtime's speed.
+      CONTAINARIUM_E2E_SCALEDOWN_TIMEOUT: 30m
+      CONTAINARIUM_E2E_DELETE_TIMEOUT: 8m
+      # Below the job timeout on purpose: the Go test must be the thing
+      # that times out, so it prints its diagnostics before the runner is
+      # taken away.
+      CONTAINARIUM_E2E_GO_TIMEOUT: 85m
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      - name: Provision Incus (the incus-create.yml precedent, minus KVM)
+        run: bash scripts/ci-incus-container-host.sh
+
+      - name: Run the lane
+        # No pipe around the script: its exit status is `go test`'s, and
+        # the job's is the script's. A lane whose exit code is piped away
+        # is a lane that cannot report red.
+        run: bash scripts/cluster-e2e.sh
+
+      - name: Diagnostics on failure
+        if: failure()
+        run: |
+          sudo incus list || true
+          sudo incus info || true
+          free -m || true
+          df -h /mnt / || true
+
+  prove-lane-can-fail:
+    name: sabotage run (suite must go red)
+    if: github.event_name == 'workflow_dispatch' && inputs.sabotage == 'join-token'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      CONTAINARIUM_E2E_ISOLATION: container
+      CONTAINARIUM_CLUSTER_ALLOW_CONTAINER_NODES: 'true'
+      CONTAINARIUM_REQUIRE_INCUS: '1'
+      CONTAINARIUM_E2E_SABOTAGE: join-token
+      # Sabotaged workers can never register; don't wait the full
+      # production bound to learn what we broke on purpose.
+      CONTAINARIUM_E2E_READY_TIMEOUT: 10m
+      CONTAINARIUM_E2E_GO_TIMEOUT: 35m
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      - name: Provision Incus (the incus-create.yml precedent, minus KVM)
+        run: bash scripts/ci-incus-container-host.sh
+
+      - name: Corrupt join tokens and expect the suite to fail
+        # Inversion is explicit and lives only in this dispatch-only
+        # job: green here means the lane DETECTED the sabotage.
+        run: |
+          if bash scripts/cluster-e2e.sh; then
+            echo "::error::lane stayed GREEN under join-token sabotage — it cannot fail, so its green proves nothing"
+            exit 1
+          fi
+          echo "lane went red under sabotage: it can fail, and its green is evidence."

--- a/scripts/ci-incus-container-host.sh
+++ b/scripts/ci-incus-container-host.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# ci-incus-container-host.sh — turn a stock GitHub-hosted `ubuntu-latest`
+# runner into a host that can run Containarium CONTAINER-mode cluster
+# nodes (#1430). Used by .github/workflows/cluster-container-e2e.yml,
+# whose two jobs both need it.
+#
+# Follows the incus-create.yml precedent, minus KVM: container-mode
+# cluster nodes are Incus system containers, so no /dev/kvm is involved
+# anywhere below. This host CANNOT run VM-mode clusters, which is why
+# that lane stays on the self-hosted incus+kvm runner.
+#
+# Every precondition is asserted here, at the step that provisions it,
+# rather than discovered minutes later inside a product test — an
+# unusable runner should name itself, not wear the costume of a bug.
+set -euo pipefail
+
+log() { echo "==> $*"; }
+fail() { echo "::error::$*"; exit 1; }
+
+log "installing Incus, dnsmasq and ZFS"
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends incus dnsmasq-base zfsutils-linux
+# The module ships in linux-modules-extra on Ubuntu; usually already
+# present on the runner image, so only fetch it if needed.
+if ! sudo modprobe zfs 2>/dev/null; then
+  log "zfs module not loadable yet; installing linux-modules-extra-$(uname -r)"
+  sudo apt-get install -y "linux-modules-extra-$(uname -r)"
+  sudo modprobe zfs
+fi
+
+# The pool is named incus-local with a `containers` dataset because that
+# is what the daemon's OWN storage detection probes for; under any other
+# name it falls back to the `dir` driver, which cannot honour the node
+# groups' disk sizes. /mnt is the runner's large scratch disk and the
+# image is sparse.
+log "creating the ZFS pool the daemon detects"
+sudo truncate -s 40G /mnt/incus-zfs.img
+sudo zpool create -f -m /mnt/incus-local incus-local /mnt/incus-zfs.img
+sudo zfs create incus-local/containers
+
+# Kernel modules the daemon's container-node probe (#1429) requires:
+# br_netfilter for k3s networking, overlay for containerd's snapshotter.
+# Loaded here — on a shared kernel the daemon cannot load them itself.
+log "loading the kernel modules k3s-in-container needs"
+sudo modprobe br_netfilter
+sudo modprobe overlay
+
+# Two runner-specific facts that would otherwise surface as a mystifying
+# failure minutes into the journey:
+#  1. Ubuntu restricts unprivileged user namespaces via AppArmor, which
+#     is what an unprivileged Incus container needs.
+#  2. Docker is running on GitHub runners and sets the iptables FORWARD
+#     policy to DROP, which silently kills incusbr0's NAT — nodes then
+#     boot with no route out and fail while fetching k3s.
+log "making the runner able to host containers"
+sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
+sudo iptables -P FORWARD ACCEPT
+grep -q '^root:' /etc/subuid || echo 'root:1000000:1000000000' | sudo tee -a /etc/subuid
+grep -q '^root:' /etc/subgid || echo 'root:1000000:1000000000' | sudo tee -a /etc/subgid
+
+# Socket-activated: this both proves the client works and brings the
+# daemon up, so the socket the lane connects to exists.
+sudo incus version
+
+log "verifying the host is actually usable (fail, don't skip)"
+[ -S /var/lib/incus/unix.socket ] || {
+  sudo systemctl status incus.service --no-pager || true
+  sudo journalctl -u incus.service --no-pager -n 100 || true
+  fail "no Incus socket at /var/lib/incus/unix.socket — the daemon did not come up"
+}
+command -v dnsmasq >/dev/null || fail "dnsmasq is absent — Incus cannot bring up incusbr0"
+sudo zfs list incus-local/containers >/dev/null || fail "incus-local/containers is absent — the daemon would select the dir driver"
+# The same four preconditions the daemon's own probe checks, asserted
+# here so a provisioning gap is named by the provisioning step.
+[ -e /sys/fs/cgroup/cgroup.controllers ] || fail "no unified cgroup v2 hierarchy — k3s-in-container needs cgroup v2 delegation"
+[ -d /sys/module/br_netfilter ] || fail "br_netfilter is not loaded — k3s networking needs it"
+[ -d /sys/module/overlay ] || fail "overlay is not loaded — containerd's snapshotter needs it"
+sudo incus info | grep -q 'driver: ' || fail "incus info reports no instance drivers"
+
+log "host ready for container-mode cluster nodes (no KVM required or used)"

--- a/scripts/cluster-e2e.sh
+++ b/scripts/cluster-e2e.sh
@@ -1,25 +1,41 @@
 #!/usr/bin/env bash
 #
-# cluster-e2e.sh — the gated KVM e2e lane for managed Kubernetes
-# clusters (#1418). Builds the CLI+daemon from this tree, starts a real
-# daemon against a real Postgres on a VM-capable Incus host, and runs
-# the six-step MVP journey in test/e2e/cluster/ against it.
+# cluster-e2e.sh — the gated e2e lane for managed Kubernetes clusters
+# (#1418). Builds the CLI+daemon from this tree, starts a real daemon
+# against a real Postgres on a real Incus host, and runs the six-step
+# MVP journey in test/e2e/cluster/ against it.
 #
 # Local use:   sudo -v && bash scripts/cluster-e2e.sh
 # Sabotage:    CONTAINARIUM_E2E_SABOTAGE=join-token bash scripts/cluster-e2e.sh
 #              (expected to exit non-zero — that is the point; the
 #              workflow's prove-can-fail job asserts it)
+# Container:   CONTAINARIUM_E2E_ISOLATION=container \
+#              CONTAINARIUM_CLUSTER_ALLOW_CONTAINER_NODES=true \
+#              bash scripts/cluster-e2e.sh
 # CI:          .github/workflows/cluster-e2e.yml on the self-hosted
-#              incus+kvm runner (nightly + release tags, not per-PR).
+#              incus+kvm runner (nightly + release tags, not per-PR), and
+#              .github/workflows/cluster-container-e2e.yml on a
+#              GitHub-hosted runner for the container class (#1430).
+#
+# Isolation (#1430): CONTAINARIUM_E2E_ISOLATION selects the class the
+# journey runs in — unset/`vm` (default, unchanged) or `container`.
+# Container mode also needs the operator opt-in
+# CONTAINARIUM_CLUSTER_ALLOW_CONTAINER_NODES=true, which this script only
+# passes through: whether a host may weaken the tenant boundary is the
+# operator's assertion to make, never the test script's.
 #
 # Host requirements (the runner-provisioning half of #1418):
-#   - Capacity for the journey's worst case: ~16 vCPU (CP 2 + up to
-#     3×small 2 + one large 8), ~32 GB RAM, ~500 GB free in the Incus
-#     pool. On a smaller host the daemon's CPU-admission gate will
+#   - VM mode: capacity for the journey's worst case — ~16 vCPU (CP 2 +
+#     up to 3×small 2 + one large 8), ~32 GB RAM, ~500 GB free in the
+#     Incus pool. On a smaller host the daemon's CPU-admission gate will
 #     correctly REFUSE the larger-class scale-up and the lane goes red
 #     for an environmental reason that looks like a product bug.
 #   - Incus with a usable storage pool at /var/lib/incus/unix.socket
-#   - KVM (/dev/kvm) — cluster nodes are VMs, not containers
+#   - VM mode only: KVM (/dev/kvm). Container-mode nodes are Incus
+#     system containers, which is why that lane can run KVM-less on a
+#     GitHub-hosted runner; its preconditions (nesting, cgroup v2,
+#     br_netfilter, overlay) are probed by the daemon itself, which
+#     refuses loudly rather than provisioning a broken node.
 #   - Go toolchain, passwordless sudo for the invoking user
 #   - Postgres reachable via CONTAINARIUM_POSTGRES_URL, or Docker/Podman
 #     available so the script can start a throwaway one
@@ -34,6 +50,11 @@ cd "$REPO_ROOT"
 
 GRPC_PORT="${CONTAINARIUM_E2E_GRPC_PORT:-15051}"
 HTTP_PORT="${CONTAINARIUM_E2E_HTTP_PORT:-18080}"
+ISOLATION="${CONTAINARIUM_E2E_ISOLATION:-vm}"
+# The Go-side bound. Kept a knob so a lane whose job timeout is tighter
+# than the KVM lane's 150m can still let the test time out first and
+# print its diagnostics; the default is the KVM lane's unchanged value.
+GO_TIMEOUT="${CONTAINARIUM_E2E_GO_TIMEOUT:-110m}"
 WORKDIR="$(mktemp -d)"
 BIN="$WORKDIR/containarium"
 DAEMON_LOG="$WORKDIR/daemon.log"
@@ -41,14 +62,31 @@ PG_CONTAINER=""
 DAEMON_PID=""
 
 # The tenant/cluster names the Go test uses; the sweep below must match.
-VM_PREFIX="e2etenant-k8s-lane-"
+# Instances, not VMs: in container mode the same names are Incus system
+# containers, and `incus list` reports both classes (#1430).
+INSTANCE_PREFIX="e2etenant-k8s-lane-"
 
 log() { echo "==> $*"; }
 
 fail() { echo "FATAL: $*" >&2; exit 1; }
 
 # --- pre-flight: fail loudly, never skip silently -----------------------
-[ -e /dev/kvm ] || fail "no /dev/kvm — this lane needs a KVM-capable host (nested virt on a VM runner)"
+case "$ISOLATION" in
+  vm)
+    [ -e /dev/kvm ] || fail "no /dev/kvm — VM-mode nodes need a KVM-capable host (nested virt on a VM runner)"
+    ;;
+  container)
+    # No KVM check: container-mode nodes are system containers. The
+    # host's container-node preconditions are the daemon's probe to
+    # make (#1429), and it refuses the create rather than provisioning
+    # a node that cannot work.
+    [ -n "${CONTAINARIUM_CLUSTER_ALLOW_CONTAINER_NODES:-}" ] \
+      || fail "container mode needs the operator opt-in CONTAINARIUM_CLUSTER_ALLOW_CONTAINER_NODES=true; without it the daemon refuses container creates and the lane goes red for a configuration reason"
+    ;;
+  *)
+    fail "unknown CONTAINARIUM_E2E_ISOLATION=$ISOLATION (want vm or container)"
+    ;;
+esac
 [ -S /var/lib/incus/unix.socket ] || fail "no Incus socket at /var/lib/incus/unix.socket"
 command -v go >/dev/null || fail "no Go toolchain"
 sudo -n true 2>/dev/null || fail "needs passwordless sudo (daemon and Incus operations run as root)"
@@ -62,10 +100,12 @@ cleanup() {
     sleep 2
     sudo kill -9 "$DAEMON_PID" 2>/dev/null
   fi
-  # Sweep any VMs a red run left behind, so the next nightly starts clean.
-  for vm in $(sudo incus list --format csv --columns n 2>/dev/null | grep "^${VM_PREFIX}" || true); do
-    log "sweeping leftover VM $vm"
-    sudo incus delete --force "$vm" 2>/dev/null
+  # Sweep any instances a red run left behind, so the next run starts
+  # clean. `incus list` reports containers and VMs alike, so this sweeps
+  # both isolation classes.
+  for inst in $(sudo incus list --format csv --columns n 2>/dev/null | grep "^${INSTANCE_PREFIX}" || true); do
+    log "sweeping leftover instance $inst"
+    sudo incus delete --force "$inst" 2>/dev/null
   done
   if [ -n "$PG_CONTAINER" ]; then
     log "stopping throwaway postgres"
@@ -110,10 +150,11 @@ JWT_SECRET="${CONTAINARIUM_JWT_SECRET:-$(head -c 32 /dev/urandom | od -An -tx1 |
 ADVERTISE_HOST="${CONTAINARIUM_E2E_ADVERTISE_HOST:-$(ip -4 route get 1.1.1.1 | sed -n 's/.*src \([0-9.]*\).*/\1/p')}"
 [ -n "$ADVERTISE_HOST" ] || fail "could not determine the host's advertise address; set CONTAINARIUM_E2E_ADVERTISE_HOST"
 
-log "starting daemon (grpc :$GRPC_PORT http :$HTTP_PORT advertise $ADVERTISE_HOST)"
+log "starting daemon (grpc :$GRPC_PORT http :$HTTP_PORT advertise $ADVERTISE_HOST isolation $ISOLATION)"
 sudo env \
   CONTAINARIUM_JWT_SECRET="$JWT_SECRET" \
   CONTAINARIUM_POSTGRES_URL="$CONTAINARIUM_POSTGRES_URL" \
+  CONTAINARIUM_CLUSTER_ALLOW_CONTAINER_NODES="${CONTAINARIUM_CLUSTER_ALLOW_CONTAINER_NODES:-}" \
   CONTAINARIUM_CLUSTER_ADVERTISE_ADDR="$ADVERTISE_HOST" \
   CONTAINARIUM_CLUSTER_CA_ADVERTISE="$ADVERTISE_HOST:36442" \
   CONTAINARIUM_CLUSTER_CA_PKI_DIR="$WORKDIR/cluster-ca" \
@@ -124,20 +165,29 @@ DAEMON_PID=$!
 # Readiness: any HTTP answer on the gateway port means the REST surface
 # is up. Authenticated calls are the Go test's job — it mints its own
 # tenant token from the same secret.
-log "waiting for the daemon's HTTP gateway"
-for i in $(seq 1 60); do
+#
+# The bound is 6 minutes, not the 2 it used to be: on a COLD host (an
+# ephemeral GitHub-hosted runner, as opposed to a warm self-hosted one)
+# the daemon spends up to 2 minutes waiting for core containers that
+# have never existed before proceeding without them, and the old bound
+# declared that a dead daemon. A warm host still answers in seconds, so
+# nothing changes for the KVM lane except how long a genuinely stuck
+# daemon takes to be reported.
+DAEMON_WAIT_TRIES="${CONTAINARIUM_E2E_DAEMON_WAIT_TRIES:-180}"
+log "waiting for the daemon's HTTP gateway (up to $((DAEMON_WAIT_TRIES * 2))s)"
+for i in $(seq 1 "$DAEMON_WAIT_TRIES"); do
   if ! sudo kill -0 "$DAEMON_PID" 2>/dev/null; then
     fail "daemon exited during startup"
   fi
   if curl -s -o /dev/null "http://127.0.0.1:$HTTP_PORT/v1/clusters"; then
     break
   fi
-  [ "$i" = 60 ] && fail "daemon HTTP gateway not answering after 120s"
+  [ "$i" = "$DAEMON_WAIT_TRIES" ] && fail "daemon HTTP gateway not answering after $((DAEMON_WAIT_TRIES * 2))s"
   sleep 2
 done
 
 # --- run the lane --------------------------------------------------------
-log "running the six-step journey (sabotage: ${CONTAINARIUM_E2E_SABOTAGE:-none})"
+log "running the six-step journey (isolation: $ISOLATION, sabotage: ${CONTAINARIUM_E2E_SABOTAGE:-none})"
 sudo env \
   PATH="$PATH" HOME="$HOME" GOFLAGS="${GOFLAGS:-}" GOCACHE="$(go env GOCACHE)" GOMODCACHE="$(go env GOMODCACHE)" \
   CONTAINARIUM_REQUIRE_INCUS=1 \
@@ -146,4 +196,10 @@ sudo env \
   CONTAINARIUM_E2E_ADVERTISE_HOST="$ADVERTISE_HOST" \
   CONTAINARIUM_JWT_SECRET="$JWT_SECRET" \
   CONTAINARIUM_E2E_SABOTAGE="${CONTAINARIUM_E2E_SABOTAGE:-}" \
-  go test -tags 'incus cluster_e2e' -count=1 -timeout 110m -v ./test/e2e/cluster/
+  CONTAINARIUM_E2E_ISOLATION="$ISOLATION" \
+  CONTAINARIUM_E2E_READY_TIMEOUT="${CONTAINARIUM_E2E_READY_TIMEOUT:-}" \
+  CONTAINARIUM_E2E_SCALEUP_TIMEOUT="${CONTAINARIUM_E2E_SCALEUP_TIMEOUT:-}" \
+  CONTAINARIUM_E2E_VPA_TIMEOUT="${CONTAINARIUM_E2E_VPA_TIMEOUT:-}" \
+  CONTAINARIUM_E2E_SCALEDOWN_TIMEOUT="${CONTAINARIUM_E2E_SCALEDOWN_TIMEOUT:-}" \
+  CONTAINARIUM_E2E_DELETE_TIMEOUT="${CONTAINARIUM_E2E_DELETE_TIMEOUT:-}" \
+  go test -tags 'incus cluster_e2e' -count=1 -timeout "$GO_TIMEOUT" -v ./test/e2e/cluster/

--- a/scripts/cluster-e2e.sh
+++ b/scripts/cluster-e2e.sh
@@ -143,12 +143,24 @@ if [ -z "${CONTAINARIUM_POSTGRES_URL:-}" ]; then
     -e POSTGRES_USER=containarium -e POSTGRES_PASSWORD=e2e -e POSTGRES_DB=containarium \
     -p "127.0.0.1:${PG_PORT}:5432" postgres:16-alpine >/dev/null
   export CONTAINARIUM_POSTGRES_URL="postgres://containarium:e2e@127.0.0.1:${PG_PORT}/containarium?sslmode=disable"
-  for _ in $(seq 1 30); do
+  # 90s, not 30s. Run 18 died here: on a cold runner the image pull is
+  # followed by initdb on contended IO, and 30s was not always enough.
+  # A flake at this line costs a full lane run (~15 min) and produces a
+  # red build that has nothing to do with the product.
+  for _ in $(seq 1 90); do
     "$CONTAINER_RUNTIME" exec "$PG_CONTAINER" pg_isready -U containarium >/dev/null 2>&1 && break
     sleep 1
   done
-  "$CONTAINER_RUNTIME" exec "$PG_CONTAINER" pg_isready -U containarium >/dev/null 2>&1 \
-    || fail "postgres did not become ready"
+  if ! "$CONTAINER_RUNTIME" exec "$PG_CONTAINER" pg_isready -U containarium >/dev/null 2>&1; then
+    # Say why, rather than just that. Without this the failure is
+    # indistinguishable between "still starting", "crashed on startup"
+    # and "port already bound".
+    echo "---- postgres container state ----"
+    "$CONTAINER_RUNTIME" ps -a --filter "name=$PG_CONTAINER" 2>&1 || true
+    echo "---- postgres container log ----"
+    "$CONTAINER_RUNTIME" logs "$PG_CONTAINER" 2>&1 | tail -40 || true
+    fail "postgres did not become ready"
+  fi
 else
   CONTAINER_RUNTIME=""
 fi

--- a/scripts/cluster-e2e.sh
+++ b/scripts/cluster-e2e.sh
@@ -112,10 +112,22 @@ cleanup() {
     "$CONTAINER_RUNTIME" rm -f "$PG_CONTAINER" >/dev/null 2>&1
   fi
   if [ $status -ne 0 ] && [ -f "$DAEMON_LOG" ]; then
-    echo "---- daemon log (last 100 lines) ----"
-    tail -100 "$DAEMON_LOG"
+    # Cluster lines first, over the WHOLE log. The tail alone is not
+    # enough: the daemon decides at startup whether the autoscaler and
+    # the endpoint publisher are wired at all, and says so once. In run
+    # 15 that verdict sat ~200 lines above the tail window, so a lane
+    # that failed on a missing scale-up could not answer "was the
+    # autoscaler ever enabled?" from its own log.
+    echo "---- daemon log: cluster/autoscaler lines (whole run) ----"
+    grep -E '\[cluster\]|autoscaler|[Pp]assthrough|Managed-cluster' "$DAEMON_LOG" || echo "(none)"
+    echo "---- daemon log (last 200 lines) ----"
+    tail -200 "$DAEMON_LOG"
   fi
-  rm -rf "$WORKDIR"
+  # The daemon runs under sudo and creates root-owned trees here (the
+  # cluster CA PKI dir among them), so an unprivileged rm leaves them
+  # behind and prints a permission error that looks like a real
+  # failure. Remove as root, matching who created it.
+  sudo rm -rf "$WORKDIR" 2>/dev/null || rm -rf "$WORKDIR"
   exit $status
 }
 trap cleanup EXIT

--- a/test/e2e/cluster/e2e_test.go
+++ b/test/e2e/cluster/e2e_test.go
@@ -2,10 +2,18 @@
 
 package clustere2e
 
-// The gated KVM e2e lane (#1418): the managed-clusters MVP journey run
-// against real everything — real Incus VMs, real k3s, real
-// cluster-autoscaler, real VPA — on a VM-capable host. Design:
+// The gated e2e lane (#1418): the managed-clusters MVP journey run
+// against real everything — real Incus instances, real k3s, real
+// cluster-autoscaler, real VPA. Design:
 // docs/architecture/managed-k8s-clusters.md, "End-to-end".
+//
+// One journey, two isolation classes (#1430). CONTAINARIUM_E2E_ISOLATION
+// selects which: unset/vm is the VM class the self-hosted KVM lane gates,
+// `container` is the Incus-system-container class (#1428/#1429) the
+// GitHub-hosted lane runs without KVM. Only the `cluster create` call
+// differs; every assertion below is shared, and none of them may look at
+// the instance TYPE — a container-mode node is an Incus container, so a
+// type filter would silently observe an empty cluster.
 //
 // Every assertion is against observed cluster or Incus state (the k8s
 // API through the tenant kubeconfig, the Incus API, TCP reachability),
@@ -27,6 +35,7 @@ package clustere2e
 //	CONTAINARIUM_JWT_SECRET         daemon's JWT secret; the lane mints its tenant token
 //	CONTAINARIUM_E2E_ADVERTISE_HOST host the kubeconfig must point at ("outside" reach)
 //	CONTAINARIUM_E2E_SABOTAGE       "" or "join-token" (prove-the-lane-can-fail runs)
+//	CONTAINARIUM_E2E_ISOLATION      "", "vm" (default) or "container" (#1430)
 //	CONTAINARIUM_REQUIRE_INCUS      "1" in the lane: a missing environment fails, not skips
 //
 // Timeouts (durations, optional): CONTAINARIUM_E2E_READY_TIMEOUT
@@ -72,9 +81,10 @@ const (
 	burnImage = "registry.k8s.io/e2e-test-images/busybox:1.36.1-1"
 )
 
-// vmPrefix is the Incus name prefix every VM of the lane cluster
-// carries (spec.go's naming scheme).
-var vmPrefix = tenant + "-k8s-" + clusterName + "-"
+// instancePrefix is the Incus name prefix every node of the lane
+// cluster carries (spec.go's naming scheme), whatever its isolation
+// class: VMs in the KVM lane, system containers in the container lane.
+var instancePrefix = tenant + "-k8s-" + clusterName + "-"
 
 type lane struct {
 	t             *testing.T
@@ -82,14 +92,15 @@ type lane struct {
 	server        string
 	token         string
 	advertiseHost string
+	isolation     IsolationMode
 	incus         *incus.Client
 
 	cs  *kubernetes.Clientset
 	dyn dynamic.Interface
 
-	kubeconfig    []byte
-	baselineNodes []string
-	baselineVMs   []string
+	kubeconfig        []byte
+	baselineNodes     []string
+	baselineInstances []string
 }
 
 func env(t *testing.T, key string) string {
@@ -140,6 +151,12 @@ func TestManagedClusterJourney(t *testing.T) {
 		t.Fatalf("mint tenant token: %v", err)
 	}
 
+	l.isolation, err = ParseIsolation(os.Getenv("CONTAINARIUM_E2E_ISOLATION"))
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	t.Logf("isolation class under test: %s", l.isolation)
+
 	sabotage, err := ParseSabotage(os.Getenv("CONTAINARIUM_E2E_SABOTAGE"))
 	if err != nil {
 		t.Fatalf("%v", err)
@@ -167,7 +184,7 @@ func TestManagedClusterJourney(t *testing.T) {
 		{"2_overflow_scales_up_via_new_ready_node", l.stepOverflowScaleUp},
 		{"3_big_pod_lands_on_larger_class_node", l.stepLargerClass},
 		{"4_vpa_raises_requests_without_restart_loop", l.stepVPA},
-		{"5_scale_to_zero_drains_and_deletes_vm", l.stepScaleToZero},
+		{"5_scale_to_zero_drains_and_deletes_instance", l.stepScaleToZero},
 		{"6_delete_leaves_nothing", l.stepDelete},
 	}
 	for _, s := range steps {
@@ -204,8 +221,11 @@ func (l *lane) runCLI(args ...string) (string, error) {
 func (l *lane) stepCreate() error {
 	readyTimeout := timeoutEnv("CONTAINARIUM_E2E_READY_TIMEOUT", 15*time.Minute)
 
-	if out, err := l.runCLI("cluster", "create", clusterName); err != nil {
-		return fmt.Errorf("cluster create: %v\n%s", err, out)
+	// CLI-first, and the isolation class is a CLI flag exactly as a
+	// tenant would pass it (#1428). VM mode adds no flag at all.
+	createArgs := append([]string{"cluster", "create", clusterName}, l.isolation.CreateArgs()...)
+	if out, err := l.runCLI(createArgs...); err != nil {
+		return fmt.Errorf("cluster create (%s): %v\n%s", l.isolation, err, out)
 	}
 
 	// The kubeconfig RPC is FailedPrecondition until the cluster is
@@ -266,8 +286,18 @@ func (l *lane) stepCreate() error {
 	for name := range ready {
 		l.baselineNodes = append(l.baselineNodes, name)
 	}
-	l.baselineVMs = l.clusterVMs()
-	l.t.Logf("baseline nodes: %v, VMs: %v", l.baselineNodes, l.baselineVMs)
+	l.baselineInstances = l.clusterInstances()
+	l.t.Logf("baseline nodes: %v, instances: %v", l.baselineNodes, l.baselineInstances)
+
+	// Observed Incus state, not the daemon's report of itself: the
+	// nodes really are of the class this run asked for. Without this a
+	// container-mode lane whose daemon quietly provisioned VMs would
+	// run the whole journey and report VM behaviour as container
+	// behaviour (#1430).
+	if wrong := WrongClassInstances(l.observedInstances(), instancePrefix, l.isolation); len(wrong) > 0 {
+		return fmt.Errorf("isolation %s requested, but Incus reports instances of another class: %s",
+			l.isolation, strings.Join(wrong, ", "))
+	}
 	return nil
 }
 
@@ -495,27 +525,28 @@ func (l *lane) stepScaleToZero() error {
 	}
 
 	baseline := map[string]bool{}
-	for _, v := range l.baselineVMs {
+	for _, v := range l.baselineInstances {
 		baseline[v] = true
 	}
 
-	return l.waitFor("surplus nodes drained and VMs deleted", scaledownTimeout, 20*time.Second, func() (bool, string) {
+	return l.waitFor("surplus nodes drained and instances deleted", scaledownTimeout, 20*time.Second, func() (bool, string) {
 		// Observed k8s state: no surplus node is Ready anymore. (The
-		// Node *object* may linger NotReady after its VM dies — k3s
-		// has no cloud node-lifecycle controller to reap it — so
-		// Ready-ness plus the VM check below is the robust signal.)
+		// Node *object* may linger NotReady after its instance dies —
+		// k3s has no cloud node-lifecycle controller to reap it — so
+		// Ready-ness plus the instance check below is the robust
+		// signal.)
 		ready, _ := l.readyNodes()
 		surplusNodes := NewReadyNodes(l.baselineNodes, ready)
 
-		// Observed Incus state: no VM beyond the baseline set.
-		var surplusVMs []string
-		for _, vm := range l.clusterVMs() {
-			if !baseline[vm] {
-				surplusVMs = append(surplusVMs, vm)
+		// Observed Incus state: no instance beyond the baseline set.
+		var surplusInstances []string
+		for _, name := range l.clusterInstances() {
+			if !baseline[name] {
+				surplusInstances = append(surplusInstances, name)
 			}
 		}
-		return len(surplusNodes) == 0 && len(surplusVMs) == 0,
-			fmt.Sprintf("surplus nodes=%v surplus VMs=%v", surplusNodes, surplusVMs)
+		return len(surplusNodes) == 0 && len(surplusInstances) == 0,
+			fmt.Sprintf("surplus nodes=%v surplus instances=%v", surplusNodes, surplusInstances)
 	})
 }
 
@@ -533,7 +564,7 @@ func (l *lane) stepDelete() error {
 		return fmt.Errorf("cluster delete: %v\n%s", err, out)
 	}
 
-	return l.waitFor("no rows, no VMs, no passthrough", deleteTimeout, 10*time.Second, func() (bool, string) {
+	return l.waitFor("no rows, no instances, no passthrough", deleteTimeout, 10*time.Second, func() (bool, string) {
 		// No rows, observed through the product API.
 		out, err := l.runCLI("cluster", "get", clusterName)
 		if err == nil {
@@ -543,9 +574,9 @@ func (l *lane) stepDelete() error {
 			return false, fmt.Sprintf("cluster get: %s", strings.TrimSpace(out))
 		}
 
-		// No VMs, observed through Incus.
-		if vms := l.clusterVMs(); len(vms) > 0 {
-			return false, fmt.Sprintf("VMs remain: %v", vms)
+		// No instances of either class, observed through Incus.
+		if insts := l.clusterInstances(); len(insts) > 0 {
+			return false, fmt.Sprintf("instances remain: %v", insts)
 		}
 
 		// No passthrough rule: the published API endpoint stopped
@@ -562,9 +593,12 @@ func (l *lane) stepDelete() error {
 // --- sabotage ------------------------------------------------------------
 
 // sabotageJoinTokens continuously corrupts the pre-pushed join token on
-// every worker VM and kills any running agent, so no worker can ever
-// register: the lane MUST go red. This is the #1418 guardrail — a lane
-// that stays green under this cannot fail, and proves nothing.
+// every worker instance and kills any running agent, so no worker can
+// ever register: the lane MUST go red. This is the #1418 guardrail — a
+// lane that stays green under this cannot fail, and proves nothing. It
+// is isolation-agnostic: Incus exec reaches a system container the same
+// way it reaches a VM, so the container lane proves itself the same way
+// (#1430).
 func (l *lane) sabotageJoinTokens(stop <-chan struct{}) {
 	for {
 		select {
@@ -572,7 +606,7 @@ func (l *lane) sabotageJoinTokens(stop <-chan struct{}) {
 			return
 		case <-time.After(3 * time.Second):
 		}
-		for _, vm := range l.clusterVMs() {
+		for _, vm := range l.clusterInstances() {
 			if strings.HasSuffix(vm, "-cp") {
 				continue
 			}
@@ -606,20 +640,31 @@ func (l *lane) readyNodes() (map[string]bool, string) {
 	return out, strings.Join(parts, ", ")
 }
 
-// clusterVMs lists the lane cluster's VMs as Incus sees them.
-func (l *lane) clusterVMs() []string {
+// clusterInstances lists the lane cluster's Incus instances as Incus
+// sees them: VMs in VM mode, system containers in container mode.
+// ListContainers asks Incus for InstanceTypeAny and ClusterInstanceNames
+// matches on the name prefix alone, so one assertion sees both classes
+// (#1430) — see TestClusterInstanceNames for why the type is never a
+// filter.
+func (l *lane) clusterInstances() []string {
+	return ClusterInstanceNames(l.observedInstances(), instancePrefix)
+}
+
+// observedInstances is every instance Incus reports, name and class.
+// ListContainers asks for InstanceTypeAny, so containers and VMs are
+// both in here and the filtering is the caller's (and the pure
+// helpers') business.
+func (l *lane) observedInstances() []ClusterInstance {
 	all, err := l.incus.ListContainers()
 	if err != nil {
 		l.t.Logf("incus list: %v", err)
 		return nil
 	}
-	var vms []string
+	observed := make([]ClusterInstance, 0, len(all))
 	for _, c := range all {
-		if strings.HasPrefix(c.Name, vmPrefix) {
-			vms = append(vms, c.Name)
-		}
+		observed = append(observed, ClusterInstance{Name: c.Name, Type: c.InstanceType})
 	}
-	return vms
+	return observed
 }
 
 func (l *lane) restartCounts(ctx context.Context, selector string) (map[string]int32, error) {
@@ -661,7 +706,7 @@ func (l *lane) waitFor(what string, timeout, interval time.Duration, probe func(
 func (l *lane) dumpDiagnostics() {
 	out, err := l.runCLI("cluster", "status", clusterName)
 	l.t.Logf("cluster status (err=%v):\n%s", err, out)
-	l.t.Logf("incus VMs with prefix %s: %v", vmPrefix, l.clusterVMs())
+	l.t.Logf("incus instances with prefix %s: %v", instancePrefix, l.clusterInstances())
 	if l.cs != nil {
 		if evs, err := l.cs.CoreV1().Events("default").List(context.Background(), metav1.ListOptions{Limit: 30}); err == nil {
 			var lines []string

--- a/test/e2e/cluster/e2e_test.go
+++ b/test/e2e/cluster/e2e_test.go
@@ -716,4 +716,49 @@ func (l *lane) dumpDiagnostics() {
 			l.t.Logf("recent k8s events:\n%s", strings.Join(lines, "\n"))
 		}
 	}
+	l.dumpNodeJournals()
+}
+
+// dumpNodeJournals prints each node's systemd journal for the units
+// that actually run the cluster. Without this a failure inside k3s or
+// the autoscaler is invisible: run 15 lost ten minutes to an
+// autoscaler that never scaled, and the log that would have said why
+// was on the control plane, uncollected.
+//
+// The autoscaler is a systemd unit (`ctr run` task) on the control
+// plane, not a pod, so it appears in no kubectl output at all — it is
+// the unit most likely to be missed and the one hardest to reach after
+// the run is torn down.
+func (l *lane) dumpNodeJournals() {
+	units := map[string][]string{
+		"cp":     {"k3s", "k3s-cluster-autoscaler"},
+		"worker": {"k3s-agent"},
+	}
+	for _, name := range l.clusterInstances() {
+		role := "worker"
+		if strings.HasSuffix(name, "-cp") {
+			role = "cp"
+		}
+		args := []string{"journalctl", "--no-pager", "-n", "120"}
+		for _, u := range units[role] {
+			args = append(args, "-u", u)
+		}
+		stdout, stderr, err := l.incus.ExecWithOutput(name, args)
+		if err != nil {
+			l.t.Logf("journal %s: %v\n%s", name, err, stderr)
+			continue
+		}
+		l.t.Logf("journal %s (%s):\n%s", name, strings.Join(units[role], ","), stdout)
+	}
+	// Unit state separately: a unit that never started has an empty
+	// journal, which reads identically to a unit that started and said
+	// nothing. `is-active` tells those two apart.
+	for _, name := range l.clusterInstances() {
+		if !strings.HasSuffix(name, "-cp") {
+			continue
+		}
+		stdout, _, _ := l.incus.ExecWithOutput(name,
+			[]string{"systemctl", "is-active", "k3s-cluster-autoscaler"})
+		l.t.Logf("autoscaler unit on %s: %s", name, strings.TrimSpace(stdout))
+	}
 }

--- a/test/e2e/cluster/e2e_test.go
+++ b/test/e2e/cluster/e2e_test.go
@@ -717,6 +717,81 @@ func (l *lane) dumpDiagnostics() {
 		}
 	}
 	l.dumpNodeJournals()
+	l.dumpVPA()
+}
+
+// dumpVPA prints what the VPA stack is doing. The components live in
+// kube-system and the VPA object carries its recommendation in status,
+// so a plain look at the default namespace — which is all the rest of
+// dumpDiagnostics does — shows a workload sitting at its original
+// requests with no hint as to why.
+//
+// Three distinct failures look identical from the workload's side: the
+// recommender never ran, it ran and produced no recommendation (no
+// metrics to work from), or it recommended and the updater never
+// applied it. These are the three things that tell them apart.
+func (l *lane) dumpVPA() {
+	if l.cs == nil {
+		return
+	}
+	ctx := context.Background()
+	pods, err := l.cs.CoreV1().Pods("kube-system").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		l.t.Logf("kube-system pods: %v", err)
+	} else {
+		var lines []string
+		for _, p := range pods.Items {
+			restarts := 0
+			for _, cs := range p.Status.ContainerStatuses {
+				restarts += int(cs.RestartCount)
+			}
+			lines = append(lines, fmt.Sprintf("%s %s restarts=%d %s",
+				p.Name, p.Status.Phase, restarts, p.Status.Reason))
+		}
+		l.t.Logf("kube-system pods:\n%s", strings.Join(lines, "\n"))
+	}
+	// The recommendation itself: present means the recommender has
+	// metrics and the updater is the suspect; absent means the
+	// recommender is.
+	if l.dyn != nil {
+		obj, err := l.dyn.Resource(vpaGVR).Namespace("default").
+			Get(ctx, "burner", metav1.GetOptions{})
+		if err != nil {
+			l.t.Logf("VPA object: %v", err)
+		} else {
+			status, _, _ := unstructured.NestedMap(obj.Object, "status")
+			l.t.Logf("VPA burner status: %v", status)
+		}
+	}
+	// Node metrics are what the recommender consumes. If this is empty
+	// or errors, no recommendation was ever possible and the VPA
+	// components are not the bug.
+	raw, err := l.cs.RESTClient().Get().
+		AbsPath("/apis/metrics.k8s.io/v1beta1/nodes").DoRaw(ctx)
+	if err != nil {
+		l.t.Logf("metrics.k8s.io nodes: %v", err)
+	} else {
+		l.t.Logf("metrics.k8s.io nodes: %s", truncate(string(raw), 1200))
+	}
+	for _, ns := range []string{"kube-system"} {
+		evs, err := l.cs.CoreV1().Events(ns).List(ctx, metav1.ListOptions{Limit: 30})
+		if err != nil {
+			continue
+		}
+		var lines []string
+		for _, e := range evs.Items {
+			lines = append(lines, fmt.Sprintf("%s %s/%s: %s",
+				e.Reason, e.InvolvedObject.Kind, e.InvolvedObject.Name, e.Message))
+		}
+		l.t.Logf("%s events:\n%s", ns, strings.Join(lines, "\n"))
+	}
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "... (truncated)"
 }
 
 // dumpNodeJournals prints each node's systemd journal for the units

--- a/test/e2e/cluster/helpers.go
+++ b/test/e2e/cluster/helpers.go
@@ -90,6 +90,112 @@ func ParseSabotage(value string) (SabotageMode, error) {
 	}
 }
 
+// IsolationMode is the node isolation class the lane exercises
+// (#1430). The same six-step journey runs in both classes; what
+// changes is the `cluster create` call and what the runner must be
+// able to do (KVM for VMs, container-node preconditions otherwise).
+type IsolationMode int
+
+const (
+	// IsolationVM is the default: cluster nodes are Incus VMs, the
+	// class the self-hosted KVM lane gates (#1418).
+	IsolationVM IsolationMode = iota
+	// IsolationContainer: cluster nodes are Incus system containers
+	// (#1429), the class the GitHub-hosted lane runs without KVM.
+	IsolationContainer
+)
+
+func (m IsolationMode) String() string {
+	if m == IsolationContainer {
+		return "container"
+	}
+	return "vm"
+}
+
+// ParseIsolation maps CONTAINARIUM_E2E_ISOLATION onto a mode. Unset is
+// VM so the KVM lane's environment keeps meaning exactly what it meant
+// before this knob existed. Unknown values are an error, for
+// ParseSabotage's reason: a typo'd container run that silently took the
+// VM path would report "container mode works" having never asked for a
+// container node.
+func ParseIsolation(value string) (IsolationMode, error) {
+	switch strings.TrimSpace(value) {
+	case "", "vm":
+		return IsolationVM, nil
+	case "container":
+		return IsolationContainer, nil
+	default:
+		return IsolationVM, fmt.Errorf("unknown CONTAINARIUM_E2E_ISOLATION value %q (want empty, vm or container)", value)
+	}
+}
+
+// CreateArgs returns the extra `containarium cluster create` arguments
+// for the mode. VM mode adds none — the KVM lane invokes the CLI
+// byte-identically to its pre-#1430 self, and the daemon's own default
+// (never the weaker class) decides.
+func (m IsolationMode) CreateArgs() []string {
+	if m == IsolationContainer {
+		return []string{"--isolation", "container"}
+	}
+	return nil
+}
+
+// ClusterInstance is one Incus instance as the lane observes it.
+type ClusterInstance struct {
+	Name string
+	// Type is Incus's instance type ("container" or "virtual-machine").
+	// Carried for logs only — see ClusterInstanceNames.
+	Type string
+}
+
+// ClusterInstanceNames returns the names of the instances belonging to
+// a cluster, matched on the cluster's name prefix and NOTHING else,
+// sorted. The type is deliberately not a filter: a container-mode
+// cluster's nodes are Incus containers and a VM-mode cluster's are VMs,
+// so a type filter would make one of the two lanes observe an empty
+// cluster and report "no leftover nodes" as a pass.
+func ClusterInstanceNames(all []ClusterInstance, prefix string) []string {
+	var out []string
+	for _, inst := range all {
+		if strings.HasPrefix(inst.Name, prefix) {
+			out = append(out, inst.Name)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// incusInstanceType is Incus's own name for the instance class the
+// mode provisions ("container" / "virtual-machine" on the API).
+func (m IsolationMode) incusInstanceType() string {
+	if m == IsolationContainer {
+		return "container"
+	}
+	return "virtual-machine"
+}
+
+// WrongClassInstances returns "name (type)" for every instance of the
+// cluster whose Incus instance type is not the class the lane asked
+// for, sorted. This is what makes the isolation knob provable: a
+// container-mode run whose daemon quietly provisioned VMs (or the
+// reverse) would otherwise run the entire journey and report the wrong
+// class as green. A type Incus did not report counts as a mismatch —
+// an unverified class is not a verified one.
+func WrongClassInstances(all []ClusterInstance, prefix string, mode IsolationMode) []string {
+	want := mode.incusInstanceType()
+	var out []string
+	for _, inst := range all {
+		if !strings.HasPrefix(inst.Name, prefix) {
+			continue
+		}
+		if inst.Type != want {
+			out = append(out, fmt.Sprintf("%s (%s)", inst.Name, inst.Type))
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
 // MaxRestartDelta returns the largest restart-count increase across
 // containers between two observations keyed by pod/container name. A
 // container unseen before counts from zero; one gone in after (its pod

--- a/test/e2e/cluster/helpers_test.go
+++ b/test/e2e/cluster/helpers_test.go
@@ -200,3 +200,160 @@ func TestMaxRestartDelta(t *testing.T) {
 		})
 	}
 }
+
+func TestParseIsolation(t *testing.T) {
+	tests := []struct {
+		value    string
+		want     IsolationMode
+		wantArgs []string
+		wantErr  bool
+	}{
+		// Unset is VM: the KVM lane (#1418) sets nothing, and must keep
+		// invoking `cluster create <name>` with no extra arguments.
+		{value: "", want: IsolationVM, wantArgs: nil},
+		{value: "vm", want: IsolationVM, wantArgs: nil},
+		{value: "container", want: IsolationContainer, wantArgs: []string{"--isolation", "container"}},
+		{value: "  container \n", want: IsolationContainer, wantArgs: []string{"--isolation", "container"}},
+		// Fail closed, like ParseSabotage: a typo'd container run that
+		// quietly took the VM path would report "container mode works"
+		// having never asked for a container node.
+		{value: "containers", wantErr: true},
+		{value: "VM", wantErr: true},
+		{value: "none", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run("value="+tt.value, func(t *testing.T) {
+			got, err := ParseIsolation(tt.value)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("want error for %q, got mode %v", tt.value, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("mode = %v, want %v", got, tt.want)
+			}
+			if args := got.CreateArgs(); !reflect.DeepEqual(args, tt.wantArgs) {
+				t.Fatalf("CreateArgs = %v, want %v", args, tt.wantArgs)
+			}
+		})
+	}
+}
+
+func TestWrongClassInstances(t *testing.T) {
+	// The knob has to be provable: a container lane whose daemon quietly
+	// provisioned VMs (or a VM lane that got containers) would run the
+	// whole journey and report the wrong class as green. Incus's own
+	// instance type is the observed state that settles it.
+	tests := []struct {
+		name   string
+		all    []ClusterInstance
+		mode   IsolationMode
+		want   []string
+		prefix string
+	}{
+		{
+			name:   "container mode with container nodes is clean",
+			all:    []ClusterInstance{{Name: "c-cp", Type: "container"}, {Name: "c-small-1", Type: "container"}},
+			mode:   IsolationContainer,
+			prefix: "c-",
+			want:   nil,
+		},
+		{
+			name:   "container mode that got a VM names it",
+			all:    []ClusterInstance{{Name: "c-cp", Type: "container"}, {Name: "c-small-1", Type: "virtual-machine"}},
+			mode:   IsolationContainer,
+			prefix: "c-",
+			want:   []string{"c-small-1 (virtual-machine)"},
+		},
+		{
+			name:   "vm mode that got a container names it",
+			all:    []ClusterInstance{{Name: "c-cp", Type: "container"}},
+			mode:   IsolationVM,
+			prefix: "c-",
+			want:   []string{"c-cp (container)"},
+		},
+		{
+			name:   "an unreported type is a mismatch, not a pass",
+			all:    []ClusterInstance{{Name: "c-cp", Type: ""}},
+			mode:   IsolationContainer,
+			prefix: "c-",
+			want:   []string{`c-cp ()`},
+		},
+		{
+			name:   "instances outside the cluster are none of our business",
+			all:    []ClusterInstance{{Name: "other-box", Type: "virtual-machine"}},
+			mode:   IsolationContainer,
+			prefix: "c-",
+			want:   nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := WrongClassInstances(tt.all, tt.prefix, tt.mode)
+			if len(got) == 0 && len(tt.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("WrongClassInstances = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClusterInstanceNames(t *testing.T) {
+	// Container-mode nodes are Incus containers and VM-mode nodes are
+	// Incus VMs, so the lane's instance-listing assertions match on the
+	// cluster's name prefix and NEVER on the instance type — a type
+	// filter would make the container lane observe an empty cluster and
+	// call that "no leftover nodes".
+	all := []ClusterInstance{
+		{Name: "e2etenant-k8s-lane-cp", Type: "virtual-machine"},
+		{Name: "e2etenant-k8s-lane-small-1", Type: "container"},
+		{Name: "othertenant-k8s-lane-cp", Type: "container"},
+		{Name: "e2etenant-k8s-other-cp", Type: "container"},
+		{Name: "unrelated-box", Type: "container"},
+	}
+	tests := []struct {
+		name   string
+		all    []ClusterInstance
+		prefix string
+		want   []string
+	}{
+		{
+			name:   "both instance types match on prefix alone",
+			all:    all,
+			prefix: "e2etenant-k8s-lane-",
+			want:   []string{"e2etenant-k8s-lane-cp", "e2etenant-k8s-lane-small-1"},
+		},
+		{
+			name:   "another tenant's or cluster's instances never match",
+			all:    all,
+			prefix: "nosuchtenant-k8s-lane-",
+			want:   nil,
+		},
+		{
+			name: "output is sorted for stable logs",
+			all: []ClusterInstance{
+				{Name: "p-b", Type: "container"},
+				{Name: "p-a", Type: "virtual-machine"},
+			},
+			prefix: "p-",
+			want:   []string{"p-a", "p-b"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ClusterInstanceNames(tt.all, tt.prefix)
+			if len(got) == 0 && len(tt.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("ClusterInstanceNames = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #1430

Implements the e2e layer of `docs/architecture/cluster-container-node-pools.md`
("Test strategy"): the **same six-step tenant journey** as the KVM lane, run with
cluster nodes provisioned as Incus **system containers**, on a stock GitHub-hosted
`ubuntu-latest` runner with **no KVM**.

## What changed

- **`test/e2e/cluster` gains an isolation knob.** `CONTAINARIUM_E2E_ISOLATION`
  (unset/`vm` default, or `container`) selects the class; container mode passes
  `--isolation container` to `containarium cluster create`, CLI-first, exactly as a
  tenant would. VM mode adds no flag at all, so the KVM lane's CLI call is
  byte-identical to its pre-#1430 self. Unknown values are an error, not a silent
  fallback — a typo'd container run that quietly took the VM path would report
  "container mode works" having never asked for a container node.
- **Instance-listing assertions are now class-agnostic.** A container-mode node is
  an Incus *container*, so every "which instances exist" assertion matches on the
  cluster's name prefix and never on the instance type; a type filter would make one
  of the two lanes observe an empty cluster and call that "no leftover nodes".
- **The knob is provable.** `WrongClassInstances` asserts, against observed Incus
  state, that the nodes really are the class the run asked for — a container lane
  whose daemon quietly provisioned VMs now goes red instead of reporting VM
  behaviour as container behaviour.
- **New workflow `cluster-container-e2e.yml`**, plus `scripts/ci-incus-container-host.sh`
  (the `incus-create.yml` provisioning precedent, minus KVM: Incus + dnsmasq, ZFS pool
  the daemon detects, `br_netfilter`/`overlay`, AppArmor userns, iptables FORWARD,
  subuid/subgid — each precondition asserted at the step that provisions it). The
  daemon gets the operator opt-in `CONTAINARIUM_CLUSTER_ALLOW_CONTAINER_NODES=true`,
  because a throwaway runner is one trust domain — never a product default.
- **`scripts/cluster-e2e.sh` pass-through only**: isolation + the operator opt-in to
  the daemon, KVM pre-flight skipped in container mode, VM mode unchanged by default.

## Not a substitute for the KVM lane (#1234)

`.github/workflows/cluster-e2e.yml` is **untouched** (`git diff` against `main` on that
file is empty) and stays the definition-of-done gate for VM mode. The new workflow's
header states this explicitly: nothing here exercises qemu, VM boot, or VM-sized
capacity, and a green run here says nothing about any of them.

## Blocking fix included, flagged: #1435

The first real run of this lane could not provision a node **of either isolation
class**: the node's root disk device carried only a size, which Incus refuses with
`Disk entry is missing the required "source" or "path" property`, so the reconciler
looped and the cluster landed in `error`. Filed as #1435 and fixed here in one commit
(`fix(cluster): give the node root disk a path and a pool`), because the lane this PR
delivers cannot run at all without it. Happy to split it out if you'd rather review it
separately — the two commits are already clean.

## Test evidence

Untagged unit tests, each written red first (undefined symbol → implementation → green):

| Test | Covers |
| --- | --- |
| `TestParseIsolation` | the knob: unset/`vm` → no CLI flag, `container` → `--isolation container`, unknown → error (fail closed) |
| `TestClusterInstanceNames` | prefix-only matching across both instance types; other tenants/clusters excluded |
| `TestWrongClassInstances` | requested class vs observed Incus class, unreported type counts as a mismatch |
| `TestNodeContainerConfig` | the #1435 shape: root disk carries path + pool + size; container nodes carry the nesting profile |

These run in CI in the existing `cluster-e2e.yml / build-unit` job (`go test -race -count=1
-v ./test/e2e/cluster/`) and in the repo's Go lanes for `pkg/core/cluster`; the tagged
file compiles under `go vet -tags 'incus cluster_e2e'` there too.

The container lane itself runs on this PR (paths trigger) — its run is the real evidence,
and its exit code is unpiped end to end: `go test` → script → job.

## Prove-the-lane-can-fail

`prove-lane-can-fail` reuses #1418's mechanism unchanged (`CONTAINARIUM_E2E_SABOTAGE=join-token`,
corrupting worker join tokens through Incus exec, which reaches a system container exactly as
it reaches a VM) and inverts the exit code: the job is green only if the suite went red.
`workflow_dispatch` only becomes available once this workflow is on the default branch, so the
proof run is the first thing to do after merge — please dispatch it with `sabotage=join-token`
before trusting any green from this lane.

## Two things worth a reviewer's eye

1. **`sudo env` was dropping the per-step timeout envs.** The script re-execs `go test` under
   `sudo env <explicit list>`, and `CONTAINARIUM_E2E_*_TIMEOUT` were not on that list — so the
   KVM lane's own sabotage job has been setting `READY_TIMEOUT=12m` into a void. They are
   forwarded now; the container lane needs them to tighten its waits *in the workflow* rather
   than in the test defaults.
2. **The daemon-readiness bound moved from 120s to 360s** (env-tunable). On a *cold* host the
   daemon waits up to 2 minutes for core containers that have never existed before proceeding
   without them, and the old bound declared that a dead daemon. A warm self-hosted host still
   answers in seconds, so the KVM lane only sees a difference in how long a genuinely stuck
   daemon takes to be reported.

## Timing budget

Job timeout 100m with `go test` bounded at 85m below it, so the test times out first and prints
its diagnostics. Scale-down is left at 30m: that bound is stock cluster-autoscaler's schedule
(10m delay-after-add + 10m unneeded), not the node runtime's speed, so container nodes booting
in seconds does not shorten it.
