### PR TITLE
fix(sentinel): default MemoryHigh to MemoryMax so a burst restarts instead of stalling (#1454)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Sentinel `MemoryHigh` no longer sits below `MemoryMax` by default** (#1454,
+  correcting #1350). A soft cap under the hard cap only helps if reclaim can
+  make progress, and progress needs page cache or swap. The sentinel hosts have
+  no swap and the #1349 burst is anonymous memory, so file cache is exhausted
+  within minutes and reclaim has nothing left to evict: the cgroup parks between
+  the two limits and is throttled indefinitely. It never reaches the cap, so
+  `Restart=always` never fires and systemd keeps reporting `active (running)`
+  while the process serves nothing.
+
+  Measured on a production sentinel: `memory.events` `high=556267` with
+  `oom_kill=0`, PSI `full avg300=86.10`, and `pgsteal`/`pgscan` of 3% — about 90
+  minutes of total edge outage, ended by hand, where the OOM-and-restart path it
+  replaced recovered in seconds. It surfaced as `Permission denied (publickey)`
+  on every SSH attempt, because the stalled process could not open an upstream
+  and sshpiper re-prompted until clients ran out of keys.
+
+  `MemoryHigh` now defaults to `MemoryMax`, so there is no window to stall in;
+  reclaim still runs at the threshold and the `high` counter still serves as an
+  early signal. `containarium sentinel service install` refuses a `--memory-high`
+  below `--memory-max` unless the host actually has swap, and reads an
+  unreadable `/proc/meminfo` as "no swap" so an unverifiable host still gets the
+  safe configuration.
+
 - **Sentinel no longer tears down a backend's own reconnect (#769).** After a
   backend host reboots — a routine event when it runs on preemptible capacity
   — it reconnects its tunnel under the same spot id. `TunnelRegistry.Register`

--- a/internal/cmd/sentinel_service.go
+++ b/internal/cmd/sentinel_service.go
@@ -7,11 +7,48 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
 
 const sentinelSystemdServicePath = "/etc/systemd/system/containarium-sentinel.service"
+
+// procMeminfoPath is a variable so tests can point it at a fixture.
+var procMeminfoPath = "/proc/meminfo"
+
+// hostHasSwap reports whether this host can page anonymous memory out, which
+// is what decides whether a MemoryHigh below MemoryMax is a safety valve or the
+// #1454 livelock.
+//
+// Unreadable or unparseable /proc/meminfo is reported as NO swap. That is the
+// conservative direction: it only ever tightens the check, and the failure it
+// guards against (a cgroup stalled below its cap, never restarted, still
+// reporting healthy) is far more expensive than an install that asks the
+// operator to be explicit.
+func hostHasSwap() bool {
+	data, err := os.ReadFile(procMeminfoPath)
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		rest, ok := strings.CutPrefix(line, "SwapTotal:")
+		if !ok {
+			continue
+		}
+		fields := strings.Fields(rest)
+		if len(fields) == 0 {
+			return false
+		}
+		kb, err := strconv.ParseUint(fields[0], 10, 64)
+		if err != nil {
+			return false
+		}
+		return kb > 0
+	}
+	return false
+}
 
 var (
 	sentinelSvcSpotVM     string
@@ -60,7 +97,9 @@ func init() {
 	sentinelServiceInstallCmd.Flags().StringVar(&sentinelSvcZone, "zone", "", "GCP zone (required)")
 	sentinelServiceInstallCmd.Flags().StringVar(&sentinelSvcProject, "project", "", "GCP project ID (required)")
 	sentinelServiceInstallCmd.Flags().StringVar(&sentinelSvcMemoryHigh, "memory-high", defaultSentinelMemoryHigh,
-		"Soft memory limit; past it the kernel reclaims inside the sentinel's cgroup instead of stalling the host (#1350). Percentage of RAM or a size like 512M.")
+		"Soft memory limit; past it the kernel reclaims inside the sentinel's cgroup instead of stalling the host (#1350). "+
+			"Defaults to --memory-max: a lower value is refused unless the host has swap, because a swapless cgroup stalls "+
+			"between the two limits instead of restarting (#1454). Percentage of RAM or a size like 512M.")
 	sentinelServiceInstallCmd.Flags().StringVar(&sentinelSvcMemoryMax, "memory-max", defaultSentinelMemoryMax,
 		"Hard memory limit; exceeding it restarts the sentinel (Restart=always) rather than letting the OOM killer take the host down (#1350).")
 }
