### PR TITLE
fix(cluster): read the join token through its symlink — Incus returns a symlink's target path, not its content

### DIFF
--- a/pkg/core/cluster/manager_test.go
+++ b/pkg/core/cluster/manager_test.go
@@ -115,7 +115,12 @@ func TestProvisionCPSequence(t *testing.T) {
 
 func TestProvisionWorkerSequence(t *testing.T) {
 	f := newFakeHost()
-	f.files["alice-k8s-demo-cp:"+NodeTokenPath] = []byte("K10secret::token")
+	// Shaped like a real k3s node-token — CA hash, separator,
+	// credential, trailing newline — so byte-identity below means
+	// the CA hash and the newline both survived the round trip
+	// (#1446). Value is synthetic.
+	const nodeToken = "K10aaaabbbbccccddddeeeeffff00001111222233334444555566667777888899::server:0123456789abcdef\n"
+	f.files["alice-k8s-demo-cp:"+NodeTokenPath] = []byte(nodeToken)
 	m := testManager(f)
 
 	err := m.ProvisionWorker("alice", "demo", IsolationVM,
@@ -140,8 +145,10 @@ func TestProvisionWorkerSequence(t *testing.T) {
 	}
 	assertCalls(t, f.calls, want)
 
-	if got := string(f.files["alice-k8s-demo-small-1:"+AgentTokenPath]); got != "K10secret::token" {
-		t.Fatalf("token pushed = %q", got)
+	// Byte-identical to what the CP has at NodeTokenPath — no
+	// truncation, no transformation, newline intact (#1446).
+	if got := string(f.files["alice-k8s-demo-small-1:"+AgentTokenPath]); got != nodeToken {
+		t.Fatalf("token pushed = %q, want the CP's node-token byte-identical %q", got, nodeToken)
 	}
 	script := string(f.files["alice-k8s-demo-small-1:"+bootstrapScriptPath])
 	if !strings.Contains(script, "--server https://10.166.11.5:6443") {

--- a/pkg/core/incus/client.go
+++ b/pkg/core/incus/client.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	gopath "path"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -2263,20 +2264,52 @@ func (c *Client) WriteFile(containerName, path string, content []byte, mode stri
 	return nil
 }
 
-// ReadFile reads content from a file inside a container
-func (c *Client) ReadFile(containerName, path string) ([]byte, error) {
-	reader, _, err := c.server.GetInstanceFile(containerName, path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read file: %w", err)
-	}
-	defer reader.Close()
+// maxSymlinkHops bounds how many links ReadFile follows before
+// declaring a loop. Deep legitimate chains are 1-2 hops; anything
+// near this bound is a cycle.
+const maxSymlinkHops = 10
 
-	content, err := io.ReadAll(reader)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read file content: %w", err)
+// ReadFile reads content from a file inside a container, following
+// symlinks to the real file.
+//
+// Incus's file API answers a read of a symlink with the link *target
+// path* as the response body (response Type "symlink"), not the
+// file's content — so ignoring the type metadata silently returns a
+// path string where the caller expects file bytes. k3s's join token
+// at server/node-token is exactly such a symlink, which is how
+// workers were pushed a "token" with no CA hash (#1446).
+func (c *Client) ReadFile(containerName, filePath string) ([]byte, error) {
+	current := filePath
+	for hop := 0; ; hop++ {
+		reader, resp, err := c.server.GetInstanceFile(containerName, current)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read file %s: %w", current, err)
+		}
+		if resp != nil && resp.Type == "directory" {
+			// Incus returns a nil reader for directories.
+			return nil, fmt.Errorf("failed to read file %s: it is a directory", current)
+		}
+		content, err := io.ReadAll(reader)
+		_ = reader.Close()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read file content of %s: %w", current, err)
+		}
+		if resp == nil || resp.Type != "symlink" {
+			return content, nil
+		}
+		if hop >= maxSymlinkHops {
+			return nil, fmt.Errorf("failed to read file %s: too many symlink hops (loop?)", filePath)
+		}
+		target := strings.TrimSpace(string(content))
+		if target == "" {
+			return nil, fmt.Errorf("failed to read file %s: symlink %s has an empty target", filePath, current)
+		}
+		// Instance paths are POSIX regardless of the host platform.
+		if !gopath.IsAbs(target) {
+			target = gopath.Join(gopath.Dir(current), target)
+		}
+		current = target
 	}
-
-	return content, nil
 }
 
 // ExecWithOutput executes a command inside a container and returns stdout/stderr

--- a/pkg/core/incus/read_file_test.go
+++ b/pkg/core/incus/read_file_test.go
@@ -1,0 +1,168 @@
+package incus
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	incusclient "github.com/lxc/incus/v6/client"
+)
+
+// These pin ReadFile's contract: the bytes it returns are the bytes of
+// the file inside the instance — following symlinks, byte-identical,
+// never the symlink's target path.
+//
+// Why this matters: Incus's file API answers a read of a symlink with
+// the link *target path* as the response body (Type "symlink"), not
+// the file's content. k3s creates its join token at
+// /var/lib/rancher/k3s/server/node-token as a symlink to
+// <datadir>/token, so a ReadFile that ignores the type metadata hands
+// the caller the literal path string instead of the token — which is
+// exactly how workers ended up joining with a token that "lacks the
+// CA hash" (#1446).
+
+// fakeFileServer implements only the file half of incus.InstanceServer.
+//
+// The embedded interface is nil on purpose: any method these tests do
+// not stub panics rather than silently returning a zero value.
+type fakeFileServer struct {
+	incusclient.InstanceServer
+
+	// files maps path -> regular file content.
+	files map[string]string
+	// symlinks maps path -> link target (what the incus API returns
+	// as the body of a symlink read).
+	symlinks map[string]string
+	// dirs is the set of paths that answer as directories.
+	dirs map[string]bool
+
+	// reads records every path requested, in order.
+	reads []string
+}
+
+func (f *fakeFileServer) GetInstanceFile(instance, path string) (io.ReadCloser, *incusclient.InstanceFileResponse, error) {
+	f.reads = append(f.reads, path)
+	if target, ok := f.symlinks[path]; ok {
+		return io.NopCloser(strings.NewReader(target)),
+			&incusclient.InstanceFileResponse{Type: "symlink"}, nil
+	}
+	if f.dirs[path] {
+		return nil, &incusclient.InstanceFileResponse{Type: "directory"}, nil
+	}
+	if content, ok := f.files[path]; ok {
+		return io.NopCloser(strings.NewReader(content)),
+			&incusclient.InstanceFileResponse{Type: "file"}, nil
+	}
+	return nil, nil, notFoundErr()
+}
+
+// fullToken mirrors the shape of a real k3s node-token: CA hash,
+// separator, credential. The value is synthetic.
+const fullToken = "K10aaaabbbbccccddddeeeeffff00001111222233334444555566667777888899::server:0123456789abcdef\n"
+
+func TestReadFile_FollowsSymlinkToAbsoluteTarget(t *testing.T) {
+	// The real k3s layout: node-token is a symlink with an absolute
+	// target (k3s-io/k3s pkg/server: os.Symlink(serverTokenFile, np)).
+	f := &fakeFileServer{
+		files:    map[string]string{"/var/lib/rancher/k3s/server/token": fullToken},
+		symlinks: map[string]string{"/var/lib/rancher/k3s/server/node-token": "/var/lib/rancher/k3s/server/token"},
+	}
+	c := &Client{server: f}
+
+	got, err := c.ReadFile("cp", "/var/lib/rancher/k3s/server/node-token")
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != fullToken {
+		t.Errorf("ReadFile returned %q, want the symlink target's content %q", got, fullToken)
+	}
+}
+
+func TestReadFile_FollowsSymlinkToRelativeTarget(t *testing.T) {
+	// A relative target resolves against the symlink's own directory.
+	f := &fakeFileServer{
+		files:    map[string]string{"/var/lib/rancher/k3s/server/token": fullToken},
+		symlinks: map[string]string{"/var/lib/rancher/k3s/server/node-token": "token"},
+	}
+	c := &Client{server: f}
+
+	got, err := c.ReadFile("cp", "/var/lib/rancher/k3s/server/node-token")
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != fullToken {
+		t.Errorf("ReadFile returned %q, want %q", got, fullToken)
+	}
+}
+
+func TestReadFile_SymlinkChainResolves(t *testing.T) {
+	f := &fakeFileServer{
+		files: map[string]string{"/data/real": "payload"},
+		symlinks: map[string]string{
+			"/a": "/b",
+			"/b": "/data/real",
+		},
+	}
+	c := &Client{server: f}
+
+	got, err := c.ReadFile("cp", "/a")
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != "payload" {
+		t.Errorf("ReadFile returned %q, want %q", got, "payload")
+	}
+}
+
+func TestReadFile_SymlinkLoopErrors(t *testing.T) {
+	f := &fakeFileServer{
+		symlinks: map[string]string{
+			"/a": "/b",
+			"/b": "/a",
+		},
+	}
+	c := &Client{server: f}
+
+	_, err := c.ReadFile("cp", "/a")
+	if err == nil {
+		t.Fatal("ReadFile on a symlink loop returned nil error, want a bounded failure")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Errorf("error %q does not name the symlink loop", err)
+	}
+}
+
+func TestReadFile_RegularFileBytesAreExact(t *testing.T) {
+	// Guard against any transformation of a regular file's bytes —
+	// trailing newline, interior newlines, and the token's own
+	// separators must all survive the round trip untouched.
+	content := "line1\nline2\n\ttrailing whitespace \nK10hash::server:pw\n"
+	f := &fakeFileServer{files: map[string]string{"/etc/some-file": content}}
+	c := &Client{server: f}
+
+	got, err := c.ReadFile("cp", "/etc/some-file")
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != content {
+		t.Errorf("ReadFile returned %q, want byte-identical %q", got, content)
+	}
+	if len(f.reads) != 1 {
+		t.Errorf("regular file was read %d times, want 1 (%v)", len(f.reads), f.reads)
+	}
+}
+
+func TestReadFile_DirectoryErrorsInsteadOfPanicking(t *testing.T) {
+	// Incus returns a nil reader for directories; ReadFile must
+	// answer with an error, not a nil dereference.
+	f := &fakeFileServer{dirs: map[string]bool{"/etc": true}}
+	c := &Client{server: f}
+
+	_, err := c.ReadFile("cp", "/etc")
+	if err == nil {
+		t.Fatal("ReadFile on a directory returned nil error, want an error")
+	}
+	if !strings.Contains(err.Error(), "directory") {
+		t.Errorf("error %q does not say it is a directory", err)
+	}
+}


### PR DESCRIPTION
Closes #1446

## Root cause — the incus file read, not ordering

k3s does not write `node-token` as a regular file. It writes the token to
`<datadir>/token` and creates `server/node-token` as a **symlink** to it,
for backwards compatibility (k3s-io/k3s `pkg/server/server.go`,
`os.Symlink(serverTokenFile, np)`).

Incus's file API answers a read of a symlink with the link **target
path** as the response body, flagged only by `Type: "symlink"` in the
response metadata (`X-Incus-type` header; see the client's
`GetInstanceFile`). Our `pkg/core/incus` `Client.ReadFile` discarded that
metadata (`reader, _, err := c.server.GetInstanceFile(...)`) and returned
the body verbatim — so the manager read the literal string
`/var/lib/rancher/k3s/server/token` and pushed *that* as the join token.
A "token" with no `K10<ca-hash>::` prefix produces exactly the observed
agent failure ("the token does not include a CA hash") and the run-4
server-side counterpart ("not authorized").

**Ordering was checked and is not the cause.** In `RenderServerScript`,
the #1444 containerd stanza (derive template → `systemctl restart k3s`)
renders *before* the bootstrap's final wait loop, which blocks until
both the kubeconfig and the node-token are non-empty — and the manager
only reads the token in `ProvisionWorker`, after `ProvisionCP`'s
synchronous `Exec` of that script has returned. The token content is
also stable across k3s restarts (written once from the server token).
No ordering change was needed, so no ordering assertion was added.

## What changed

- `pkg/core/incus/client.go` — `ReadFile` now follows symlinks: when the
  response type is `symlink`, the body is treated as the target path
  (relative targets resolved against the link's directory, POSIX `path`
  semantics) and re-read, bounded at 10 hops so a link loop errors
  instead of spinning. Reading a directory now returns an error instead
  of dereferencing Incus's nil reader.
- `pkg/core/incus/read_file_test.go` — new table of fake-server tests
  pinning the contract (see below).
- `pkg/core/cluster/manager_test.go` — the existing fake-host
  byte-identity assertion now uses a realistically shaped node-token
  (CA hash + `::server:` + credential + trailing newline) so
  byte-identity proves the hash and the newline both survive.

## Test evidence

Acceptance criterion 1 (token at `AgentTokenPath` byte-identical to the
CP's `NodeTokenPath`, provable with the fake host, no Incus):

- `TestProvisionWorkerSequence` (`pkg/core/cluster/manager_test.go`) —
  asserts the pushed bytes equal the CP's node-token exactly, including
  the trailing newline.

Acceptance criterion 3 (cause is in `pkg/core/incus` `ReadFile`; fix
there with a test that catches a wrong/partial read):

- `TestReadFile_FollowsSymlinkToAbsoluteTarget` — the real k3s layout;
  fails on the old code by returning the target path string.
- `TestReadFile_FollowsSymlinkToRelativeTarget` — relative target
  resolved against the link's directory.
- `TestReadFile_SymlinkChainResolves` / `TestReadFile_SymlinkLoopErrors`
  — chains resolve, loops error at a bounded hop count.
- `TestReadFile_RegularFileBytesAreExact` — a regular file's bytes come
  back byte-identical (newlines, whitespace, token separators) in a
  single read; catches any truncating/transforming regression.
- `TestReadFile_DirectoryErrorsInsteadOfPanicking` — the nil-reader
  directory case errors instead of SIGSEGV (the old code panicked; the
  red run's stack trace showed it at the pre-fix `client.go:2272`).

All six new tests were run red-first against the unmodified `ReadFile`:
the two symlink tests returned the target path, the loop test never
errored, and the directory test nil-panicked — then green after the fix.

Criterion 2 (ordering asserted if ordering is the cause) is N/A — the
cause is the symlink read; the ordering analysis above is the evidence.

Local: `go test ./pkg/core/incus/ ./pkg/core/cluster/` — `ok` both
packages; full suite is CI's job on this branch.

Reviewer note: the only behavior change for other `ReadFile` callers
(authorized_keys, backup, kubeconfig reads) is that a symlinked file now
returns its content instead of its target path — strictly the intended
semantics for all of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
