### PR TITLE
fix(cluster): give the node root disk a path and a pool

### DIFF
--- a/pkg/core/cluster/incushost.go
+++ b/pkg/core/cluster/incushost.go
@@ -52,7 +52,10 @@ func (h *IncusHost) ContainerNodeCapable() error {
 	}))
 }
 
-func (h *IncusHost) CreateNode(spec NodeSpec, isolation Isolation) error {
+// nodeContainerConfig is the Incus config one cluster node is created
+// from. Pure (no Incus calls) so the shape Incus validates is
+// unit-testable — see nodeconfig_test.go and #1435.
+func nodeContainerConfig(spec NodeSpec, isolation Isolation, pool string) incus.ContainerConfig {
 	cfg := incus.ContainerConfig{
 		Name:         spec.Name,
 		Image:        "images:ubuntu/24.04", // the nodevm default; VM image bake is a later phase
@@ -70,8 +73,18 @@ func (h *IncusHost) CreateNode(spec NodeSpec, isolation Isolation) error {
 		cfg.ExtraConfig = ContainerNodeConfig()
 	}
 	if spec.Disk != "" {
-		cfg.Disk = &incus.DiskDevice{Size: spec.Disk}
+		// Path and Pool alongside the size, as every other caller in the
+		// tree does: Incus refuses a root disk that carries only a size
+		// ("Disk entry is missing the required source or path property"),
+		// and it refuses it at instance creation — inside the
+		// reconciler's provisioning loop, not at config time (#1435).
+		cfg.Disk = &incus.DiskDevice{Path: "/", Pool: pool, Size: spec.Disk}
 	}
+	return cfg
+}
+
+func (h *IncusHost) CreateNode(spec NodeSpec, isolation Isolation) error {
+	cfg := nodeContainerConfig(spec, isolation, h.client.StoragePool())
 	if err := h.client.CreateContainer(cfg); err != nil {
 		return err
 	}

--- a/pkg/core/cluster/nodeconfig_test.go
+++ b/pkg/core/cluster/nodeconfig_test.go
@@ -1,0 +1,88 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/lxc/incus/v6/shared/api"
+)
+
+// The Incus config a cluster node is created from. Pure, so the parts
+// Incus validates before it will create anything are testable without a
+// real host — which is where #1435 hid: a root disk carrying only a
+// size is rejected with `Disk entry is missing the required "source" or
+// "path" property`, so no node of either isolation class was ever
+// created.
+func TestNodeContainerConfig(t *testing.T) {
+	spec := NodeSpec{Name: "t-k8s-c-small-1", CPU: "2", Memory: "4GB", Disk: "40GB"}
+
+	tests := []struct {
+		name         string
+		spec         NodeSpec
+		isolation    Isolation
+		wantType     api.InstanceType
+		wantNesting  bool
+		wantDisk     bool
+		wantDiskSize string
+	}{
+		{
+			name:         "vm node",
+			spec:         spec,
+			isolation:    IsolationVM,
+			wantType:     api.InstanceTypeVM,
+			wantDisk:     true,
+			wantDiskSize: "40GB",
+		},
+		{
+			name:         "container node carries the container profile",
+			spec:         spec,
+			isolation:    IsolationContainer,
+			wantType:     api.InstanceTypeContainer,
+			wantNesting:  true,
+			wantDisk:     true,
+			wantDiskSize: "40GB",
+		},
+		{
+			name:      "no disk size means no root device, not an empty one",
+			spec:      NodeSpec{Name: "t-k8s-c-small-1", CPU: "2", Memory: "4GB"},
+			isolation: IsolationVM,
+			wantType:  api.InstanceTypeVM,
+			wantDisk:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := nodeContainerConfig(tt.spec, tt.isolation, "poolname")
+
+			if cfg.Name != tt.spec.Name {
+				t.Fatalf("Name = %q, want %q", cfg.Name, tt.spec.Name)
+			}
+			if cfg.InstanceType != tt.wantType {
+				t.Fatalf("InstanceType = %q, want %q", cfg.InstanceType, tt.wantType)
+			}
+			if got := cfg.ExtraConfig["security.nesting"] == "true"; got != tt.wantNesting {
+				t.Fatalf("security.nesting = %v, want %v", got, tt.wantNesting)
+			}
+			if !tt.wantDisk {
+				if cfg.Disk != nil {
+					t.Fatalf("Disk = %+v, want none", cfg.Disk)
+				}
+				return
+			}
+			if cfg.Disk == nil {
+				t.Fatal("Disk is nil, want a root device")
+			}
+			// The three properties Incus validates. A device with only a
+			// size is refused, and the refusal happens at instance
+			// creation — minutes into a provisioning loop, not here.
+			if cfg.Disk.Path != "/" {
+				t.Fatalf("Disk.Path = %q, want %q — Incus rejects a root disk with no path", cfg.Disk.Path, "/")
+			}
+			if cfg.Disk.Pool != "poolname" {
+				t.Fatalf("Disk.Pool = %q, want the host's resolved pool", cfg.Disk.Pool)
+			}
+			if cfg.Disk.Size != tt.wantDiskSize {
+				t.Fatalf("Disk.Size = %q, want %q", cfg.Disk.Size, tt.wantDiskSize)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #1435

**Every managed-cluster create on `main` fails to provision — VM *and* container mode.** The node's root disk device is built with only a size, and Incus refuses it at instance creation:

```
Device validation failed for "root": Disk entry is missing the required "source" or "path" property
```

The reconciler then retries forever and the cluster lands in `error`, so `cluster kubeconfig` correctly answers `FailedPrecondition`. The product behaviour downstream is right; the create simply never succeeds.

## Why nothing caught it

`pkg/core/cluster/manager_test.go` drives a fake `VMHost`, so the config Incus would have rejected was never validated by anything. The KVM lane (#1418) that would have caught it has never run — its self-hosted runner is still unprovisioned. This surfaced the first time a lane actually created a node against a real Incus, which is exactly what those lanes are for.

## The fix

The root disk now carries `Path: "/"` and `Pool` alongside the size, matching every other caller in the tree. The config construction moves into a pure `nodeContainerConfig()` so the shape Incus validates is unit-testable without an Incus.

## Test evidence

`TestNodeContainerConfig` (new, `pkg/core/cluster/nodeconfig_test.go`) — 3 subtests, all passing locally:
- `vm_node` — root device has path + pool + size
- `container_node_carries_the_container_profile` — the container profile config is applied alongside
- `no_disk_size_means_no_root_device,_not_an_empty_one` — pins that an unset size produces no device rather than an invalid one

Full package green locally: `ok github.com/footprintai/containarium/pkg/core/cluster`, `go vet` clean.

## Provenance

Found and fixed while building the container-mode e2e lane (#1430, PR #1436). Split out here because it blocks **both** isolation classes and should not wait on that PR's remaining work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)