@@ -75,11 +114,12 @@ func runSentinelServiceInstall(cmd *cobra.Command, args []string) error {
 	}
 
 	serviceContent, err := buildSentinelUnit(sentinelUnitConfig{
-		SpotVM:     sentinelSvcSpotVM,
-		Zone:       sentinelSvcZone,
-		Project:    sentinelSvcProject,
-		MemoryHigh: sentinelSvcMemoryHigh,
-		MemoryMax:  sentinelSvcMemoryMax,
+		SpotVM:      sentinelSvcSpotVM,
+		Zone:        sentinelSvcZone,
+		Project:     sentinelSvcProject,
+		MemoryHigh:  sentinelSvcMemoryHigh,
+		MemoryMax:   sentinelSvcMemoryMax,
+		HostHasSwap: hostHasSwap(),
 	})
 	if err != nil {
 		return err

--- a/internal/cmd/sentinel_unit.go
+++ b/internal/cmd/sentinel_unit.go
@@ -9,36 +9,63 @@ import (
 	"strings"
 )
 
-// Sentinel unit memory bounds (#1350).
+// Sentinel unit memory bounds (#1350, corrected by #1454).
 //
-// #1349 leaked ~18 MB/day until the sentinel held 565 MB anon-RSS on a 1 GB
-// host. Nothing bounded it, so the KERNEL resolved it — 36 minutes into a
-// full-host stall (73.91% iowait, load 32.46, 12 tasks blocked in D), long
-// after the box had stopped serving usefully. `Restart=always` did its job and
-// the sentinel came back; what was missing was anything that acts on memory
-// pressure BEFORE the host is thrashing.
+// #1349 bursts ~330 MB in ~35 min on backend loss until the sentinel held
+// 565 MB anon-RSS on a 1 GB host. Nothing bounded it, so the KERNEL resolved
+// it — 36 minutes into a full-host stall (73.91% iowait, load 32.46, 12 tasks
+// blocked in D), long after the box had stopped serving usefully.
+// `Restart=always` did its job and the sentinel came back.
 //
-// MemoryHigh is the directive that changes the outcome. Past it, reclaim
-// pressure is applied inside the sentinel's own cgroup rather than by global
-// reclaim evicting the host's page cache — the failure stays local and the box
-// stays responsive. MemoryMax is the hard stop; paired with Restart=always it
-// costs a restart measured in seconds instead of a 36-minute apex outage. The
-// kernel's OOM killer picked `containarium` last time because it was the
-// biggest process, which was luck rather than policy: sshpiperd invoked the
-// killer, and SSH could as easily have been the casualty.
+// MemoryMax is the hard stop; paired with Restart=always it costs a restart
+// measured in seconds instead of a 36-minute apex outage. That half was right.
+//
+// MemoryHigh BELOW MemoryMax was not. #1454: a soft cap only helps if reclaim
+// can make progress, and progress needs something reclaimable — page cache, or
+// anon plus swap. These hosts have NO swap, and the #1349 burst is
+// anon-dominated, so file cache is squeezed to ~0 within minutes and reclaim
+// has nothing left to do. The cgroup then parks between MemoryHigh and
+// MemoryMax and is throttled indefinitely: it never reaches the hard cap, so
+// Restart=always never fires, and systemd reports active(running) throughout.
+//
+// Measured during the #1454 outage: memory.events high=556267 with max=0 and
+// oom_kill=0, PSI full avg300=86.10 (86% of wall-clock with every task in the
+// cgroup frozen), anon 271 MB against file 0.36 MB, and pgscan 79.4M against
+// pgsteal 2.4M — a 3% reclaim success rate, i.e. futile scanning. ~90 minutes
+// of total edge outage, ended by manual intervention, where the OOM-and-restart
+// path it replaced self-recovered in seconds.
+//
+// So the dead band is the bug, and the old 35%/50% defaults had one: a ~154 MB
+// window (~358 MB to ~512 MB on a 1 GB host) in which any burst that comes to
+// rest is stuck. Note that neither burst measured so far lands there — 271 MB
+// sits below it and 565 MB above it — so the shipped defaults are a LATENT
+// stall window, not the cause of the #1454 outage; that host carried a tighter
+// operator drop-in (256M/384M) and the burst came to rest inside its band. The
+// window is still indefensible: nothing chooses where a burst stops, and the
+// only reason to keep a band is a reclaim path that these hosts do not have.
+//
+// Defaulting MemoryHigh to MemoryMax removes the window — the cgroup is still
+// reclaimed locally at the threshold rather than by global reclaim evicting the
+// host's page cache, and memory.events "high" still increments as an early
+// signal, but a burst that cannot be reclaimed now proceeds to the cap and is
+// restarted instead of hanging.
+//
+// A gap remains legitimate where reclaim CAN make progress, so it is allowed
+// on hosts that have swap and rejected on hosts that do not.
 //
 // Defaults are PERCENTAGES so one value works across the 1 GB (e2-micro) and
 // 2 GB (e2-small, per #770) sentinel hosts without per-host tuning. They are
 // overridable because BYOC and larger sentinels exist.
 
 const (
-	// defaultSentinelMemoryHigh throttles at ~358 MB on a 1 GB host — roughly
-	// 4x the 82 MB cold start observed while diagnosing #1349, so a busy
-	// sentinel is not throttled in normal operation.
-	defaultSentinelMemoryHigh = "35%"
+	// defaultSentinelMemoryHigh deliberately EQUALS defaultSentinelMemoryMax.
+	// Any lower value opens the #1454 throttle band, in which a swapless host
+	// stalls forever instead of restarting. Reclaim still runs at the
+	// threshold; what is removed is the window to get stuck in.
+	defaultSentinelMemoryHigh = "50%"
 
 	// defaultSentinelMemoryMax caps at ~512 MB on a 1 GB host, deliberately
-	// BELOW the 565 MB the #1349 leak reached — a ceiling above that would
+	// BELOW the 565 MB the #1349 burst reached — a ceiling above that would
 	// never have fired and would be decoration.
 	defaultSentinelMemoryMax = "50%"
 )
@@ -50,6 +77,13 @@ type sentinelUnitConfig struct {
 	Project    string
 	MemoryHigh string
 	MemoryMax  string
+
+	// HostHasSwap reports whether the target host can page anonymous memory
+	// out. It decides whether a MemoryHigh below MemoryMax is a safety valve
+	// or the #1454 livelock, so it is passed in rather than read here: this
+	// file stays pure and testable without /proc, and the install path is the
+	// only thing that touches the host.
+	HostHasSwap bool
 }
 
 // systemdMemoryPattern matches the value forms systemd accepts for
@@ -118,31 +152,69 @@ func comparableBytes(v string) (uint64, bool) {
 	}
 }
 
