### PR TITLE
perf(container): per-stage latency instrumentation on the create path

### DIFF
--- a/internal/metrics/create_stages.go
+++ b/internal/metrics/create_stages.go
@@ -1,0 +1,41 @@
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	otelmetric "go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+
+	"github.com/footprintai/containarium/pkg/core/container"
+)
+
+// NewCreateStageObserver builds the container.StageObserver that records
+// per-stage create latency into the histogram
+// containarium.container.create_stage_duration_seconds, labeled by stage.
+//
+// This is the Phase 0 instrument of
+// docs/architecture/two-digit-ms-sandbox-spawn.md: it replaces that note's
+// code-derived cost table with measured numbers, and any later create-path
+// regression names its stage instead of a total.
+func NewCreateStageObserver(provider *sdkmetric.MeterProvider) (container.StageObserver, error) {
+	meter := provider.Meter("containarium.container")
+
+	// Buckets span the path's real dynamic range: get_info at ~10ms up to an
+	// unbaked install_packages at minutes.
+	hist, err := meter.Float64Histogram("containarium.container.create_stage_duration_seconds",
+		otelmetric.WithDescription("Duration of each stage of container create"),
+		otelmetric.WithUnit("s"),
+		otelmetric.WithExplicitBucketBoundaries(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create create-stage histogram: %w", err)
+	}
+
+	return func(stage container.CreateStage, d time.Duration) {
+		hist.Record(context.Background(), d.Seconds(),
+			otelmetric.WithAttributes(attribute.String("stage", string(stage))))
+	}, nil
+}

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -1303,6 +1303,14 @@ skipAppHosting:
 			} else {
 				metricsCollector = mc
 				log.Printf("OTel metrics collector configured (target: %s)", config.VictoriaMetricsURL)
+
+				// Per-stage create latency (Phase 0 of
+				// docs/architecture/two-digit-ms-sandbox-spawn.md).
+				if obs, err := metrics.NewCreateStageObserver(mc.MeterProvider()); err != nil {
+					log.Printf("Warning: create-stage latency instrumentation disabled: %v", err)
+				} else {
+					containerServer.GetManager().SetStageObserver(obs)
+				}
 			}
 		}
 	}

--- a/pkg/core/container/create_stages.go
+++ b/pkg/core/container/create_stages.go
@@ -1,0 +1,72 @@
+package container
+
+import "time"
+
+// CreateStage identifies one stage of Manager.Create for latency
+// instrumentation. The values are the `stage` label on the
+// containarium.container.create_stage_duration_seconds histogram, so
+// renaming one is a dashboard-visible change.
+//
+// These stages exist because the create path had no per-stage measurement at
+// all — the cost table in docs/architecture/two-digit-ms-sandbox-spawn.md was
+// derived by reading the code, and Phase 0 of that note is replacing it with
+// numbers from here.
+type CreateStage string
+
+const (
+	// StageCreateInstance is incus.CreateContainer — image/ZFS clone plus the
+	// instance record.
+	StageCreateInstance CreateStage = "create_instance"
+	// StageStartInstance is incus.StartContainer — the full guest boot.
+	StageStartInstance CreateStage = "start_instance"
+	// StageSetLabels is the SetLabels API round-trip.
+	StageSetLabels CreateStage = "set_labels"
+	// StageJumpAccount is the host-side jump-server account creation,
+	// including authorizing any additional keys. Skipped when the create has
+	// no SSH keys.
+	StageJumpAccount CreateStage = "jump_account"
+	// StageWaitNetwork is the DHCP/lease wait.
+	StageWaitNetwork CreateStage = "wait_network"
+	// StageInstallPackages is the in-guest package install. Skipped on the
+	// baked-image fast path, so its histogram count also says how often
+	// creates miss the bake.
+	StageInstallPackages CreateStage = "install_packages"
+	// StageCreateUser is the in-guest tenant user creation.
+	StageCreateUser CreateStage = "create_user"
+	// StageAddSSHKeys is the in-guest authorized_keys seeding. Skipped when
+	// there are no keys to add.
+	StageAddSSHKeys CreateStage = "add_ssh_keys"
+	// StageGitSource is the optional git workspace provisioning.
+	StageGitSource CreateStage = "git_source"
+	// StageGetInfo is the final GetContainer lookup.
+	StageGetInfo CreateStage = "get_info"
+	// StageTotal is the whole Create call, recorded only on success so the
+	// histogram reads as "latency of a successful create" rather than being
+	// dragged down by fast failures. Per-stage observations, by contrast,
+	// are recorded even when the stage errors — a WaitForNetwork that spends
+	// its full timeout before failing is exactly the sample worth keeping.
+	StageTotal CreateStage = "total"
+)
+
+// StageObserver receives the duration of each create stage. Implementations
+// must be safe for concurrent use (creates can run in parallel) and cheap —
+// it is called on the create path.
+type StageObserver func(stage CreateStage, d time.Duration)
+
+// SetStageObserver installs the per-stage latency observer. nil (the
+// default) disables observation. Call before the Manager serves requests;
+// the field is not synchronized against in-flight creates.
+func (m *Manager) SetStageObserver(obs StageObserver) {
+	m.observeStage = obs
+}
+
+// timed runs f and reports its duration to the stage observer, error or not.
+func (m *Manager) timed(stage CreateStage, f func() error) error {
+	if m.observeStage == nil {
+		return f()
+	}
+	start := time.Now()
+	err := f()
+	m.observeStage(stage, time.Since(start))
+	return err
+}

