### PR TITLE
fix(cluster): put the published endpoint on the control plane's certificate

### DIFF
--- a/internal/server/cluster_reconciler.go
+++ b/internal/server/cluster_reconciler.go
@@ -37,8 +37,12 @@ type ClusterReconciler struct {
 	// publish allocates/records the external API endpoint for a
 	// cluster whose control plane is up; unpublish reverses it.
 	// Seamed for tests; production wires the passthrough route.
-	publish   func(ctx context.Context, c *clusterstore.Cluster, cpIP string) (string, error)
-	unpublish func(ctx context.Context, c *clusterstore.Cluster) error
+	// advertiseHost is the address tenants reach a cluster's API on.
+	// It must be a subject-alt-name on the control plane's certificate,
+	// or the kubeconfig we hand the tenant cannot verify (#1461).
+	advertiseHost string
+	publish       func(ctx context.Context, c *clusterstore.Cluster, cpIP string) (string, error)
+	unpublish     func(ctx context.Context, c *clusterstore.Cluster) error
 
 	// vpaDisabled turns off VPA deployment (CONTAINARIUM_CLUSTER_VPA=false);
 	// default is on — pod vertical autoscaling is a P0 story (#1416).
@@ -183,7 +187,7 @@ func (r *ClusterReconciler) reconcileCluster(ctx context.Context, c *clusterstor
 			if err := r.admitSize(c, cpSize, "control-plane"); err != nil {
 				return nil // refusal recorded; retry next pass
 			}
-			cpIP, err := r.mgr.ProvisionCP(c.Owner, c.Name, iso, cpSize, nil)
+			cpIP, err := r.mgr.ProvisionCP(c.Owner, c.Name, iso, cpSize, r.controlPlaneSANs())
 			if err != nil {
 				return fmt.Errorf("provision control plane: %w", err)
 			}
@@ -357,7 +361,25 @@ func (r *ClusterReconciler) settleState(ctx context.Context, c *clusterstore.Clu
 // external port from portRange, DNAT it to <cp>:6443, and record
 // <advertiseAddr>:<port> as the cluster's API endpoint. Invoked with
 // the _system identity — this is a daemon-internal reconciler path.
+// controlPlaneSANs are the extra subject-alt-names the API server
+// certificate must carry. The node's own IP is added by the manager;
+// this adds the published endpoint's host, which is what a tenant's
+// kubeconfig actually dials (#1461).
+func (r *ClusterReconciler) controlPlaneSANs() []string {
+	if r.advertiseHost == "" {
+		return nil
+	}
+	return []string{r.advertiseHost}
+}
+
+// SetAdvertiseHost records the address the published endpoint uses, so
+// the control plane's certificate can cover it. Without this the cert
+// covers only the node's own IP and the kubeconfig fails verification
+// against the endpoint it points at (#1461).
+func (r *ClusterReconciler) SetAdvertiseHost(host string) { r.advertiseHost = host }
+
 func (r *ClusterReconciler) WireEndpointPublisher(network *NetworkServer, advertiseAddr, portRange string) error {
+	r.SetAdvertiseHost(advertiseAddr)
 	lo, hi, err := parsePortRange(portRange)
 	if err != nil {
 		return err

--- a/internal/server/cluster_reconciler.go
+++ b/internal/server/cluster_reconciler.go
@@ -37,12 +37,14 @@ type ClusterReconciler struct {
 	// publish allocates/records the external API endpoint for a
 	// cluster whose control plane is up; unpublish reverses it.
 	// Seamed for tests; production wires the passthrough route.
-	// advertiseHost is the address tenants reach a cluster's API on.
-	// It must be a subject-alt-name on the control plane's certificate,
-	// or the kubeconfig we hand the tenant cannot verify (#1464).
+	publish   func(ctx context.Context, c *clusterstore.Cluster, cpIP string) (string, error)
+	unpublish func(ctx context.Context, c *clusterstore.Cluster) error
+
+	// advertiseHost is the host part of the address publish hands out,
+	// recorded by WireEndpointPublisher. It must be a subject-alt-name
+	// on the control plane's certificate, or the kubeconfig we give the
+	// tenant cannot verify against the endpoint it dials (#1464).
 	advertiseHost string
-	publish       func(ctx context.Context, c *clusterstore.Cluster, cpIP string) (string, error)
-	unpublish     func(ctx context.Context, c *clusterstore.Cluster) error
 
 	// vpaDisabled turns off VPA deployment (CONTAINARIUM_CLUSTER_VPA=false);
 	// default is on — pod vertical autoscaling is a P0 story (#1416).
@@ -356,15 +358,12 @@ func (r *ClusterReconciler) settleState(ctx context.Context, c *clusterstore.Clu
 
 // --- endpoint publishing over the passthrough surface ------------------
 
-// WireEndpointPublisher connects the reconciler to the durable
-// passthrough surface (design: create flow step 3): allocate an
-// external port from portRange, DNAT it to <cp>:6443, and record
-// <advertiseAddr>:<port> as the cluster's API endpoint. Invoked with
-// the _system identity — this is a daemon-internal reconciler path.
 // controlPlaneSANs are the extra subject-alt-names the API server
 // certificate must carry. The node's own IP is added by the manager;
 // this adds the published endpoint's host, which is what a tenant's
-// kubeconfig actually dials (#1464).
+// kubeconfig actually dials (#1464). Empty until
+// WireEndpointPublisher runs — with no published endpoint there is no
+// extra name to cover.
 func (r *ClusterReconciler) controlPlaneSANs() []string {
 	if r.advertiseHost == "" {
 		return nil
@@ -372,14 +371,16 @@ func (r *ClusterReconciler) controlPlaneSANs() []string {
 	return []string{r.advertiseHost}
 }
 
-// SetAdvertiseHost records the address the published endpoint uses, so
-// the control plane's certificate can cover it. Without this the cert
-// covers only the node's own IP and the kubeconfig fails verification
-// against the endpoint it points at (#1464).
-func (r *ClusterReconciler) SetAdvertiseHost(host string) { r.advertiseHost = host }
-
+// WireEndpointPublisher connects the reconciler to the durable
+// passthrough surface (design: create flow step 3): allocate an
+// external port from portRange, DNAT it to <cp>:6443, and record
+// <advertiseAddr>:<port> as the cluster's API endpoint. Invoked with
+// the _system identity — this is a daemon-internal reconciler path.
 func (r *ClusterReconciler) WireEndpointPublisher(network *NetworkServer, advertiseAddr, portRange string) error {
-	r.SetAdvertiseHost(advertiseAddr)
+	// Recorded here rather than through a setter of its own: a SAN for
+	// an endpoint nobody publishes is worse than no SAN, so the two
+	// stay welded to one call.
+	r.advertiseHost = advertiseAddr
 	lo, hi, err := parsePortRange(portRange)
 	if err != nil {
 		return err

--- a/internal/server/cluster_reconciler.go
+++ b/internal/server/cluster_reconciler.go
@@ -39,7 +39,7 @@ type ClusterReconciler struct {
 	// Seamed for tests; production wires the passthrough route.
 	// advertiseHost is the address tenants reach a cluster's API on.
 	// It must be a subject-alt-name on the control plane's certificate,
-	// or the kubeconfig we hand the tenant cannot verify (#1461).
+	// or the kubeconfig we hand the tenant cannot verify (#1464).
 	advertiseHost string
 	publish       func(ctx context.Context, c *clusterstore.Cluster, cpIP string) (string, error)
 	unpublish     func(ctx context.Context, c *clusterstore.Cluster) error
@@ -364,7 +364,7 @@ func (r *ClusterReconciler) settleState(ctx context.Context, c *clusterstore.Clu
 // controlPlaneSANs are the extra subject-alt-names the API server
 // certificate must carry. The node's own IP is added by the manager;
 // this adds the published endpoint's host, which is what a tenant's
-// kubeconfig actually dials (#1461).
+// kubeconfig actually dials (#1464).
 func (r *ClusterReconciler) controlPlaneSANs() []string {
 	if r.advertiseHost == "" {
 		return nil
@@ -375,7 +375,7 @@ func (r *ClusterReconciler) controlPlaneSANs() []string {
 // SetAdvertiseHost records the address the published endpoint uses, so
 // the control plane's certificate can cover it. Without this the cert
 // covers only the node's own IP and the kubeconfig fails verification
-// against the endpoint it points at (#1461).
+// against the endpoint it points at (#1464).
 func (r *ClusterReconciler) SetAdvertiseHost(host string) { r.advertiseHost = host }
 
 func (r *ClusterReconciler) WireEndpointPublisher(network *NetworkServer, advertiseAddr, portRange string) error {

--- a/internal/server/cluster_reconciler_test.go
+++ b/internal/server/cluster_reconciler_test.go
@@ -396,7 +396,7 @@ func TestReconciler_ProvisionIsolationMatchesCluster(t *testing.T) {
 // reconciler simply passed nil (#1464).
 func TestReconcilerGivesControlPlaneTheAdvertiseSAN(t *testing.T) {
 	srv, rec, host := testReconcilerRig(t)
-	rec.SetAdvertiseHost("198.51.100.20")
+	rec.advertiseHost = "198.51.100.20"
 	mustCreate(t, srv, tenantCtx("alice"), "demo")
 
 	rec.ReconcileOnce(context.Background())

--- a/internal/server/cluster_reconciler_test.go
+++ b/internal/server/cluster_reconciler_test.go
@@ -383,3 +383,29 @@ func TestReconciler_ProvisionIsolationMatchesCluster(t *testing.T) {
 		})
 	}
 }
+
+// The published endpoint must be a subject-alt-name on the API server
+// certificate, or the kubeconfig the product hands a tenant cannot
+// verify — precisely what run 14 of the container lane hit:
+//
+//	x509: certificate is valid for 10.100.0.102, 10.43.0.1, 127.0.0.1,
+//	  ::1, fd42:..., not <advertise-host>
+//
+// The design always intended this ("TLSSANs are ... the external
+// endpoint and the VM IP, so the rewritten kubeconfig verifies"); the
+// reconciler simply passed nil (#1461).
+func TestReconcilerGivesControlPlaneTheAdvertiseSAN(t *testing.T) {
+	srv, rec, host := testReconcilerRig(t)
+	rec.SetAdvertiseHost("198.51.100.20")
+	mustCreate(t, srv, tenantCtx("alice"), "demo")
+
+	rec.ReconcileOnce(context.Background())
+
+	script := string(host.files["alice-k8s-demo-cp:/root/containarium-bootstrap.sh"])
+	if script == "" {
+		t.Fatal("control plane was never bootstrapped")
+	}
+	if !strings.Contains(script, "--tls-san 198.51.100.20") {
+		t.Errorf("control-plane cert will not cover the published endpoint:\n%s", script)
+	}
+}

--- a/internal/server/cluster_reconciler_test.go
+++ b/internal/server/cluster_reconciler_test.go
@@ -393,7 +393,7 @@ func TestReconciler_ProvisionIsolationMatchesCluster(t *testing.T) {
 //
 // The design always intended this ("TLSSANs are ... the external
 // endpoint and the VM IP, so the rewritten kubeconfig verifies"); the
-// reconciler simply passed nil (#1461).
+// reconciler simply passed nil (#1464).
 func TestReconcilerGivesControlPlaneTheAdvertiseSAN(t *testing.T) {
 	srv, rec, host := testReconcilerRig(t)
 	rec.SetAdvertiseHost("198.51.100.20")


### PR DESCRIPTION
Closes #1464.

## What run 14 showed

#1459's OUTPUT rule worked — the published endpoint now **accepts** connections. The next layer failed:

```
tls: failed to verify certificate: x509: certificate is valid for
10.100.0.102, 10.43.0.1, 127.0.0.1, ::1, fd42:..., not <advertise-host>
```

The certificate covers the control plane's own container IP, the cluster service IP and loopback — not the address the kubeconfig points at.

## Cause

```go
cpIP, err := r.mgr.ProvisionCP(c.Owner, c.Name, iso, cpSize, nil)   // ← no SANs
```

The reconciler *knows* the advertise address (`WireEndpointPublisher` closes over it) but used it only to format the endpoint string. `ServerBootstrap.TLSSANs` exists for precisely this, and its comment says so: *"the external endpoint and the VM IP, so the rewritten kubeconfig verifies."* The intent was written down; the wiring was never done.

## Consequence — this is the headline promise, broken

**No tenant kubeconfig has ever verified against its published endpoint, in either isolation class.** `cluster kubeconfig` hands out a credential pointing at an address the certificate does not cover, so every `kubectl` fails TLS verification unless the user disables it. Sixth both-classes defect this sprint, and the most user-visible: `cluster create` → working kubeconfig is the product's core claim.

## Why the test is at the reconciler level

The renderer already honoured `TLSSANs` correctly — `RenderServerScript` faithfully emitted `--tls-san` for whatever it was given, and a renderer test would have passed happily while the product stayed broken, because the caller passed `nil`. `TestReconcilerGivesControlPlaneTheAdvertiseSAN` asserts at the layer that **has** the address, driving a real reconcile pass and checking the bootstrap script the control plane actually receives.

That is the same lesson as #1452's dead `KubeletArgs`: testing the renderer proves the renderer works, not that anything calls it correctly.

`go test ./internal/server/ ./pkg/core/cluster/` green, `go vet` clean, `go build ./...` clean.

## Provenance

Orchestrator-authored; same-session author/reviewer caveat as the sprint's other fixes.

Unblocks #1430 · umbrella #1432.

🤖 Generated with [Claude Code](https://claude.com/claude-code)