### PR TITLE
fix(cluster): run container-class kubelets with KubeletInUserNamespace

### DIFF
--- a/pkg/core/cluster/bootstrap.go
+++ b/pkg/core/cluster/bootstrap.go
@@ -36,6 +36,11 @@ type ServerBootstrap struct {
 	// the zero value renders the VM script byte-identically to
 	// pre-#1429.
 	Isolation Isolation
+	// KubeletArgs are extra `k3s server` flags. k3s server runs an
+	// embedded kubelet, so a container-class control plane needs the
+	// same kubelet treatment a worker does (#1452). Empty on the VM
+	// path, whose unit stays byte-identical to its golden.
+	KubeletArgs []string
 }
 
 // RenderServerScript renders the control-plane first-boot script: a
@@ -64,7 +69,7 @@ Wants=network-online.target
 
 [Service]
 Type=notify
-%[5]sExecStart=%[1]s server --disable traefik --node-taint node-role.kubernetes.io/control-plane=:NoSchedule --write-kubeconfig-mode 0600%[2]s
+%[5]sExecStart=%[1]s server --disable traefik --node-taint node-role.kubernetes.io/control-plane=:NoSchedule --write-kubeconfig-mode 0600%[2]s%[7]s
 Restart=always
 RestartSec=5
 # A node legitimately takes longer than systemd's default 90s to signal
