### PR TITLE
docs(k8s): gVisor boxes must be reached via the sshpiper gateway, not port-forward

### DIFF
--- a/charts/containarium-k8s/values.yaml
+++ b/charts/containarium-k8s/values.yaml
@@ -73,6 +73,13 @@ storageClass: ""
 # kernel. Set to "runsc" to run boxes inside a gVisor sandbox instead; that
 # requires a RuntimeClass named "runsc" in the cluster AND gVisor installed on
 # every node the daemon schedules onto, or box pods will not start.
+#
+# Caveat: `kubectl port-forward`/`kubectl exec` directly against a `runsc`-
+# scheduled box pod does not work (a gVisor networking characteristic, not a
+# Containarium bug — see kubernetes-sigs/agent-sandbox#158, and this repo's
+# own #1489). Real pod-to-pod networking is unaffected, so reach a gVisor box
+# through the sshpiper gateway (`gateway.service`, below) — never by
+# port-forwarding straight to the box pod.
 runtimeClass: ""
 
 # -- Annotations to add to all resources

--- a/deploy/k8s/sshpiper/README.md
+++ b/deploy/k8s/sshpiper/README.md
@@ -87,6 +87,15 @@ ssh -i <agent-private-key> <tenant>@"$GW"
   and `ssh -p 2222 <tenant>@127.0.0.1`.
 - **kindnet doesn't enforce NetworkPolicy** — the box default-deny policy is a
   no-op there; use a Calico-backed kind config to exercise enforcement.
+- **gVisor boxes: only port-forward to `svc/sshpiper`, never to a box pod.**
+  sshpiper itself always runs on the cluster's default runtime, so
+  port-forwarding to it works regardless of what `RuntimeClass` boxes use.
+  A box pod scheduled under a gVisor `RuntimeClass` (e.g. `runsc`) is fully
+  reachable over real pod networking — which is exactly the path sshpiper's
+  upstream connection uses — but `kubectl port-forward`/`kubectl exec`
+  straight to that box pod's SSH port does not work (upstream gVisor
+  characteristic: kubernetes-sigs/agent-sandbox#158, reproduced here as
+  #1489). Always go through the gateway for a gVisor box.
 
 ## Security notes
 

--- a/docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md
+++ b/docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md
@@ -43,8 +43,11 @@ its known_hosts pin, and its scoped key are identical to the LXC path.
 | SSH ingress | **In-cluster `sshpiper` Deployment** | Reuse the sentinel reverse-proxy pattern; per-user fan-out behind one IP. |
 | Isolation | **Namespace-per-tenant + default-deny NetworkPolicy** | Soft multi-tenancy; the K8s expression of eBPF deny-by-default + egress allowlist. |
 
-Hard isolation (gVisor/Kata `RuntimeClass`) and ephemeral/pooled lifecycles
-are explicitly **out of scope for v1** — see "Deferred".
+Ephemeral/pooled lifecycles are explicitly **out of scope for v1** — see
+"Deferred". Hard isolation via `RuntimeClass` shipped after v1 (#1122, see
+"Shipped features" below) — gVisor (`runsc`) works for a box's real,
+designed traffic (SSH/MCP over pod networking), with one known upstream
+gap on local debugging access; Kata remains unevaluated.
 
 ## Topology
 
@@ -741,6 +744,40 @@ The GPU *type* (L4, A100, etc.) is expressed via node affinity, driven by a
 node. This is deliberately different from the LXC/GCE path, where the daemon
 selects the exact machine type; on K8s, the scheduler owns that decision.
 
