### PR TITLE
perf(incus): poll for the container IP with backoff, not a flat 1s sleep

### DIFF
--- a/pkg/core/incus/client.go
+++ b/pkg/core/incus/client.go
@@ -1286,24 +1286,62 @@ func (c *Client) Exec(containerName string, command []string) error {
 	})
 }
 
-// WaitForNetwork waits for the container to have a network IP
-func (c *Client) WaitForNetwork(containerName string, timeout time.Duration) (string, error) {
-	deadline := time.Now().Add(timeout)
+// waitNetPollMin and waitNetPollMax bound the WaitForNetwork poll interval.
+//
+// This loop used to sleep a flat 1s between checks, which put a ~1s quantum
+// on every container create: a DHCP lease landing at 300ms was not observed
+// until 1s, and every caller of Manager.Create paid the difference. Opening
+// at 25ms and backing off to 500ms sees a fast lease almost immediately,
+// while a slow one — a Windows VM is given 120s — settles into a half-second
+// cadence instead of thousands of round-trips on the Incus socket.
+//
+// vars, not consts, so tests can zero them; production keeps the defaults.
+var (
+	waitNetPollMin = 25 * time.Millisecond
+	waitNetPollMax = 500 * time.Millisecond
+)
 
-	for time.Now().Before(deadline) {
+// WaitForNetwork waits for the container to have a network IP.
+func (c *Client) WaitForNetwork(containerName string, timeout time.Duration) (string, error) {
+	return waitForIP(timeout, func() (string, error) {
 		info, err := c.GetContainer(containerName)
 		if err != nil {
 			return "", err
 		}
+		return info.IPAddress, nil
+	})
+}
 
-		if info.IPAddress != "" {
-			return info.IPAddress, nil
+// waitForIP polls get until it returns a non-empty address or timeout
+// elapses, backing off from waitNetPollMin to waitNetPollMax between
+// attempts. An error from get is returned immediately — a lookup that fails
+// is not a container that hasn't leased yet.
+//
+// Split out (mirroring stateWithRetry) so tests can exercise the polling
+// against a fake get func without a real Incus server.
+func waitForIP(timeout time.Duration, get func() (string, error)) (string, error) {
+	deadline := time.Now().Add(timeout)
+	poll := waitNetPollMin
+
+	for {
+		ip, err := get()
+		if err != nil {
+			return "", err
+		}
+		if ip != "" {
+			return ip, nil
 		}
 
-		time.Sleep(1 * time.Second)
+		// Never sleep past the deadline: clamping here makes the last
+		// attempt land on it rather than overshooting by a full interval,
+		// which is what turned a 30s budget into a 31s one.
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return "", fmt.Errorf("timeout waiting for container network")
+		}
+		time.Sleep(min(poll, remaining))
+		poll = min(poll*2, waitNetPollMax)
 	}
-
-	return "", fmt.Errorf("timeout waiting for container network")
 }
 
 // GetContainerIP returns the IP address of a container, or empty string if not found

--- a/pkg/core/incus/wait_network_test.go
+++ b/pkg/core/incus/wait_network_test.go
@@ -1,0 +1,132 @@
+package incus
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// noWaitNetBackoff shrinks the poll bounds for the duration of a test so the
+// polling loop doesn't actually sleep for meaningful wall-clock time.
+func noWaitNetBackoff(t *testing.T) {
+	t.Helper()
+	oldMin, oldMax := waitNetPollMin, waitNetPollMax
+	waitNetPollMin, waitNetPollMax = 0, 0
+	t.Cleanup(func() { waitNetPollMin, waitNetPollMax = oldMin, oldMax })
+}
+
+// TestWaitForIP_ReturnsAsSoonAsTheLeaseLands is the regression test for the
+// flat 1s sleep. The fake leases on the 2nd attempt; with the old loop that
+// took ~1s regardless, so an assertion well under 1s fails against it and
+// passes against the backoff.
+func TestWaitForIP_ReturnsAsSoonAsTheLeaseLands(t *testing.T) {
+	calls := 0
+	get := func() (string, error) {
+		calls++
+		if calls < 2 {
+			return "", nil
+		}
+		return "10.0.0.5", nil
+	}
+
+	start := time.Now()
+	ip, err := waitForIP(30*time.Second, get)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("waitForIP err = %v, want nil", err)
+	}
+	if ip != "10.0.0.5" {
+		t.Errorf("ip = %q, want 10.0.0.5", ip)
+	}
+	// The first backoff is waitNetPollMin (25ms). A generous ceiling that is
+	// still far below the 1s quantum this replaces.
+	if elapsed > 200*time.Millisecond {
+		t.Errorf("elapsed = %v, want < 200ms — a lease on the 2nd poll must not cost a full quantum", elapsed)
+	}
+}
+
+// TestWaitForIP_ImmediateHitDoesNotSleep: an address already present returns
+// on the first attempt without polling at all.
+func TestWaitForIP_ImmediateHitDoesNotSleep(t *testing.T) {
+	calls := 0
+	start := time.Now()
+	ip, err := waitForIP(30*time.Second, func() (string, error) {
+		calls++
+		return "10.0.0.9", nil
+	})
+	if err != nil {
+		t.Fatalf("waitForIP err = %v, want nil", err)
+	}
+	if ip != "10.0.0.9" {
+		t.Errorf("ip = %q, want 10.0.0.9", ip)
+	}
+	if calls != 1 {
+		t.Errorf("calls = %d, want 1", calls)
+	}
+	if elapsed := time.Since(start); elapsed > 50*time.Millisecond {
+		t.Errorf("elapsed = %v, want ~0 for an immediate hit", elapsed)
+	}
+}
+
+// TestWaitForIP_BacksOffToTheCap: the interval must grow, otherwise a 120s
+// Windows VM wait becomes thousands of round-trips on the Incus socket. With
+// the real bounds (25ms doubling to 500ms), a 1s budget admits far fewer
+// polls than a flat 25ms cadence would.
+func TestWaitForIP_BacksOffToTheCap(t *testing.T) {
+	calls := 0
+	_, err := waitForIP(1*time.Second, func() (string, error) {
+		calls++
+		return "", nil
+	})
+	if err == nil {
+		t.Fatal("waitForIP err = nil, want timeout")
+	}
+	// 25+50+100+200+400 = 775ms covers 5 sleeps; the 6th is clamped to the
+	// remainder. A flat 25ms poll would be ~40 calls.
+	if calls > 10 {
+		t.Errorf("calls = %d, want <= 10 — the interval is not backing off", calls)
+	}
+	if calls < 3 {
+		t.Errorf("calls = %d, want >= 3 — the interval is not opening small", calls)
+	}
+}
+
+// TestWaitForIP_HonorsDeadlineWithoutOvershooting: the clamp means a budget
+// is not exceeded by a full poll interval.
+func TestWaitForIP_HonorsDeadlineWithoutOvershooting(t *testing.T) {
+	start := time.Now()
+	_, err := waitForIP(300*time.Millisecond, func() (string, error) {
+		return "", nil
+	})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("waitForIP err = nil, want timeout")
+	}
+	if elapsed < 300*time.Millisecond {
+		t.Errorf("elapsed = %v, want >= the 300ms budget", elapsed)
+	}
+	if elapsed > 400*time.Millisecond {
+		t.Errorf("elapsed = %v, want the budget not overshot by a full interval", elapsed)
+	}
+}
+
+// TestWaitForIP_ReturnsLookupErrorImmediately: a failing lookup is not a
+// container that hasn't leased yet — it must not be retried until timeout.
+func TestWaitForIP_ReturnsLookupErrorImmediately(t *testing.T) {
+	noWaitNetBackoff(t)
+
+	wantErr := errors.New("connection refused")
+	calls := 0
+	_, err := waitForIP(30*time.Second, func() (string, error) {
+		calls++
+		return "", wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Errorf("err = %v, want %v", err, wantErr)
+	}
+	if calls != 1 {
+		t.Errorf("calls = %d, want 1 — a lookup error must not be polled through", calls)
+	}
+}


### PR DESCRIPTION
## What

`WaitForNetwork` polls with backoff instead of a flat `time.Sleep(1 * time.Second)`.

The design investigation that surfaced this is split out into #1488 so it can be argued about separately — this PR is the fix alone.

## The fix

`WaitForNetwork` checked for the container's IP, then slept a flat second before checking again. A DHCP lease landing at 300ms was not observed until ~1010ms, and **every caller of `Manager.Create` paid the difference** — roughly 700ms on an average create, persistent boxes included, not just the sandbox workload that surfaced it.

Three changes, not one:

- **Opens at 25ms.** That is the ~700ms payoff.
- **Backs off to a 500ms cap.** The cap matters as much as the opening interval — a flat fast poll would have been the naive fix and a bad one. Call sites pass timeouts up to 120s (Windows VMs, `pkg/core/container/manager.go:468`), so a flat 25ms cadence turns one slow boot into ~4,800 round-trips on the Incus socket. Backoff keeps it nearer 240.
- **Clamps the sleep to the remaining budget.** The old loop could sleep a full interval past its deadline, so a 30s timeout was really up to 31s.

The polling is split into `waitForIP`, mirroring the `stateWithRetry` / `execWithRetry` shape already in this file, so it is testable against a fake lookup with no real Incus server. The bounds are `var` rather than `const` for the same reason `stateBackoffBase` is.

## Testing

Five tests in `pkg/core/incus/wait_network_test.go` covering: fast lease returns fast, immediate hit does not sleep, interval actually backs off, deadline is not overshot, lookup error is not polled through.

**Verified they can fail.** Restoring the flat 1s interval fails the regression test with:

```
--- FAIL: TestWaitForIP_ReturnsAsSoonAsTheLeaseLands (1.00s)
    elapsed = 1.001235875s, want < 200ms — a lease on the 2nd poll must not cost a full quantum
--- FAIL: TestWaitForIP_BacksOffToTheCap (1.00s)
    calls = 2, want >= 3 — the interval is not opening small
```

Green against the fix: `go build ./...`, `go vet`, `go test ./pkg/core/incus/ ./pkg/core/container/`, and `go test -race ./pkg/core/incus/`.

## Reviewer notes

- The stage-cost table in the design note is **derived from the code, not a profiler**, and says so. There is no per-stage instrumentation on the create path today, which is why Phase 0 of the plan is measurement rather than optimization.
- Pre-existing and deliberately out of scope: a lookup error still returns immediately rather than being retried. `GetContainer` can transiently return "Instance not found" on a wedged connection (the path `getInstanceStateWithRetry` exists to absorb). If that ever surfaces during early boot, `WaitForNetwork` would abort a create that would have succeeded. Worth a follow-up; not changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
