### PR TITLE
fix(recipes): drop the no-op --user root from risingwave

### DIFF
--- a/pkg/core/recipes/recipes.yaml
+++ b/pkg/core/recipes/recipes.yaml
@@ -848,16 +848,16 @@ recipes:
       - podman volume create risingwave-data
       - 'podman pull "docker.io/risingwavelabs/risingwave:${CONTAINARIUM_PARAM_VERSION}" >/dev/null'
       - podman rm -f risingwave >/dev/null 2>&1 || true
-      # --user root: named Podman volumes are created root-owned and the
-      # image's own user cannot write to the mount. The box is already an
-      # unprivileged LXC, so root in the inner container crosses no new
-      # boundary.
+      # No --user override: the image sets no User, so it already runs as root
+      # and writes the root-owned named volume fine (verified on a live box,
+      # v3.0.0). An explicit --user root would be a no-op that reads like a
+      # deliberate privilege choice.
       #
       # --listen-addr is passed explicitly even though 0.0.0.0:4566 is the
       # frontend default: a loopback bind would silently make the published
       # port unreachable, and that failure looks like a hung psql.
       - |
-        podman run -d --name risingwave --restart=always --user root \
+        podman run -d --name risingwave --restart=always \
           -p 4566:4566 -p 5691:5691 -p 4560:4560 \
           -v risingwave-data:/var/lib/risingwave \
           -e RUST_BACKTRACE=1 \

--- a/pkg/core/recipes/recipes_test.go
+++ b/pkg/core/recipes/recipes_test.go
@@ -163,7 +163,6 @@ func TestRisingWaveRecipe(t *testing.T) {
 		"--listen-addr 0.0.0.0:4566", // a loopback bind makes the published port unreachable
 		"-p 4566:4566",               // published on the box for SSH local-forward
 		"--restart=always",           // survives box reboot and SSH logout
-		"--user root",                // root-owned named volume must be writable
 		"/dev/tcp/127.0.0.1/4566",    // readiness gate: boot failure surfaces at deploy time
 	} {
 		if !strings.Contains(joined, want) {


### PR DESCRIPTION
Follow-up to #1461, which shipped with `--user root` flagged as the one thing needing live verification. I deployed it and verified. **`--user root` is a no-op** — removing it.

## What the check actually showed

The `risingwavelabs/risingwave` image sets **no `User`** in its config, so it already runs as root:

```
User=[] Entrypoint=[/risingwave/bin/risingwave] Cmd=[single_node]
$ podman run --rm --entrypoint "" risingwavelabs/risingwave:v3.0.0 id
uid=0(root) gid=0(root) groups=0(root)
```

The control test — the root-owned named volume mounted **without** any `--user` override:

```
host-side owner: uid=0 gid=0 mode=755
WRITE OK
```

So the flag changed nothing. Worse than redundant: it reads as a deliberate privilege decision and invites a reviewer to weigh a trade-off that was never real. The comment justifying it described a non-root image user that does not exist.

## Rest of the recipe, verified live

Ubuntu 24.04 LXC (8 cpu / 16 GB / 100 GB) on an AVX2 host, podman, RisingWave v3.0.0. `post_start` run verbatim with `CONTAINARIUM_PARAM_*` exported as `buildPostStartScript` sets them:

| Check | Result |
|---|---|
| `post_start` completes, readiness gate returns | `risingwave: SQL up on :4566, dashboard :5691, webhook :4560` |
| Streaming MV maintains itself | `INSERT (1,10),(1,5),(2,7)` + `FLUSH` → `1=15 2=7` |
| Dashboard `:5691` | HTTP 200 |
| Webhook `:4560` | accepts connections |
| State on the named volume | `meta_store/` + `state_store/` present |
| Survives container restart | totals still `1=15 2=7` |
| **Without** `--user root` | boots, data preserved, still `uid=0` |

## Scope note

This exercised the recipe's `post_start`, the podman invocation, volume permissions, RisingWave's boot, and the port bindings. It did **not** exercise the recipe plumbing — param resolution and `exposePorts` route creation — because no released daemon carries the catalog yet and I did not want to put an unreleased build on a live pool backend. Worth re-checking after the next release cuts.

Test updated to drop the now-meaningless `--user root` assertion; `go test ./pkg/core/recipes/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