@@ -89,7 +94,7 @@ until [ -s %[3]s ] && [ -s %[4]s ]; do
   sleep 2
 done
 `, K3sBinaryPath, sanFlags.String(), KubeconfigPath, NodeTokenPath, kmsgShimUnitLine(b.Isolation),
-		containerdTemplateStanza(b.Isolation, "k3s.service"))
+		containerdTemplateStanza(b.Isolation, "k3s.service"), kubeletArgsSuffix(b.KubeletArgs))
 }
 
 // AgentBootstrap parameterizes a worker script.

--- a/pkg/core/cluster/capacity.go
+++ b/pkg/core/cluster/capacity.go
@@ -248,3 +248,22 @@ func DeriveContainerdTemplate(generated []byte) ([]byte, error) {
 	}
 	return []byte(out), nil
 }
+
+// ContainerKubeletArgs are the kubelet flags every container-class node
+// needs, with any additional args (e.g. a reservation) appended.
+//
+// kubelet's ContainerManager writes kernel sysctls at startup —
+// /proc/sys/kernel/panic_on_oops, /proc/sys/vm/overcommit_memory,
+// /proc/sys/kernel/panic — which an unprivileged container may not
+// touch. It fails with "Failed to start ContainerManager" and names the
+// remedy itself: the KubeletInUserNamespace feature gate makes it skip
+// those writes (#1452).
+//
+// This applies to BOTH roles: k3s server runs an embedded kubelet, so a
+// control plane fails identically to a worker without it — which is why
+// the control plane could report `ready` (its files exist) while its
+// supervisor never finished starting and no agent could ever join.
+func ContainerKubeletArgs(extra []string) []string {
+	args := []string{"--kubelet-arg=feature-gates=KubeletInUserNamespace=true"}
+	return append(args, extra...)
+}

--- a/pkg/core/cluster/capacity_test.go
+++ b/pkg/core/cluster/capacity_test.go
@@ -399,3 +399,46 @@ func TestK3sUnitsDisableStartTimeout(t *testing.T) {
 		})
 	}
 }
+
+// kubelet's ContainerManager writes kernel sysctls at startup, which an
+// unprivileged container may not touch — it fails with "Failed to start
+// ContainerManager" and names its own remedy: the KubeletInUserNamespace
+// feature gate (#1452, observed on the control plane in run 10).
+//
+// BOTH node roles need it: k3s server runs an embedded kubelet.
+func TestContainerKubeletArgsEnableUserNamespace(t *testing.T) {
+	args := ContainerKubeletArgs(nil)
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "KubeletInUserNamespace=true") {
+		t.Fatalf("container kubelet args do not enable KubeletInUserNamespace: %v", args)
+	}
+
+	// A reservation composes with it rather than replacing it.
+	withReservation := strings.Join(ContainerKubeletArgs(KubeletReservedArgs(Reserved{CPU: 6, MemoryBytes: 1 << 30})), " ")
+	if !strings.Contains(withReservation, "KubeletInUserNamespace=true") || !strings.Contains(withReservation, "system-reserved") {
+		t.Errorf("reservation dropped the feature gate or vice versa: %s", withReservation)
+	}
+}
+
+// Both bootstrap scripts must carry the gate on the container path —
+// the control plane's embedded kubelet fails identically to a worker's.
+func TestBothScriptsCarryUserNamespaceGate(t *testing.T) {
+	server := RenderServerScript(ServerBootstrap{
+		TLSSANs: []string{"203.0.113.10"}, Isolation: IsolationContainer,
+		KubeletArgs: ContainerKubeletArgs(nil),
+	})
+	agent := RenderAgentScript(AgentBootstrap{
+		ServerURL: "https://10.0.0.1:6443", Isolation: IsolationContainer,
+		KubeletArgs: ContainerKubeletArgs(nil),
+	})
+	for name, script := range map[string]string{"server": server, "agent": agent} {
+		if !strings.Contains(script, "KubeletInUserNamespace=true") {
+			t.Errorf("%s script does not enable KubeletInUserNamespace", name)
+		}
+	}
+	// VM path untouched.
+	vm := RenderServerScript(ServerBootstrap{TLSSANs: []string{"203.0.113.10"}})
+	if strings.Contains(vm, "KubeletInUserNamespace") {
+		t.Error("VM server script carries a container-only kubelet gate")
+	}
+}

--- a/pkg/core/cluster/manager.go
+++ b/pkg/core/cluster/manager.go
@@ -112,6 +112,30 @@ func (m *Manager) pushFile(name, path string, content []byte, mode string) error
 	return m.host.Push(name, path, content, mode)
 }
 
+// containerKubeletArgs assembles the kubelet flags a container-class
+// node needs: the user-namespace gate every such node requires
+// (#1452), plus a reservation that makes allocatable truthful when the
+// host is bigger than the node asked for (#1439). Empty on the VM
+// path, whose units stay byte-identical.
+//
+// A reservation that cannot be computed is NOT fatal here: the gate is
+// what makes kubelet start at all, and a node that starts with
+// imperfect allocatable beats a node that does not start. The capacity
+// probe in ProvisionWorker is the place that refuses a host too small
+// to host the node truthfully.
+func (m *Manager) containerKubeletArgs(iso Isolation, spec NodeSpec) []string {
+	if iso != IsolationContainer {
+		return nil
+	}
+	var extra []string
+	if cpu, mem, err := HostCapacity("/"); err == nil {
+		if reserved, rErr := ReservedResources(cpu, mem, spec); rErr == nil {
+			extra = KubeletReservedArgs(reserved)
+		}
+	}
+	return ContainerKubeletArgs(extra)
+}
+
 // ProvisionCP creates and bootstraps the control-plane VM: create →
 // start → wait → push pinned binary + rendered script → exec. Returns
 // the VM's IP (workers join over it). cpSize is the smallest preset —
@@ -136,7 +160,11 @@ func (m *Manager) ProvisionCP(tenant, clusterName string, iso Isolation, cpSize 
 	if err := m.pushFile(name, K3sBinaryPath, bin, "0755"); err != nil {
 		return "", fmt.Errorf("push k3s binary: %w", err)
 	}
-	script := RenderServerScript(ServerBootstrap{TLSSANs: append([]string{ip}, tlsSANs...), Isolation: iso})
+	script := RenderServerScript(ServerBootstrap{
+		TLSSANs:     append([]string{ip}, tlsSANs...),
+		Isolation:   iso,
+		KubeletArgs: m.containerKubeletArgs(iso, spec),
+	})
 	if err := m.pushFile(name, bootstrapScriptPath, []byte(script), "0755"); err != nil {
 		return "", fmt.Errorf("push bootstrap script: %w", err)
 	}
@@ -205,7 +233,11 @@ func (m *Manager) ProvisionWorker(tenant, clusterName string, iso Isolation, g D
 			return fmt.Errorf("push containerd template: %w", err)
 		}
 	}
-	script := RenderAgentScript(AgentBootstrap{ServerURL: "https://" + cpIP + ":6443", Isolation: iso})
+	script := RenderAgentScript(AgentBootstrap{
+		ServerURL:   "https://" + cpIP + ":6443",
+		Isolation:   iso,
+		KubeletArgs: m.containerKubeletArgs(iso, spec),
+	})
 	if err := m.pushFile(vmName, bootstrapScriptPath, []byte(script), "0755"); err != nil {
 		return fmt.Errorf("push bootstrap script: %w", err)
 	}

--- a/pkg/core/cluster/manager_test.go
+++ b/pkg/core/cluster/manager_test.go
@@ -384,3 +384,46 @@ func TestProvisionWorkerFailsLoudlyWithoutCPContainerdConfig(t *testing.T) {
 		t.Errorf("error does not name what failed: %v", err)
 	}
 }
+
+// #1440 added KubeletArgs and its rendering, but nothing ever populated
+// it — the reservation was dead code and the tests pinned rendering
+// rather than wiring (#1452). These assert the WIRING: what the manager
+// actually writes into the node's bootstrap script.
+func TestProvisionWiresContainerKubeletArgs(t *testing.T) {
+	f := newFakeHost()
+	f.files["alice-k8s-demo-cp:"+NodeTokenPath] = []byte("K10hash::server:secret\n")
+	f.files["alice-k8s-demo-cp:"+ContainerdGeneratedConfigPath] = []byte(
+		"version = 3\n  enable_unprivileged_ports = true\n  enable_unprivileged_icmp = true\n")
+	m := testManager(f)
+
+	if _, err := m.ProvisionCP("alice", "demo", IsolationContainer,
+		DesiredGroup{CPU: "2", Memory: "4GB", Disk: "40GB"}, []string{"203.0.113.10"}); err != nil {
+		t.Fatalf("ProvisionCP: %v", err)
+	}
+	cpScript := string(f.files["alice-k8s-demo-cp:"+bootstrapScriptPath])
+	if !strings.Contains(cpScript, "KubeletInUserNamespace=true") {
+		t.Errorf("control-plane script has no KubeletInUserNamespace gate:\n%s", cpScript)
+	}
+
+	if err := m.ProvisionWorker("alice", "demo", IsolationContainer,
+		DesiredGroup{Name: "small", CPU: "2", Memory: "4GB", Disk: "40GB"},
+		"alice-k8s-demo-small-1", "10.0.0.1"); err != nil {
+		t.Fatalf("ProvisionWorker: %v", err)
+	}
+	workerScript := string(f.files["alice-k8s-demo-small-1:"+bootstrapScriptPath])
+	if !strings.Contains(workerScript, "KubeletInUserNamespace=true") {
+		t.Errorf("worker script has no KubeletInUserNamespace gate:\n%s", workerScript)
+	}
+
+	// The VM path must not acquire container-only kubelet flags.
+	f2 := newFakeHost()
+	f2.files["alice-k8s-demo-cp:"+NodeTokenPath] = []byte("K10hash::server:secret\n")
+	m2 := testManager(f2)
+	if _, err := m2.ProvisionCP("alice", "demo", IsolationVM,
+		DesiredGroup{CPU: "2", Memory: "4GB", Disk: "40GB"}, []string{"203.0.113.10"}); err != nil {
+		t.Fatalf("ProvisionCP(vm): %v", err)
+	}
+	if strings.Contains(string(f2.files["alice-k8s-demo-cp:"+bootstrapScriptPath]), "KubeletInUserNamespace") {
+		t.Error("VM control-plane script carries a container-only kubelet gate")
+	}
+}


### PR DESCRIPTION
Closes #1452. Run 10's control-plane journal — readable at last because #1450 stopped systemd killing the agent — shows the root cause behind **every worker-join failure since run 4**.

## kubelet names its own fix

```
kubelet.go:1688 "Failed to start ContainerManager" err="[open /proc/sys/kernel/panic_on_oops: permission denied,
  open /proc/sys/vm/overcommit_memory: permission denied, open /proc/sys/kernel/panic: permission denied]"
