### PR TITLE
fix(cluster): stop reserving allocatable from the daemon host's capacity

### DIFF
--- a/pkg/core/cluster/manager.go
+++ b/pkg/core/cluster/manager.go
@@ -113,27 +113,32 @@ func (m *Manager) pushFile(name, path string, content []byte, mode string) error
 }
 
 // containerKubeletArgs assembles the kubelet flags a container-class
-// node needs: the user-namespace gate every such node requires
-// (#1452), plus a reservation that makes allocatable truthful when the
-// host is bigger than the node asked for (#1439). Empty on the VM
-// path, whose units stay byte-identical.
+// node needs.
 //
-// A reservation that cannot be computed is NOT fatal here: the gate is
-// what makes kubelet start at all, and a node that starts with
-// imperfect allocatable beats a node that does not start. The capacity
-// probe in ProvisionWorker is the place that refuses a host too small
-// to host the node truthfully.
-func (m *Manager) containerKubeletArgs(iso Isolation, spec NodeSpec) []string {
+// Today that is only the user-namespace gate (#1452): kubelet writes
+// kernel sysctls an unprivileged container may not touch, and without
+// the gate ContainerManager never starts.
+//
+// It deliberately does NOT reserve resources. #1452 wired a
+// reservation computed as (daemon host capacity - requested size), on
+// Amendment 1's premise that a container node always reports the
+// host's capacity. That premise holds only on a NESTED host, where
+// lxcfs masking does not reach the inner instances. On a plain host
+// running Incus directly the node sees its real limit, and the
+// reservation becomes larger than the node's whole capacity -- kubelet
+// rejects it ("capacity >= reservation") and refuses to start, so the
+// correction meant to make allocatable truthful prevented the node
+// from running at all (#1456).
+//
+// ReservedResources and HostCapacity remain: they are correct as
+// functions. What was wrong was applying them unconditionally, from
+// the wrong vantage point. #1456 covers deciding from the node itself
+// whether a correction is needed.
+func (m *Manager) containerKubeletArgs(iso Isolation, _ NodeSpec) []string {
 	if iso != IsolationContainer {
 		return nil
 	}
-	var extra []string
-	if cpu, mem, err := HostCapacity("/"); err == nil {
-		if reserved, rErr := ReservedResources(cpu, mem, spec); rErr == nil {
-			extra = KubeletReservedArgs(reserved)
-		}
-	}
-	return ContainerKubeletArgs(extra)
+	return ContainerKubeletArgs(nil)
 }
 
 // ProvisionCP creates and bootstraps the control-plane VM: create →

--- a/pkg/core/cluster/manager_test.go
+++ b/pkg/core/cluster/manager_test.go
@@ -427,3 +427,29 @@ func TestProvisionWiresContainerKubeletArgs(t *testing.T) {
 		t.Error("VM control-plane script carries a container-only kubelet gate")
 	}
 }
+
+// A container node must not be handed a reservation inferred from the
+// daemon host's /proc. Where lxcfs works the node sees its own limits,
+// and such a reservation exceeds the node's entire capacity — kubelet
+// rejects it and refuses to start, which is worse than an uncorrected
+// allocatable (#1456, observed on the CI runner in run 11).
+func TestProvisionDoesNotReserveFromHostCapacity(t *testing.T) {
+	f := newFakeHost()
+	f.files["alice-k8s-demo-cp:"+NodeTokenPath] = []byte("K10hash::server:secret\n")
+	f.files["alice-k8s-demo-cp:"+ContainerdGeneratedConfigPath] = []byte(
+		"version = 3\n  enable_unprivileged_ports = true\n  enable_unprivileged_icmp = true\n")
+	m := testManager(f)
+
+	if _, err := m.ProvisionCP("alice", "demo", IsolationContainer,
+		DesiredGroup{CPU: "2", Memory: "4GB", Disk: "40GB"}, []string{"203.0.113.10"}); err != nil {
+		t.Fatalf("ProvisionCP: %v", err)
+	}
+	script := string(f.files["alice-k8s-demo-cp:"+bootstrapScriptPath])
+	if strings.Contains(script, "system-reserved") {
+		t.Errorf("node was given a reservation inferred from the daemon host (#1456):\n%s", script)
+	}
+	// The gate that makes kubelet start at all must still be there.
+	if !strings.Contains(script, "KubeletInUserNamespace=true") {
+		t.Error("dropping the reservation also dropped the user-namespace gate")
+	}
+}


### PR DESCRIPTION
Closes #1456. Run 11 of the container lane.

**The good news:** #1452's `KubeletInUserNamespace` gate worked — the permission-denied `ContainerManager` failure is gone.

**The bad news:** it was immediately replaced by a failure from the *other half* of #1452, which I wired in the same PR:

```
invalid Node Allocatable configuration. Resource "memory" has a reservation
of 12766414848 but capacity of 3999997952. Expected capacity >= reservation.
```

**12.8 GB reserved on a 4 GB node.**

## The wrong assumption, named

Design Amendment 1 measured a container node reporting the **host's** capacity (8 cpu / ~63 GB for a 2 cpu / 3 GB node) and generalised: container nodes misreport, so allocatable must be corrected by (host − requested).

That measurement came from a **nested** host — an LXC box whose own Incus creates the node containers, where lxcfs masking does not reach the inner instances. On a **plain host** running Incus directly, lxcfs works and the node sees its real limit. The correction then exceeds the node's entire capacity, kubelet rejects it, and the node never starts. A fix intended to make allocatable truthful stopped the node running at all — on exactly the hosts that needed no correction.

## What changes

The gate stays (it is what makes kubelet start). The unconditional reservation goes. `ReservedResources`, `HostCapacity` and their tests remain — **they are correct as functions**; what was wrong was applying them unconditionally from the daemon host's vantage point. #1456 covers deciding from the node itself whether a correction is needed, and correcting Amendment 1's over-general claim.

## Test

`TestProvisionDoesNotReserveFromHostCapacity` — a container CP's script carries **no** `system-reserved`, and still carries the gate, so removing one cannot silently remove the other.

`go test ./pkg/core/cluster/ ./internal/server/` green, `go vet` and `go build ./...` clean, goldens unchanged.

## Note for the retro

This is the **third** regression I have introduced into this lane and the third the lane caught within a single run (after the invalid containerd template and the worker bootstrap deadlock). Each came from generalising one environment's measurement into a rule. The lane is doing the job the unit tests structurally cannot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)