### PR TITLE
fix(cluster): run the autoscaler as uid 0 so it can read its credentials

### DIFF
--- a/pkg/core/cluster/bootstrap.go
+++ b/pkg/core/cluster/bootstrap.go
@@ -267,6 +267,20 @@ func RenderCACloudConfig(d CADeploy) string {
 // cluster-autoscaler systemd unit: the digest-pinned stock image run
 // as a plain containerd task via `k3s ctr` — never a Pod, so no
 // tenant with cluster-admin can exec into it or read its credential.
+// The task runs as uid 0. Upstream's cluster-autoscaler image is
+// distroless nonroot, and every file the autoscaler must read on the
+// control plane is root-owned and tight: k3s writes
+// /etc/rancher/k3s/k3s.yaml 0600, and DeployCA pushes the mTLS client
+// key 0600. Run 16 of the container lane caught the first of those —
+//
+//	Failed to build config: error loading config file
+//	"/etc/kubeconfig": open /etc/kubeconfig: permission denied
+//
+// followed by exit 255 and a unit stuck restarting forever. Loosening
+// the file modes instead would only move the failure onto the private
+// key and then leave it readable to every user on the node, so the
+// credentials stay 0600 and the task gets the uid that can read them
+// (#1470).
 func RenderCAUnitScript(d CADeploy) string {
 	return fmt.Sprintf(`#!/bin/sh
 # containarium managed-cluster autoscaler bootstrap (#1415).
@@ -284,7 +298,7 @@ Requires=k3s.service
 ExecStartPre=%[1]s ctr images pull %[2]s
 ExecStartPre=-%[1]s ctr task kill --signal SIGKILL cluster-autoscaler
 ExecStartPre=-%[1]s ctr container rm cluster-autoscaler
-ExecStart=%[1]s ctr run --rm --net-host \
+ExecStart=%[1]s ctr run --rm --net-host --user 0 \
   --mount type=bind,src=%[3]s,dst=%[3]s,options=rbind:ro \
   --mount type=bind,src=/etc/rancher/k3s/k3s.yaml,dst=/etc/kubeconfig,options=rbind:ro \
   %[2]s cluster-autoscaler \

--- a/pkg/core/cluster/bootstrap_test.go
+++ b/pkg/core/cluster/bootstrap_test.go
@@ -103,6 +103,20 @@ func TestRenderCAUnitScript(t *testing.T) {
 	if strings.Contains(got, "kubectl apply") || strings.Contains(got, "Pod") {
 		t.Fatal("the autoscaler must not run as a Kubernetes object")
 	}
+	// The task must run as uid 0. Upstream's image is distroless
+	// nonroot, and everything it needs to read is root-owned and
+	// tight: k3s writes /etc/rancher/k3s/k3s.yaml 0600, and we push
+	// the mTLS client key 0600 ourselves. Run 16 caught the first of
+	// those —
+	//
+	//	Failed to build config: error loading config file
+	//	"/etc/kubeconfig": open /etc/kubeconfig: permission denied
+	//
+	// — and loosening file modes would only move the failure onto the
+	// private key, then leak it. See #1470.
+	if !strings.Contains(got, "--user 0") {
+		t.Fatalf("autoscaler task must run as uid 0 or it cannot read its own 0600 credentials:\n%s", got)
+	}
 }
 
 func TestRenderCACloudConfig(t *testing.T) {

--- a/pkg/core/cluster/testdata/ca-unit.sh.golden
+++ b/pkg/core/cluster/testdata/ca-unit.sh.golden
@@ -14,7 +14,7 @@ Requires=k3s.service
 ExecStartPre=/usr/local/bin/k3s ctr images pull registry.k8s.io/autoscaling/cluster-autoscaler:v1.33.0@sha256:6ef10d108e0e45ecd883e074682330bbd4a3403e767ad56804800f2f4ee816da
 ExecStartPre=-/usr/local/bin/k3s ctr task kill --signal SIGKILL cluster-autoscaler
 ExecStartPre=-/usr/local/bin/k3s ctr container rm cluster-autoscaler
-ExecStart=/usr/local/bin/k3s ctr run --rm --net-host \
+ExecStart=/usr/local/bin/k3s ctr run --rm --net-host --user 0 \
   --mount type=bind,src=/etc/containarium/ca,dst=/etc/containarium/ca,options=rbind:ro \
   --mount type=bind,src=/etc/rancher/k3s/k3s.yaml,dst=/etc/kubeconfig,options=rbind:ro \
   registry.k8s.io/autoscaling/cluster-autoscaler:v1.33.0@sha256:6ef10d108e0e45ecd883e074682330bbd4a3403e767ad56804800f2f4ee816da cluster-autoscaler \


### PR DESCRIPTION
Closes #1470. Answers #1469.

## The evidence

Run 16 shipped only diagnostics — the journal collection #1469 called for. It paid off on the first run:

```
autoscaler unit on e2etenant-k8s-lane-cp: activating

F0820 04:04:59.956083  1 client.go:52] Failed to build config: error loading config
  file "/etc/kubeconfig": open /etc/kubeconfig: permission denied
k3s-cluster-autoscaler.service: Main process exited, code=exited, status=255/EXCEPTION
```

Starts, dies in under a second, `Restart=always` restarts it forever. That's why `is-active` said **`activating`** and never `active`, and why neither `TriggeredScaleUp` nor `NotTriggerScaleUp` ever reached the pending pod.

Worth noting: my stated hypothesis in #1469 was `ctr run --net-host` failing on an unprivileged container. **It was wrong.** The container ran fine. I'm glad I collected the journal instead of acting on the guess.

## Cause

Upstream's image is distroless **nonroot**. Everything the autoscaler reads is root-owned and tight:

| File | Mode | Written by |
|---|---|---|
| `/etc/rancher/k3s/k3s.yaml` → `/etc/kubeconfig` | `0600` root | k3s |
| `/etc/containarium/ca/client.key` | `0600` root | `DeployCA` |

`ctr run` was given no `--user`, so the task took the image's nonroot uid and could open neither.

## Why `--user 0` and not looser file modes

Relaxing modes is wrong twice. Making `k3s.yaml` world-readable only moves the failure onto `client.key` — and relaxing *that* leaves a **per-cluster mTLS private key readable by every user on the node**. The credentials stay `0600`; the task gets the uid that can read them. The unit already runs as root under systemd with `--net-host` on a node outside the tenant-visible surface, so this is not an escalation.

## This is not container-specific

It fails **identically on a VM node** — image user, file modes and mount don't vary by isolation class. The autoscaler shipped in #1415 has **never started on any cluster, in either class**. The reconciler's `min_nodes` convergence has been doing all the scaling anyone has observed.

Seventh both-classes defect this sprint. Invisible for the usual reason plus one: #1418's KVM lane has no runner, *and* #1415's tests pin the rendered unit text — which rendered exactly as designed. The design was wrong, not the renderer. Same shape as #1452's dead `KubeletArgs`: a test that passes while proving less than it appears to.

## Test evidence

Test written first, confirmed red for the right reason:

```
bootstrap_test.go: autoscaler task must run as uid 0 or it cannot read its own 0600 credentials
```

Then green. The golden diff is exactly one line:

```diff
-ExecStart=/usr/local/bin/k3s ctr run --rm --net-host \
+ExecStart=/usr/local/bin/k3s ctr run --rm --net-host --user 0 \
```

`go test ./pkg/core/cluster/` green, `go vet` clean, `go build ./...` clean. The rationale lives as a Go doc comment on `RenderCAUnitScript`, not inside the deployed unit.

The real proof is the lane: the autoscaler must reach `active` and step 2 must pass. That runs after merge.

## Provenance

Orchestrator-authored; same-session author/reviewer caveat as the sprint's other fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)