-// validateMemoryBounds checks that the throttle sits below the hard cap.
+// validateMemoryBounds enforces the #1454 rule: a throttle band below the hard
+// cap is only safe where reclaim can make progress.
 //
-// A MemoryHigh at or above MemoryMax is the no-throttle behaviour with extra
-// words: the cgroup reaches the hard cap without ever having been reclaimed
-// under pressure first, which is precisely the #1349 shape this is meant to
-// prevent. Mixed forms (a percentage against an absolute size) cannot be
-// ordered without knowing physical RAM, so they pass rather than being guessed
-// at — systemd will still enforce whichever binds first.
-func validateMemoryBounds(high, max string) error {
-	if hp, herr := percentValue(high); herr == nil {
-		if mp, merr := percentValue(max); merr == nil {
-			if hp >= mp {
-				return fmt.Errorf("MemoryHigh (%s) must be below MemoryMax (%s), otherwise the cgroup "+
-					"hits the hard cap without ever being reclaimed under pressure first", high, max)
-			}
-		}
+// MemoryHigh ABOVE MemoryMax is rejected outright — MemoryMax binds first, so
+// the throttle it advertises can never engage, and a unit that documents a
+// limit that cannot fire is worse than one that omits it.
+//
+// MemoryHigh BELOW MemoryMax is rejected on a host with no swap. There, an
+// anon-dominated cgroup has nothing to reclaim once page cache is gone, so the
+// band is not a safety valve but a trap the process cannot leave and cannot
+// die in (#1454: PSI full 86%, pgsteal/pgscan 3%, ~90 min outage). With swap,
+// the same band is fine: reclaim can page anon out and the throttle does what
+// it was meant to do.
+//
+// MemoryHigh EQUAL to MemoryMax is always allowed and is the default. Reclaim
+// still runs at the threshold and memory.events `high` still increments as an
+// early signal; there is simply no window to get stuck in.
+//
+// Mixed forms (a percentage against an absolute size) cannot be ordered without
+// knowing physical RAM, so they pass rather than being guessed at — systemd
+// will still enforce whichever binds first.
+func validateMemoryBounds(high, max string, hostHasSwap bool) error {
+	cmp, ok := compareMemoryValues(high, max)
+	if !ok {
 		return nil
 	}
-	hb, hok := comparableBytes(high)
-	mb, mok := comparableBytes(max)
-	if hok && mok && hb >= mb {
-		return fmt.Errorf("MemoryHigh (%s) must be below MemoryMax (%s), otherwise the cgroup "+
-			"hits the hard cap without ever being reclaimed under pressure first", high, max)
+	if cmp > 0 {
+		return fmt.Errorf("MemoryHigh (%s) must not be above MemoryMax (%s): MemoryMax binds first, "+
+			"so the throttle could never engage", high, max)
+	}
+	if cmp < 0 && !hostHasSwap {
+		return fmt.Errorf("MemoryHigh (%s) must not be below MemoryMax (%s) on a host with no swap: "+
+			"an anon-dominated cgroup has nothing left to reclaim once page cache is gone, so it "+
+			"stalls between the two limits instead of reaching the cap — it never gets restarted "+
+			"and systemd still reports it active (#1454). Set --memory-high equal to --memory-max, "+
+			"or enable swap on the host", high, max)
 	}
 	return nil
+}
+
+// compareMemoryValues orders two systemd memory values, reporting ok=false when
+// they are not comparable (mixed percentage/absolute forms, or "infinity").
+func compareMemoryValues(a, b string) (int, bool) {
+	if ap, aerr := percentValue(a); aerr == nil {
+		bp, berr := percentValue(b)
+		if berr != nil {
+			return 0, false
+		}
+		return ap - bp, true
+	}
+	ab, aok := comparableBytes(a)
+	bb, bok := comparableBytes(b)
+	if !aok || !bok {
+		return 0, false
+	}
+	switch {
+	case ab > bb:
+		return 1, true
+	case ab < bb:
+		return -1, true
+	default:
+		return 0, true
+	}
 }
 
 // buildSentinelUnit renders the systemd unit. Pure and separate from the
@@ -158,7 +230,7 @@ func buildSentinelUnit(cfg sentinelUnitConfig) (string, error) {
 	if err := validateSystemdMemoryValue(cfg.MemoryMax); err != nil {
 		return "", fmt.Errorf("--memory-max: %w", err)
 	}
-	if err := validateMemoryBounds(cfg.MemoryHigh, cfg.MemoryMax); err != nil {
+	if err := validateMemoryBounds(cfg.MemoryHigh, cfg.MemoryMax, cfg.HostHasSwap); err != nil {
 		return "", err
 	}
 
@@ -200,23 +272,32 @@ RestartMaxDelaySec=5min
 User=root
 Group=root
 
-# Memory bounds (#1350). #1349 leaked ~18 MB/day until this process held
-# 565 MB on a 1 GB host; with nothing bounding it, the kernel's OOM killer
-# resolved it 36 minutes into a full-host stall (73.91%% iowait, load
-# 32.46) rather than systemd restarting one process in seconds.
+# Memory bounds (#1350, corrected by #1454). #1349 bursts ~330 MB in
+# ~35 min on backend loss; this process reached 565 MB on a 1 GB host and,
+# with nothing bounding it, the kernel's OOM killer resolved it 36 minutes
+# into a full-host stall (73.91%% iowait, load 32.46) rather than systemd
+# restarting one process in seconds. MemoryMax plus Restart=always above
+# is what turns that into a restart.
 #
-# MemoryHigh is the directive that changes the outcome: past it, reclaim
-# pressure applies inside THIS cgroup instead of global reclaim evicting
-# the whole host's page cache, so the failure stays local and the box
-# keeps serving. MemoryMax is the hard stop, and with Restart=always
-# above it costs a restart rather than an outage.
+# MemoryHigh EQUALS MemoryMax on purpose. A soft cap below the hard cap
+# only helps if reclaim can make progress, and that needs page cache or
+# swap. These hosts have no swap and the burst is anon-dominated, so file
+# cache is gone within minutes and reclaim has nothing to do: the cgroup
+# parks between the two limits and is throttled indefinitely. It never
+# reaches the cap, so Restart=always never fires and systemd keeps
+# reporting active(running). #1454 measured that as memory.events
+# high=556267 with oom_kill=0, PSI full avg300=86%%, and pgsteal/pgscan of
+# 3%% — ~90 minutes of total edge outage, worse than the OOM kill it
+# replaced. Equal values keep local reclaim and the memory.events "high"
+# early-warning counter while removing the window to get stuck in.
 #
 # Percentages so one value fits both the 1 GB (e2-micro) and 2 GB
-# (e2-small, #770) sentinel hosts. Defaults are ~358 MB / ~512 MB on a
-# 1 GB host: roughly 4x the observed 82 MB cold start, and deliberately
-# below the 565 MB the leak actually reached — a cap above that would
-# never have fired. Override with --memory-high / --memory-max on
-# "containarium sentinel service install" for a larger host.
+# (e2-small, #770) sentinel hosts. Default is ~512 MB on a 1 GB host:
+# well above the observed 82 MB cold start, and deliberately below the
+# 565 MB the burst actually reached — a cap above that would never have
+# fired. Override with --memory-high / --memory-max on
+# "containarium sentinel service install" for a larger host; a
+# --memory-high below --memory-max is refused unless the host has swap.
 MemoryAccounting=yes
 MemoryHigh=%s
 MemoryMax=%s

--- a/internal/cmd/service_memory_test.go
+++ b/internal/cmd/service_memory_test.go
@@ -3,6 +3,9 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -19,6 +22,12 @@ import (
 // The distinction these tests protect: with MemoryHigh, reclaim pressure stays
 // inside the sentinel's own cgroup instead of evicting the host's page cache.
 // The failure becomes local and survivable rather than taking the apex down.
+//
+// Corrected by #1454: that holds only where reclaim can make progress. With no
+// swap and an anon-dominated cgroup there is nothing to reclaim, so a
+// MemoryHigh BELOW MemoryMax stalls the process below its cap indefinitely —
+// never restarted, still reported healthy. The band, not the cap, was the bug;
+// see TestSentinelUnitMemoryBandRules.
 
 func sentinelUnitForTest(t *testing.T) string {
 	t.Helper()
@@ -123,30 +132,54 @@ func TestParseSystemdMemoryValue(t *testing.T) {
 	}
 }
 
-// A MemoryHigh at or above MemoryMax is the no-throttle behaviour with extra
-// words: the cgroup would hit the hard cap without ever having been reclaimed
-// under pressure first, which is exactly the #1349 failure shape.
-func TestSentinelUnitRejectsHighAtOrAboveMax(t *testing.T) {
+// #1454 inverted the rule these cases used to assert.
+//
+// The old rule REQUIRED MemoryHigh below MemoryMax, on the reasoning that
+// reaching the cap without being reclaimed first was the #1349 shape. That
+// reasoning holds only where reclaim can make progress. On a swapless host
+// with an anon-dominated cgroup it cannot: page cache is gone within minutes
+// and there is nothing left to evict, so the band between the two limits is a
+// trap the process can neither leave nor die in. It stalls below the cap
+// forever, Restart=always never fires, and systemd still reports it running.
+//
+// So: above max is still rejected, below max is rejected only without swap,
+// and equal — the new default — is always allowed.
+func TestSentinelUnitMemoryBandRules(t *testing.T) {
 	tests := []struct {
-		name, high, max, wantErr string
+		name, high, max string
+		hasSwap         bool
+		wantErr         string
 	}{
-		{name: "equal percentages", high: "50%", max: "50%", wantErr: "must be below"},
-		{name: "high above max, percent", high: "80%", max: "50%", wantErr: "must be below"},
-		{name: "equal sizes", high: "512M", max: "512M", wantErr: "must be below"},
-		{name: "high above max, sizes", high: "1G", max: "512M", wantErr: "must be below"},
-		{name: "valid percentages", high: "35%", max: "50%"},
-		{name: "valid sizes", high: "256M", max: "512M"},
-		// Mixed units cannot be compared without knowing physical RAM, so they
+		// Equal is the default and must always build.
+		{name: "equal percentages, no swap", high: "50%", max: "50%"},
+		{name: "equal percentages, swap", high: "50%", max: "50%", hasSwap: true},
+		{name: "equal sizes, no swap", high: "512M", max: "512M"},
+
+		// The regression this issue is about: a band on a swapless host.
+		{name: "band without swap, percent", high: "35%", max: "50%", wantErr: "no swap"},
+		{name: "band without swap, sizes", high: "256M", max: "512M", wantErr: "no swap"},
+
+		// The same band is legitimate where anon can actually be paged out.
+		{name: "band with swap, percent", high: "35%", max: "50%", hasSwap: true},
+		{name: "band with swap, sizes", high: "256M", max: "512M", hasSwap: true},
+
+		// Above the cap is incoherent regardless of swap: MemoryMax binds
+		// first, so the advertised throttle can never engage.
+		{name: "high above max, percent", high: "80%", max: "50%", wantErr: "must not be above"},
+		{name: "high above max, sizes", high: "1G", max: "512M", wantErr: "must not be above"},
+		{name: "high above max, with swap", high: "80%", max: "50%", hasSwap: true, wantErr: "must not be above"},
+
+		// Mixed units cannot be ordered without knowing physical RAM, so they
 		// are allowed through rather than guessed at.
 		{name: "mixed units pass validation", high: "35%", max: "512M"},
-		{name: "infinity max is always above", high: "35%", max: "infinity"},
+		{name: "infinity max is not comparable", high: "35%", max: "infinity"},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := buildSentinelUnit(sentinelUnitConfig{
 				SpotVM: "vm", Zone: "z", Project: "p",
-				MemoryHigh: tc.high, MemoryMax: tc.max,
+				MemoryHigh: tc.high, MemoryMax: tc.max, HostHasSwap: tc.hasSwap,
 			})
 			if tc.wantErr == "" {
 				if err != nil {
@@ -164,41 +197,75 @@ func TestSentinelUnitRejectsHighAtOrAboveMax(t *testing.T) {
 	}
 }
 
-// The defaults have to leave real headroom over the sentinel's actual working
-// set, or the cap causes restart loops — a worse failure than the slow leak it
-// guards against. Cold start was 82 MB when #1349 was diagnosed; on the 1 GB
-// host these percentages must sit several times above that.
-func TestSentinelMemoryDefaultsLeaveHeadroom(t *testing.T) {
-	const (
-		oneGiB            = 1024 * 1024 * 1024
-		observedColdStart = 82 * 1024 * 1024
-		observedLeakPeak  = 565 * 1024 * 1024 // RSS at the OOM kill
-	)
+// The shipped defaults must not themselves open a throttle band — that is the
+// #1454 bug, and defaults are what almost every host actually runs. A host with
+// no swap is the case that matters, since that is what the sentinel fleet is.
+func TestSentinelMemoryDefaultsHaveNoThrottleBand(t *testing.T) {
+	if defaultSentinelMemoryHigh != defaultSentinelMemoryMax {
+		t.Errorf("default MemoryHigh (%s) != MemoryMax (%s): on a swapless host that band is where "+
+			"the cgroup stalls below the cap and never gets restarted (#1454)",
+			defaultSentinelMemoryHigh, defaultSentinelMemoryMax)
+	}
+	if _, err := buildSentinelUnit(sentinelUnitConfig{
+		SpotVM: "vm", Zone: "z", Project: "p",
+		MemoryHigh: defaultSentinelMemoryHigh, MemoryMax: defaultSentinelMemoryMax,
+		HostHasSwap: false,
+	}); err != nil {
+		t.Fatalf("defaults must build on a swapless host, got: %v", err)
+	}
+}
 
-	highPct, err := percentValue(defaultSentinelMemoryHigh)
-	if err != nil {
-		t.Fatalf("default MemoryHigh is not a percentage: %v", err)
-	}
-	maxPct, err := percentValue(defaultSentinelMemoryMax)
-	if err != nil {
-		t.Fatalf("default MemoryMax is not a percentage: %v", err)
+// hostHasSwap decides which of the two band rules applies, so a
+// misparse silently re-enables the #1454 configuration on a swapless host.
+// Unreadable or malformed input must read as "no swap" — the conservative
+// direction, since that only ever tightens the check.
+func TestHostHasSwap(t *testing.T) {
+	const meminfo = `MemTotal:         978352 kB
+MemFree:           67784 kB
+SwapTotal:      %s kB
+SwapFree:              0 kB
+`
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{name: "no swap", content: fmt.Sprintf(meminfo, "0"), want: false},
+		{name: "has swap", content: fmt.Sprintf(meminfo, "2097148"), want: true},
+		{name: "SwapTotal absent", content: "MemTotal: 978352 kB\n", want: false},
+		{name: "unparseable value", content: "SwapTotal:  banana kB\n", want: false},
+		{name: "no value at all", content: "SwapTotal:\n", want: false},
+		{name: "empty file", content: "", want: false},
 	}
 
-	highBytes := oneGiB * highPct / 100
-	maxBytes := oneGiB * maxPct / 100
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "meminfo")
+			if err := os.WriteFile(path, []byte(tc.content), 0o644); err != nil {
+				t.Fatalf("write fixture: %v", err)
+			}
+			t.Cleanup(func(orig string) func() {
+				return func() { procMeminfoPath = orig }
+			}(procMeminfoPath))
+			procMeminfoPath = path
 
-	if highBytes < 3*observedColdStart {
-		t.Errorf("MemoryHigh default (%s = %d bytes on a 1 GB host) is under 3x the observed "+
-			"82 MB cold start; a busy sentinel would be throttled in normal operation",
-			defaultSentinelMemoryHigh, highBytes)
+			if got := hostHasSwap(); got != tc.want {
+				t.Errorf("hostHasSwap() = %v, want %v", got, tc.want)
+			}
+		})
 	}
-	// The whole point: both bounds must engage below where #1349 actually got
-	// to, or they would not have changed that outcome at all.
-	if maxBytes >= observedLeakPeak {
-		t.Errorf("MemoryMax default (%s = %d bytes on a 1 GB host) is at or above the 565 MB the "+
-			"#1349 leak reached — the cap would never have fired", defaultSentinelMemoryMax, maxBytes)
-	}
-	if highBytes >= maxBytes {
-		t.Errorf("MemoryHigh (%d) must be below MemoryMax (%d)", highBytes, maxBytes)
+}
+
+// A missing /proc/meminfo must not read as "has swap" — that would let the
+// install path emit the throttle band on exactly the hosts it cannot verify.
+func TestHostHasSwapMissingFileIsConservative(t *testing.T) {
+	t.Cleanup(func(orig string) func() {
+		return func() { procMeminfoPath = orig }
+	}(procMeminfoPath))
+	procMeminfoPath = filepath.Join(t.TempDir(), "definitely-absent")
+
+	if hostHasSwap() {
+		t.Error("hostHasSwap() = true for an unreadable /proc/meminfo; it must fail closed so an " +
+			"unverifiable host still gets the no-band configuration (#1454)")
 	}
 }


### PR DESCRIPTION
Fixes #1454.

## The bug

`MemoryHigh` below `MemoryMax` is only a safety valve where reclaim can make
progress, and progress needs page cache or swap. The sentinel hosts have
neither: no swap, and the #1349 burst is anonymous memory, so file cache is
exhausted within minutes and reclaim has nothing left to evict.

The cgroup then parks between the two limits and is throttled indefinitely. It
never reaches the hard cap, so `Restart=always` never fires, and systemd keeps
reporting `active (running)` while the process serves nothing — strictly worse
than the OOM-and-restart behaviour #1350 replaced, which self-recovered in
seconds.

Measured during the outage:

```
memory.events    high 556267, max 0, oom_kill 0
memory.pressure  full avg300=86.10     <- 86% of wall-clock fully stalled
memory.stat      anon 271 MB, file 0.36 MB
                 pgscan 79.4M, pgsteal 2.4M   <- 3%: futile reclaim
```

~90 minutes of total edge outage, ended by hand. It surfaced as
`Permission denied (publickey)` on every SSH attempt: the stalled process could
not open an upstream, so sshpiper authenticated the client downstream and
re-prompted until it ran out of keys.

## The fix

The band is the bug, not the cap.

- **`MemoryHigh` defaults to `MemoryMax`.** No window to stall in. Reclaim still
  runs at the threshold, and `memory.events` `high` still increments as an early
  signal — the two things the soft cap was actually wanted for.
- **`validateMemoryBounds` is inverted and made swap-aware.** Above the cap stays
  rejected (`MemoryMax` binds first, so the advertised throttle could never
  engage); below the cap is rejected only on a host with no swap; equal is always
  allowed. A band remains available where reclaim genuinely works.
- **The install path reads `SwapTotal` from `/proc/meminfo`** and passes it in, so
  `buildSentinelUnit` stays pure and testable without `/proc`, systemd, or root.
  An unreadable meminfo reads as *no swap*: that only ever tightens the check,
  and an unverifiable host should still get the safe configuration.

## Scope correction worth reading

The shipped `35%`/`50%` defaults were a **latent** window, not the cause of this
outage. Neither burst measured so far lands inside them — 271 MB sits below and
565 MB above — and the affected host carried a tighter operator drop-in
(`256M`/`384M`) whose band did catch it.

I initially wrote that the 565 MB burst fell inside the shipped band; it does
not. The window still goes, because nothing chooses where a burst comes to rest
and the only reason to keep a band is a reclaim path these hosts lack.

## Tests

- `TestSentinelUnitMemoryBandRules` — replaces the old
  `TestSentinelUnitRejectsHighAtOrAboveMax`, which encoded the falsified premise.
  Covers equal/band/above against both swap states.
- `TestSentinelMemoryDefaultsHaveNoThrottleBand` — the shipped defaults must not
  themselves open a band on a swapless host. **Verified this fails against the
  old `35%` default** and passes with the fix, rather than assuming it would.
- `TestHostHasSwap` and `TestHostHasSwapMissingFileIsConservative` — a misparse
  silently re-enables the unsafe configuration, so absent/malformed/unreadable
  input is pinned to "no swap".

A first draft also asserted that the observed 565 MB burst could not be stranded
by the defaults. It passed against the old configuration too — that is what
caught the scope error above — so it was removed as redundant rather than kept
as a test that cannot fail for the right reason.

`go build ./...`, `go vet`, and `go test ./internal/cmd/` all pass.

## Not addressed here

#1349 itself — the burst is unchanged. This only ensures it ends in a restart
rather than a livelock. Worth noting for whoever picks it up: capturing a pprof
profile *during* a burst (#1352) is hard while the admin HTTP handler is itself
stalled at 86% PSI, and this change makes the process stay responsive on its way
to the cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
