### PR TITLE
fix(cluster): create a node file's parent directory before pushing it

### DIFF
--- a/pkg/core/cluster/manager.go
+++ b/pkg/core/cluster/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -95,6 +96,22 @@ func (m *Manager) DeleteVM(name string) error { return m.host.Delete(name) }
 
 const bootstrapScriptPath = "/root/containarium-bootstrap.sh"
 
+// pushFile writes a file into a node, creating its parent directory
+// first. Incus answers "Not Found" when the parent is missing, and
+// none of the directories the cluster flow writes into
+// (/etc/containarium, its ca/ subdir, k3s's manifests dir) exist in a
+// fresh node image — so every push failed until the parent was made
+// (#1442). mkdir -p is idempotent, so this is safe on the paths whose
+// parent already exists.
+func (m *Manager) pushFile(name, path string, content []byte, mode string) error {
+	if dir := filepath.Dir(path); dir != "" && dir != "/" && dir != "." {
+		if _, err := m.host.Exec(name, []string{"mkdir", "-p", dir}); err != nil {
+			return fmt.Errorf("create %s: %w", dir, err)
+		}
+	}
+	return m.host.Push(name, path, content, mode)
+}
+
 // ProvisionCP creates and bootstraps the control-plane VM: create →
 // start → wait → push pinned binary + rendered script → exec. Returns
 // the VM's IP (workers join over it). cpSize is the smallest preset —