--- a/pkg/core/container/create_stages_test.go
+++ b/pkg/core/container/create_stages_test.go
@@ -1,0 +1,171 @@
+package container
+
+import (
+	"errors"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/footprintai/containarium/pkg/core/incus"
+)
+
+// stagesBackend fakes exactly what Create touches on the baked-image path.
+// It embeds incus.Backend (nil) for the rest of the interface, so a call to
+// anything unimplemented panics and names the gap.
+type stagesBackend struct {
+	incus.Backend
+	waitNetworkErr error
+}
+
+func (b *stagesBackend) GetImageAliasProperties(string) (map[string]string, bool, error) {
+	// A baked image matching Create's default image + podman=false, so the
+	// test skips installPackages (which sleeps 5s waiting for cloud-init).
+	return map[string]string{
+		bakedPropBaked:  "true",
+		bakedPropSource: "images:ubuntu/24.04",
+		bakedPropPodman: strconv.FormatBool(false),
+	}, true, nil
+}
+
+func (b *stagesBackend) CreateContainer(incus.ContainerConfig) error { return nil }
+func (b *stagesBackend) StartContainer(string) error                 { return nil }
+func (b *stagesBackend) StopContainer(string, bool) error            { return nil }
+func (b *stagesBackend) DeleteContainer(string) error                { return nil }
+func (b *stagesBackend) SetLabels(string, map[string]string) error   { return nil }
+func (b *stagesBackend) Exec(string, []string) error                 { return nil }
+func (b *stagesBackend) WriteFile(string, string, []byte, string) error {
+	return nil
+}
+
+func (b *stagesBackend) WaitForNetwork(string, time.Duration) (string, error) {
+	if b.waitNetworkErr != nil {
+		return "", b.waitNetworkErr
+	}
+	return "203.0.113.7", nil
+}
+
+func (b *stagesBackend) GetContainer(name string) (*incus.ContainerInfo, error) {
+	return &incus.ContainerInfo{Name: name}, nil
+}
+
+// stageLog records every observation in order.
+type stageLog struct {
+	stages    []CreateStage
+	durations map[CreateStage]time.Duration
+}
+
+func newStageLog() *stageLog {
+	return &stageLog{durations: make(map[CreateStage]time.Duration)}
+}
+
+func (l *stageLog) observer() StageObserver {
+	return func(s CreateStage, d time.Duration) {
+		l.stages = append(l.stages, s)
+		l.durations[s] = d
+	}
+}
+
+func stagesOpts() CreateOptions {
+	return CreateOptions{
+		Username: "alice",
+		Image:    "images:ubuntu/24.04",
+		// No SSHKeys: the jump-account stage runs host useradd, which a unit
+		// test must not touch. Its absence is asserted below.
+	}
+}
+
+// TestCreate_ObservesStagesInOrder pins the Phase 0 instrumentation contract
+// (docs/architecture/two-digit-ms-sandbox-spawn.md): every stage that runs is
+// observed, in execution order, and stages that are skipped — baked image,
+// no SSH keys, no git source — produce no observation at all.
+func TestCreate_ObservesStagesInOrder(t *testing.T) {
+	// Keep getJumpServerSSHKey from finding a real key in $HOME, which would
+	// nondeterministically add an add_ssh_keys stage on developer machines.
+	t.Setenv("HOME", t.TempDir())
+
+	log := newStageLog()
+	m := NewWithBackend(&stagesBackend{})
+	m.SetStageObserver(log.observer())
+
+	if _, err := m.Create(stagesOpts()); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Every stage this create actually runs, in path order. add_ssh_keys is
+	// excluded: it depends on whether the host has a jump-server key, which
+	// the HOME override above pins to "no".
+	want := []CreateStage{
+		StageCreateInstance,
+		StageStartInstance,
+		StageSetLabels,
+		StageWaitNetwork,
+		StageCreateUser,
+		StageGetInfo,
+		StageTotal,
+	}
+	assertSubsequence(t, log.stages, want)
+
+	for _, absent := range []CreateStage{StageJumpAccount, StageInstallPackages, StageGitSource, StageAddSSHKeys} {
+		if _, ok := log.durations[absent]; ok {
+			t.Errorf("stage %q was observed but should have been skipped (observed: %v)", absent, log.stages)
+		}
+	}
+
+	for stage, d := range log.durations {
+		if d < 0 {
+			t.Errorf("stage %q recorded negative duration %v", stage, d)
+		}
+	}
+	if log.durations[StageTotal] < log.durations[StageStartInstance] {
+		t.Errorf("total (%v) must cover start_instance (%v)", log.durations[StageTotal], log.durations[StageStartInstance])
+	}
+}
+
+// TestCreate_NilObserverIsNoop — the default: no observer, no panic, same
+// create.
+func TestCreate_NilObserverIsNoop(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	m := NewWithBackend(&stagesBackend{})
+	if _, err := m.Create(stagesOpts()); err != nil {
+		t.Fatalf("Create without observer: %v", err)
+	}
+}
+
+// TestCreate_FailedStageIsStillObserved pins the documented semantics: a
+// stage that errors is still recorded (its duration is real — a network wait
+// that burns its timeout is exactly the sample worth keeping), while total is
+// recorded only on success.
+func TestCreate_FailedStageIsStillObserved(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	log := newStageLog()
+	m := NewWithBackend(&stagesBackend{waitNetworkErr: errors.New("no lease")})
+	m.SetStageObserver(log.observer())
+
+	if _, err := m.Create(stagesOpts()); err == nil {
+		t.Fatal("Create should fail when WaitForNetwork fails")
+	}
+
+	if _, ok := log.durations[StageWaitNetwork]; !ok {
+		t.Errorf("failed wait_network stage was not observed (observed: %v)", log.stages)
+	}
+	if _, ok := log.durations[StageTotal]; ok {
+		t.Errorf("total must not be observed on a failed create (observed: %v)", log.stages)
+	}
+}
+
+// assertSubsequence fails unless want appears in got in order (other
+// elements may be interleaved).
+func assertSubsequence(t *testing.T, got, want []CreateStage) {
+	t.Helper()
+	i := 0
+	for _, s := range got {
+		if i < len(want) && s == want[i] {
+			i++
+		}
+	}
+	if i != len(want) {
+		t.Errorf("stage order mismatch: missing %q\n  got:  %v\n  want subsequence: %v", want[i], got, want)
+	}
+}

