### PR TITLE
fix(cluster): give the k3s units TimeoutStartSec=0

### DIFF
--- a/pkg/core/cluster/bootstrap.go
+++ b/pkg/core/cluster/bootstrap.go
@@ -67,6 +67,11 @@ Type=notify
 %[5]sExecStart=%[1]s server --disable traefik --node-taint node-role.kubernetes.io/control-plane=:NoSchedule --write-kubeconfig-mode 0600%[2]s
 Restart=always
 RestartSec=5
+# A node legitimately takes longer than systemd's default 90s to signal
+# readiness -- an agent waits for the server to finish coming up -- and a
+# Type=notify unit that has not signalled by then is killed mid-start,
+# restarted, and never joins (#1450). Upstream k3s's unit does the same.
+TimeoutStartSec=0
 LimitNOFILE=1048576
 
 [Install]
@@ -124,6 +129,11 @@ Type=notify
 %[4]sExecStart=%[1]s agent --server %[3]s --token-file %[2]s%[6]s
 Restart=always
 RestartSec=5
+# A node legitimately takes longer than systemd's default 90s to signal
+# readiness -- an agent waits for the server to finish coming up -- and a
+# Type=notify unit that has not signalled by then is killed mid-start,
+# restarted, and never joins (#1450). Upstream k3s's unit does the same.
+TimeoutStartSec=0
 LimitNOFILE=1048576
 
 [Install]

--- a/pkg/core/cluster/capacity_test.go
+++ b/pkg/core/cluster/capacity_test.go
@@ -375,3 +375,27 @@ func TestDeriveContainerdTemplate(t *testing.T) {
 		t.Error("a config without the toggles must be an error, not a silent pass-through")
 	}
 }
+
+// A k3s node legitimately takes longer than systemd's default 90s
+// start timeout: the agent waits for the server to finish coming up,
+// and a Type=notify unit that has not signalled readiness by then is
+// killed and restarted, so it never joins (#1450, observed in the
+// container lane's run 9). Upstream k3s's own unit sets
+// TimeoutStartSec=0 for this reason.
+func TestK3sUnitsDisableStartTimeout(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		script string
+	}{
+		{"server/vm", RenderServerScript(ServerBootstrap{TLSSANs: []string{"203.0.113.10"}})},
+		{"server/container", RenderServerScript(ServerBootstrap{TLSSANs: []string{"203.0.113.10"}, Isolation: IsolationContainer})},
+		{"agent/vm", RenderAgentScript(AgentBootstrap{ServerURL: "https://10.0.0.1:6443"})},
+		{"agent/container", RenderAgentScript(AgentBootstrap{ServerURL: "https://10.0.0.1:6443", Isolation: IsolationContainer})},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(tc.script, "TimeoutStartSec=0") {
+				t.Errorf("unit has no TimeoutStartSec=0; systemd will kill it at 90s while it is still legitimately starting:\n%s", tc.script)
+			}
+		})
+	}
+}

--- a/pkg/core/cluster/testdata/agent-container.sh.golden
+++ b/pkg/core/cluster/testdata/agent-container.sh.golden
@@ -18,6 +18,11 @@ ExecStartPre=/bin/sh -c '[ -e /dev/kmsg ] || ln -s /dev/console /dev/kmsg'
 ExecStart=/usr/local/bin/k3s agent --server https://10.166.11.5:6443 --token-file /etc/containarium/k3s-agent-token
 Restart=always
 RestartSec=5
+# A node legitimately takes longer than systemd's default 90s to signal
+# readiness -- an agent waits for the server to finish coming up -- and a
+# Type=notify unit that has not signalled by then is killed mid-start,
+# restarted, and never joins (#1450). Upstream k3s's unit does the same.
+TimeoutStartSec=0
 LimitNOFILE=1048576
 
 [Install]

--- a/pkg/core/cluster/testdata/agent.sh.golden
+++ b/pkg/core/cluster/testdata/agent.sh.golden
@@ -17,6 +17,11 @@ Type=notify
 ExecStart=/usr/local/bin/k3s agent --server https://10.166.11.5:6443 --token-file /etc/containarium/k3s-agent-token
 Restart=always
 RestartSec=5
