### PR TITLE
perf(container): collapse identity seeding from 7 in-guest execs to 2

### DIFF
--- a/pkg/core/box/lxc/lxc_test.go
+++ b/pkg/core/box/lxc/lxc_test.go
@@ -3,6 +3,7 @@ package lxc
 import (
 	"context"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/footprintai/containarium/pkg/core/box"
@@ -252,17 +253,27 @@ func TestMetricsDelegation(t *testing.T) {
 func TestSetAuthorizedKeysDelegation(t *testing.T) {
 	mock := incustest.NewMockBackend()
 	var wrotePath string
+	var execArgv []string
 	mock.WriteFileFunc = func(_, path string, _ []byte, _ string) error {
 		wrotePath = path
 		return nil
 	}
+	mock.ExecFunc = func(_ string, command []string) error {
+		execArgv = command
+		return nil
+	}
 	b := newTestBackend(mock)
-	// Empty key set exercises the delegation path (mkdir/chmod/write/chown)
-	// without depending on SSH key validation.
+	// Empty key set exercises the delegation path (stage via file push,
+	// then one placement exec) without depending on SSH key validation.
 	if err := b.SetAuthorizedKeys(context.Background(), box.BoxRef{Tenant: "alice"}, nil); err != nil {
 		t.Fatalf("SetAuthorizedKeys: %v", err)
 	}
-	if wrotePath != "/home/alice/.ssh/authorized_keys" {
-		t.Errorf("authorized_keys written to %q", wrotePath)
+	// Content is staged via the file API, and the placement exec receives
+	// the user's .ssh dir as a positional parameter.
+	if !strings.HasSuffix(wrotePath, "authorized_keys.alice") {
+		t.Errorf("staged authorized_keys written to %q", wrotePath)
+	}
+	if len(execArgv) < 5 || execArgv[4] != "/home/alice/.ssh" {
+		t.Errorf("placement exec argv = %v, want /home/alice/.ssh as $1", execArgv)
 	}
 }

--- a/pkg/core/container/identity_seeding_test.go
+++ b/pkg/core/container/identity_seeding_test.go
@@ -1,0 +1,175 @@
+package container
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/footprintai/containarium/pkg/core/incus/incustest"
+	"github.com/footprintai/containarium/pkg/core/ostype"
+)
+
+// The collapse contract (#1488 Finding 2): identity seeding pays one
+// in-guest exec per function, not one per command. Each Incus Exec is a
+// websocket-upgrading operation at ~50-150ms, so the exec COUNT is the
+// behavior under test, alongside the safety of the generated script.
+
+func TestShellQuote(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"alice", "'alice'"},
+		{"", "''"},
+		{"a b", "'a b'"},
+		{"a'b", `'a'\''b'`},
+		{"'; touch /pwned; '", `''\''; touch /pwned; '\'''`},
+		{"$HOME `id` \\", "'$HOME `id` \\'"},
+	}
+	for _, c := range cases {
+		if got := shellQuote(c.in); got != c.want {
+			t.Errorf("shellQuote(%q) = %s, want %s", c.in, got, c.want)
+		}
+	}
+}
+
+func TestShellJoin(t *testing.T) {
+	got := shellJoin([]string{"adduser", "--gecos", "", "a'b"})
+	want := `'adduser' '--gecos' '' 'a'\''b'`
+	if got != want {
+		t.Errorf("shellJoin = %s, want %s", got, want)
+	}
+}
+
+// seedRecorder captures every Exec and WriteFile.
+type seedRecorder struct {
+	execs  [][]string
+	writes []struct {
+		path, mode string
+		content    string
+	}
+}
+
+func newSeedBackend() (*incustest.MockBackend, *seedRecorder) {
+	rec := &seedRecorder{}
+	mock := incustest.NewMockBackend()
+	mock.ExecFunc = func(_ string, command []string) error {
+		rec.execs = append(rec.execs, command)
+		return nil
+	}
+	mock.WriteFileFunc = func(_, path string, content []byte, mode string) error {
+		rec.writes = append(rec.writes, struct {
+			path, mode string
+			content    string
+		}{path, mode, string(content)})
+		return nil
+	}
+	return mock, rec
+}
+
+func TestCreateUser_SingleExecPerFamily(t *testing.T) {
+	cases := []struct {
+		family      ostype.OSFamily
+		wantCreate  string
+		wantSudoGrp string
+	}{
+		{ostype.Debian, "'adduser'", "'sudo'"},
+		{ostype.RHEL, "'useradd'", "'wheel'"},
+	}
+	for _, c := range cases {
+		t.Run(string(c.family), func(t *testing.T) {
+			mock, rec := newSeedBackend()
+			m := NewWithBackend(mock)
+
+			if err := m.createUser("alice-container", "alice", c.family); err != nil {
+				t.Fatalf("createUser: %v", err)
+			}
+
+			if len(rec.execs) != 1 {
+				t.Fatalf("createUser issued %d execs, want exactly 1: %v", len(rec.execs), rec.execs)
+			}
+			argv := rec.execs[0]
+			if len(argv) != 3 || argv[0] != "/bin/sh" || argv[1] != "-c" {
+				t.Fatalf("exec argv = %v, want [/bin/sh -c <script>]", argv)
+			}
+			script := argv[2]
+			for _, frag := range []string{c.wantCreate, "'usermod'", c.wantSudoGrp, "'podman'", "|| true", "'alice'"} {
+				if !strings.Contains(script, frag) {
+					t.Errorf("script missing %s:\n%s", frag, script)
+				}
+			}
+
+			if len(rec.writes) != 1 {
+				t.Fatalf("createUser issued %d writes, want 1 (sudoers): %+v", len(rec.writes), rec.writes)
+			}
+			w := rec.writes[0]
+			if w.path != "/etc/sudoers.d/alice" || w.mode != "0440" {
+				t.Errorf("sudoers write = %q mode %q", w.path, w.mode)
+			}
+		})
+	}
+}
+
+// A hostile username must reach the script only inside single quotes —
+// the quoted rendition appears, the raw breakout never does.
+func TestCreateUser_HostileUsernameIsQuoted(t *testing.T) {
+	const evil = "eve'; touch /pwned; '"
+	mock, rec := newSeedBackend()
+	m := NewWithBackend(mock)
+
+	if err := m.createUser("c", evil, ostype.Debian); err != nil {
+		t.Fatalf("createUser: %v", err)
+	}
+	script := rec.execs[0][2]
+	if !strings.Contains(script, shellQuote(evil)) {
+		t.Errorf("script does not contain the quoted username:\n%s", script)
+	}
+	if strings.Contains(script, "'"+evil+"'") {
+		t.Errorf("script contains a naively-quoted breakout:\n%s", script)
+	}
+}
+
+func TestAddSSHKeys_StagesOnceThenPlacesOnce(t *testing.T) {
+	const key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMw0GUYQZVPWxSAC4T8RdKFGqzb8jxbFFM/SB6ILi1Ji test@host"
+	mock, rec := newSeedBackend()
+	m := NewWithBackend(mock)
+
+	if err := m.addSSHKeys("alice-container", "alice", []string{key, "  ", ""}); err != nil {
+		t.Fatalf("addSSHKeys: %v", err)
+	}
+
+	if len(rec.writes) != 1 {
+		t.Fatalf("addSSHKeys issued %d writes, want 1 (staging): %+v", len(rec.writes), rec.writes)
+	}
+	w := rec.writes[0]
+	if w.path != addSSHKeysStagingPath("alice") || w.mode != "0600" {
+		t.Errorf("staging write = %q mode %q", w.path, w.mode)
+	}
+	if w.content != key+"\n" {
+		t.Errorf("staged content = %q", w.content)
+	}
+
+	if len(rec.execs) != 1 {
+		t.Fatalf("addSSHKeys issued %d execs, want exactly 1: %v", len(rec.execs), rec.execs)
+	}
+	argv := rec.execs[0]
+	// [/bin/sh -c <script> sh <sshDir> <username> <staging>] — data rides
+	// as positional parameters, never spliced into the script text.
+	if len(argv) != 7 || argv[0] != "/bin/sh" || argv[1] != "-c" {
+		t.Fatalf("exec argv = %v", argv)
+	}
+	if argv[4] != "/home/alice/.ssh" || argv[5] != "alice" || argv[6] != addSSHKeysStagingPath("alice") {
+		t.Errorf("positional params = %v", argv[4:])
+	}
+	if strings.Contains(argv[2], "alice") {
+		t.Errorf("script text embeds the username instead of using positional params:\n%s", argv[2])
+	}
+}
+
+func TestAddSSHKeys_InvalidKeyRejectedBeforeAnySideEffect(t *testing.T) {
+	mock, rec := newSeedBackend()
+	m := NewWithBackend(mock)
+
+	if err := m.addSSHKeys("alice-container", "alice", []string{"YOUR_KEY_HERE"}); err == nil {
+		t.Fatal("addSSHKeys accepted an invalid key")
+	}
+	if len(rec.writes) != 0 || len(rec.execs) != 0 {
+		t.Errorf("invalid key still caused side effects: writes=%+v execs=%v", rec.writes, rec.execs)
+	}
+}

