### PR TITLE
fix(cluster): push the worker's containerd template instead of deriving it in-band

### DIFF
--- a/pkg/core/cluster/bootstrap.go
+++ b/pkg/core/cluster/bootstrap.go
@@ -133,7 +133,21 @@ UNIT
 systemctl daemon-reload
 systemctl enable --now k3s-agent.service
 %[5]s`, K3sBinaryPath, AgentTokenPath, b.ServerURL, kmsgShimUnitLine(b.Isolation),
-		containerdTemplateStanza(b.Isolation, "k3s-agent.service"), kubeletArgsSuffix(b.KubeletArgs))
+		workerContainerdNote(b.Isolation), kubeletArgsSuffix(b.KubeletArgs))
+}
+
+// workerContainerdNote documents why a worker carries no in-band
+// containerd derivation. A worker cannot derive its own: k3s agent
+// writes config.toml only after retrieving configuration from the
+// server, so waiting for it here blocks on something downstream of the
+// startup being blocked (#1448). The daemon pushes the derived
+// template — taken from the control plane's generated config — before
+// this script runs.
+func workerContainerdNote(iso Isolation) string {
+	if iso != IsolationContainer {
+		return ""
+	}
+	return "\n# containerd template was pushed by the daemon before boot (#1448).\n"
 }
 
 // containerdTemplateStanza derives the containerd config template that

--- a/pkg/core/cluster/capacity.go
+++ b/pkg/core/cluster/capacity.go
@@ -212,3 +212,39 @@ func CheckNodeCapacity(observedCPU int, observedMemBytes int64, spec NodeSpec) e
 	}
 	return nil
 }
+
+// DeriveContainerdTemplate turns a *generated* containerd config into
+// the template a container-class node should use: the same content
+// with the unprivileged-port/ICMP toggles flipped off.
+//
+// This is the Go-side counterpart of the sed the control-plane
+// bootstrap runs, and it exists because a **worker cannot derive its
+// own** (#1448): k3s agent writes config.toml only after it has
+// retrieved configuration from the server, so a worker that waits for
+// that file blocks on something downstream of the startup it is
+// blocking. The daemon instead derives from the control plane's
+// already-generated config — same pinned k3s version, same base shape
+// — and pushes the result before the agent first starts.
+//
+// A config that does not contain a toggle is an ERROR, not a
+// pass-through: silently shipping a template that leaves the toggles
+// enabled would restore the failure #1444 fixed, with nothing to say
+// so. #1444's loudness is the property being preserved here.
+func DeriveContainerdTemplate(generated []byte) ([]byte, error) {
+	out := string(generated)
+	for _, key := range containerdUnprivilegedToggles {
+		enabled := key + " = true"
+		disabled := key + " = false"
+		switch {
+		case strings.Contains(out, enabled):
+			out = strings.ReplaceAll(out, enabled, disabled)
+		case strings.Contains(out, disabled):
+			// Already off — nothing to flip, still correct.
+		default:
+			return nil, fmt.Errorf(
+				"generated containerd config contains no %q setting to disable; "+
+					"the config shape changed and a container node would run with pod sandboxes broken", key)
+		}
+	}
+	return []byte(out), nil
+}

--- a/pkg/core/cluster/capacity_test.go
+++ b/pkg/core/cluster/capacity_test.go
@@ -206,47 +206,35 @@ func TestKubeletReservedArgs(t *testing.T) {
 
 // The template and the reserved args only matter if the node actually
 // receives them, so pin the wiring, not just the pure functions.
-func TestAgentScriptCarriesTemplateAndReservedArgs(t *testing.T) {
+func TestAgentScriptCarriesReservedArgs(t *testing.T) {
 	container := RenderAgentScript(AgentBootstrap{
 		ServerURL:   "https://10.0.0.1:6443",
 		Isolation:   IsolationContainer,
 		KubeletArgs: KubeletReservedArgs(Reserved{CPU: 6, MemoryBytes: 61_000_000_000}),
 	})
-	if !strings.Contains(container, ContainerdConfigTemplatePath) {
-		t.Error("container agent script does not write the containerd template")
-	}
-	if !strings.Contains(container, ContainerdGeneratedConfigPath) {
-		t.Error("container agent script does not derive the template from the generated config")
-	}
-	if !strings.Contains(container, "systemctl restart k3s-agent.service") {
-		t.Error("container agent script does not restart k3s after deriving the template")
-	}
 	if !strings.Contains(container, "system-reserved=cpu=6") {
 		t.Error("container agent script does not pass the kubelet reservation")
 	}
 	// The #1444 regression: a hand-written template re-declaring a
-	// table k3s's base template already emits. Neither form may come
-	// back — the derivation copies the generated config instead.
+	// table k3s's base template already emits. It must never come back
+	// in any bootstrap script.
 	if strings.Contains(container, "{{ template") {
 		t.Error("container agent script embeds a hand-written containerd template (#1444)")
 	}
 	if strings.Contains(container, "[plugins.") {
 		t.Error("container agent script re-declares a containerd table k3s already emits (#1444)")
 	}
-	// The generated config exists only after k3s starts, so the
-	// derivation must come after the unit is enabled — and its wait
-	// must fail loudly, never skip silently (#1444).
-	enable := strings.Index(container, "systemctl enable --now k3s-agent.service")
-	derive := strings.Index(container, ContainerdGeneratedConfigPath)
-	if enable == -1 || derive < enable {
-		t.Error("containerd derivation must run after k3s-agent is enabled")
-	}
-	if !strings.Contains(container, "was never generated") {
-		t.Error("containerd derivation wait does not fail loudly on timeout")
-	}
 
-	// The VM path must stay exactly what it was: no template, no args,
-	// no behaviour bought with a change to the other isolation class.
+	// This test used to assert the agent derived its containerd
+	// template in-band (wait for the generated config -> sed ->
+	// restart). That behaviour was #1448: an agent writes that config
+	// only after it has joined, so the wait deadlocked. The inverse is
+	// now pinned by TestAgentScriptDoesNotWaitForContainerdConfig, and
+	// the daemon-side push it was replaced with by
+	// TestProvisionWorkerPushesContainerdTemplateBeforeBootstrap. The
+	// control plane keeps the in-band derivation, asserted by
+	// TestServerScriptCarriesContainerdDerivation.
+
 	vm := RenderAgentScript(AgentBootstrap{ServerURL: "https://10.0.0.1:6443", Isolation: IsolationVM})
 	for _, unwanted := range []string{ContainerdConfigTemplatePath, "system-reserved", "enable_unprivileged"} {
 		if strings.Contains(vm, unwanted) {
@@ -255,9 +243,6 @@ func TestAgentScriptCarriesTemplateAndReservedArgs(t *testing.T) {
 	}
 }
 
-// k3s server runs an embedded agent: the control plane starts
-// containerd exactly like a worker does, so it needs the sysctl fix
-// too — the container lane's run 5 failed on the CP first (#1444).
 func TestServerScriptCarriesContainerdDerivation(t *testing.T) {
 	container := RenderServerScript(ServerBootstrap{
 		TLSSANs:   []string{"203.0.113.10"},
@@ -329,5 +314,64 @@ func TestCheckNodeCapacity(t *testing.T) {
 	}
 	if !errors.Is(err, ErrContainerNodesUnsupported) {
 		t.Errorf("refusal should carry the container-node sentinel: %v", err)
+	}
+}
+
+// A worker cannot derive its own containerd template: k3s agent writes
+// config.toml only after it has retrieved configuration from the
+// server, so a bootstrap that waits for that file blocks on something
+// downstream of the startup it is blocking (#1448, observed in the
+// container lane's run 8). The control plane has no such problem — k3s
+// server starts containerd immediately — so only the agent path changes.
+func TestAgentScriptDoesNotWaitForContainerdConfig(t *testing.T) {
+	container := RenderAgentScript(AgentBootstrap{
+		ServerURL: "https://10.0.0.1:6443",
+		Isolation: IsolationContainer,
+	})
+	for _, forbidden := range []string{
+		ContainerdGeneratedConfigPath, // the file the agent cannot produce yet
+		"was never generated",         // the wait's failure message
+		"systemctl restart",           // the restart that followed the wait
+	} {
+		if strings.Contains(container, forbidden) {
+			t.Errorf("agent script still derives containerd config in-band (%q) — it deadlocks (#1448)", forbidden)
+		}
+	}
+
+	// The control-plane path keeps its proven behaviour.
+	server := RenderServerScript(ServerBootstrap{TLSSANs: []string{"203.0.113.10"}, Isolation: IsolationContainer})
+	for _, want := range []string{ContainerdGeneratedConfigPath, "systemctl restart k3s.service"} {
+		if !strings.Contains(server, want) {
+			t.Errorf("server script lost its containerd derivation (%q)", want)
+		}
+	}
+}
+
+// The worker's template is instead derived by the daemon from the
+// control plane's already-generated config and pushed before the agent
+// starts. Deriving in Go keeps the failure loud: a config that cannot
+// be flipped is an error, not a silently-unmodified template.
+func TestDeriveContainerdTemplate(t *testing.T) {
+	generated := "version = 3\n\n[plugins.'io.containerd.cri.v1.runtime']\n" +
+		"  enable_unprivileged_ports = true\n  enable_unprivileged_icmp = true\n"
+
+	got, err := DeriveContainerdTemplate([]byte(generated))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, want := range []string{"enable_unprivileged_ports = false", "enable_unprivileged_icmp = false"} {
+		if !strings.Contains(string(got), want) {
+			t.Errorf("derived template missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(string(got), "= true") {
+		t.Errorf("derived template still enables a toggle:\n%s", got)
+	}
+
+	// A config missing a toggle entirely must ERROR rather than return
+	// a template that silently leaves pods broken — the whole point of
+	// #1444's loud failure, preserved on the new path.
+	if _, err := DeriveContainerdTemplate([]byte("version = 3\n")); err == nil {
+		t.Error("a config without the toggles must be an error, not a silent pass-through")
 	}
 }

--- a/pkg/core/cluster/manager.go
+++ b/pkg/core/cluster/manager.go
@@ -186,6 +186,25 @@ func (m *Manager) ProvisionWorker(tenant, clusterName string, iso Isolation, g D
 	if err := m.pushFile(vmName, AgentTokenPath, token, "0600"); err != nil {
 		return fmt.Errorf("push join token: %w", err)
 	}
+	// A container-class worker cannot derive its own containerd
+	// template: k3s agent writes config.toml only after retrieving
+	// configuration from the server, so waiting for it in the bootstrap
+	// blocks on something downstream of the startup being blocked
+	// (#1448). Derive from the control plane's generated config — same
+	// pinned k3s version, same base shape — and push it before boot.
+	if iso == IsolationContainer {
+		generated, err := m.host.Read(cp, ContainerdGeneratedConfigPath)
+		if err != nil {
+			return fmt.Errorf("read containerd config from %s: %w", cp, err)
+		}
+		tmpl, err := DeriveContainerdTemplate(generated)
+		if err != nil {
+			return fmt.Errorf("derive containerd template: %w", err)
+		}
+		if err := m.pushFile(vmName, ContainerdConfigTemplatePath, tmpl, "0644"); err != nil {
+			return fmt.Errorf("push containerd template: %w", err)
+		}
+	}
 	script := RenderAgentScript(AgentBootstrap{ServerURL: "https://" + cpIP + ":6443", Isolation: iso})
 	if err := m.pushFile(vmName, bootstrapScriptPath, []byte(script), "0755"); err != nil {
 		return fmt.Errorf("push bootstrap script: %w", err)

--- a/pkg/core/cluster/manager_test.go
+++ b/pkg/core/cluster/manager_test.go
@@ -225,6 +225,11 @@ func TestProvisionCarriesIsolationThroughTheSeam(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			f := newFakeHost()
+			// #1448: a container-mode provision derives the worker's
+			// containerd template from the CP's generated config, so the
+			// fake CP must have one — its absence is a loud failure by design.
+			f.files["alice-k8s-demo-cp:"+ContainerdGeneratedConfigPath] = []byte(
+				"version = 3\n  enable_unprivileged_ports = true\n  enable_unprivileged_icmp = true\n")
 			m := testManager(f)
 
 			if _, err := m.ProvisionCP("alice", "demo", tc.iso, DesiredGroup{CPU: "2", Memory: "4GB", Disk: "40GB"}, nil); err != nil {
@@ -321,5 +326,61 @@ func TestPushCreatesParentDirectoryFirst(t *testing.T) {
 	}
 	if mkdirAt > pushAt {
 		t.Fatalf("parent directory created AFTER the push (mkdir at %d, push at %d): %v", mkdirAt, pushAt, f.calls)
+	}
+}
+
+// The worker's containerd template is derived by the daemon from the
+// control plane's generated config and pushed BEFORE the bootstrap
+// runs — a worker cannot produce that file itself until it has already
+// joined (#1448). Ordering is the assertion: pushing it after the
+// agent starts would be the same deadlock wearing a different hat.
+func TestProvisionWorkerPushesContainerdTemplateBeforeBootstrap(t *testing.T) {
+	f := newFakeHost()
+	f.files["alice-k8s-demo-cp:"+NodeTokenPath] = []byte("K10hash::server:secret\n")
+	f.files["alice-k8s-demo-cp:"+ContainerdGeneratedConfigPath] = []byte(
+		"version = 3\n[plugins.'io.containerd.cri.v1.runtime']\n  enable_unprivileged_ports = true\n  enable_unprivileged_icmp = true\n")
+
+	if err := testManager(f).ProvisionWorker("alice", "demo", IsolationContainer,
+		DesiredGroup{Name: "small", CPU: "2", Memory: "4GB", Disk: "40GB"},
+		"alice-k8s-demo-small-1", "10.0.0.1"); err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+
+	got := string(f.files["alice-k8s-demo-small-1:"+ContainerdConfigTemplatePath])
+	if !strings.Contains(got, "enable_unprivileged_ports = false") ||
+		!strings.Contains(got, "enable_unprivileged_icmp = false") {
+		t.Fatalf("worker did not receive a derived containerd template, got %q", got)
+	}
+
+	tmplAt, bootstrapAt := -1, -1
+	for i, call := range f.calls {
+		if tmplAt < 0 && strings.Contains(call, "push ") && strings.Contains(call, ContainerdConfigTemplatePath) {
+			tmplAt = i
+		}
+		if bootstrapAt < 0 && strings.Contains(call, "exec ") && strings.Contains(call, bootstrapScriptPath) {
+			bootstrapAt = i
+		}
+	}
+	if tmplAt < 0 || bootstrapAt < 0 || tmplAt > bootstrapAt {
+		t.Fatalf("template must be pushed before the bootstrap runs (tmpl %d, bootstrap %d): %v", tmplAt, bootstrapAt, f.calls)
+	}
+}
+
+// A control plane whose generated config cannot be read must fail the
+// worker loudly: shipping a node with pod sandboxes broken and a green
+// bootstrap is exactly the silent failure #1448 warned against.
+func TestProvisionWorkerFailsLoudlyWithoutCPContainerdConfig(t *testing.T) {
+	f := newFakeHost()
+	f.files["alice-k8s-demo-cp:"+NodeTokenPath] = []byte("K10hash::server:secret\n")
+	// No CP containerd config on purpose.
+
+	err := testManager(f).ProvisionWorker("alice", "demo", IsolationContainer,
+		DesiredGroup{Name: "small", CPU: "2", Memory: "4GB", Disk: "40GB"},
+		"alice-k8s-demo-small-1", "10.0.0.1")
+	if err == nil {
+		t.Fatal("provisioning must fail when the containerd template cannot be derived")
+	}
+	if !strings.Contains(err.Error(), "containerd") {
+		t.Errorf("error does not name what failed: %v", err)
 	}
 }

--- a/pkg/core/cluster/testdata/agent-container.sh.golden
+++ b/pkg/core/cluster/testdata/agent-container.sh.golden
@@ -27,18 +27,4 @@ UNIT
 systemctl daemon-reload
 systemctl enable --now k3s-agent.service
 
-# containerd's CRI plugin makes runc write sysctls an unprivileged
-# container may not touch, killing every pod sandbox. Derive the config
-# template from the config k3s just generated, with the two toggles
-# flipped -- a hand-written template would re-declare a table the base
-# template already emits, which is invalid TOML (#1444).
-i=0
-until [ -s /var/lib/rancher/k3s/agent/etc/containerd/config.toml ]; do
-  i=$((i+1))
-  [ "$i" -gt 120 ] && { echo "containerd config /var/lib/rancher/k3s/agent/etc/containerd/config.toml was never generated" >&2; exit 1; }
-  sleep 2
-done
-sed -e 's/enable_unprivileged_ports = true/enable_unprivileged_ports = false/' -e 's/enable_unprivileged_icmp = true/enable_unprivileged_icmp = false/' /var/lib/rancher/k3s/agent/etc/containerd/config.toml > /var/lib/rancher/k3s/agent/etc/containerd/config-v3.toml.tmpl
-grep -q 'enable_unprivileged_ports = false' /var/lib/rancher/k3s/agent/etc/containerd/config-v3.toml.tmpl || { echo "derived containerd template does not disable enable_unprivileged_ports" >&2; exit 1; }
-grep -q 'enable_unprivileged_icmp = false' /var/lib/rancher/k3s/agent/etc/containerd/config-v3.toml.tmpl || { echo "derived containerd template does not disable enable_unprivileged_icmp" >&2; exit 1; }
-systemctl restart k3s-agent.service
+# containerd template was pushed by the daemon before boot (#1448).


### PR DESCRIPTION
Closes #1448. Found by the container lane's run 8 — the first run with a correct join token, where the control plane reached `ready` and the **worker bootstrap** failed instead.

## The deadlock

#1444 derives the containerd template from the generated config: enable k3s → wait for `config.toml` → sed → restart. Correct on the **control plane**, where k3s server starts containerd immediately.

On a **worker** the dependency runs the other way: `k3s agent` writes containerd's config only after it has retrieved configuration from the server. So the bootstrap blocked on a file whose creation is downstream of the startup it was blocking:

```
containerd config /var/lib/rancher/k3s/agent/etc/containerd/config.toml was never generated
k3s-agent.service: start operation timed out. Terminating.
```

**Evidence for the ordering claim:** run 7's agent journal shows the agent looping on `Waiting to retrieve agent configuration` with no containerd activity, and run 8 shows `config.toml` still absent when the bounded wait expired. The control plane, running the identical stanza, produced its config and reached `ready` in both runs. I did not read the k3s source for this — the claim rests on those two observations, and I would rather say so than imply a source citation I did not make.

## The fix — derive on the daemon, push before boot

`ProvisionWorker` reads the **control plane's** already-generated `config.toml` (same pinned k3s version → same base shape), derives the flipped template in Go, and pushes it to the worker *before* the bootstrap runs. No wait, no restart, no chicken-and-egg. The CP path is untouched.

**Loudness preserved** — the explicit risk called out in #1448 was trading a loud failure for a silent one:
- `DeriveContainerdTemplate` **errors** on a config containing neither toggle, rather than passing it through. A template that silently left the toggles enabled would restore #1444's breakage with nothing to say so.
- `ProvisionWorker` fails the node if the CP config cannot be read or derived.

## Test evidence (written before the code)

| Test | Pins |
| --- | --- |
| `TestAgentScriptDoesNotWaitForContainerdConfig` | the agent script contains **none** of the wait/derive/restart — and the server script still does |
| `TestDeriveContainerdTemplate` | both toggles flipped; a config missing a toggle **errors** |
| `TestProvisionWorkerPushesContainerdTemplateBeforeBootstrap` | the template lands on the worker **before** the bootstrap exec — ordering by index, since pushing it afterwards is the same deadlock in a different hat |
| `TestProvisionWorkerFailsLoudlyWithoutCPContainerdConfig` | no CP config → provisioning fails, error names containerd |

`go test ./pkg/core/cluster/ ./internal/server/` green, `go vet` clean, `go build ./...` clean.

## One existing test changed — read this bit

`TestAgentScriptCarriesTemplateAndReservedArgs` asserted the agent derived its template in-band. **That assertion pinned the bug.** It is retargeted (renamed `...CarriesReservedArgs`), keeps its still-valid parts including the #1444 anti-regression checks, and carries a comment naming the three tests that now pin the replacement behaviour. Nothing was deleted to make anything pass — the inverse property is asserted more strictly than before.

Goldens: VM and `server-container` byte-unchanged; only `agent-container.sh.golden` changes, removing the wait (−15/+1).

## Provenance

Implemented in the orchestrator session at the user's explicit request, after three engineer agents in a row were terminated by API session limits. Same-session author/reviewer caveat as #1440/#1441 applies — a human read of `ProvisionWorker`'s new block is worth having.

Unblocks #1430 · umbrella #1432.

🤖 Generated with [Claude Code](https://claude.com/claude-code)