+# A node legitimately takes longer than systemd's default 90s to signal
+# readiness -- an agent waits for the server to finish coming up -- and a
+# Type=notify unit that has not signalled by then is killed mid-start,
+# restarted, and never joins (#1450). Upstream k3s's unit does the same.
+TimeoutStartSec=0
 LimitNOFILE=1048576
 
 [Install]

--- a/pkg/core/cluster/testdata/server-container.sh.golden
+++ b/pkg/core/cluster/testdata/server-container.sh.golden
@@ -17,6 +17,11 @@ ExecStartPre=/bin/sh -c '[ -e /dev/kmsg ] || ln -s /dev/console /dev/kmsg'
 ExecStart=/usr/local/bin/k3s server --disable traefik --node-taint node-role.kubernetes.io/control-plane=:NoSchedule --write-kubeconfig-mode 0600 --tls-san 10.166.11.5 --tls-san 203.0.113.10
 Restart=always
 RestartSec=5
+# A node legitimately takes longer than systemd's default 90s to signal
+# readiness -- an agent waits for the server to finish coming up -- and a
+# Type=notify unit that has not signalled by then is killed mid-start,
+# restarted, and never joins (#1450). Upstream k3s's unit does the same.
+TimeoutStartSec=0
 LimitNOFILE=1048576
 
 [Install]

--- a/pkg/core/cluster/testdata/server.sh.golden
+++ b/pkg/core/cluster/testdata/server.sh.golden
@@ -16,6 +16,11 @@ Type=notify
 ExecStart=/usr/local/bin/k3s server --disable traefik --node-taint node-role.kubernetes.io/control-plane=:NoSchedule --write-kubeconfig-mode 0600 --tls-san 10.166.11.5 --tls-san 203.0.113.10
 Restart=always
 RestartSec=5
+# A node legitimately takes longer than systemd's default 90s to signal
+# readiness -- an agent waits for the server to finish coming up -- and a
+# Type=notify unit that has not signalled by then is killed mid-start,
+# restarted, and never joins (#1450). Upstream k3s's unit does the same.
+TimeoutStartSec=0
 LimitNOFILE=1048576
 
 [Install]


### PR DESCRIPTION
Closes #1450. Found by the container lane's run 9 — the first run past #1448's bootstrap deadlock.

## What run 9 showed

Control plane `ready`. Worker bootstrap **succeeded** (so #1449 works). Worker still never joined, and its journal shows the agent doing exactly the right thing and being killed for it:

```
level=info msg="Waiting to retrieve agent configuration; server is not ready: failed to get CA certs: ... EOF"
level=info msg="Waiting to retrieve agent configuration; server is not ready: ..."   (repeats)
k3s-agent.service: start operation timed out. Terminating.
k3s-agent.service: Scheduled restart job, restart counter is at 5.
```

No `not authorized`, no CA-hash complaint — #1446's token fix is working. The agent just never gets to finish.

## Cause

Both units are `Type=notify` with **no `TimeoutStartSec`**, so systemd's default 90s applies. A k3s agent legitimately exceeds that while waiting for the server to come up; systemd kills it mid-start, and each restart begins the wait again. **Upstream k3s's own systemd unit sets `TimeoutStartSec=0`** for precisely this reason.

## Scope — both isolation classes

This is the shared unit template, not a container-mode detail. VM clusters have never been exercised (the #1418 lane still has no runner), so a VM worker joining a slow control plane would hit the identical kill. That makes it the **fourth** defect this sprint whose blast radius is both classes, after #1435, #1442 and #1446 — all of them in code no test could reach without a running lane.

## Test evidence

`TestK3sUnitsDisableStartTimeout` — a 4-case table covering server and agent in **both** isolation classes; all four failed before the change (verified) and pass after. Pinning all four matters because the unit text is rendered by two separate functions with isolation-dependent variants, so one fix could easily miss half the matrix.

`go test ./pkg/core/cluster/ ./internal/server/` green, `go vet` clean, `go build ./...` clean.

**Goldens:** all four change, and the complete set of changed lines across all of them is the `TimeoutStartSec=0` line plus its four-line comment — additions only, nothing reordered or removed. Unlike the earlier fixes this one *is* a unit-content change, so a VM golden diff is expected here rather than a red flag.

## Provenance

Orchestrator-authored (three engineer agents lost to API session limits). Same-session author/reviewer caveat as #1440/#1441/#1449.

Unblocks #1430 · umbrella #1432.

🤖 Generated with [Claude Code](https://claude.com/claude-code)