--- a/pkg/core/container/manager.go
+++ b/pkg/core/container/manager.go
@@ -788,23 +788,26 @@ chown -R "$1:$1" "$home/.config"`
 	}
 }
 
-// createUser creates a user in the container with sudo access
+// createUser creates a user in the container with sudo access.
+//
+// The three account commands run as ONE `sh -c` exec, not three: each
+// in-guest Exec is a websocket-upgrading Incus operation at ~50-150ms
+// apiece, and this path is on every create (Finding 2 in
+// docs/architecture/two-digit-ms-sandbox-spawn.md). Every argv is
+// rendered through shellJoin, so nothing in it — username included —
+// is ever interpreted by the shell.
 func (m *Manager) createUser(containerName, username string, family ostype.OSFamily) error {
 	pkgMgr := ospkg.ForFamily(family)
 
-	// Create user (OS-aware: adduser on Debian, useradd on RHEL)
-	if err := m.incus.Exec(containerName, pkgMgr.CreateUserCmd(username, "")); err != nil {
+	script := shellJoin(pkgMgr.CreateUserCmd(username, "")) + // OS-aware: adduser on Debian, useradd on RHEL
+		" && " + shellJoin([]string{"usermod", "-aG", pkgMgr.SudoGroup(), username}) + // "sudo" on Debian, "wheel" on RHEL
+		// Podman typically runs rootless; group membership is best-effort
+		// (ignored when the group doesn't exist), as it always was.
+		" && { " + shellJoin([]string{"usermod", "-aG", "podman", username}) + " || true; }"
+
+	if err := m.incus.Exec(containerName, []string{"/bin/sh", "-c", script}); err != nil {
 		return fmt.Errorf("failed to create user: %w", err)
 	}
-
-	// Add to sudo group (OS-aware: "sudo" on Debian, "wheel" on RHEL)
-	if err := m.incus.Exec(containerName, []string{"usermod", "-aG", pkgMgr.SudoGroup(), username}); err != nil {
-		return fmt.Errorf("failed to add user to sudo: %w", err)
-	}
-
-	// Note: Podman typically runs rootless and doesn't require a group
-	// But we can optionally add user to 'podman' group if it exists
-	_ = m.incus.Exec(containerName, []string{"usermod", "-aG", "podman", username})
 
 	// Allow passwordless sudo
 	// SECURITY FIX: Use Incus file push API instead of shell echo
@@ -828,21 +831,27 @@ func (m *Manager) SetAuthorizedKeys(username string, sshKeys []string) error {
 	return m.addSSHKeys(username+"-container", username, sshKeys)
 }
 
-// addSSHKeys adds SSH public keys to a user's authorized_keys
+// addSSHKeysStagingPath is where addSSHKeys stages the authorized_keys
+// content (via the file push API, root-owned 0600) before the placement
+// exec installs it into the user's home. Suffixed per-user so concurrent
+// seeding of different accounts can't collide.
+func addSSHKeysStagingPath(username string) string {
+	return "/run/containarium.authorized_keys." + username
+}
+
+// addSSHKeys sets the SSH public keys in a user's authorized_keys.
 // SECURITY: Uses Incus file push API to avoid shell injection vulnerabilities
+//
+// One WriteFile + one exec, not three execs around a write: the content
+// is staged via the file API (so key material still never passes through
+// a shell), then a single script creates the directory and installs the
+// file with the right mode and owner. Each in-guest Exec is a
+// websocket-upgrading Incus operation at ~50-150ms apiece (Finding 2 in
+// docs/architecture/two-digit-ms-sandbox-spawn.md). The username reaches
+// the script only as a positional parameter, never spliced into the
+// script text — same idiom as enablePodmanRestartDurability.
 func (m *Manager) addSSHKeys(containerName, username string, sshKeys []string) error {
 	sshDir := fmt.Sprintf("/home/%s/.ssh", username)
-	authorizedKeysPath := fmt.Sprintf("%s/authorized_keys", sshDir)
-
-	// Create .ssh directory
-	if err := m.incus.Exec(containerName, []string{"mkdir", "-p", sshDir}); err != nil {
-		return fmt.Errorf("failed to create .ssh directory: %w", err)
-	}
-
-	// Set permissions on .ssh directory
-	if err := m.incus.Exec(containerName, []string{"chmod", "700", sshDir}); err != nil {
-		return fmt.Errorf("failed to set .ssh permissions: %w", err)
-	}
 
 	// Build authorized_keys content safely (no shell involved).
 	// Validate each key to prevent placeholder/template strings (e.g., "YOUR_KEY")
@@ -860,16 +869,18 @@ func (m *Manager) addSSHKeys(containerName, username string, sshKeys []string) e
 		keysContent.WriteString("\n")
 	}
 
-	// SECURITY FIX: Use Incus file push API instead of shell echo
-	// This prevents shell injection attacks via malicious SSH key content
-	if err := m.incus.WriteFile(containerName, authorizedKeysPath, []byte(keysContent.String()), "0600"); err != nil {
+	staging := addSSHKeysStagingPath(username)
+	if err := m.incus.WriteFile(containerName, staging, []byte(keysContent.String()), "0600"); err != nil {
 		return fmt.Errorf("failed to write authorized_keys: %w", err)
 	}
 
-	// Set ownership
-	chownTarget := fmt.Sprintf("%s:%s", username, username)
-	if err := m.incus.Exec(containerName, []string{"chown", "-R", chownTarget, sshDir}); err != nil {
-		return fmt.Errorf("failed to set .ssh ownership: %w", err)
+	// $1 = .ssh dir, $2 = username, $3 = staged content.
+	const placeKeys = `set -e
+install -d -m 700 -o "$2" -g "$2" "$1"
+install -m 600 -o "$2" -g "$2" "$3" "$1/authorized_keys"
+rm -f "$3"`
+	if err := m.incus.Exec(containerName, []string{"/bin/sh", "-c", placeKeys, "sh", sshDir, username, staging}); err != nil {
+		return fmt.Errorf("failed to install authorized_keys: %w", err)
 	}
 
 	return nil

--- a/pkg/core/container/shell_join.go
+++ b/pkg/core/container/shell_join.go
@@ -1,0 +1,25 @@
+package container
+
+import "strings"
+
+// shellQuote wraps s in single quotes for POSIX sh, escaping embedded
+// single quotes ('foo'\''bar'). Inside single quotes the shell expands
+// nothing, so the result is injection-safe for any input, including a
+// username crafted to break out of the quoting.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// shellJoin renders argv as one safely-quoted sh command word sequence.
+// Used to fold several Exec round-trips into a single `sh -c` script:
+// each in-guest Exec is a websocket-upgrading Incus operation at
+// ~50-150ms apiece (Finding 2 in
+// docs/architecture/two-digit-ms-sandbox-spawn.md), so the join buys
+// one round-trip where there were several.
+func shellJoin(argv []string) string {
+	quoted := make([]string, len(argv))
+	for i, a := range argv {
+		quoted[i] = shellQuote(a)
+	}
+	return strings.Join(quoted, " ")
+}

--- a/pkg/core/container/shell_join.go
+++ b/pkg/core/container/shell_join.go
@@ -2,11 +2,14 @@ package container
 
 import "strings"
 
-// shellQuote wraps s in single quotes for POSIX sh, escaping embedded
-// single quotes ('foo'\''bar'). Inside single quotes the shell expands
+// shellQuote wraps s in single quotes for POSIX sh, escaping any
+// embedded single quote. Inside single quotes the shell expands
 // nothing, so the result is injection-safe for any input, including a
 // username crafted to break out of the quoting.
 func shellQuote(s string) string {
+	// Each embedded quote becomes: close the quoting, emit an escaped
+	// quote, reopen. (The literal is kept out of the doc comment above
+	// because gofmt rewrites consecutive apostrophes there.)
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 


### PR DESCRIPTION
## What

Game-1 win #1 from the two-digit-ms design note (#1488, Finding 2): identity seeding paid **7 in-guest exec round-trips** per create, each a websocket-upgrading Incus operation at ~50–150ms. This collapses them to **2** — saving ~5 round-trips (~0.25–0.75s) on every create, and the same on every `SetAuthorizedKeys` / collaborator key sync.

## How

- **`createUser`**: the three account commands (create user, sudo group, best-effort podman group) run as one `sh -c` script. Every argv is rendered through a strict single-quoting `shellJoin` (new `shell_join.go`), so nothing — username included — is ever interpreted by the shell. Error semantics preserved: user-create or sudo-group failure fails the call; podman-group stays best-effort (`|| true`). The sudoers write stays on the file push API, unchanged.
- **`addSSHKeys`**: `mkdir` + `chmod` + write + `chown -R` becomes one **staged** `WriteFile` (key material still never passes through a shell) plus one placement exec (`install -d -m700 -o user`, `install -m600 -o user`, `rm` staging), with username and paths passed as **positional parameters** — the same idiom the file already uses in `enablePodmanRestartDurability`. End state identical: 0700 dir, 0600 `authorized_keys`, user-owned. Key validation (`ValidateSSHPublicKey`) unchanged and still runs before any side effect.

## Tests

`identity_seeding_test.go` against the shared `incustest.MockBackend`:

- exec **count** pinned to exactly 1 per function (verified to fail when an extra exec is injected);
- per-family script content (adduser/sudo on Debian, useradd/wheel on RHEL);
- a hostile username (`eve'; touch /pwned; '`) appears only in its single-quoted rendition;
- staging path/mode/content; positional params carry the data, the script text embeds none of it;
- invalid key → error before any write or exec.

`TestSetAuthorizedKeysDelegation` (lxc) updated to the staged contract. `shellQuote`/`shellJoin` covered directly, including quote-breakout inputs.

## Scope

No API change, no interface change; all three `addSSHKeys` callers (create, `SetAuthorizedKeys`, collaborator sync) get the reduction for free. One behavioral nuance: the placement script no longer `chown -R`s pre-existing unrelated files in `~/.ssh` — the dir and `authorized_keys` themselves are still explicitly owned; files the flow doesn't manage keep their existing (already user-owned) ownership.

Refs #1488 (Game-1). Built on #1499's instrumentation, so the win will be visible as a drop in the `create_user` and `add_ssh_keys` stage histograms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
