### PR TITLE
fix(cluster): lower the group target before deleting a node, and clear its node-password (#1498)

### DIFF
--- a/internal/server/ca_provider_server.go
+++ b/internal/server/ca_provider_server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -220,26 +221,56 @@ func (s *CAProviderServer) NodeGroupDeleteNodes(ctx context.Context, req *capb.N
 	// (it only creates up to Min, never scales down) and which the
 	// autoscaler retries. The reverse — a target higher than reality —
 	// is the one state that resurrects a drained node.
-	target := g.EffectiveTarget() - int32(len(req.Nodes)) //nolint:gosec // batch length is bounded by the group's int32 max_nodes (validated above)
+	// The target is derived from how many nodes the group ACTUALLY has,
+	// not by subtracting the batch from the current target.
+	//
+	// Because the decrement is committed before anything is destroyed,
+	// subtracting from the current target would move it again on every
+	// retry of a delete that keeps failing — the node row survives a
+	// failed delete, so the retry re-validates as legitimate and
+	// subtracts a second time. Three retries walked a 3-node group's
+	// target to MinNodes with all three instances still present.
+	// Counting the rows makes the result idempotent: the same request,
+	// repeated, lands on the same target.
+	inGroupCount := int32(0)
+	for _, n := range rows {
+		if n.Group == g.Name {
+			inGroupCount++
+		}
+	}
+	target := inGroupCount - int32(len(req.Nodes)) //nolint:gosec // batch length is bounded by the group's int32 max_nodes (validated above)
 	if target < g.MinNodes {
 		target = g.MinNodes
 	}
 	if err := s.setTarget(ctx, c, g.Name, target); err != nil {
 		return nil, err
 	}
+	var staleSecrets []string
 	for _, n := range req.Nodes {
 		// CA has already drained the node; removing the VM is safe.
 		// ForgetNode also clears the control plane's node-password
 		// secret, without which a later node of the same name can
 		// never join (#1498).
 		if err := s.mgr.ForgetNode(owner, name, n.GetName()); err != nil {
-			return nil, status.Errorf(codes.Internal, "delete %s: %v", n.GetName(), err)
+			if !errors.Is(err, clustercore.ErrNodePasswordNotCleared) {
+				return nil, status.Errorf(codes.Internal, "delete %s: %v", n.GetName(), err)
+			}
+			// The instance IS gone, so the removal must not be
+			// retried — but the residue is not harmless, and a log
+			// line is not where anyone looks. Record it on the
+			// cluster's own history.
+			staleSecrets = append(staleSecrets, n.GetName())
 		}
 		_ = s.store.DeleteNode(ctx, owner, name, n.GetName())
 	}
+	reason := fmt.Sprintf("autoscaler removed %d drained node(s); target now %d", len(req.Nodes), target)
+	if len(staleSecrets) > 0 {
+		reason += fmt.Sprintf("; WARNING: node-password secret still present for %s — a future node of that name will be refused until it is removed",
+			strings.Join(staleSecrets, ", "))
+	}
 	_ = s.store.AppendEvent(ctx, owner, name, clusterstore.Event{
 		At: time.Now().UTC(), Kind: clusterstore.EventScaleDown, Group: g.Name,
-		Reason: fmt.Sprintf("autoscaler removed %d drained node(s); target now %d", len(req.Nodes), target),
+		Reason: reason,
 	})
 	return &capb.NodeGroupDeleteNodesResponse{}, nil
 }

--- a/internal/server/ca_provider_server.go
+++ b/internal/server/ca_provider_server.go
@@ -204,19 +204,38 @@ func (s *CAProviderServer) NodeGroupDeleteNodes(ctx context.Context, req *capb.N
 			return nil, status.Errorf(codes.NotFound, "node %q is not in group %q", n.GetName(), g.Name)
 		}
 	}