container_manager_linux.go:449 "Updating kernel flag failed
  (Hint: enable KubeletInUserNamespace feature flag to ignore the error)"
```

kubelet writes kernel sysctls at startup that an unprivileged container may not touch. The `KubeletInUserNamespace` feature gate makes it skip them.

**Why this hid for six runs:** our control-plane readiness check is "kubeconfig and node-token exist" — files k3s writes early. The embedded kubelet then failed, so k3s's supervisor never finished coming up, and agents saw `server is not ready: failed to get CA certs: starting` indefinitely. The control plane has been reporting `ready` while being, to an agent, permanently starting. An earlier probe of mine saw `systemctl is-active k3s` → `active` and I read that as "the server works"; the unit was up and its kubelet was failing underneath it.

**Both roles need it** — k3s server runs an embedded kubelet, so a container-class control plane fails exactly as a worker does. `ServerBootstrap` gains `KubeletArgs` for this.

## Second fix: #1440's work was dead code

`KubeletArgs` was never populated by the manager. #1440 added the field, the rendering, and rendering tests — and nothing ever set it, so the truthful-allocatable work never reached a node. **The tests pinned rendering, not wiring**, and passed while proving less than they appeared to. That is the same trap as a golden recording invalid TOML in #1444.

`TestProvisionWiresContainerKubeletArgs` now asserts what the manager actually writes into each node's bootstrap script, for **both** roles, plus that the VM path acquires none of it.

## Deliberate judgement, stated for review

A reservation that cannot be computed is **not** fatal in `containerKubeletArgs`: the gate is what makes kubelet start at all, and a node that starts with imperfect allocatable beats a node that does not start. `ProvisionWorker`'s capacity probe (#1439) remains the place that refuses a host too small to host the node truthfully. If you disagree with that split, this is the line to argue with.

## Evidence

`go test ./pkg/core/cluster/ ./internal/server/` green, `go vet` clean, `go build ./...` clean. Goldens **unchanged** — they render scripts directly, and the VM path takes no kubelet args.

## Provenance

Orchestrator-authored; same-session author/reviewer caveat as #1440/#1441/#1449/#1451.

Unblocks #1430 · umbrella #1432.

🤖 Generated with [Claude Code](https://claude.com/claude-code)