### PR TITLE
fix(cluster): restore the VPA admission controller a missing --- deleted

### DIFF
--- a/pkg/core/cluster/vpa.go
+++ b/pkg/core/cluster/vpa.go
@@ -29,7 +29,7 @@ const (
 	// bundle — the reviewable surface (golden-tested like the k3s
 	// binary pin): what runs inside tenant clusters changes only as
 	// a visible re-vendor diff.
-	VPAManifestSHA256 = "6804cbac5efe0b4f258ed6d8a61477ccf304aff9c7f37e6b4bef0a9a94e8518b"
+	VPAManifestSHA256 = "a74ea4c0e47561d4fd0bb9003a5e005dd5eb43fe173161b7dd86ff97ffebecd4"
 )
 
 //go:embed vpa/manifests.yaml

--- a/pkg/core/cluster/vpa/manifests.yaml
+++ b/pkg/core/cluster/vpa/manifests.yaml
@@ -1649,6 +1649,7 @@ spec:
         - name: tls-certs
           secret:
             secretName: vpa-tls-certs
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/pkg/core/cluster/vpa_test.go
+++ b/pkg/core/cluster/vpa_test.go
@@ -1,11 +1,15 @@
 package cluster
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/pem"
+	"errors"
+	"gopkg.in/yaml.v3"
+	"io"
 	"regexp"
 	"strings"
 	"testing"
@@ -142,3 +146,44 @@ func TestDeployVPA(t *testing.T) {
 type errNotDeployed struct{}
 
 func (errNotDeployed) Error() string { return "no such file" }
+
+// The VPA bundle is three Deployments. Asserting on the manifest as
+// *text* is not enough and this is how we learned it: the previous
+// check looked for the string "vpa-admission-controller", which
+// appears in its ServiceAccount and RBAC, so it passed while the
+// admission-controller Deployment was being silently discarded by a
+// missing `---` separator (#1473). Parse the documents and count the
+// objects Kubernetes would actually get.
+func TestVPAManifestsCarryAllThreeDeployments(t *testing.T) {
+	raw, err := VPAManifests()
+	if err != nil {
+		t.Fatal(err)
+	}
+	type object struct {
+		Kind     string `yaml:"kind"`
+		Metadata struct {
+			Name string `yaml:"name"`
+		} `yaml:"metadata"`
+	}
+	got := map[string]bool{}
+	dec := yaml.NewDecoder(bytes.NewReader(raw))
+	for {
+		var o object
+		err := dec.Decode(&o)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("VPA manifests are not valid YAML: %v", err)
+		}
+		if o.Kind == "Deployment" {
+			got[o.Metadata.Name] = true
+		}
+	}
+	for _, want := range []string{"vpa-recommender", "vpa-updater", "vpa-admission-controller"} {
+		if !got[want] {
+			t.Errorf("Deployment %q is missing from the parsed manifests (got %v) — "+
+				"without the admission controller a recommendation is computed and never applied", want, got)
+		}
+	}
+}


### PR DESCRIPTION
Closes #1473. Answers #1472.

## Evidence

Run 19 carried only the VPA diagnostics from #1472. They settled it in one pass:

```
VPA burner status: conditions: [{type: RecommendationProvided, status: True}]
                   recommendation: target: {cpu: 1101m, memory: 250Mi}

metrics.k8s.io nodes: ... medium-1 usage: {cpu: 824637152n}

kube-system pods:
  vpa-recommender-...  Running restarts=0
  vpa-updater-...      Running restarts=0
  (no vpa-admission-controller)
```

The recommender works and recommends 1101m against a 100m request. Metrics are healthy — my #1472 hypothesis about metrics-server was **wrong**, the second guess in a row this lane has corrected. The admission controller simply does not exist: no pod, no events, nothing.

## Cause — one missing `---`

```yaml
      volumes:
        - name: tls-certs
          secret:
            secretName: vpa-tls-certs
apiVersion: v1          # <-- no separator
kind: Service
```

The Service is glued onto the Deployment as a single document with duplicate `apiVersion`/`kind`/`metadata`/`spec` keys. Kubernetes' YAML path is last-wins, so the merged object resolves to the **Service** and the Deployment vanishes without an error. Parsed:

```
deployments: ['vpa-recommender', 'vpa-updater']    # admission-controller gone
services:    ['vpa-webhook']
```

## Consequence

The admission controller is the webhook that injects recommended requests into pods. Without it, VPA computes a recommendation, publishes it, and applies it to nothing. **VPA has been decorative on every cluster since #1416 merged**, in both isolation classes — eighth both-classes defect this sprint.

## Why the tests passed

`vpa_test.go` asserted the manifest *text* contains `"vpa-admission-controller"`. It does — in the ServiceAccount, ClusterRole and RoleBinding. The string was present; the Deployment was not. The SHA pin then faithfully pinned the broken bytes.

Third instance this sprint, after #1452's dead `KubeletArgs` and #1415's rendered-unit assertions. Same shape every time: asserting on the *representation* rather than on what the system actually receives.

The replacement decodes the documents and asserts all three Deployments are present. Confirmed red on the old manifest — and Go's stricter decoder names the glue point outright:

```
line 1653: mapping key "kind" already defined at line 1590
```

## Diff

Surgical: one line of YAML, one SHA re-pin, one real test.

```
 pkg/core/cluster/vpa.go             |  2 +-
 pkg/core/cluster/vpa/manifests.yaml |  1 +
 pkg/core/cluster/vpa_test.go        | 45 ++++++++++++++++++++++++++++
```

`go test ./pkg/core/cluster/` green, `go vet` clean, `go build ./...` clean. The lane is the real proof: the admission controller must run and step 4 must pass.

## Provenance

Orchestrator-authored; same-session author/reviewer caveat as the sprint's other fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)