-	for _, n := range req.Nodes {
-		// CA has already drained the node; removing the VM is safe.
-		if err := s.mgr.DeleteVM(n.GetName()); err != nil {
-			return nil, status.Errorf(codes.Internal, "delete %s: %v", n.GetName(), err)
-		}
-		_ = s.store.DeleteNode(ctx, owner, name, n.GetName())
-	}
+	// The target is lowered BEFORE anything is destroyed (#1498).
+	//
+	// The reconciler ticks independently and derives each group's
+	// desired minimum from EffectiveTarget(), so any pass that lands
+	// while the store still counts a node we have already destroyed
+	// will faithfully rebuild it — and the rebuilt node reuses the
+	// released name, which k3s refuses forever (see ForgetNode). Doing
+	// this last left a window one DeleteVM wide, seconds against a 15s
+	// tick, and run 21 landed in it.
+	//
+	// Ordering it this way makes the failure modes converge downward:
+	// if a delete below fails, the group is left with a target lower
+	// than its node count, which the reconciler will not act on
+	// (it only creates up to Min, never scales down) and which the
+	// autoscaler retries. The reverse — a target higher than reality —
+	// is the one state that resurrects a drained node.
 	target := g.EffectiveTarget() - int32(len(req.Nodes)) //nolint:gosec // batch length is bounded by the group's int32 max_nodes (validated above)
 	if target < g.MinNodes {
 		target = g.MinNodes
 	}
 	if err := s.setTarget(ctx, c, g.Name, target); err != nil {
 		return nil, err
+	}
+	for _, n := range req.Nodes {
+		// CA has already drained the node; removing the VM is safe.
+		// ForgetNode also clears the control plane's node-password
+		// secret, without which a later node of the same name can
+		// never join (#1498).
+		if err := s.mgr.ForgetNode(owner, name, n.GetName()); err != nil {
+			return nil, status.Errorf(codes.Internal, "delete %s: %v", n.GetName(), err)
+		}
+		_ = s.store.DeleteNode(ctx, owner, name, n.GetName())
 	}
 	_ = s.store.AppendEvent(ctx, owner, name, clusterstore.Event{
 		At: time.Now().UTC(), Kind: clusterstore.EventScaleDown, Group: g.Name,

--- a/internal/server/ca_provider_server_test.go
+++ b/internal/server/ca_provider_server_test.go
@@ -246,3 +246,109 @@ func TestCAProvider_TemplateAndNodeMapping(t *testing.T) {
 		t.Fatalf("provider id = %q", nodes.Instances[0].Id)
 	}
 }
+
+// #1498: scale-down must survive a reconciler pass landing INSIDE the
+// DeleteNodes batch.
+//
+// TestCAProvider_DeleteNodesAndDecrease already runs a reconciler pass
+// after DeleteNodes returns and asserts the node is not resurrected —
+// and it passed throughout, because by then the target has been
+// lowered. Production interleaved differently: the loop ticks every
+// 15s and DeleteVM (stop, then delete) takes seconds, so a pass landed
+// between the instance being destroyed and the target being lowered.
+// It saw target=1 with zero workers, and created the node the
+// autoscaler had just drained. The replacement then reused the node
+// name, which k3s refuses forever (see the manager-side test), so the
+// cluster carried an instance it did not know about until the run
+// timed out.
+//
+// The hook is the point of the test: the pass has to happen mid-batch,
+// and calling the two in sequence cannot express that.
+func TestCAProvider_DeleteNodesIsNotUndoneByAConcurrentReconcilerPass(t *testing.T) {
+	client, srv, rec, host := caRig(t)
+	ctx := context.Background()
+	mustCreate(t, srv, tenantCtx("alice"), "demo")
+	rec.ReconcileOnce(ctx)
+	rec.ReconcileOnce(ctx)
+	if _, err := client.NodeGroupIncreaseSize(caCtx("alice", "demo"),
+		&capb.NodeGroupIncreaseSizeRequest{Id: "alice/demo/small", Delta: 1}); err != nil {
+		t.Fatal(err)
+	}
+	rec.ReconcileOnce(ctx) // two small workers
+	if _, ok := host.vms["alice-k8s-demo-small-2"]; !ok {
+		t.Fatalf("setup did not produce a second worker: %v", vmNames(host))
+	}
+
+	// A reconciler tick lands while the instance is being destroyed.
+	var passes int
+	host.onDelete = func(string) {
+		passes++
+		rec.ReconcileOnce(ctx)
+	}
+
+	if _, err := client.NodeGroupDeleteNodes(caCtx("alice", "demo"), &capb.NodeGroupDeleteNodesRequest{
+		Id: "alice/demo/small", Nodes: []*capb.ExternalGrpcNode{{Name: "alice-k8s-demo-small-2"}},
+	}); err != nil {
+		t.Fatalf("DeleteNodes: %v", err)
+	}
+	if passes == 0 {
+		t.Fatal("the mid-batch reconciler pass never ran; the test proves nothing")
+	}
+
+	host.onDelete = nil
+	rec.ReconcileOnce(ctx) // let anything queued settle
+
+	if _, ok := host.vms["alice-k8s-demo-small-2"]; ok {
+		t.Error("a reconciler pass inside the batch recreated the drained node (#1498)")
+	}
+	workers := 0
+	for name := range host.vms {
+		if strings.HasPrefix(name, "alice-k8s-demo-small-") {
+			workers++
+		}
+	}
+	if workers != 1 {
+		t.Errorf("small group has %d instances, want 1: %v", workers, vmNames(host))
+	}
+}
+
+// The mechanism behind the test above, asserted directly: no instance
+// may be destroyed while the store still advertises a target that
+// counts it. Any reconciler pass in that window is entitled to rebuild
+// the node, so the ordering — not the width of the window — is the
+// fix.
+func TestCAProvider_TargetIsLoweredBeforeAnyInstanceIsDestroyed(t *testing.T) {
+	client, srv, rec, host := caRig(t)
+	ctx := context.Background()
+	mustCreate(t, srv, tenantCtx("alice"), "demo")
+	rec.ReconcileOnce(ctx)
+	rec.ReconcileOnce(ctx)
+	if _, err := client.NodeGroupIncreaseSize(caCtx("alice", "demo"),
+		&capb.NodeGroupIncreaseSizeRequest{Id: "alice/demo/small", Delta: 1}); err != nil {
+		t.Fatal(err)
+	}
+	rec.ReconcileOnce(ctx)
+
+	var targetAtDelete int32 = -1
+	host.onDelete = func(string) {
+		c, err := srv.Store().Get(ctx, "alice", "demo")
+		if err != nil {
+			t.Errorf("store.Get inside delete: %v", err)
+			return
+		}
+		for _, g := range c.NodeGroups {
+			if g.Name == "small" {
+				targetAtDelete = g.EffectiveTarget()
+			}
+		}
+	}
+
+	if _, err := client.NodeGroupDeleteNodes(caCtx("alice", "demo"), &capb.NodeGroupDeleteNodesRequest{
+		Id: "alice/demo/small", Nodes: []*capb.ExternalGrpcNode{{Name: "alice-k8s-demo-small-2"}},
+	}); err != nil {
+		t.Fatalf("DeleteNodes: %v", err)
+	}
+	if targetAtDelete != 1 {
+		t.Errorf("target was %d while the instance was being destroyed, want 1 (already lowered)", targetAtDelete)
+	}
+}

--- a/internal/server/ca_provider_server_test.go
+++ b/internal/server/ca_provider_server_test.go
@@ -8,6 +8,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"net"
 	"strings"
 	"testing"
@@ -350,5 +351,113 @@ func TestCAProvider_TargetIsLoweredBeforeAnyInstanceIsDestroyed(t *testing.T) {
 	}
 	if targetAtDelete != 1 {
 		t.Errorf("target was %d while the instance was being destroyed, want 1 (already lowered)", targetAtDelete)
+	}
+}
+
+// The target must be derived from how many nodes the group ACTUALLY
+// has, not by subtracting the batch length from the current target.
+//
+// Lowering the target before deleting (#1498) means the decrement is
+// committed even when a delete then fails — and because the node row
+// survives a failed delete, the autoscaler's retry is validated as
+// legitimate and subtracts again. Repeated retries walk the target
+// down to MinNodes while every instance is still there, leaving a
+// group whose target is far below its node count. Upstream CA treats
+// target != node count as not-in-steady-state and stops scaling the
+// group, and the reconciler never scales down, so the surplus is never
+// reclaimed.
+func TestCAProvider_TargetDoesNotDriftWhenDeletionKeepsFailing(t *testing.T) {
+	client, srv, rec, host := caRig(t)
+	ctx := context.Background()
+	mustCreate(t, srv, tenantCtx("alice"), "demo")
+	rec.ReconcileOnce(ctx)
+	rec.ReconcileOnce(ctx)
+	if _, err := client.NodeGroupIncreaseSize(caCtx("alice", "demo"),
+		&capb.NodeGroupIncreaseSizeRequest{Id: "alice/demo/small", Delta: 2}); err != nil {
+		t.Fatal(err)
+	}
+	rec.ReconcileOnce(ctx) // three small workers, target 3
+
+	// Every delete fails, so no node is ever removed and no row goes.
+	host.deleteErr = errors.New("incus: instance is busy")
+
+	for attempt := 1; attempt <= 3; attempt++ {
+		_, err := client.NodeGroupDeleteNodes(caCtx("alice", "demo"), &capb.NodeGroupDeleteNodesRequest{
+			Id: "alice/demo/small", Nodes: []*capb.ExternalGrpcNode{{Name: "alice-k8s-demo-small-3"}},
+		})
+		if err == nil {
+			t.Fatalf("attempt %d: DeleteNodes succeeded though every delete fails", attempt)
+		}
+		ts, tsErr := client.NodeGroupTargetSize(caCtx("alice", "demo"),
+			&capb.NodeGroupTargetSizeRequest{Id: "alice/demo/small"})
+		if tsErr != nil {
+			t.Fatal(tsErr)
+		}
+		// Three nodes still exist; one was asked to go. The target
+		// reflects that intent and must not move further on retries.
+		if ts.GetTargetSize() != 2 {
+			t.Fatalf("after %d failed attempt(s) target = %d, want 2 (three nodes present, one requested gone)",
+				attempt, ts.GetTargetSize())
+		}
+	}
+
+	nodes, err := client.NodeGroupNodes(caCtx("alice", "demo"), &capb.NodeGroupNodesRequest{Id: "alice/demo/small"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nodes.GetInstances()) != 3 {
+		t.Fatalf("group reports %d nodes, want 3 — nothing was deleted", len(nodes.GetInstances()))
+	}
+}
+
+// The resurrect race is only closed if the reconciler's DESIRED state
+// is at least as fresh as its OBSERVATION.
+//
+// ReconcileOnce lists every cluster once and reconcileCluster then
+// derived Desired from that snapshot BEFORE calling Observe. A
+// scale-down landing in between produced the stale-high target with a
+// post-deletion observation — the #1498 symptom again, now with the
+// node-password cleared, so the resurrected node rejoins silently as a
+// node nothing asked for. On a multi-cluster host that window is as
+// wide as all the preceding clusters' work in the same pass, and
+// provisioning blocks on a multi-minute WaitReady.
+//
+// The hook lands the delete after the host has been read, which is the
+// window the mid-batch test cannot reach (it re-reads the store fresh).
+func TestReconcilerDoesNotDecideOnAStaleTarget(t *testing.T) {
+	client, srv, rec, host := caRig(t)
+	ctx := context.Background()
+	mustCreate(t, srv, tenantCtx("alice"), "demo")
+	rec.ReconcileOnce(ctx)
+	rec.ReconcileOnce(ctx)
+	if _, err := client.NodeGroupIncreaseSize(caCtx("alice", "demo"),
+		&capb.NodeGroupIncreaseSizeRequest{Id: "alice/demo/small", Delta: 1}); err != nil {
+		t.Fatal(err)
+	}
+	rec.ReconcileOnce(ctx) // two small workers
+
+	var fired bool
+	host.onObserve = func() {
+		if fired {
+			return
+		}
+		fired = true
+		host.onObserve = nil
+		if _, err := client.NodeGroupDeleteNodes(caCtx("alice", "demo"), &capb.NodeGroupDeleteNodesRequest{
+			Id: "alice/demo/small", Nodes: []*capb.ExternalGrpcNode{{Name: "alice-k8s-demo-small-2"}},
+		}); err != nil {
+			t.Errorf("DeleteNodes inside observe: %v", err)
+		}
+	}
+
+	rec.ReconcileOnce(ctx)
+	if !fired {
+		t.Fatal("the delete never landed inside the observation; the test proves nothing")
+	}
+	host.onObserve = nil
+	rec.ReconcileOnce(ctx)
+
+	if _, ok := host.vms["alice-k8s-demo-small-2"]; ok {
+		t.Error("a scale-down landing between Observe and Decide was undone by a stale target")
 	}
 }

--- a/internal/server/cluster_reconciler.go
+++ b/internal/server/cluster_reconciler.go
@@ -170,12 +170,34 @@ func desiredFrom(c *clusterstore.Cluster) clustercore.Desired {
 var cpSize = clustercore.DesiredGroup{CPU: "2", Memory: "4GB", Disk: "40GB"}
 
 func (r *ClusterReconciler) reconcileCluster(ctx context.Context, c *clusterstore.Cluster) error {
-	desired := desiredFrom(c)
-	iso := coreIsolation(c.NodeIsolation)
 	observed, err := r.mgr.Observe(c.Owner, c.Name)
 	if err != nil {
 		return fmt.Errorf("observe: %w", err)
 	}
+	// Desired is read AFTER the observation, never before.
+	//
+	// ReconcileOnce lists every cluster once, so the record reaching
+	// this function can be arbitrarily old — as old as all the
+	// preceding clusters' work in the same pass, and provisioning
+	// blocks on a multi-minute WaitReady. Deriving Desired from that
+	// snapshot and pairing it with a fresh observation is the #1498
+	// resurrect race in its remaining form: a scale-down landing in
+	// between yields a target that still counts a node the observation
+	// no longer sees, and Decide rebuilds it.
+	//
+	// Reading the record last cannot produce that pairing. The worst
+	// case becomes a target LOWER than the observation, which Decide
+	// leaves alone (it only creates up to Min, never scales down) and
+	// the autoscaler resolves.
+	//
+	// A record that cannot be re-read falls back to the snapshot: that
+	// is the status quo, not a new failure, and refusing to reconcile
+	// on a transient store error would be worse.
+	if fresh, ferr := r.store.Get(ctx, c.Owner, c.Name); ferr == nil && fresh != nil {
+		c = fresh
+	}
+	desired := desiredFrom(c)
+	iso := coreIsolation(c.NodeIsolation)
 	actions := clustercore.Decide(desired, observed)
 
 	groupByName := make(map[string]clustercore.DesiredGroup, len(desired.Groups))

--- a/internal/server/cluster_reconciler_test.go
+++ b/internal/server/cluster_reconciler_test.go
@@ -34,6 +34,13 @@ type stateHost struct {
 	capacityErr     error
 	// isolations records the class each node was created with (#1429).
 	isolations map[string]clustercore.Isolation
+	// deleteErr makes every Delete fail, so a test can drive the
+	// retry path without racing anything.
+	deleteErr error
+	// onObserve fires after ClusterVMs has read the host, so a test
+	// can land a scale-down between the observation and the decision
+	// that consumes it (#1498 review).
+	onObserve func()
 	// onDelete fires inside Delete, before the instance is removed.
 	// It exists so a test can drive a reconciler pass into the middle
 	// of a DeleteNodes batch — the interleaving that recreated a
@@ -112,6 +119,11 @@ func (h *stateHost) Stop(name string) error {
 
 func (h *stateHost) Delete(name string) error {
 	h.mu.Lock()
+	if h.deleteErr != nil {
+		err := h.deleteErr
+		h.mu.Unlock()
+		return err
+	}
 	if _, ok := h.vms[name]; !ok {
 		h.mu.Unlock()
 		return fmt.Errorf("no vm %s", name)
@@ -203,6 +215,16 @@ func (h *stateHost) Exec(name string, cmd []string) (string, error) {
 }
 
 func (h *stateHost) ClusterVMs(tenant, clusterName string) (clustercore.Observed, error) {
+	// Fired BEFORE the host is read, so the observation this call
+	// returns already reflects the hook's work while the caller's
+	// Desired does not — the stale-target window (#1498 review).
+	h.mu.Lock()
+	hook := h.onObserve
+	h.mu.Unlock()
+	if hook != nil {
+		hook()
+	}
+
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	obs := clustercore.Observed{Workers: map[string][]clustercore.ObservedVM{}}

--- a/internal/server/cluster_reconciler_test.go
+++ b/internal/server/cluster_reconciler_test.go
@@ -34,6 +34,16 @@ type stateHost struct {
 	capacityErr     error
 	// isolations records the class each node was created with (#1429).
 	isolations map[string]clustercore.Isolation
+	// onDelete fires inside Delete, before the instance is removed.
+	// It exists so a test can drive a reconciler pass into the middle
+	// of a DeleteNodes batch — the interleaving that recreated a
+	// drained node in production (#1498) and cannot be reproduced by
+	// calling the two in sequence.
+	onDelete func(name string)
+	// execCalls records every Exec argv, so a test can assert on what
+	// the control plane was actually told to do rather than on the
+	// code that was supposed to tell it.
+	execCalls []string
 }
 
 type stateVM struct {
@@ -106,11 +116,22 @@ func (h *stateHost) Stop(name string) error {
 
 func (h *stateHost) Delete(name string) error {
 	h.mu.Lock()
-	defer h.mu.Unlock()
 	if _, ok := h.vms[name]; !ok {
+		h.mu.Unlock()
 		return fmt.Errorf("no vm %s", name)
 	}
 	delete(h.vms, name)
+	hook := h.onDelete
+	h.mu.Unlock()
+
+	// Fired with the instance already gone and the caller not yet
+	// returned — the production window, where a reconciler tick sees
+	// a group short of a target that has not been lowered yet
+	// (#1498). Outside the lock, because the hook re-enters this fake
+	// through the reconciler exactly as a real tick would.
+	if hook != nil {
+		hook(name)
+	}
 	return nil
 }
 
@@ -172,7 +193,11 @@ func (h *stateHost) Exec(name string, cmd []string) (string, error) {
 			return fmt.Sprintf("MemTotal:%15d kB\n", (bytes-6_144)/1024), nil
 		}
 	}
-	if len(cmd) >= 2 && cmd[1] == "kubectl" {
+	h.execCalls = append(h.execCalls, name+": "+strings.Join(cmd, " "))
+	// Only `kubectl get nodes` lists nodes. Answering the node list to
+	// every kubectl subcommand would make a `delete secret` look like
+	// a success no matter what it was handed.
+	if len(cmd) >= 3 && cmd[1] == "kubectl" && cmd[2] == "get" {
 		var b strings.Builder
 		for vm := range h.vms {
 			fmt.Fprintf(&b, "%s   Ready   <none>   1m   v-test\n", vm)
@@ -180,6 +205,13 @@ func (h *stateHost) Exec(name string, cmd []string) (string, error) {
 		return b.String(), nil
 	}
 	return "", nil
+}
+
+// execs returns a copy of the recorded Exec argv list.
+func (h *stateHost) execs() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]string(nil), h.execCalls...)
 }
 
 func (h *stateHost) ClusterVMs(tenant, clusterName string) (clustercore.Observed, error) {

--- a/internal/server/cluster_reconciler_test.go
+++ b/internal/server/cluster_reconciler_test.go
@@ -40,10 +40,6 @@ type stateHost struct {
 	// drained node in production (#1498) and cannot be reproduced by
 	// calling the two in sequence.
 	onDelete func(name string)
-	// execCalls records every Exec argv, so a test can assert on what
-	// the control plane was actually told to do rather than on the
-	// code that was supposed to tell it.
-	execCalls []string
 }
 
 type stateVM struct {
@@ -193,7 +189,6 @@ func (h *stateHost) Exec(name string, cmd []string) (string, error) {
 			return fmt.Sprintf("MemTotal:%15d kB\n", (bytes-6_144)/1024), nil
 		}
 	}
-	h.execCalls = append(h.execCalls, name+": "+strings.Join(cmd, " "))
 	// Only `kubectl get nodes` lists nodes. Answering the node list to
 	// every kubectl subcommand would make a `delete secret` look like
 	// a success no matter what it was handed.
@@ -205,13 +200,6 @@ func (h *stateHost) Exec(name string, cmd []string) (string, error) {
 		return b.String(), nil
 	}
 	return "", nil
-}
-
-// execs returns a copy of the recorded Exec argv list.
-func (h *stateHost) execs() []string {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	return append([]string(nil), h.execCalls...)
 }
 
 func (h *stateHost) ClusterVMs(tenant, clusterName string) (clustercore.Observed, error) {

--- a/pkg/core/cluster/manager.go
+++ b/pkg/core/cluster/manager.go
@@ -136,6 +136,54 @@ func (m *Manager) abandon(name string, cause error) error {
 	return cause
 }
 
+// NodePasswordSecret is the secret k3s stores per node in kube-system
+// and checks on every join. Deleting the Kubernetes Node object does
+// not remove it, so a node name that is released and reused is
+// refused forever unless it is cleared (#1498).
+func NodePasswordSecret(node string) string { return node + ".node-password.k3s" }
+
+// ForgetNode removes a worker node AND the control plane's memory of
+// it: the instance, then the k3s node-password secret that would
+// otherwise refuse any future node of the same name.
+//
+// Why the secret matters. k3s writes `<node>.node-password.k3s` into
+// kube-system on first join and compares it on every subsequent one.
+// cluster-autoscaler deletes the Kubernetes Node; we delete the
+// instance; neither touches that secret. Node names are derived from
+// the group and an index, so a released name comes back — and when it
+// does the new agent generates a fresh password, the stored hash does
+// not match, and the control plane answers 403 indefinitely:
+//
+//	unable to verify password for node <name>: hash does not match
+//
+// The node never registers, so it is invisible to kubectl and absent
+// from `cluster status` while consuming its full size (#1498, run 21:
+// 19 minutes of retries at ~8s intervals).
+//
+// Order is deliberate: the instance goes FIRST. A running agent
+// re-creates the secret on its next request, so clearing it while the
+// node still runs would simply leave a fresh stale password behind.
+//
+// A control plane that cannot be reached does NOT fail the removal.
+// The instance is already gone; returning an error would have the
+// autoscaler retry a deletion that has nothing left to delete. The
+// stale secret is real, so it is logged rather than swallowed.
+func (m *Manager) ForgetNode(tenant, clusterName, vmName string) error {
+	if err := m.DeleteVM(vmName); err != nil {
+		return err
+	}
+	cp := CPName(tenant, clusterName)
+	if _, err := m.host.Exec(cp, []string{
+		K3sBinaryPath, "kubectl", "delete", "secret",
+		NodePasswordSecret(vmName), "-n", "kube-system", "--ignore-not-found",
+	}); err != nil {
+		log.Printf("[cluster] %s deleted, but its node-password secret could not be cleared on %s: %v; "+
+			"a future node named %s will be refused with \"hash does not match\" until it is removed",
+			vmName, cp, err, vmName)
+	}
+	return nil
+}
+
 const bootstrapScriptPath = "/root/containarium-bootstrap.sh"
 
 // pushFile writes a file into a node, creating its parent directory

--- a/pkg/core/cluster/manager.go
+++ b/pkg/core/cluster/manager.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -136,6 +137,16 @@ func (m *Manager) abandon(name string, cause error) error {
 	return cause
 }
 
+// ErrNodePasswordNotCleared reports that a node's instance was removed
+// but the control plane still holds its node-password secret.
+//
+// It is deliberately distinct from a removal failure: the node IS
+// gone, so the caller must not retry the deletion, but the residue is
+// not harmless — the next node to take that name can never join. A
+// caller that only logs this re-arms #1498 from a single flaky exec,
+// so callers are expected to record it where operators look.
+var ErrNodePasswordNotCleared = errors.New("node-password secret not cleared")
+
 // NodePasswordSecret is the secret k3s stores per node in kube-system
 // and checks on every join. Deleting the Kubernetes Node object does
 // not remove it, so a node name that is released and reused is
@@ -180,6 +191,7 @@ func (m *Manager) ForgetNode(tenant, clusterName, vmName string) error {
 		log.Printf("[cluster] %s deleted, but its node-password secret could not be cleared on %s: %v; "+
 			"a future node named %s will be refused with \"hash does not match\" until it is removed",
 			vmName, cp, err, vmName)
+		return fmt.Errorf("%w on %s: %v", ErrNodePasswordNotCleared, cp, err)
 	}
 	return nil
 }

--- a/pkg/core/cluster/manager_test.go
+++ b/pkg/core/cluster/manager_test.go
@@ -848,7 +848,7 @@ func TestForgetNodeClearsTheNodePasswordAfterDeletingTheInstance(t *testing.T) {
 	if forgetAt < 0 {
 		t.Fatalf("the control plane was never told to forget the node password: %v", f.calls)
 	}
-	if !(stopAt < deleteAt && deleteAt < forgetAt) {
+	if stopAt >= deleteAt || deleteAt >= forgetAt {
 		t.Errorf("want stop -> delete -> forget, got stop=%d delete=%d forget=%d in %v",
 			stopAt, deleteAt, forgetAt, f.calls)
 	}

--- a/pkg/core/cluster/manager_test.go
+++ b/pkg/core/cluster/manager_test.go
@@ -870,19 +870,46 @@ func TestForgetNodeClearsTheNodePasswordAfterDeletingTheInstance(t *testing.T) {
 }
 
 // A control plane that cannot be reached must not turn a completed
-// removal into a failed one: the instance is already gone, and
-// reporting failure would have the autoscaler retry a delete that
-// cannot succeed. The stale password is a real problem, so it is
-// surfaced — but as the non-fatal thing it is.
-func TestForgetNodeSucceedsWhenTheControlPlaneCannotBeReached(t *testing.T) {
+// removal into a retryable failure: the instance IS gone, and an
+// opaque error would have the autoscaler retry a delete with nothing
+// left to delete.
+//
+// But it is not success either. A stale secret means the next node to
+// take this name can never join — the whole of #1498's second half —
+// so it is reported as a DISTINCT, typed condition that a caller can
+// tell apart from "removal failed" and record where operators look.
+// Returning nil here would re-arm #1498 from a single flaky exec with
+// only a daemon log line as evidence.
+func TestForgetNodeReportsAnUnclearedPasswordDistinctlyFromAFailedRemoval(t *testing.T) {
 	f := newFakeHost()
 	f.execErr = errors.New("control plane unreachable")
 	m := testManager(f)
 
-	if err := m.ForgetNode("alice", "demo", "alice-k8s-demo-small-2"); err != nil {
-		t.Fatalf("ForgetNode must not fail because the control plane is unreachable: %v", err)
+	err := m.ForgetNode("alice", "demo", "alice-k8s-demo-small-2")
+	if err == nil {
+		t.Fatal("an uncleared node-password secret must not be reported as success")
 	}
-	if _, ok := f.deleted["alice-k8s-demo-small-2"]; !ok {
+	if !errors.Is(err, ErrNodePasswordNotCleared) {
+		t.Fatalf("error must be distinguishable from a failed removal, got %v", err)
+	}
+	if !f.deleted["alice-k8s-demo-small-2"] {
 		t.Error("the instance was not deleted")
+	}
+}
+
+// The removal itself failing is the other case, and must NOT be
+// mistaken for the one above: nothing was removed, so the caller has
+// to retry.
+func TestForgetNodeReportsAFailedRemovalAsAFailure(t *testing.T) {
+	f := newFakeHost()
+	f.deleteErr = errors.New("incus: instance is busy")
+	m := testManager(f)
+
+	err := m.ForgetNode("alice", "demo", "alice-k8s-demo-small-2")
+	if err == nil {
+		t.Fatal("a failed removal must not be reported as success")
+	}
+	if errors.Is(err, ErrNodePasswordNotCleared) {
+		t.Fatalf("a failed removal must not look like a cleared-secret problem, got %v", err)
 	}
 }

--- a/pkg/core/cluster/manager_test.go
+++ b/pkg/core/cluster/manager_test.go
@@ -25,7 +25,10 @@ type fakeHost struct {
 	isolations map[string]Isolation
 	stopErr    error
 	deleteErr  error
-	// deleted records every instance Delete removed.
+	execErr    error
+	// deleted records every instance Delete removed, so a test can
+	// assert the removal happened without reading it back out of the
+	// call log.
 	deleted map[string]bool
 }
 
@@ -77,6 +80,9 @@ func (f *fakeHost) Read(name, path string) ([]byte, error) {
 }
 func (f *fakeHost) Exec(name string, cmd []string) (string, error) {
 	f.record("exec %s:%s", name, strings.Join(cmd, " "))
+	if f.execErr != nil {
+		return "", f.execErr
+	}
 	// Keyed on the whole argv first so a test can stub two commands
 	// that share an argv0 (cat /proc/cpuinfo vs cat /proc/meminfo);
 	// argv0 alone remains for the stubs that predate that need.
@@ -795,5 +801,88 @@ func TestFailedProvisionLeavesNoOrphanInstance(t *testing.T) {
 					node, f.calls)
 			}
 		})
+	}
+}
+
+// #1498, second half: a node name that is released and later reused
+// can never rejoin unless the control plane forgets it.
+//
+// k3s stores a per-node secret `<node>.node-password.k3s` in
+// kube-system and checks it on every join. Deleting the Kubernetes
+// Node object does not delete that secret — cluster-autoscaler deletes
+// the Node, we delete the instance, and the secret survives both. A
+// later node created under the same name generates a fresh password,
+// the stored hash does not match, and the control plane answers 403
+// forever:
+//
+//	unable to verify password for node <name>: hash does not match
+//
+// In run 21 that node retried every ~8s for 19 minutes: invisible to
+// kubectl, absent from `cluster status`, and consuming its full size.
+//
+// Order matters. The secret must be cleared AFTER the instance is
+// gone: a running agent re-creates the secret on its next request, so
+// clearing first would leave the stale password behind again.
+func TestForgetNodeClearsTheNodePasswordAfterDeletingTheInstance(t *testing.T) {
+	f := newFakeHost()
+	m := testManager(f)
+
+	if err := m.ForgetNode("alice", "demo", "alice-k8s-demo-small-2"); err != nil {
+		t.Fatalf("ForgetNode: %v", err)
+	}
+
+	stopAt, deleteAt, forgetAt := -1, -1, -1
+	for i, c := range f.calls {
+		switch {
+		case c == "stop alice-k8s-demo-small-2":
+			stopAt = i
+		case c == "delete alice-k8s-demo-small-2":
+			deleteAt = i
+		case strings.Contains(c, "node-password"):
+			forgetAt = i
+		}
+	}
+	if stopAt < 0 || deleteAt < 0 {
+		t.Fatalf("node was not stopped and deleted: %v", f.calls)
+	}
+	if forgetAt < 0 {
+		t.Fatalf("the control plane was never told to forget the node password: %v", f.calls)
+	}
+	if !(stopAt < deleteAt && deleteAt < forgetAt) {
+		t.Errorf("want stop -> delete -> forget, got stop=%d delete=%d forget=%d in %v",
+			stopAt, deleteAt, forgetAt, f.calls)
+	}
+
+	// The command must name THIS node's secret, run against the
+	// control plane, and tolerate the secret's absence — a node that
+	// never joined has none, and that is not a failure.
+	forget := f.calls[forgetAt]
+	for _, want := range []string{
+		"alice-k8s-demo-cp:",
+		"alice-k8s-demo-small-2.node-password.k3s",
+		"kube-system",
+		"--ignore-not-found",
+	} {
+		if !strings.Contains(forget, want) {
+			t.Errorf("forget command %q is missing %q", forget, want)
+		}
+	}
+}
+
+// A control plane that cannot be reached must not turn a completed
+// removal into a failed one: the instance is already gone, and
+// reporting failure would have the autoscaler retry a delete that
+// cannot succeed. The stale password is a real problem, so it is
+// surfaced — but as the non-fatal thing it is.
+func TestForgetNodeSucceedsWhenTheControlPlaneCannotBeReached(t *testing.T) {
+	f := newFakeHost()
+	f.execErr = errors.New("control plane unreachable")
+	m := testManager(f)
+
+	if err := m.ForgetNode("alice", "demo", "alice-k8s-demo-small-2"); err != nil {
+		t.Fatalf("ForgetNode must not fail because the control plane is unreachable: %v", err)
+	}
+	if _, ok := f.deleted["alice-k8s-demo-small-2"]; !ok {
+		t.Error("the instance was not deleted")
 	}
 }


### PR DESCRIPTION
Closes #1498. Unblocks #1430 / PR #1436 — step 5 is the last red step in the container lane.

Run 21 removed both surplus nodes correctly and one came straight back. The daemon's own container count is the whole story:

```
06:26:36  Container cache refreshed: 5 containers
06:27:06  Container cache refreshed: 3 containers   <- both surplus instances gone
06:27:36  Container cache refreshed: 4 containers   <- one returned
```

## 1. The target was lowered after the instance was destroyed

`NodeGroupDeleteNodes` called `DeleteVM` for each node and only then lowered the group target. The reconciler ticks every 15s and derives each group's desired minimum from `EffectiveTarget()`, so a pass landing in that window saw a group short of a target that still counted the node — and rebuilt it, doing exactly what `Decide` is written to do. `DeleteVM` (stop, then delete) is seconds wide against a 15s tick.

**The target is now lowered first.** That also makes the failure modes converge downward: a failed delete leaves a target *below* the node count, which the reconciler will not act on (it only creates up to `Min`, never scales down) and which the autoscaler retries. A target *above* reality is the one state that resurrects a drained node.

## 2. The rebuilt node reused the name, and k3s refuses that forever

k3s stores `<node>.node-password.k3s` in `kube-system` and checks it on every join. Deleting the Kubernetes Node does not remove it — CA deletes the Node, we delete the instance, neither touches the secret. The replacement generated a fresh password and was refused, once every ~8s for 19 minutes:

```
unable to verify password for node <cluster>-medium-1: hash does not match
```

It never registers, so it is **invisible to `kubectl` and absent from `cluster status`** while consuming its full size. `grep -rn "node-password"` over the repo previously returned nothing.

`ForgetNode` deletes the instance and *then* clears the secret. Order matters: a running agent re-creates the secret on its next request, so clearing first would leave a fresh stale password behind. An unreachable control plane does **not** fail the removal — the instance is already gone, and erroring would have the autoscaler retry a delete with nothing left to delete — but it is logged, naming the consequence.

## Why the existing test did not catch this

`TestCAProvider_DeleteNodesAndDecrease` already runs a reconciler pass after `DeleteNodes` returns and asserts the node is not resurrected. It passed throughout, because by then the target *is* lowered. The bug lives in the interleaving, and calling the two in sequence cannot express it.

The new test drives a reconciler pass **inside** the batch, via an `onDelete` hook on the stateful host fake that fires with the instance already removed and the caller not yet returned. That is the production window.

This is the same review heuristic the umbrella has flagged three times (#1452, #1473, #1415): the old test asserted on the sequence the code was *supposed* to produce, not on what the system ends up holding.

## Test evidence

| Test | Covers |
| --- | --- |
| `TestCAProvider_DeleteNodesIsNotUndoneByAConcurrentReconcilerPass` | **done-means 2** — a pass mid-batch produces no `ActionCreateWorker`; asserted on the instances the host actually holds |
| `TestCAProvider_TargetIsLoweredBeforeAnyInstanceIsDestroyed` | **done-means 1** — the mechanism directly: the store must never advertise a target counting a node being destroyed |
| `TestForgetNodeClearsTheNodePasswordAfterDeletingTheInstance` | **done-means 3** — stop → delete → forget, the right secret, `-n kube-system`, `--ignore-not-found` |
| `TestForgetNodeSucceedsWhenTheControlPlaneCannotBeReached` | an unreachable CP does not turn a completed removal into a failed one |

**All three behaviours were confirmed to fail against the old code**, by reverting each and watching the suite go red:

- destroy-first ordering → both provider tests fail, the second reporting `target was 2 while the instance was being destroyed`
- instance deleted but secret left → `the control plane was never told to forget the node password`

`go test ./internal/server/ ./pkg/core/cluster/ -count=1` green locally; CI on this branch is the gate.

## Reviewer's eye

- The `onDelete` hook fires **outside** the fake's mutex, because it re-enters the fake through the reconciler exactly as a real tick would. Holding the lock would deadlock rather than reproduce anything.
- The fake's `Exec` previously answered the node list to *any* `kubectl` subcommand, which would have made a `delete secret` look successful regardless of what it was handed. It now answers only `kubectl get`.
- Not addressed here, deliberately: **done-means 4** (the lane's surviving instance set matching what the cluster claims) is an assertion in the lane itself, which lives in PR #1436.

🤖 Generated with [Claude Code](https://claude.com/claude-code)