+### Hard isolation via RuntimeClass (#1122)
+
+`Config.RuntimeClass` (`CONTAINARIUM_K8S_RUNTIME_CLASS` / chart
+`runtimeClass`) sets `RuntimeClassName` on every box pod. Empty (default)
+leaves it unset — pods run on `runc`, sharing the host kernel, byte-identical
+to pre-#1122 behavior. Set to `runsc` to schedule boxes behind a gVisor
+sandbox instead, on a node pool where gVisor is installed and a `RuntimeClass`
+named `runsc` exists. Daemon-wide, not per-box: the runtime is a property of
+the node pool the daemon schedules onto.
+
+**Verified working** (live kind cluster with `runsc` installed as a
+containerd runtime handler, manual QA 2026-08-22, following up on this PR):
+pod genuinely runs on the gVisor kernel; SSH/dropbear handshake and the
+`ForceCommand` pin; a full MCP `initialize` round-trip; `shell_exec`
+(fork/pipe/exec); `write_file`; PVC-backed storage permissions (identical to
+`runc`); and default-deny `NetworkPolicy` enforcement (both directions) —
+all pass over the box's real, designed traffic path (SSH/MCP over pod
+networking, the same path the sshpiper gateway uses in production).
+
+**Known gap:** `kubectl port-forward` / `kubectl exec` dialed directly
+against a `runsc`-scheduled box pod does not work — `connection refused`,
+even though the same port is fully reachable over real pod-to-pod
+networking. This is an upstream gVisor/kubelet characteristic, not a
+Containarium defect: the exact same failure is documented independently at
+[kubernetes-sigs/agent-sandbox#158](https://github.com/kubernetes-sigs/agent-sandbox/issues/158)
+("planned to be supported later" — no committed timeline as of this
+writing). Tracked here as #1489. **Practical consequence:** never reach a
+gVisor box by port-forwarding straight to its pod — go through the sshpiper
+gateway (a NodePort/LoadBalancer, or a port-forward to `svc/sshpiper`
+itself, which is not gVisor-scheduled) the same way production traffic
+does. See [`KIND-QUICKSTART.md`](KIND-QUICKSTART.md) and
+[`deploy/k8s/sshpiper/README.md`](../deploy/k8s/sshpiper/README.md) for the
+gateway-based access path.
+
 ### Tenant secret delivery (#1190)
 
 A tenant's secrets are materialized into a per-tenant Secret and mounted into
@@ -871,8 +908,9 @@ release so the post-upgrade cleanup in step 1 works, then it gets dropped.
 
 ## Deferred (not in v1)
 
-- **Hard isolation** (gVisor/Kata `RuntimeClass`) — for tenants needing a
-  VM/syscall boundary closer to the LXC trust boundary.
+- **Kata `RuntimeClass`** — gVisor shipped instead (#1122, see "Shipped
+  features"); Kata (a VM-per-pod boundary rather than gVisor's userspace
+  kernel) remains unevaluated.
 - **Ephemeral / pooled lifecycles** — spin-up-on-connect or warm-pool leasing.
   agent-sandbox ships SandboxTemplate/SandboxWarmPool/SandboxClaim for this,
   but claim adoption is same-namespace-only (`ErrCrossNamespaceAdoption`), so

--- a/docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md
+++ b/docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md
@@ -496,6 +496,17 @@ handing it `kubectl` or a kube-apiserver token.*
   same scoped-JWT model, the same CLI (`containarium box create`) whether the
   box lands on LXC or K8s. Teams standardize the agent interface once and pick
   the substrate per environment.
+- **The access path survives hard isolation.** The standard way most
+  agent-sandbox tooling reaches a pod — `kubectl exec` / `kubectl
+  port-forward` — does not work against a gVisor (`runsc`)-scheduled pod
+  ([kubernetes-sigs/agent-sandbox#158](https://github.com/kubernetes-sigs/agent-sandbox/issues/158),
+  "planned to be supported later," no committed timeline). An operator who
+  wants gVisor's kernel boundary *and* a working access path is stuck
+  choosing one. Containarium's box access was never built on that
+  mechanism — it's SSH through the sshpiper gateway over real pod
+  networking (see "Hard isolation via RuntimeClass" below) — so turning on
+  `runsc` costs nothing on the access side; #1489 tracks the one gap
+  (direct port-forward to the box pod, which nothing here depends on).
 
 In one line: **the safest blast-radius for an autonomous agent in your cluster —
 SSH-native, RBAC-minimal, default-deny — with zero new control plane.**

--- a/docs/KIND-QUICKSTART.md
+++ b/docs/KIND-QUICKSTART.md
@@ -65,8 +65,14 @@ kubectl exec -n tenant-mybox box -- \
 ```
 
 > **SSH access** requires the full agent-box image and sshpiper (installed by
-> the chart). Forward port 32022 from the kind node to reach the SSH gateway:
-> `ssh -p 32022 mybox@localhost`
+> the chart). The chart exposes the gateway as a real `NodePort` (32022 by
+> default) — kind maps that straight through to the host, so
+> `ssh -p 32022 mybox@localhost` reaches sshpiper directly, no
+> `kubectl port-forward` involved. Keep it that way if you set
+> `runtimeClass: runsc` (below): `kubectl port-forward`/`kubectl exec`
+> straight to a gVisor-scheduled box pod does not work (a gVisor
+> characteristic, not a Containarium bug — see #1489), but the NodePort →
+> sshpiper → box path is real pod networking the whole way and is unaffected.
 
 ---
 
@@ -145,7 +151,12 @@ turn this into an actual SSH-reachable gateway.
 > Alternative: if you don't need gateway routing for this quickstart at all,
 > set `CONTAINARIUM_K8S_GATEWAY_NAMESPACE=""` on the daemon (step 5) instead
 > of creating the namespace/CRD — `create` then skips the Pipe step
-> entirely.
+> entirely. **Don't do this if boxes run under a gVisor `RuntimeClass`**
+> (`CONTAINARIUM_K8S_RUNTIME_CLASS=runsc` / chart `runtimeClass: runsc`):
+> without the gateway, the only way left to reach the box is
+> `kubectl port-forward`/`kubectl exec` straight to its pod, and that
+> doesn't work under gVisor (#1489) — the gateway is then your only working
+> access path.
 
 ## 5. Start the daemon
 


### PR DESCRIPTION
## What

Following up on #1489: `kubectl port-forward`/`kubectl exec` straight to a `runsc`-scheduled box pod doesn't work, even though the box is fully reachable over real pod networking. This documents the correct access path instead — the sshpiper gateway (NodePort/LoadBalancer), which was already what the Helm quickstart's default `runtimeClass`-agnostic setup uses (chart exposes a real NodePort, not a port-forward).

Prompted by the [kubernetes-sigs/agent-sandbox `examples/containarium-ssh-sandbox`](https://github.com/kubernetes-sigs/agent-sandbox/tree/main/examples/containarium-ssh-sandbox) example, whose own README independently documents the same gVisor+port-forward limitation and points at [agent-sandbox#158](https://github.com/kubernetes-sigs/agent-sandbox/issues/158) — confirming #1489 is a known upstream characteristic, not something specific to this repo.

## Changes

- `charts/containarium-k8s/values.yaml`: caveat on the `runtimeClass` value.
- `deploy/k8s/sshpiper/README.md`: dev note — port-forward to `svc/sshpiper` (not gVisor-scheduled) is fine; port-forward straight to a box pod is not, under `runsc`.
- `docs/KIND-QUICKSTART.md`: caveat on the Helm quickstart's SSH callout, and on the "skip gateway routing" shortcut (which removes your only working access path once `runsc` is set).
- `docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md`: corrects a stale claim that hard isolation (`RuntimeClass`) is deferred — it shipped in #1122 — and adds a "Shipped features" entry recording what was verified working (SSH/MCP/shell_exec/file ops/PVC permissions/NetworkPolicy, all pass) and the one known gap (port-forward).

## Testing

Docs-only change. The underlying claims were verified live on a local kind test cluster with gVisor installed (see #1489 for the full test matrix and evidence); this PR does not change any code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)