--- a/pkg/core/container/manager.go
+++ b/pkg/core/container/manager.go
@@ -24,6 +24,9 @@ type Manager struct {
 	// injected into each podman-enabled box's registries.conf.d. Empty = boxes
 	// pull from upstream registries as before. See registry_mirror.go.
 	mirrors []RegistryMirror
+	// observeStage, when non-nil, receives per-stage create latency.
+	// See create_stages.go.
+	observeStage StageObserver
 }
 
 // CreateOptions holds options for creating a container
@@ -132,6 +135,7 @@ func resolveGPUDevices(b incus.Backend, inputs []string) ([]incus.GPUDevice, err
 
 // Create creates a new container with full setup
 func (m *Manager) Create(opts CreateOptions) (*incus.ContainerInfo, error) {
+	createStart := time.Now()
 	containerName := opts.Username + "-container"
 
 	if opts.Verbose {
@@ -252,7 +256,9 @@ func (m *Manager) Create(opts CreateOptions) (*incus.ContainerInfo, error) {
 		config.GPUs = gpus
 	}
 
-	if err := m.incus.CreateContainer(config); err != nil {
+	if err := m.timed(StageCreateInstance, func() error {
+		return m.incus.CreateContainer(config)
+	}); err != nil {
 		return nil, fmt.Errorf("failed to create container: %w", err)
 	}
 
@@ -261,7 +267,9 @@ func (m *Manager) Create(opts CreateOptions) (*incus.ContainerInfo, error) {
 		fmt.Println("  [2/6] Starting container...")
 	}
 
-	if err := m.incus.StartContainer(containerName); err != nil {
+	if err := m.timed(StageStartInstance, func() error {
+		return m.incus.StartContainer(containerName)
+	}); err != nil {
 		// Clean up on failure
 		_ = m.incus.DeleteContainer(containerName)
 		return nil, fmt.Errorf("failed to start container: %w", err)
@@ -275,7 +283,9 @@ func (m *Manager) Create(opts CreateOptions) (*incus.ContainerInfo, error) {
 	if opts.Verbose {
 		fmt.Printf("  Setting %d label(s)...\n", len(opts.Labels))
 	}
-	if err := m.incus.SetLabels(containerName, opts.Labels); err != nil {
+	if err := m.timed(StageSetLabels, func() error {
+		return m.incus.SetLabels(containerName, opts.Labels)
+	}); err != nil {
 		_ = m.cleanup(containerName)
 		return nil, fmt.Errorf("failed to set labels: %w", err)
 	}
@@ -293,25 +303,29 @@ func (m *Manager) Create(opts CreateOptions) (*incus.ContainerInfo, error) {
 	}
 
 	if len(opts.SSHKeys) > 0 {
-		// Seed the jump-server account with the first key.
-		if err := CreateJumpServerAccount(opts.Username, opts.SSHKeys[0], opts.Verbose); err != nil {
-			_ = m.cleanup(containerName)
-			return nil, fmt.Errorf("failed to create jump server account: %w", err)
-		}
-		// Then authorize the REST of the keys host-side. CreateJumpServerAccount
-		// only seeds the host /home/<user>/.ssh/authorized_keys with SSHKeys[0];
-		// without this loop the remaining keys land in the CONTAINER's
-		// authorized_keys (addSSHKeys, step 7) but NOT in the host jump-user
-		// file that ServeAuthorizedKeys exposes and the sentinel syncs into
-		// sshpiper. A client using any key other than SSHKeys[0] is then
-		// rejected at the sentinel (publickey) even though the box would accept
-		// it — e.g. an automation/runner key that sorts after a registered key.
-		// Mirrors the seed-then-authorize-the-rest pattern in collaborator.go.
-		for _, key := range opts.SSHKeys[1:] {
-			if err := AddAuthorizedKey(opts.Username, key); err != nil {
-				_ = m.cleanup(containerName)
-				return nil, fmt.Errorf("failed to authorize additional jump-server ssh key: %w", err)
+		if err := m.timed(StageJumpAccount, func() error {
+			// Seed the jump-server account with the first key.
+			if err := CreateJumpServerAccount(opts.Username, opts.SSHKeys[0], opts.Verbose); err != nil {
+				return fmt.Errorf("failed to create jump server account: %w", err)
 			}
+			// Then authorize the REST of the keys host-side. CreateJumpServerAccount
+			// only seeds the host /home/<user>/.ssh/authorized_keys with SSHKeys[0];
+			// without this loop the remaining keys land in the CONTAINER's
+			// authorized_keys (addSSHKeys, step 7) but NOT in the host jump-user
+			// file that ServeAuthorizedKeys exposes and the sentinel syncs into
+			// sshpiper. A client using any key other than SSHKeys[0] is then
+			// rejected at the sentinel (publickey) even though the box would accept
+			// it — e.g. an automation/runner key that sorts after a registered key.
+			// Mirrors the seed-then-authorize-the-rest pattern in collaborator.go.
+			for _, key := range opts.SSHKeys[1:] {
+				if err := AddAuthorizedKey(opts.Username, key); err != nil {
+					return fmt.Errorf("failed to authorize additional jump-server ssh key: %w", err)
+				}
+			}
+			return nil
+		}); err != nil {
+			_ = m.cleanup(containerName)
+			return nil, err
 		}
 	} else {
 		if opts.Verbose {
@@ -324,8 +338,12 @@ func (m *Manager) Create(opts CreateOptions) (*incus.ContainerInfo, error) {
 		fmt.Println("  [4/7] Waiting for network...")
 	}
 
-	ipAddr, err := m.incus.WaitForNetwork(containerName, 30*time.Second)
-	if err != nil {
+	var ipAddr string
+	if err := m.timed(StageWaitNetwork, func() error {
+		var err error
+		ipAddr, err = m.incus.WaitForNetwork(containerName, 30*time.Second)
+		return err
+	}); err != nil {
 		_ = m.cleanup(containerName)
 		return nil, fmt.Errorf("failed to get container IP: %w", err)
 	}
@@ -368,7 +386,9 @@ func (m *Manager) Create(opts CreateOptions) (*incus.ContainerInfo, error) {
 		if opts.Verbose {
 			fmt.Println("  [5/7] Package install pre-baked into the base image — skipping")
 		}
-	} else if err := m.installPackages(containerName, opts.EnablePodman, opts.Stack, opts.StackParameters, opts.Username, family); err != nil {
+	} else if err := m.timed(StageInstallPackages, func() error {
+		return m.installPackages(containerName, opts.EnablePodman, opts.Stack, opts.StackParameters, opts.Username, family)
+	}); err != nil {
 		_ = m.cleanup(containerName)
 		return nil, fmt.Errorf("failed to install packages: %w", err)
 	}
@@ -386,7 +406,9 @@ func (m *Manager) Create(opts CreateOptions) (*incus.ContainerInfo, error) {
 		fmt.Printf("  [6/7] Creating user: %s...\n", opts.Username)
 	}
 
-	if err := m.createUser(containerName, opts.Username, family); err != nil {
+	if err := m.timed(StageCreateUser, func() error {
+		return m.createUser(containerName, opts.Username, family)
+	}); err != nil {
 		_ = m.cleanup(containerName)
 		return nil, fmt.Errorf("failed to create user: %w", err)
 	}
@@ -415,7 +437,9 @@ func (m *Manager) Create(opts CreateOptions) (*incus.ContainerInfo, error) {
 			fmt.Printf("       Adding %d SSH key(s)...\n", len(allKeys))
 		}
 
-		if err := m.addSSHKeys(containerName, opts.Username, allKeys); err != nil {
+		if err := m.timed(StageAddSSHKeys, func() error {
+			return m.addSSHKeys(containerName, opts.Username, allKeys)
+		}); err != nil {
 			_ = m.cleanup(containerName)
 			return nil, fmt.Errorf("failed to add SSH keys: %w", err)
 		}
@@ -433,18 +457,27 @@ func (m *Manager) Create(opts CreateOptions) (*incus.ContainerInfo, error) {
 		if opts.Verbose {
 			fmt.Printf("  [8/8] Fetching git source %s into %s...\n", opts.GitSource, gitWorkspacePath(opts.WorkspacePath))
 		}
-		if err := m.provisionGitSource(containerName, opts); err != nil {
+		if err := m.timed(StageGitSource, func() error {
+			return m.provisionGitSource(containerName, opts)
+		}); err != nil {
 			_ = m.cleanup(containerName)
 			return nil, fmt.Errorf("failed to provision git source: %w", err)
 		}
 	}
 
 	// Get container info
-	info, err := m.incus.GetContainer(containerName)
-	if err != nil {
+	var info *incus.ContainerInfo
+	if err := m.timed(StageGetInfo, func() error {
+		var err error
+		info, err = m.incus.GetContainer(containerName)
+		return err
+	}); err != nil {
 		return nil, fmt.Errorf("failed to get container info: %w", err)
 	}
 
+	if m.observeStage != nil {
+		m.observeStage(StageTotal, time.Since(createStart))
+	}
 	return info, nil
 }
 


### PR DESCRIPTION
## What

Phase 0 of the two-digit-ms sandbox spawn design note (#1488): per-stage latency instrumentation on the container create path. The note's cost table is code-derived guesswork — this PR is what replaces it with measured numbers, and it makes any future create-path regression name its stage instead of a total.

## How

- **`pkg/core/container/create_stages.go`** — typed `CreateStage` constants (one per stage of `Manager.Create`), an optional `StageObserver` on `Manager` (nil = today's behavior, zero overhead), and a `timed()` wrapper around each stage call site.
- **Semantics**: a stage that errors is still recorded — a `WaitForNetwork` that burns its full timeout is exactly the sample worth keeping. `total` is recorded only on success, so its histogram reads "latency of a successful create" rather than being dragged down by fast failures. Skipped stages (baked image, no SSH keys, no git source) record nothing, so the `install_packages` sample count doubles as a bake-hit-rate signal.
- **`internal/metrics/create_stages.go`** — the OTel observer: histogram `containarium.container.create_stage_duration_seconds` labeled by `stage`, buckets spanning ~5ms (`get_info`) to minutes (unbaked package install).
- **`internal/server/dual_server.go`** — wired where the metrics collector is configured (same pattern as the pentest recorder). Daemons without VictoriaMetrics are byte-identical to today.

## Tests

`pkg/core/container/create_stages_test.go`, against a fake `incus.Backend` on the baked-image path (no host side effects, no 5s cloud-init sleep):

- stage observations arrive in execution order;
- skipped stages produce no observation;
- nil observer (the default) is a no-op;
- a failed stage is still observed while `total` is not.

Each test was verified to fail when the corresponding observation is removed.

## Scope

No behavior change on the create path itself — every stage runs exactly as before; the jump-account block was refactored into a closure for timing but keeps identical error wrapping and cleanup. Windows creates record the shared prefix (create/start/labels) and nothing after the VM-provisioning branch.

Refs #1488 (Phase 0). The remaining Phase 0 exit criterion — replacing the design note's table with measured numbers — needs this deployed and a day of real creates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