@@ -116,11 +133,11 @@ func (m *Manager) ProvisionCP(tenant, clusterName string, iso Isolation, cpSize 
 	if err != nil {
 		return "", err
 	}
-	if err := m.host.Push(name, K3sBinaryPath, bin, "0755"); err != nil {
+	if err := m.pushFile(name, K3sBinaryPath, bin, "0755"); err != nil {
 		return "", fmt.Errorf("push k3s binary: %w", err)
 	}
 	script := RenderServerScript(ServerBootstrap{TLSSANs: append([]string{ip}, tlsSANs...), Isolation: iso})
-	if err := m.host.Push(name, bootstrapScriptPath, []byte(script), "0755"); err != nil {
+	if err := m.pushFile(name, bootstrapScriptPath, []byte(script), "0755"); err != nil {
 		return "", fmt.Errorf("push bootstrap script: %w", err)
 	}
 	if _, err := m.host.Exec(name, []string{"sh", bootstrapScriptPath}); err != nil {
@@ -163,14 +180,14 @@ func (m *Manager) ProvisionWorker(tenant, clusterName string, iso Isolation, g D
 	if err != nil {
 		return err
 	}
-	if err := m.host.Push(vmName, K3sBinaryPath, bin, "0755"); err != nil {
+	if err := m.pushFile(vmName, K3sBinaryPath, bin, "0755"); err != nil {
 		return fmt.Errorf("push k3s binary: %w", err)
 	}
-	if err := m.host.Push(vmName, AgentTokenPath, token, "0600"); err != nil {
+	if err := m.pushFile(vmName, AgentTokenPath, token, "0600"); err != nil {
 		return fmt.Errorf("push join token: %w", err)
 	}
 	script := RenderAgentScript(AgentBootstrap{ServerURL: "https://" + cpIP + ":6443", Isolation: iso})
-	if err := m.host.Push(vmName, bootstrapScriptPath, []byte(script), "0755"); err != nil {
+	if err := m.pushFile(vmName, bootstrapScriptPath, []byte(script), "0755"); err != nil {
 		return fmt.Errorf("push bootstrap script: %w", err)
 	}
 	if _, err := m.host.Exec(vmName, []string{"sh", bootstrapScriptPath}); err != nil {
@@ -242,12 +259,12 @@ func (m *Manager) DeployCA(tenant, clusterName string, d CADeploy, creds CACrede
 		{CACloudConfigPath, []byte(RenderCACloudConfig(d)), "0644"},
 	}
 	for _, f := range files {
-		if err := m.host.Push(cp, f.path, f.content, f.mode); err != nil {
+		if err := m.pushFile(cp, f.path, f.content, f.mode); err != nil {
 			return fmt.Errorf("push %s: %w", f.path, err)
 		}
 	}
 	script := RenderCAUnitScript(d)
-	if err := m.host.Push(cp, "/root/containarium-ca-bootstrap.sh", []byte(script), "0755"); err != nil {
+	if err := m.pushFile(cp, "/root/containarium-ca-bootstrap.sh", []byte(script), "0755"); err != nil {
 		return fmt.Errorf("push CA bootstrap: %w", err)
 	}
 	if _, err := m.host.Exec(cp, []string{"sh", "/root/containarium-ca-bootstrap.sh"}); err != nil {

--- a/pkg/core/cluster/manager_test.go
+++ b/pkg/core/cluster/manager_test.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -92,7 +93,12 @@ func TestProvisionCPSequence(t *testing.T) {
 	want := []string{
 		"create alice-k8s-demo-cp cpu=2 mem=4GB disk=40GB role=control-plane",
 		"wait alice-k8s-demo-cp",
+		// Each push is preceded by its parent mkdir (#1442): Incus
+		// answers Not Found for a missing parent, and these
+		// directories do not exist in a fresh node image.
+		"exec alice-k8s-demo-cp:mkdir -p " + filepath.Dir(K3sBinaryPath),
 		"push alice-k8s-demo-cp:" + K3sBinaryPath + " mode=0755",
+		"exec alice-k8s-demo-cp:mkdir -p " + filepath.Dir(bootstrapScriptPath),
 		"push alice-k8s-demo-cp:" + bootstrapScriptPath + " mode=0755",
 		"exec alice-k8s-demo-cp:sh " + bootstrapScriptPath,
 	}
@@ -122,8 +128,13 @@ func TestProvisionWorkerSequence(t *testing.T) {
 		"read alice-k8s-demo-cp:" + NodeTokenPath,
 		"create alice-k8s-demo-small-1 cpu=2 mem=4GB disk=40GB role=worker",
 		"wait alice-k8s-demo-small-1",
+		"exec alice-k8s-demo-small-1:mkdir -p " + filepath.Dir(K3sBinaryPath),
 		"push alice-k8s-demo-small-1:" + K3sBinaryPath + " mode=0755",
+		// The one that was actually failing in production: /etc/containarium
+		// does not exist in a fresh image, so this push returned Not Found.
+		"exec alice-k8s-demo-small-1:mkdir -p " + filepath.Dir(AgentTokenPath),
 		"push alice-k8s-demo-small-1:" + AgentTokenPath + " mode=0600",
+		"exec alice-k8s-demo-small-1:mkdir -p " + filepath.Dir(bootstrapScriptPath),
 		"push alice-k8s-demo-small-1:" + bootstrapScriptPath + " mode=0755",
 		"exec alice-k8s-demo-small-1:sh " + bootstrapScriptPath,
 	}
@@ -268,5 +279,40 @@ func TestProvisionWorkerRefusesUnhonourableCapacity(t *testing.T) {
 		DesiredGroup{Name: "small", CPU: "8", Memory: "16GB", Disk: "40GB"},
 		"alice-k8s-demo-small-1", "10.0.0.1"); err != nil {
 		t.Fatalf("VM provisioning must not consult the container capacity probe: %v", err)
+	}
+}
+
+// Every path the cluster flow pushes to lives in a directory that does
+// not exist in a fresh node image, and Incus answers "Not Found" for a
+// missing parent. The parent must therefore be created BEFORE the push
+// — ordering is the assertion, since a push that happens to succeed
+// proves nothing about a fresh node (#1442).
+func TestPushCreatesParentDirectoryFirst(t *testing.T) {
+	f := newFakeHost()
+	f.files["alice-k8s-demo-cp:"+NodeTokenPath] = []byte("token")
+
+	if err := testManager(f).ProvisionWorker("alice", "demo", IsolationVM,
+		DesiredGroup{Name: "small", CPU: "2", Memory: "4GB", Disk: "40GB"},
+		"alice-k8s-demo-small-1", "10.0.0.1"); err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+
+	mkdirAt, pushAt := -1, -1
+	for i, call := range f.calls {
+		if mkdirAt < 0 && strings.Contains(call, "mkdir") && strings.Contains(call, "/etc/containarium") {
+			mkdirAt = i
+		}
+		if pushAt < 0 && strings.Contains(call, "push ") && strings.Contains(call, AgentTokenPath) {
+			pushAt = i
+		}
+	}
+	if mkdirAt < 0 {
+		t.Fatalf("no parent directory was created for %s: %v", AgentTokenPath, f.calls)
+	}
+	if pushAt < 0 {
+		t.Fatalf("join token was never pushed: %v", f.calls)
+	}
+	if mkdirAt > pushAt {
+		t.Fatalf("parent directory created AFTER the push (mkdir at %d, push at %d): %v", mkdirAt, pushAt, f.calls)
 	}
 }

--- a/pkg/core/cluster/vpa.go
+++ b/pkg/core/cluster/vpa.go
@@ -153,10 +153,10 @@ func (m *Manager) DeployVPA(tenant, clusterName string) error {
 	if err != nil {
 		return fmt.Errorf("generate VPA webhook certs: %w", err)
 	}
-	if err := m.host.Push(cp, VPACertsPath, secret, "0600"); err != nil {
+	if err := m.pushFile(cp, VPACertsPath, secret, "0600"); err != nil {
 		return fmt.Errorf("push VPA certs manifest: %w", err)
 	}
-	if err := m.host.Push(cp, VPAManifestPath, manifests, "0644"); err != nil {
+	if err := m.pushFile(cp, VPAManifestPath, manifests, "0644"); err != nil {
 		return fmt.Errorf("push VPA manifests: %w", err)
 	}
 	return nil


### PR DESCRIPTION
Closes #1442. Found by the container-mode lane (#1430) on its first run with provisioning actually working.

## The bug

Every file push into a cluster node failed with `Not Found`, in **both** isolation classes:

```
provision worker <node>: push join token: failed to write file: Not Found
deploy autoscaler: push /etc/containarium/ca/client.crt: failed to write file: Not Found
deploy VPA: push VPA certs manifest: failed to write file: Not Found
```

Incus rejects a push whose **parent directory** does not exist, and none of these exist in a fresh node image — `/etc/containarium`, its `ca/` subdir, k3s's manifests dir. The cluster then sat in `error`, and `cluster kubeconfig` correctly refused with `FailedPrecondition`, which presents as the journey hanging at step 1 rather than as an obvious error.

## The fix

Manager pushes route through `pushFile`, which `mkdir -p`s the parent first. Idempotent, so the paths whose parent already exists (`/usr/local/bin`, `/root`) are unaffected.

## Why nothing caught it

`manager_test.go`'s fake `Push` is a map write — it cannot fail on a missing parent. The two lanes that would have caught it are exactly the two that had never run: #1418 (still no runner) and #1430 (blocked until this week). Same shape as #1435, and the second real product bug this lane has surfaced.

## On the two existing tests that changed

`TestProvisionCPSequence` and `TestProvisionWorkerSequence` are **extended, not weakened**: they still assert the exact full call sequence, now including each `mkdir` before its push. No assertion was removed or loosened.

The new `TestPushCreatesParentDirectoryFirst` asserts the **ordering** (mkdir index < push index), not merely that the push succeeded — a push that happens to succeed proves nothing about a fresh node, which is precisely how this shipped.

Also worth recording: my first attempt at the helper recursed infinitely (a blanket call-site rewrite caught the call inside the helper itself). The test suite caught it immediately as a stack overflow.

`go test ./pkg/core/cluster/ ./internal/server/` green, `go vet` clean, `go build ./...` clean, goldens unchanged.

Unblocks #1430 · umbrella #1432.

🤖 Generated with [Claude Code](https://claude.com/claude-code)