### PR TITLE
fix(recipes): derive the awscli arch in agentcore-cli instead of hardcoding x86_64

### DIFF
--- a/pkg/core/recipes/recipes.yaml
+++ b/pkg/core/recipes/recipes.yaml
@@ -1002,7 +1002,11 @@ recipes:
       - 'curl -fsSL https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh'
       # awscli is how the interceptor Lambda gets deployed and how the gateway
       # is wired; the agentcore CLI does not cover those verbs.
-      - 'curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscli.zip && unzip -q /tmp/awscli.zip -d /tmp && /tmp/aws/install --update && rm -rf /tmp/awscli.zip /tmp/aws'
+      # `uname -m` yields exactly the suffixes AWS publishes (x86_64 /
+      # aarch64), so this is a 1:1 map — hardcoding x86_64 failed
+      # provisioning outright on an arm64 host, since this step is not
+      # best-effort.
+      - 'curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o /tmp/awscli.zip && unzip -q /tmp/awscli.zip -d /tmp && /tmp/aws/install --update && rm -rf /tmp/awscli.zip /tmp/aws'
       - mkdir -p /opt/agentcore
       # Point the SDK at the secrets mount rather than copying anything to
       # disk. Conditional, so a box provisioned before the secret exists still


### PR DESCRIPTION
## What

`agentcore-cli`'s `post_start` pulled `awscli-exe-linux-x86_64.zip` unconditionally. That step has no `|| true`, so on an arm64 host — a BYOC box, an Apple Silicon dev machine — provisioning failed outright rather than degrading.

`uname -m` yields exactly the suffixes AWS publishes, so it is a 1:1 substitution:

| `uname -m` | URL | |
| --- | --- | --- |
| `x86_64` | `awscli-exe-linux-x86_64.zip` | HTTP 200 |
| `aarch64` | `awscli-exe-linux-aarch64.zip` | HTTP 200 |

(Linux arm64 reports `aarch64`; recipes run in Ubuntu LXC, so that is the relevant value.)

## How it was found

By dry-running the recipe's `post_start` by hand on a plain Ubuntu 24.04 box. That was necessary because the catalog is compiled into the daemon (`recipes.go:18` `//go:embed *.yaml`, no disk/env override), so `agentcore-cli` is not available to any released daemon until a release carries it — the latest, v0.66.0, predates it.

Every other step passed on x86_64, ~75s end to end:

- `node v20.20.2`, `npm 10.8.2`, **`@aws/agentcore@0.27.1`**, `uv 0.12.5`, `aws-cli 2.36.27` — all reachable as the non-root box user
- the profile script rendered correctly and reached **both login and non-login** SSH sessions (the box's login path goes through `su -`)
- with a secret mounted at `/run/secrets/aws-credentials` (0440 root:*boxuser*), `aws configure list` resolved `access_key` from `shared-credentials-file` and region from env — credentials never leave tmpfs

The dry-run box was deleted and the container list reconciled.

## Not fixed here

The box ignored requested sizing — asked for CPU=2/4GB/30GB, got CPU=8/16GB/40GB. That is platform-side, not a recipe bug, but it means the recipe's declared `resources:` are likely ignored too and `agentcore-cli` boxes will provision larger (and bill higher) than declared. Worth a separate issue.

`agentcore dev` remains untested, as the recipe's comment states — it needs nested containers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)