### PR TITLE
fix(cluster): decide a container node's reservation from what the node observes (#1466)

### DIFF
--- a/docs/architecture/cluster-container-node-pools.md
+++ b/docs/architecture/cluster-container-node-pools.md
@@ -285,18 +285,33 @@ plain host the two differ by enough to make kubelet reject the config.
 What survives is the shape of the answer, not its trigger. A
 reservation is correct **only when the node actually misreports**, and
 that can only be established from the node itself after boot — never
-inferred from the daemon host. `ReservedResources`,
-`KubeletReservedArgs` and `HostCapacity` remain in
-`pkg/core/cluster/capacity.go` and remain correct as functions; nothing
-currently calls them, by design, until the *when* is settled.
+inferred from the daemon host.
 
-**Still true, and still unsolved:** on a nested host a node claiming
-four times its real CPU and twenty times its real memory means pods are
-scheduled where they cannot run and **scale-up is never triggered** —
-the autoscaling story this feature exists for, silently disabled.
-Deferred, tracked in #1466. The consequence of the deferral is that
-container node pools on a nested Incus host are usable but must not be
-trusted to autoscale.
+> **Settled 2026-08-22 (#1466).** The *when* now has an answer, and it
+> is the only one that distinguishes the two environments: after
+> `WaitReady` and before the bootstrap script is pushed, the daemon
+> reads `/proc/cpuinfo` and `/proc/meminfo` **inside the node** and
+> compares them with the size that node was asked for. Excess is
+> reserved; no excess reserves nothing. A node whose `/proc` cannot be
+> read fails the provision rather than proceeding uncorrected — an
+> unmeasurable node is not a node known to be honest, and proceeding
+> silently is the failure this whole section is about.
+>
+> One thing the implementation had to get right that the reasoning
+> above misses: an honest node reports **slightly less** than its
+> configured size, because the kernel's `MemTotal` excludes
+> firmware-reserved and unavailable memory (a 4GB node reports about
+> 3,999,993,856 bytes). `ReservedResources` treats observed-below-
+> requested as an error, which is correct for the create-time sizing
+> question it serves and wrong here — it would refuse every honest
+> container node, i.e. #1456 with the sign flipped. The post-boot
+> trigger is therefore a separate function, `NodeReservation`, with a
+> one-way comparison: reserve the excess a node claims over its own
+> size, per dimension, and nothing when it claims none.
+>
+> `ReservedResources` and `HostCapacity` keep their create-time role
+> (`CheckNodeCapacity` — can this host fit a node of this size); they
+> are no longer uncalled.
 
 ### Consequences for the stories as merged
 

--- a/internal/server/cluster_reconciler_test.go
+++ b/internal/server/cluster_reconciler_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -38,6 +39,12 @@ type stateHost struct {
 type stateVM struct {
 	labels  map[string]string
 	running bool
+	// cpu/mem are the size the node was created with. The fake serves
+	// them back through /proc so a container-class provision can read
+	// its own capacity the way the real probe does (#1466) — an
+	// HONEST node, seeing exactly its own limits.
+	cpu string
+	mem string
 }
 
 func newStateHost() *stateHost {
@@ -55,12 +62,19 @@ func (h *stateHost) CreateNode(spec clustercore.NodeSpec, isolation clustercore.
 	if _, ok := h.vms[spec.Name]; ok {
 		return fmt.Errorf("vm %s already exists", spec.Name)
 	}
-	h.vms[spec.Name] = &stateVM{labels: spec.Labels, running: true}
+	h.vms[spec.Name] = &stateVM{labels: spec.Labels, running: true, cpu: spec.CPU, mem: spec.Memory}
 	h.isolations[spec.Name] = isolation
 	// A booted CP "writes" its own kubeconfig and join token.
 	if spec.Labels[clustercore.LabelClusterRole] == clustercore.RoleControlPlane {
 		h.files[spec.Name+":"+clustercore.KubeconfigPath] = []byte("clusters:\n- cluster:\n    server: https://127.0.0.1:6443\n")
 		h.files[spec.Name+":"+clustercore.NodeTokenPath] = []byte("K10::join-token")
+		// k3s writes its generated containerd config on start, and a
+		// container-class worker derives its template from the CP's
+		// copy (#1448) — without it no container worker can be
+		// provisioned here at all.
+		h.files[spec.Name+":"+clustercore.ContainerdGeneratedConfigPath] = []byte(
+			"version = 3\n[plugins.'io.containerd.cri.v1.runtime']\n" +
+				"  enable_unprivileged_ports = true\n  enable_unprivileged_icmp = true\n")
 	}
 	return nil
 }
@@ -128,6 +142,36 @@ func (h *stateHost) Read(name, path string) ([]byte, error) {
 func (h *stateHost) Exec(name string, cmd []string) (string, error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	// The container-class capacity probe reads the node's own /proc
+	// (#1466). Without this the probe fails, the provision aborts, and
+	// a test that only checks "the instance exists" still passes —
+	// because CreateNode ran before the abort.
+	if len(cmd) == 2 && cmd[0] == "cat" {
+		vm, ok := h.vms[name]
+		if !ok {
+			return "", fmt.Errorf("no vm %s", name)
+		}
+		switch cmd[1] {
+		case clustercore.ProcCPUInfoPath:
+			n, err := strconv.Atoi(vm.cpu)
+			if err != nil {
+				return "", err
+			}
+			var b strings.Builder
+			for i := 0; i < n; i++ {
+				fmt.Fprintf(&b, "processor\t: %d\n", i)
+			}
+			return b.String(), nil
+		case clustercore.ProcMemInfoPath:
+			bytes, err := clustercore.ParseSizeBytes(vm.mem)
+			if err != nil {
+				return "", err
+			}
+			// Report just under the configured size, as a real kernel
+			// does — MemTotal excludes firmware-reserved memory.
+			return fmt.Sprintf("MemTotal:%15d kB\n", (bytes-6_144)/1024), nil
+		}
+	}
 	if len(cmd) >= 2 && cmd[1] == "kubectl" {
 		var b strings.Builder
 		for vm := range h.vms {
@@ -392,6 +436,15 @@ func TestReconciler_ProvisionIsolationMatchesCluster(t *testing.T) {
 			for name := range host.vms {
 				if got := host.isolations[name]; got != tc.want {
 					t.Fatalf("node %s created with isolation %q, want %q", name, got, tc.want)
+				}
+				// Existence is not provisioning. CreateNode runs before
+				// anything that can fail later in the sequence, so a
+				// provision that aborted after it still leaves an
+				// instance here — which is how a broken container path
+				// passed this test unnoticed (#1466 review). Assert the
+				// node was actually bootstrapped.
+				if _, ok := host.files[name+":/root/containarium-bootstrap.sh"]; !ok {
+					t.Fatalf("node %s exists but was never bootstrapped; provisioning aborted after CreateNode", name)
 				}
 			}
 		})

--- a/pkg/core/cluster/capacity.go
+++ b/pkg/core/cluster/capacity.go
@@ -110,6 +110,43 @@ func ReservedResources(observedCPU int, observedMemBytes int64, spec NodeSpec) (
 	}, nil
 }
 
+// NodeReservation decides the reservation from what a BOOTED node
+// reports about itself (#1466). It is the post-boot counterpart of
+// ReservedResources, and it differs in exactly one way that matters.
+//
+// ReservedResources treats observed-smaller-than-requested as an
+// error, which is right for the create-time sizing question it serves
+// (CheckNodeCapacity): a host that cannot fit the node should refuse.
+// It is wrong here, because an honest node ALWAYS reports slightly
+// less than its configured size — the kernel's MemTotal excludes
+// firmware-reserved and unavailable memory, so a node limited to 4GB
+// (4_000_000_000) reports about 3_999_993_856. Treating that as a
+// failure would refuse every correctly-behaving container node, which
+// is the #1456 mistake with the sign flipped.
+//
+// So the rule is a one-way comparison: reserve only the excess a node
+// claims over its own size, per dimension, and nothing when it claims
+// no excess. A node under its size is a node telling the truth; a node
+// over it is the nested-host lie this exists to correct.
+func NodeReservation(observedCPU int, observedMemBytes int64, spec NodeSpec) (Reserved, error) {
+	wantCPU, err := strconv.Atoi(spec.CPU)
+	if err != nil {
+		return Reserved{}, fmt.Errorf("node cpu %q: %w", spec.CPU, err)
+	}
+	wantMem, err := ParseSizeBytes(spec.Memory)
+	if err != nil {
+		return Reserved{}, fmt.Errorf("node memory %q: %w", spec.Memory, err)
+	}
+	var r Reserved
+	if observedCPU > wantCPU {
+		r.CPU = observedCPU - wantCPU
+	}
+	if observedMemBytes > wantMem {
+		r.MemoryBytes = observedMemBytes - wantMem
+	}
+	return r, nil
+}
+
 // KubeletReservedArgs renders a reservation as k3s --kubelet-arg
 // flags. A zero reservation renders nothing: a node whose observed
 // capacity already equals its size needs no correction, and passing
@@ -154,33 +191,35 @@ func ParseSizeBytes(s string) (int64, error) {
 	}
 }
 
-// HostCapacity reads what a container node on this host will observe as
-// its own capacity: the host's /proc, because cadvisor inside the node
-// reads exactly these files and lxcfs masking does not reach a nested
-// Incus's own instances (design Amendment 1).
+// ProcCPUInfoPath and ProcMemInfoPath are the two files cadvisor
+// derives node capacity from. Named constants because they are read
+// from two vantage points — the daemon host's filesystem (create-time
+// sizing) and a booted node's own /proc over Exec (#1466) — and the
+// second is the only one that can tell a misreporting node from an
+// honest one.
+const (
+	ProcCPUInfoPath = "/proc/cpuinfo"
+	ProcMemInfoPath = "/proc/meminfo"
+)
+
+// ParseProcCapacity reconstructs the capacity cadvisor would report
+// from the contents of /proc/cpuinfo and /proc/meminfo.
 //
-// sysRoot is the filesystem root ("/" in production, a fixture in
-// tests). A /proc it cannot read is an error, never a zero capacity —
+// Pure, so it can be applied to whichever /proc is relevant: the
+// daemon host's (HostCapacity) or a booted node's own, read back over
+// Exec. A shape it cannot read is an error, never a zero capacity —
 // zero would compute a reservation that silently starves the node.
-func HostCapacity(sysRoot string) (cpu int, memBytes int64, err error) {
-	cpuinfo, err := os.ReadFile(filepath.Join(sysRoot, "proc/cpuinfo"))
-	if err != nil {
-		return 0, 0, fmt.Errorf("read cpuinfo: %w", err)
-	}
-	for _, line := range strings.Split(string(cpuinfo), "\n") {
+func ParseProcCapacity(cpuinfo, meminfo string) (cpu int, memBytes int64, err error) {
+	for _, line := range strings.Split(cpuinfo, "\n") {
 		if strings.HasPrefix(line, "processor") {
 			cpu++
 		}
 	}
 	if cpu == 0 {
-		return 0, 0, fmt.Errorf("no processor lines in %s/proc/cpuinfo", sysRoot)
+		return 0, 0, fmt.Errorf("no processor lines in %s", ProcCPUInfoPath)
 	}
 
-	meminfo, err := os.ReadFile(filepath.Join(sysRoot, "proc/meminfo"))
-	if err != nil {
-		return 0, 0, fmt.Errorf("read meminfo: %w", err)
-	}
-	for _, line := range strings.Split(string(meminfo), "\n") {
+	for _, line := range strings.Split(meminfo, "\n") {
 		if !strings.HasPrefix(line, "MemTotal:") {
 			continue
 		}
@@ -194,7 +233,29 @@ func HostCapacity(sysRoot string) (cpu int, memBytes int64, err error) {
 		}
 		return cpu, kb * 1024, nil
 	}
-	return 0, 0, fmt.Errorf("no MemTotal in %s/proc/meminfo", sysRoot)
+	return 0, 0, fmt.Errorf("no MemTotal in %s", ProcMemInfoPath)
+}
+
+// HostCapacity reads the DAEMON HOST's /proc.
+//
+// This is the create-time sizing question — "can this host host a node
+// of the size asked for" — and nothing else. It is deliberately NOT
+// the reservation trigger: the daemon host's capacity is not the
+// node's, and inferring one from the other is what #1456 removed. What
+// a node observes is established from the node itself (#1466).
+//
+// sysRoot is the filesystem root ("/" in production, a fixture in
+// tests). A /proc it cannot read is an error, never a zero capacity.
+func HostCapacity(sysRoot string) (cpu int, memBytes int64, err error) {
+	cpuinfo, err := os.ReadFile(filepath.Join(sysRoot, "proc/cpuinfo"))
+	if err != nil {
+		return 0, 0, fmt.Errorf("read cpuinfo: %w", err)
+	}
+	meminfo, err := os.ReadFile(filepath.Join(sysRoot, "proc/meminfo"))
+	if err != nil {
+		return 0, 0, fmt.Errorf("read meminfo: %w", err)
+	}
+	return ParseProcCapacity(string(cpuinfo), string(meminfo))
 }
 
 // CheckNodeCapacity is the create-time half of the capability probe:

--- a/pkg/core/cluster/capacity_test.go
+++ b/pkg/core/cluster/capacity_test.go
@@ -442,3 +442,145 @@ func TestBothScriptsCarryUserNamespaceGate(t *testing.T) {
 		t.Error("VM server script carries a container-only kubelet gate")
 	}
 }
+
+// The post-boot trigger's rule, and the trap it exists to avoid. An
+// honest node reports slightly LESS than its configured size — the
+// kernel's MemTotal excludes firmware-reserved and unavailable memory
+// — so a rule that treats observed < requested as a fault refuses
+// every correctly-behaving container node. That is #1456's mistake
+// with the sign flipped, and it is why NodeReservation is a separate
+// function from ReservedResources rather than a reuse of it (#1466).
+func TestNodeReservation(t *testing.T) {
+	spec := NodeSpec{Name: "n", CPU: "2", Memory: "4GB", Disk: "40GB"}
+
+	tests := []struct {
+		name        string
+		observedCPU int
+		observedMem int64
+		want        Reserved
+	}{
+		{
+			// 4GB limit, what /proc/meminfo actually reports.
+			name:        "honest node reporting just under its size reserves nothing",
+			observedCPU: 2,
+			observedMem: 3_999_993_856,
+			want:        Reserved{},
+		},
+		{
+			name:        "honest node reporting exactly its size reserves nothing",
+			observedCPU: 2,
+			observedMem: 4_000_000_000,
+			want:        Reserved{},
+		},
+		{
+			name:        "nested node seeing the outer host reserves the excess",
+			observedCPU: 8,
+			observedMem: 65841348 * 1024,
+			want:        Reserved{CPU: 6, MemoryBytes: 65841348*1024 - 4_000_000_000},
+		},
+		{
+			// Each dimension decided on its own: lxcfs can mask one
+			// and not the other, and a node is not obliged to lie
+			// consistently.
+			name:        "only memory misreports",
+			observedCPU: 2,
+			observedMem: 65841348 * 1024,
+			want:        Reserved{CPU: 0, MemoryBytes: 65841348*1024 - 4_000_000_000},
+		},
+		{
+			name:        "only cpu misreports",
+			observedCPU: 8,
+			observedMem: 3_999_993_856,
+			want:        Reserved{CPU: 6},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NodeReservation(tt.observedCPU, tt.observedMem, spec)
+			if err != nil {
+				t.Fatalf("NodeReservation: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %+v, want %+v", got, tt.want)
+			}
+			if tt.want.Zero() && len(KubeletReservedArgs(got)) != 0 {
+				t.Errorf("a zero reservation must render no kubelet args, got %v", KubeletReservedArgs(got))
+			}
+		})
+	}
+}
+
+// The parser cadvisor's view is reconstructed from. Split out of
+// HostCapacity so the same reading can be applied to a NODE's /proc
+// (read back over Exec after boot), which is the only vantage point
+// that can tell a misreporting node from an honest one (#1466).
+func TestParseProcCapacity(t *testing.T) {
+	const meminfo4GB = "MemTotal:        3906244 kB\nMemFree:  100 kB\n"
+
+	tests := []struct {
+		name    string
+		cpuinfo string
+		meminfo string
+		wantCPU int
+		wantMem int64
+		wantErr string
+	}{
+		{
+			name:    "a node that sees its own limits",
+			cpuinfo: "processor\t: 0\nvendor_id\t: X\n\nprocessor\t: 1\nvendor_id\t: X\n",
+			meminfo: meminfo4GB,
+			wantCPU: 2,
+			wantMem: 3906244 * 1024,
+		},
+		{
+			name: "a nested node that sees the outer host",
+			cpuinfo: "processor\t: 0\nprocessor\t: 1\nprocessor\t: 2\nprocessor\t: 3\n" +
+				"processor\t: 4\nprocessor\t: 5\nprocessor\t: 6\nprocessor\t: 7\n",
+			meminfo: "MemTotal:       65841348 kB\n",
+			wantCPU: 8,
+			wantMem: 65841348 * 1024,
+		},
+		{
+			// Zero would compute a reservation that starves the node,
+			// so an unreadable shape is an error, never a zero.
+			name:    "no processor lines",
+			cpuinfo: "vendor_id\t: X\n",
+			meminfo: meminfo4GB,
+			wantErr: "no processor lines",
+		},
+		{
+			name:    "no MemTotal",
+			cpuinfo: "processor\t: 0\n",
+			meminfo: "MemFree: 100 kB\n",
+			wantErr: "no MemTotal",
+		},
+		{
+			name:    "MemTotal is not a number",
+			cpuinfo: "processor\t: 0\n",
+			meminfo: "MemTotal:  plenty kB\n",
+			wantErr: "MemTotal",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cpu, mem, err := ParseProcCapacity(tt.cpuinfo, tt.meminfo)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("want error containing %q, got cpu=%d mem=%d", tt.wantErr, cpu, mem)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error = %v, want it to contain %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseProcCapacity: %v", err)
+			}
+			if cpu != tt.wantCPU || mem != tt.wantMem {
+				t.Errorf("got cpu=%d mem=%d, want cpu=%d mem=%d", cpu, mem, tt.wantCPU, tt.wantMem)
+			}
+		})
+	}
+}

--- a/pkg/core/cluster/manager.go
+++ b/pkg/core/cluster/manager.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -113,6 +114,28 @@ func (m *Manager) DeleteVM(name string) error {
 	return m.host.Delete(name)
 }
 
+// abandon removes an instance whose provisioning failed after it was
+// created, and returns the original error.
+//
+// Decide() re-emits ActionCreateCP / ActionCreateWorker only when an
+// instance is MISSING, so anything left behind here is never retried
+// and never replaced: the cluster stays in error with a running
+// instance consuming its full size, and on the worker path the store
+// never learns about it either — invisible to `cluster status` and to
+// the autoscaler, exactly the shape of #1498's leaked node.
+//
+// The removal is best-effort by design: the provisioning failure is
+// what the caller needs to see, and a delete that also fails only adds
+// a second symptom of the same broken host. It is logged so the orphan
+// is not silent.
+func (m *Manager) abandon(name string, cause error) error {
+	if err := m.DeleteVM(name); err != nil {
+		log.Printf("[cluster] %s failed to provision (%v) and could not be removed (%v); "+
+			"it will not be retried while the instance exists", name, cause, err)
+	}
+	return cause
+}
+
 const bootstrapScriptPath = "/root/containarium-bootstrap.sh"
 
 // pushFile writes a file into a node, creating its parent directory
@@ -221,18 +244,18 @@ func (m *Manager) ProvisionCP(tenant, clusterName string, iso Isolation, cpSize 
 	}
 	ip, err := m.host.WaitReady(name, m.waitReadyTimeout)
 	if err != nil {
-		return "", fmt.Errorf("control-plane VM %s not ready: %w", name, err)
+		return "", m.abandon(name, fmt.Errorf("control-plane VM %s not ready: %w", name, err))
 	}
 	bin, err := m.k3sBinary()
 	if err != nil {
-		return "", err
+		return "", m.abandon(name, err)
 	}
 	if err := m.pushFile(name, K3sBinaryPath, bin, "0755"); err != nil {
-		return "", fmt.Errorf("push k3s binary: %w", err)
+		return "", m.abandon(name, fmt.Errorf("push k3s binary: %w", err))
 	}
 	kubeletArgs, err := m.containerKubeletArgs(iso, spec)
 	if err != nil {
-		return "", fmt.Errorf("control-plane kubelet args: %w", err)
+		return "", m.abandon(name, fmt.Errorf("control-plane kubelet args: %w", err))
 	}
 	script := RenderServerScript(ServerBootstrap{
 		TLSSANs:     append([]string{ip}, tlsSANs...),
@@ -240,10 +263,10 @@ func (m *Manager) ProvisionCP(tenant, clusterName string, iso Isolation, cpSize 
 		KubeletArgs: kubeletArgs,
 	})
 	if err := m.pushFile(name, bootstrapScriptPath, []byte(script), "0755"); err != nil {
-		return "", fmt.Errorf("push bootstrap script: %w", err)
+		return "", m.abandon(name, fmt.Errorf("push bootstrap script: %w", err))
 	}
 	if _, err := m.host.Exec(name, []string{"sh", bootstrapScriptPath}); err != nil {
-		return "", fmt.Errorf("control-plane bootstrap: %w", err)
+		return "", m.abandon(name, fmt.Errorf("control-plane bootstrap: %w", err))
 	}
 	return ip, nil
 }
@@ -276,17 +299,17 @@ func (m *Manager) ProvisionWorker(tenant, clusterName string, iso Isolation, g D
 		return fmt.Errorf("create worker node: %w", err)
 	}
 	if _, err := m.host.WaitReady(vmName, m.waitReadyTimeout); err != nil {
-		return fmt.Errorf("worker VM %s not ready: %w", vmName, err)
+		return m.abandon(vmName, fmt.Errorf("worker VM %s not ready: %w", vmName, err))
 	}
 	bin, err := m.k3sBinary()
 	if err != nil {
 		return err
 	}
 	if err := m.pushFile(vmName, K3sBinaryPath, bin, "0755"); err != nil {
-		return fmt.Errorf("push k3s binary: %w", err)
+		return m.abandon(vmName, fmt.Errorf("push k3s binary: %w", err))
 	}
 	if err := m.pushFile(vmName, AgentTokenPath, token, "0600"); err != nil {
-		return fmt.Errorf("push join token: %w", err)
+		return m.abandon(vmName, fmt.Errorf("push join token: %w", err))
 	}
 	// A container-class worker cannot derive its own containerd
 	// template: k3s agent writes config.toml only after retrieving
@@ -297,19 +320,19 @@ func (m *Manager) ProvisionWorker(tenant, clusterName string, iso Isolation, g D
 	if iso == IsolationContainer {
 		generated, err := m.host.Read(cp, ContainerdGeneratedConfigPath)
 		if err != nil {
-			return fmt.Errorf("read containerd config from %s: %w", cp, err)
+			return m.abandon(vmName, fmt.Errorf("read containerd config from %s: %w", cp, err))
 		}
 		tmpl, err := DeriveContainerdTemplate(generated)
 		if err != nil {
-			return fmt.Errorf("derive containerd template: %w", err)
+			return m.abandon(vmName, fmt.Errorf("derive containerd template: %w", err))
 		}
 		if err := m.pushFile(vmName, ContainerdConfigTemplatePath, tmpl, "0644"); err != nil {
-			return fmt.Errorf("push containerd template: %w", err)
+			return m.abandon(vmName, fmt.Errorf("push containerd template: %w", err))
 		}
 	}
 	kubeletArgs, err := m.containerKubeletArgs(iso, spec)
 	if err != nil {
-		return fmt.Errorf("worker kubelet args: %w", err)
+		return m.abandon(vmName, fmt.Errorf("worker kubelet args: %w", err))
 	}
 	script := RenderAgentScript(AgentBootstrap{
 		ServerURL:   "https://" + cpIP + ":6443",
@@ -317,10 +340,10 @@ func (m *Manager) ProvisionWorker(tenant, clusterName string, iso Isolation, g D
 		KubeletArgs: kubeletArgs,
 	})
 	if err := m.pushFile(vmName, bootstrapScriptPath, []byte(script), "0755"); err != nil {
-		return fmt.Errorf("push bootstrap script: %w", err)
+		return m.abandon(vmName, fmt.Errorf("push bootstrap script: %w", err))
 	}
 	if _, err := m.host.Exec(vmName, []string{"sh", bootstrapScriptPath}); err != nil {
-		return fmt.Errorf("worker bootstrap: %w", err)
+		return m.abandon(vmName, fmt.Errorf("worker bootstrap: %w", err))
 	}
 	return nil
 }

--- a/pkg/core/cluster/manager.go
+++ b/pkg/core/cluster/manager.go
@@ -131,33 +131,79 @@ func (m *Manager) pushFile(name, path string, content []byte, mode string) error
 	return m.host.Push(name, path, content, mode)
 }
 
-// containerKubeletArgs assembles the kubelet flags a container-class
-// node needs.
+// observedNodeCapacity asks a BOOTED node what it observes as its own
+// capacity, by reading the two files cadvisor derives node capacity
+// from inside the node itself.
 //
-// Today that is only the user-namespace gate (#1452): kubelet writes
-// kernel sysctls an unprivileged container may not touch, and without
-// the gate ContainerManager never starts.
-//
-// It deliberately does NOT reserve resources. #1452 wired a
-// reservation computed as (daemon host capacity - requested size), on
-// Amendment 1's premise that a container node always reports the
-// host's capacity. That premise holds only on a NESTED host, where
-// lxcfs masking does not reach the inner instances. On a plain host
-// running Incus directly the node sees its real limit, and the
-// reservation becomes larger than the node's whole capacity -- kubelet
-// rejects it ("capacity >= reservation") and refuses to start, so the
-// correction meant to make allocatable truthful prevented the node
-// from running at all (#1456).
-//
-// ReservedResources and HostCapacity remain: they are correct as
-// functions. What was wrong was applying them unconditionally, from
-// the wrong vantage point. #1456 covers deciding from the node itself
-// whether a correction is needed.
-func (m *Manager) containerKubeletArgs(iso Isolation, _ NodeSpec) []string {
-	if iso != IsolationContainer {
-		return nil
+// This vantage point is the whole correction of #1466. The daemon
+// host's /proc cannot answer the question: on a plain Incus host
+// lxcfs masks these files and the node sees its real limits, while on
+// a nested host masking does not reach the inner instance and the node
+// sees the outer host. The two are indistinguishable from outside, and
+// guessing wrong in either direction has already shipped a bug —
+// #1456 (reservation applied where none was needed; kubelet refused to
+// start) and #1466 (no reservation where one was needed; autoscaling
+// silently disabled).
+func (m *Manager) observedNodeCapacity(name string) (int, int64, error) {
+	cpuinfo, err := m.host.Exec(name, []string{"cat", ProcCPUInfoPath})
+	if err != nil {
+		return 0, 0, fmt.Errorf("read %s on %s: %w", ProcCPUInfoPath, name, err)
 	}
-	return ContainerKubeletArgs(nil)
+	meminfo, err := m.host.Exec(name, []string{"cat", ProcMemInfoPath})
+	if err != nil {
+		return 0, 0, fmt.Errorf("read %s on %s: %w", ProcMemInfoPath, name, err)
+	}
+	return ParseProcCapacity(cpuinfo, meminfo)
+}
+
+// containerKubeletArgs assembles the kubelet flags a container-class
+// node needs, given what that node — already booted — reports about
+// itself.
+//
+// Two flags, for two different failures:
+//
+//   - The user-namespace gate (#1452), always. kubelet writes kernel
+//     sysctls an unprivileged container may not touch, and without the
+//     gate ContainerManager never starts.
+//   - A reservation, ONLY when the node actually misreports (#1466).
+//     Allocatable = capacity - reserved, and both the scheduler and
+//     cluster-autoscaler's fit simulation read allocatable; a node
+//     advertising the outer host's 8 cpu instead of its own 2 gets
+//     packed with pods it cannot run and never triggers the scale-up
+//     that should have happened.
+//
+// The trigger is what took three attempts to get right. #1452 computed
+// the reservation from (daemon host capacity - requested size) and
+// applied it unconditionally, on the premise that a container node
+// always reports the host's capacity. That premise holds only on a
+// NESTED host. On a plain host the node sees its real limit, the
+// reservation exceeded the node's entire capacity, and kubelet refused
+// to start ("capacity >= reservation") — so the correction meant to
+// make allocatable truthful stopped the node running at all (#1456,
+// removed in #1457). Asking the node is the only thing that
+// distinguishes the two, so that is what this does.
+//
+// A zero reservation renders no flags: where the node already observes
+// its own size the stock kubelet is correct.
+func (m *Manager) containerKubeletArgs(iso Isolation, spec NodeSpec) ([]string, error) {
+	if iso != IsolationContainer {
+		return nil, nil
+	}
+	cpu, mem, err := m.observedNodeCapacity(spec.Name)
+	if err != nil {
+		// Fail closed. An unmeasurable node is not a node that
+		// observes itself correctly — proceeding without a
+		// reservation is precisely the silent failure #1466 exists to
+		// end, and it would leave no trace anywhere.
+		return nil, fmt.Errorf(
+			"cannot establish %s's observed capacity, so its allocatable cannot be made truthful: %w",
+			spec.Name, err)
+	}
+	reserved, err := NodeReservation(cpu, mem, spec)
+	if err != nil {
+		return nil, fmt.Errorf("node %s: %w", spec.Name, err)
+	}
+	return ContainerKubeletArgs(KubeletReservedArgs(reserved)), nil
 }
 
 // ProvisionCP creates and bootstraps the control-plane VM: create →
@@ -184,10 +230,14 @@ func (m *Manager) ProvisionCP(tenant, clusterName string, iso Isolation, cpSize 
 	if err := m.pushFile(name, K3sBinaryPath, bin, "0755"); err != nil {
 		return "", fmt.Errorf("push k3s binary: %w", err)
 	}
+	kubeletArgs, err := m.containerKubeletArgs(iso, spec)
+	if err != nil {
+		return "", fmt.Errorf("control-plane kubelet args: %w", err)
+	}
 	script := RenderServerScript(ServerBootstrap{
 		TLSSANs:     append([]string{ip}, tlsSANs...),
 		Isolation:   iso,
-		KubeletArgs: m.containerKubeletArgs(iso, spec),
+		KubeletArgs: kubeletArgs,
 	})
 	if err := m.pushFile(name, bootstrapScriptPath, []byte(script), "0755"); err != nil {
 		return "", fmt.Errorf("push bootstrap script: %w", err)
@@ -257,10 +307,14 @@ func (m *Manager) ProvisionWorker(tenant, clusterName string, iso Isolation, g D
 			return fmt.Errorf("push containerd template: %w", err)
 		}
 	}
+	kubeletArgs, err := m.containerKubeletArgs(iso, spec)
+	if err != nil {
+		return fmt.Errorf("worker kubelet args: %w", err)
+	}
 	script := RenderAgentScript(AgentBootstrap{
 		ServerURL:   "https://" + cpIP + ":6443",
 		Isolation:   iso,
-		KubeletArgs: m.containerKubeletArgs(iso, spec),
+		KubeletArgs: kubeletArgs,
 	})
 	if err := m.pushFile(vmName, bootstrapScriptPath, []byte(script), "0755"); err != nil {
 		return fmt.Errorf("push bootstrap script: %w", err)

--- a/pkg/core/cluster/manager_test.go
+++ b/pkg/core/cluster/manager_test.go
@@ -71,7 +71,27 @@ func (f *fakeHost) Read(name, path string) ([]byte, error) {
 }
 func (f *fakeHost) Exec(name string, cmd []string) (string, error) {
 	f.record("exec %s:%s", name, strings.Join(cmd, " "))
+	// Keyed on the whole argv first so a test can stub two commands
+	// that share an argv0 (cat /proc/cpuinfo vs cat /proc/meminfo);
+	// argv0 alone remains for the stubs that predate that need.
+	if out, ok := f.execOut[name+":"+strings.Join(cmd, " ")]; ok {
+		return out, nil
+	}
 	return f.execOut[name+":"+cmd[0]], nil
+}
+
+// setNodeProc stubs what a node reports about itself once booted —
+// the vantage point a reservation may be derived from, and the only
+// one that can tell a nested host's lie from a plain host's truth
+// (#1466). Explicit in every test that needs it: a fake that served a
+// plausible default /proc would hide exactly the bug under test.
+func (f *fakeHost) setNodeProc(name string, cpu int, memKB int64) {
+	var b strings.Builder
+	for i := 0; i < cpu; i++ {
+		fmt.Fprintf(&b, "processor\t: %d\nvendor_id\t: GenuineIntel\n\n", i)
+	}
+	f.execOut[name+":cat "+ProcCPUInfoPath] = b.String()
+	f.execOut[name+":cat "+ProcMemInfoPath] = fmt.Sprintf("MemTotal:%15d kB\nMemFree:  1024 kB\n", memKB)
 }
 func (f *fakeHost) ClusterVMs(tenant, clusterName string) (Observed, error) {
 	return Observed{}, nil
@@ -236,6 +256,11 @@ func TestProvisionCarriesIsolationThroughTheSeam(t *testing.T) {
 			// fake CP must have one — its absence is a loud failure by design.
 			f.files["alice-k8s-demo-cp:"+ContainerdGeneratedConfigPath] = []byte(
 				"version = 3\n  enable_unprivileged_ports = true\n  enable_unprivileged_icmp = true\n")
+			// The node must be able to answer what it observes about
+			// itself: the reservation trigger asks it after boot (#1466).
+			// These fixtures are an honest node — it sees its own limits.
+			f.setNodeProc("alice-k8s-demo-cp", 2, 3906244)
+			f.setNodeProc("alice-k8s-demo-small-1", 2, 3906244)
 			m := testManager(f)
 
 			if _, err := m.ProvisionCP("alice", "demo", tc.iso, DesiredGroup{CPU: "2", Memory: "4GB", Disk: "40GB"}, nil); err != nil {
@@ -345,6 +370,11 @@ func TestProvisionWorkerPushesContainerdTemplateBeforeBootstrap(t *testing.T) {
 	f.files["alice-k8s-demo-cp:"+NodeTokenPath] = []byte("K10hash::server:secret\n")
 	f.files["alice-k8s-demo-cp:"+ContainerdGeneratedConfigPath] = []byte(
 		"version = 3\n[plugins.'io.containerd.cri.v1.runtime']\n  enable_unprivileged_ports = true\n  enable_unprivileged_icmp = true\n")
+	// The node must be able to answer what it observes about itself:
+	// the reservation trigger asks it after boot (#1466). These
+	// fixtures are an honest node — it sees its own limits.
+	f.setNodeProc("alice-k8s-demo-cp", 2, 3906244)
+	f.setNodeProc("alice-k8s-demo-small-1", 2, 3906244)
 
 	if err := testManager(f).ProvisionWorker("alice", "demo", IsolationContainer,
 		DesiredGroup{Name: "small", CPU: "2", Memory: "4GB", Disk: "40GB"},
@@ -400,6 +430,11 @@ func TestProvisionWiresContainerKubeletArgs(t *testing.T) {
 	f.files["alice-k8s-demo-cp:"+NodeTokenPath] = []byte("K10hash::server:secret\n")
 	f.files["alice-k8s-demo-cp:"+ContainerdGeneratedConfigPath] = []byte(
 		"version = 3\n  enable_unprivileged_ports = true\n  enable_unprivileged_icmp = true\n")
+	// The node must be able to answer what it observes about itself:
+	// the reservation trigger asks it after boot (#1466). These
+	// fixtures are an honest node — it sees its own limits.
+	f.setNodeProc("alice-k8s-demo-cp", 2, 3906244)
+	f.setNodeProc("alice-k8s-demo-small-1", 2, 3906244)
 	m := testManager(f)
 
 	if _, err := m.ProvisionCP("alice", "demo", IsolationContainer,
@@ -439,11 +474,22 @@ func TestProvisionWiresContainerKubeletArgs(t *testing.T) {
 // and such a reservation exceeds the node's entire capacity — kubelet
 // rejects it and refuses to start, which is worse than an uncorrected
 // allocatable (#1456, observed on the CI runner in run 11).
+//
+// Since #1466 this test also pins the environment it was implicitly
+// assuming: the fixture is a node observing its own limits, and the
+// assertion is that such a node gets no reservation. The complementary
+// case — a node observing the outer host, which must get one — lives in
+// TestContainerNodeReservationFollowsWhatTheNodeObserves.
 func TestProvisionDoesNotReserveFromHostCapacity(t *testing.T) {
 	f := newFakeHost()
 	f.files["alice-k8s-demo-cp:"+NodeTokenPath] = []byte("K10hash::server:secret\n")
 	f.files["alice-k8s-demo-cp:"+ContainerdGeneratedConfigPath] = []byte(
 		"version = 3\n  enable_unprivileged_ports = true\n  enable_unprivileged_icmp = true\n")
+	// The node must be able to answer what it observes about itself:
+	// the reservation trigger asks it after boot (#1466). These
+	// fixtures are an honest node — it sees its own limits.
+	f.setNodeProc("alice-k8s-demo-cp", 2, 3906244)
+	f.setNodeProc("alice-k8s-demo-small-1", 2, 3906244)
 	m := testManager(f)
 
 	if _, err := m.ProvisionCP("alice", "demo", IsolationContainer,
@@ -523,5 +569,177 @@ func TestDeleteNodeReturnsTheDeleteError(t *testing.T) {
 
 	if err := m.DeleteVM("alice-k8s-demo-small-1"); err == nil {
 		t.Fatal("a failed delete must be reported, not swallowed")
+	}
+}
+
+// #1466: the reservation's trigger. A container node gets a
+// reservation only when it ACTUALLY misreports, established by asking
+// the node itself after boot — never inferred from the daemon host's
+// /proc, which is what #1456 got wrong in the other direction.
+//
+// The two environments are the whole point of the test: on a plain
+// Incus host lxcfs works and the node sees its own limits, so any
+// reservation is harmful (kubelet refuses a reservation exceeding
+// capacity); on a nested host lxcfs masking does not reach the inner
+// instance, the node sees the outer host, and without a reservation
+// the scheduler and the autoscaler's fit simulation both believe a
+// node four times its real size — so scale-up never triggers.
+func TestContainerNodeReservationFollowsWhatTheNodeObserves(t *testing.T) {
+	// The nested-host measurement from the design's Amendment 1 §2.
+	const (
+		nestedCPU   = 8
+		nestedMemKB = 65841348
+	)
+
+	tests := []struct {
+		name        string
+		nodeCPU     int
+		nodeMemKB   int64
+		wantReserve bool
+		wantArgs    []string
+	}{
+		{
+			name:      "plain host: the node sees its own limits, so nothing is reserved",
+			nodeCPU:   2,
+			nodeMemKB: 3906244, // ~4GB, what a 4GB node reports where lxcfs works
+		},
+		{
+			name:        "nested host: the node sees the outer host, so the gap is reserved",
+			nodeCPU:     nestedCPU,
+			nodeMemKB:   nestedMemKB,
+			wantReserve: true,
+			wantArgs: []string{
+				fmt.Sprintf("--kubelet-arg=system-reserved=cpu=%d,memory=%d",
+					nestedCPU-2, nestedMemKB*1024-4_000_000_000),
+				"--kubelet-arg=enforce-node-allocatable=pods",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, role := range []string{"control-plane", "worker"} {
+				t.Run(role, func(t *testing.T) {
+					f := newFakeHost()
+					f.files["alice-k8s-demo-cp:"+NodeTokenPath] = []byte("K10hash::server:secret\n")
+					f.files["alice-k8s-demo-cp:"+ContainerdGeneratedConfigPath] = []byte(
+						"version = 3\n  enable_unprivileged_ports = true\n  enable_unprivileged_icmp = true\n")
+
+					node := "alice-k8s-demo-cp"
+					if role == "worker" {
+						node = "alice-k8s-demo-small-1"
+						f.setNodeProc("alice-k8s-demo-cp", 2, 3906244)
+					}
+					f.setNodeProc(node, tt.nodeCPU, tt.nodeMemKB)
+					m := testManager(f)
+
+					if _, err := m.ProvisionCP("alice", "demo", IsolationContainer,
+						DesiredGroup{CPU: "2", Memory: "4GB", Disk: "40GB"}, []string{"203.0.113.10"}); err != nil {
+						t.Fatalf("ProvisionCP: %v", err)
+					}
+					if role == "worker" {
+						if err := m.ProvisionWorker("alice", "demo", IsolationContainer,
+							DesiredGroup{Name: "small", CPU: "2", Memory: "4GB", Disk: "40GB"},
+							node, "10.0.0.1"); err != nil {
+							t.Fatalf("ProvisionWorker: %v", err)
+						}
+					}
+
+					script := string(f.files[node+":"+bootstrapScriptPath])
+					if !tt.wantReserve {
+						if strings.Contains(script, "system-reserved") {
+							t.Errorf("node observing its own limits was given a reservation:\n%s", script)
+						}
+					}
+					for _, want := range tt.wantArgs {
+						if !strings.Contains(script, want) {
+							t.Errorf("script is missing %q:\n%s", want, script)
+						}
+					}
+					// Whatever the reservation, the gate without which
+					// kubelet's ContainerManager never starts must stay.
+					if !strings.Contains(script, "KubeletInUserNamespace=true") {
+						t.Errorf("%s script lost the user-namespace gate:\n%s", role, script)
+					}
+				})
+			}
+		})
+	}
+}
+
+// A VM node has its own kernel and reports honestly, so it must never
+// be probed for a correction, let alone given one — the probe is an
+// Exec into the node, and running it on the VM path would be both
+// pointless and a behaviour change to the class this issue does not
+// touch.
+func TestVMNodeIsNeverProbedForCapacity(t *testing.T) {
+	f := newFakeHost()
+	f.files["alice-k8s-demo-cp:"+NodeTokenPath] = []byte("K10hash::server:secret\n")
+	m := testManager(f)
+
+	if _, err := m.ProvisionCP("alice", "demo", IsolationVM,
+		DesiredGroup{CPU: "2", Memory: "4GB", Disk: "40GB"}, []string{"203.0.113.10"}); err != nil {
+		t.Fatalf("ProvisionCP: %v", err)
+	}
+	for _, c := range f.calls {
+		if strings.Contains(c, ProcCPUInfoPath) || strings.Contains(c, ProcMemInfoPath) {
+			t.Errorf("VM node was probed for observed capacity: %q", c)
+		}
+	}
+	if strings.Contains(string(f.files["alice-k8s-demo-cp:"+bootstrapScriptPath]), "system-reserved") {
+		t.Error("VM node was given a container-only reservation")
+	}
+}
+
+// A node whose /proc cannot be read fails the provision rather than
+// silently proceeding without a reservation. An unreadable /proc means
+// the lie cannot be measured, not that there is no lie — and a node
+// that quietly advertises four times its size is the exact failure
+// (#1466) this trigger exists to prevent, with nothing to say so.
+func TestContainerNodeUnreadableProcFailsClosed(t *testing.T) {
+	f := newFakeHost()
+	f.files["alice-k8s-demo-cp:"+NodeTokenPath] = []byte("K10hash::server:secret\n")
+	m := testManager(f)
+	// No setNodeProc: the node answers with nothing.
+
+	_, err := m.ProvisionCP("alice", "demo", IsolationContainer,
+		DesiredGroup{CPU: "2", Memory: "4GB", Disk: "40GB"}, []string{"203.0.113.10"})
+	if err == nil {
+		t.Fatal("provisioning succeeded with an unmeasurable node capacity; it must fail closed")
+	}
+	if !strings.Contains(err.Error(), "observed capacity") {
+		t.Errorf("error should name what could not be established, got: %v", err)
+	}
+}
+
+// The node is asked what it observes AFTER it is up — asking a node
+// that has not booted cannot answer, and asking before create is the
+// daemon-host inference #1456 removed.
+func TestCapacityProbeHappensAfterWaitReady(t *testing.T) {
+	f := newFakeHost()
+	f.setNodeProc("alice-k8s-demo-cp", 8, 65841348)
+	m := testManager(f)
+
+	if _, err := m.ProvisionCP("alice", "demo", IsolationContainer,
+		DesiredGroup{CPU: "2", Memory: "4GB", Disk: "40GB"}, []string{"203.0.113.10"}); err != nil {
+		t.Fatalf("ProvisionCP: %v", err)
+	}
+	waitAt, probeAt, pushAt := -1, -1, -1
+	for i, c := range f.calls {
+		switch {
+		case c == "wait alice-k8s-demo-cp":
+			waitAt = i
+		case strings.Contains(c, ProcCPUInfoPath):
+			probeAt = i
+		case strings.Contains(c, bootstrapScriptPath) && strings.HasPrefix(c, "push"):
+			pushAt = i
+		}
+	}
+	if waitAt < 0 || probeAt < 0 || pushAt < 0 {
+		t.Fatalf("missing calls: wait=%d probe=%d push=%d in %v", waitAt, probeAt, pushAt, f.calls)
+	}
+	if !(waitAt < probeAt && probeAt < pushAt) {
+		t.Errorf("probe must sit between WaitReady and the bootstrap push; got wait=%d probe=%d push=%d",
+			waitAt, probeAt, pushAt)
 	}
 }

--- a/pkg/core/cluster/manager_test.go
+++ b/pkg/core/cluster/manager_test.go
@@ -738,7 +738,7 @@ func TestCapacityProbeHappensAfterWaitReady(t *testing.T) {
 	if waitAt < 0 || probeAt < 0 || pushAt < 0 {
 		t.Fatalf("missing calls: wait=%d probe=%d push=%d in %v", waitAt, probeAt, pushAt, f.calls)
 	}
-	if !(waitAt < probeAt && probeAt < pushAt) {
+	if waitAt >= probeAt || probeAt >= pushAt {
 		t.Errorf("probe must sit between WaitReady and the bootstrap push; got wait=%d probe=%d push=%d",
 			waitAt, probeAt, pushAt)
 	}

--- a/pkg/core/cluster/manager_test.go
+++ b/pkg/core/cluster/manager_test.go
@@ -25,10 +25,13 @@ type fakeHost struct {
 	isolations map[string]Isolation
 	stopErr    error
 	deleteErr  error
+	// deleted records every instance Delete removed.
+	deleted map[string]bool
 }
 
 func newFakeHost() *fakeHost {
-	return &fakeHost{files: map[string][]byte{}, execOut: map[string]string{}, isolations: map[string]Isolation{}}
+	return &fakeHost{files: map[string][]byte{}, execOut: map[string]string{}, isolations: map[string]Isolation{},
+		deleted: map[string]bool{}}
 }
 
 func (f *fakeHost) record(format string, a ...any) {
@@ -48,6 +51,9 @@ func (f *fakeHost) Start(name string) error { f.record("start %s", name); return
 func (f *fakeHost) Stop(name string) error  { f.record("stop %s", name); return f.stopErr }
 func (f *fakeHost) Delete(name string) error {
 	f.record("delete %s", name)
+	if f.deleteErr == nil {
+		f.deleted[name] = true
+	}
 	return f.deleteErr
 }
 func (f *fakeHost) WaitReady(name string, _ time.Duration) (string, error) {
@@ -741,5 +747,53 @@ func TestCapacityProbeHappensAfterWaitReady(t *testing.T) {
 	if waitAt >= probeAt || probeAt >= pushAt {
 		t.Errorf("probe must sit between WaitReady and the bootstrap push; got wait=%d probe=%d push=%d",
 			waitAt, probeAt, pushAt)
+	}
+}
+
+// A provision that fails AFTER the instance exists must not leave that
+// instance behind. Decide() re-emits ActionCreateCP/ActionCreateWorker
+// only when the instance is missing, so an orphan created-but-never-
+// bootstrapped node is never retried and never replaced: the cluster
+// stays in error with a running instance consuming its full size, and
+// on the worker path the store never learns about it either, so it is
+// invisible to `cluster status` and to the autoscaler.
+//
+// The capacity probe (#1466) is the first step that can fail there, so
+// this is asserted through it.
+func TestFailedProvisionLeavesNoOrphanInstance(t *testing.T) {
+	for _, role := range []string{"control-plane", "worker"} {
+		t.Run(role, func(t *testing.T) {
+			f := newFakeHost()
+			f.files["alice-k8s-demo-cp:"+NodeTokenPath] = []byte("K10hash::server:secret\n")
+			f.files["alice-k8s-demo-cp:"+ContainerdGeneratedConfigPath] = []byte(
+				"version = 3\n  enable_unprivileged_ports = true\n  enable_unprivileged_icmp = true\n")
+			m := testManager(f)
+
+			node := "alice-k8s-demo-cp"
+			var err error
+			if role == "worker" {
+				node = "alice-k8s-demo-small-1"
+				f.setNodeProc("alice-k8s-demo-cp", 2, 3906244)
+				if _, cpErr := m.ProvisionCP("alice", "demo", IsolationContainer,
+					DesiredGroup{CPU: "2", Memory: "4GB", Disk: "40GB"}, nil); cpErr != nil {
+					t.Fatalf("ProvisionCP: %v", cpErr)
+				}
+				// The worker answers nothing for /proc: probe fails.
+				err = m.ProvisionWorker("alice", "demo", IsolationContainer,
+					DesiredGroup{Name: "small", CPU: "2", Memory: "4GB", Disk: "40GB"},
+					node, "10.0.0.1")
+			} else {
+				_, err = m.ProvisionCP("alice", "demo", IsolationContainer,
+					DesiredGroup{CPU: "2", Memory: "4GB", Disk: "40GB"}, nil)
+			}
+			if err == nil {
+				t.Fatal("provision succeeded with an unmeasurable node; it must fail closed")
+			}
+			if !f.deleted[node] {
+				t.Errorf("%s was created and left behind after a failed provision; "+
+					"Decide only recreates a MISSING instance, so this node is never retried. calls=%v",
+					node, f.calls)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Closes #1466.

A container node on a **nested** Incus host advertises the outer host's capacity — `8 cpu / 65841348Ki` for a node limited to `2 cpu / 3GB` — because cadvisor derives node capacity from `/proc/cpuinfo` and `/proc/meminfo`, and lxcfs masking does not reach a nested Incus's own instances. The scheduler packs pods against allocatable and cluster-autoscaler's fit simulation reads the same number, so **scale-up never triggers**. No error, no event.

## What changed

- **The trigger, which is the whole issue.** `ReservedResources`, `KubeletReservedArgs` and `HostCapacity` were already correct as functions and deliberately uncalled. What was missing was *when*. The node is now asked directly: `/proc` is read **inside the node**, after `WaitReady` and before the bootstrap script is pushed. Excess over the requested size is reserved; no excess reserves nothing.
- **`NodeReservation` is a new function, not a reuse of `ReservedResources`** — see below.
- **Fail closed.** A node whose `/proc` cannot be read fails the provision. An unmeasurable node is not a node known to be honest, and proceeding uncorrected is precisely the silent failure this ends.
- **VM nodes are untouched** — own kernel, honest reporting, never probed. A test asserts the probe never runs on that path.

## The trigger had to be got right from two directions

Both previous attempts read the wrong vantage point, and they failed in opposite directions:

| Attempt | What it did | Result |
| --- | --- | --- |
| #1452 | reservation from the **daemon host's** `/proc`, unconditionally | on a plain host the node already sees its real limits; the reservation exceeded the node's whole capacity and kubelet refused to start (#1456, removed in #1457) |
| status quo | no reservation ever | correct on a plain host; on a nested host, this issue |

The two environments are indistinguishable from outside the node. Asking the node is the only thing that separates them.

## One thing the design note's reasoning missed

Caught by its own test, and worth a reviewer's eye. **An honest node reports slightly *less* than its configured size** — the kernel's `MemTotal` excludes firmware-reserved and unavailable memory, so a 4GB node reports about `3,999,993,856`. `ReservedResources` treats observed-below-requested as an error, which is right for the create-time sizing question it serves (`CheckNodeCapacity`) and **wrong here**: it would refuse every correctly-behaving container node — #1456 with the sign flipped.

Hence `NodeReservation`, a separate function with a one-way, per-dimension comparison: reserve the excess a node claims over its own size, nothing when it claims none. `ReservedResources` keeps its create-time role unchanged.

`docs/architecture/cluster-container-node-pools.md` Amendment 1 §2 is updated — it previously said "nothing currently calls them, by design, until the *when* is settled", which this makes untrue.

## Test evidence

Written red first (undefined symbol → implementation → green).

| Test | Acceptance criterion |
| --- | --- |
| `TestContainerNodeReservationFollowsWhatTheNodeObserves` | **#1466 done-means 2** — the two environments distinguished, not assumed: node-sees-own-limits → no reservation; node-sees-host-values → reservation. Run for both the control plane and a worker. |
| `TestNodeReservation` | the one-way rule, including the honest-node-reports-just-under case that would otherwise refuse every good node |
| `TestParseProcCapacity` | the parser, including unreadable shapes as errors rather than a zero capacity |
| `TestCapacityProbeHappensAfterWaitReady` | **done-means 1** — established from the node after boot, not inferred beforehand |
| `TestContainerNodeUnreadableProcFailsClosed` | an unmeasurable node fails rather than proceeding silently |
| `TestVMNodeIsNeverProbedForCapacity` | the VM class is not touched by any of this |
| `TestProvisionDoesNotReserveFromHostCapacity` (existing) | kept, and now pins the environment it was implicitly assuming |

**Both trigger mistakes were confirmed catchable**, by reverting the implementation to each and watching the suite go red:

- *no reservation ever* (this issue) → `TestContainerNodeReservationFollowsWhatTheNodeObserves/nested_host` fails on the missing `system-reserved=cpu=6,memory=63421540352`
- *assume every node misreports* (#1456) → the `plain_host` cases plus `TestProvisionDoesNotReserveFromHostCapacity` fail

CI on this branch is the gate; local runs were the inner loop only.

## What this does NOT do

**#1466 done-means 3** — "the lane's journey asserts scale-up actually triggers" — needs no new code: step 2 already asserts `running == replicas && onNew`, and an inflated-capacity node would fit both sleepers on the existing worker, produce no new node, and fail it. Confirmed passing on run 21 of the container lane.

This is also **not** verifiable by the CI lane, which runs plain Incus where nothing misreports. It needs the nested dev box — which is #1431.

🤖 Generated with [Claude Code](https://claude.com/claude-code)