### PR TITLE
perf(container): run jump-account creation concurrently with guest boot

### DIFF
--- a/pkg/core/container/create_stages_test.go
+++ b/pkg/core/container/create_stages_test.go
@@ -3,6 +3,7 @@ package container
 import (
 	"errors"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -15,6 +16,8 @@ import (
 type stagesBackend struct {
 	incus.Backend
 	waitNetworkErr error
+	onWaitNetwork  func() // called on entry to WaitForNetwork, when set
+	deleteCalls    int    // DeleteContainer invocations (cleanup evidence)
 }
 
 func (b *stagesBackend) GetImageAliasProperties(string) (map[string]string, bool, error) {
@@ -30,7 +33,7 @@ func (b *stagesBackend) GetImageAliasProperties(string) (map[string]string, bool
 func (b *stagesBackend) CreateContainer(incus.ContainerConfig) error { return nil }
 func (b *stagesBackend) StartContainer(string) error                 { return nil }
 func (b *stagesBackend) StopContainer(string, bool) error            { return nil }
-func (b *stagesBackend) DeleteContainer(string) error                { return nil }
+func (b *stagesBackend) DeleteContainer(string) error                { b.deleteCalls++; return nil }
 func (b *stagesBackend) SetLabels(string, map[string]string) error   { return nil }
 func (b *stagesBackend) Exec(string, []string) error                 { return nil }
 func (b *stagesBackend) WriteFile(string, string, []byte, string) error {
@@ -38,6 +41,9 @@ func (b *stagesBackend) WriteFile(string, string, []byte, string) error {
 }
 
 func (b *stagesBackend) WaitForNetwork(string, time.Duration) (string, error) {
+	if b.onWaitNetwork != nil {
+		b.onWaitNetwork()
+	}
 	if b.waitNetworkErr != nil {
 		return "", b.waitNetworkErr
 	}
@@ -48,8 +54,10 @@ func (b *stagesBackend) GetContainer(name string) (*incus.ContainerInfo, error) 
 	return &incus.ContainerInfo{Name: name}, nil
 }
 
-// stageLog records every observation in order.
+// stageLog records every observation in order. Mutex-guarded because the
+// jump-account stage reports from its own goroutine.
 type stageLog struct {
+	mu        sync.Mutex
 	stages    []CreateStage
 	durations map[CreateStage]time.Duration
 }
@@ -60,6 +68,8 @@ func newStageLog() *stageLog {
 
 func (l *stageLog) observer() StageObserver {
 	return func(s CreateStage, d time.Duration) {
+		l.mu.Lock()
+		defer l.mu.Unlock()
 		l.stages = append(l.stages, s)
 		l.durations[s] = d
 	}

--- a/pkg/core/container/jump_account_concurrent_test.go
+++ b/pkg/core/container/jump_account_concurrent_test.go
@@ -1,0 +1,90 @@
+package container
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+const testSSHKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMw0GUYQZVPWxSAC4T8RdKFGqzb8jxbFFM/SB6ILi1Ji test@host"
+
+// stubJumpAccount replaces the host-side jump-account functions for the
+// duration of the test. Not parallel-safe (package-level seam), so the
+// tests that use it must not call t.Parallel.
+func stubJumpAccount(t *testing.T, create func(username, key string, verbose bool) error) {
+	t.Helper()
+	prevCreate, prevAdd := createJumpServerAccountFn, addAuthorizedKeyFn
+	createJumpServerAccountFn = create
+	addAuthorizedKeyFn = func(string, string) error { return nil }
+	t.Cleanup(func() {
+		createJumpServerAccountFn, addAuthorizedKeyFn = prevCreate, prevAdd
+	})
+}
+
+// TestCreate_JumpAccountRunsConcurrentlyWithGuestStages pins the overlap
+// contract: the host-side jump account must NOT gate the guest stages.
+// The stub refuses to finish until WaitForNetwork has been entered — under
+// the old sequential order (jump account strictly before the network
+// wait) that condition never becomes true, the stub times out, and the
+// create fails, failing the test.
+func TestCreate_JumpAccountRunsConcurrentlyWithGuestStages(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	networkWaited := make(chan struct{})
+	backend := &stagesBackend{}
+	var closeOnce bool
+	backend.onWaitNetwork = func() {
+		if !closeOnce {
+			closeOnce = true
+			close(networkWaited)
+		}
+	}
+
+	stubJumpAccount(t, func(string, string, bool) error {
+		select {
+		case <-networkWaited:
+			return nil
+		case <-time.After(5 * time.Second):
+			return errors.New("jump account still blocked when the network wait should already have run — create is sequential again")
+		}
+	})
+
+	m := NewWithBackend(backend)
+	opts := stagesOpts()
+	opts.SSHKeys = []string{testSSHKey}
+
+	if _, err := m.Create(opts); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+}
+
+// TestCreate_JumpAccountFailureStillFailsCreate pins the join: moving the
+// account work off the critical path must not soften its error contract —
+// a failed jump account fails the create and cleans up the container.
+func TestCreate_JumpAccountFailureStillFailsCreate(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	stubJumpAccount(t, func(string, string, bool) error {
+		return errors.New("useradd exploded")
+	})
+
+	backend := &stagesBackend{}
+	m := NewWithBackend(backend)
+	log := newStageLog()
+	m.SetStageObserver(log.observer())
+	opts := stagesOpts()
+	opts.SSHKeys = []string{testSSHKey}
+
+	if _, err := m.Create(opts); err == nil {
+		t.Fatal("Create succeeded despite a failed jump account")
+	}
+	if backend.deleteCalls == 0 {
+		t.Error("failed jump account did not clean up the container")
+	}
+	if _, ok := log.durations[StageJumpAccount]; !ok {
+		t.Errorf("jump_account stage not observed (observed: %v)", log.stages)
+	}
+	if _, ok := log.durations[StageTotal]; ok {
+		t.Error("total observed on a failed create")
+	}
+}

--- a/pkg/core/container/manager.go
+++ b/pkg/core/container/manager.go
@@ -133,6 +133,17 @@ func resolveGPUDevices(b incus.Backend, inputs []string) ([]incus.GPUDevice, err
 	return devices, nil
 }
 
+// createJumpServerAccountFn and addAuthorizedKeyFn are the host-side
+// account operations Create runs in its jump-account goroutine.
+//
+// vars, not direct calls, so tests can stub the host side (useradd et
+// al.) and exercise the concurrency contract; production keeps the
+// real functions. Same idiom as waitNetPollMin in pkg/core/incus.
+var (
+	createJumpServerAccountFn = CreateJumpServerAccount
+	addAuthorizedKeyFn        = AddAuthorizedKey
+)
+
 // Create creates a new container with full setup
 func (m *Manager) Create(opts CreateOptions) (*incus.ContainerInfo, error) {
 	createStart := time.Now()
@@ -297,36 +308,46 @@ func (m *Manager) Create(opts CreateOptions) (*incus.ContainerInfo, error) {
 
 	// --- Linux container provisioning (steps 3-7) ---
 
-	// Step 3: Create jump server account (proxy-only, no shell access)
+	// Step 3: Create jump server account (proxy-only, no shell access).
+	//
+	// Runs CONCURRENTLY with the guest-side stages below (network wait,
+	// package install, user seeding): it is purely host-side — useradd +
+	// authorized_keys on the daemon host — and nothing in the create path
+	// reads its result before the join at the end. Overlapping it with the
+	// multi-second guest stages takes its ~100-300ms off the critical path.
+	// The join happens before GetContainer, so the error semantics are
+	// unchanged: a failed jump account still fails the create and cleans up
+	// the container.
 	if opts.Verbose {
 		fmt.Println("  [3/7] Creating jump server account (proxy-only)...")
 	}
 
+	var jumpAccountDone chan error
 	if len(opts.SSHKeys) > 0 {
-		if err := m.timed(StageJumpAccount, func() error {
-			// Seed the jump-server account with the first key.
-			if err := CreateJumpServerAccount(opts.Username, opts.SSHKeys[0], opts.Verbose); err != nil {
-				return fmt.Errorf("failed to create jump server account: %w", err)
-			}
-			// Then authorize the REST of the keys host-side. CreateJumpServerAccount
-			// only seeds the host /home/<user>/.ssh/authorized_keys with SSHKeys[0];
-			// without this loop the remaining keys land in the CONTAINER's
-			// authorized_keys (addSSHKeys, step 7) but NOT in the host jump-user
-			// file that ServeAuthorizedKeys exposes and the sentinel syncs into
-			// sshpiper. A client using any key other than SSHKeys[0] is then
-			// rejected at the sentinel (publickey) even though the box would accept
-			// it — e.g. an automation/runner key that sorts after a registered key.
-			// Mirrors the seed-then-authorize-the-rest pattern in collaborator.go.
-			for _, key := range opts.SSHKeys[1:] {
-				if err := AddAuthorizedKey(opts.Username, key); err != nil {
-					return fmt.Errorf("failed to authorize additional jump-server ssh key: %w", err)
+		jumpAccountDone = make(chan error, 1)
+		go func() {
+			jumpAccountDone <- m.timed(StageJumpAccount, func() error {
+				// Seed the jump-server account with the first key.
+				if err := createJumpServerAccountFn(opts.Username, opts.SSHKeys[0], opts.Verbose); err != nil {
+					return fmt.Errorf("failed to create jump server account: %w", err)
 				}
-			}
-			return nil
-		}); err != nil {
-			_ = m.cleanup(containerName)
-			return nil, err
-		}
+				// Then authorize the REST of the keys host-side. CreateJumpServerAccount
+				// only seeds the host /home/<user>/.ssh/authorized_keys with SSHKeys[0];
+				// without this loop the remaining keys land in the CONTAINER's
+				// authorized_keys (addSSHKeys, step 7) but NOT in the host jump-user
+				// file that ServeAuthorizedKeys exposes and the sentinel syncs into
+				// sshpiper. A client using any key other than SSHKeys[0] is then
+				// rejected at the sentinel (publickey) even though the box would accept
+				// it — e.g. an automation/runner key that sorts after a registered key.
+				// Mirrors the seed-then-authorize-the-rest pattern in collaborator.go.
+				for _, key := range opts.SSHKeys[1:] {
+					if err := addAuthorizedKeyFn(opts.Username, key); err != nil {
+						return fmt.Errorf("failed to authorize additional jump-server ssh key: %w", err)
+					}
+				}
+				return nil
+			})
+		}()
 	} else {
 		if opts.Verbose {
 			fmt.Println("       Warning: No SSH keys provided, skipping jump server account creation")
@@ -462,6 +483,17 @@ func (m *Manager) Create(opts CreateOptions) (*incus.ContainerInfo, error) {
 		}); err != nil {
 			_ = m.cleanup(containerName)
 			return nil, fmt.Errorf("failed to provision git source: %w", err)
+		}
+	}
+
+	// Join the jump-account goroutine (step 3). An early error return
+	// above skips this join deliberately: the goroutine's send is buffered
+	// so it never leaks, and a host account created for a failed create
+	// dangles exactly as it did when the account was created up front.
+	if jumpAccountDone != nil {
+		if err := <-jumpAccountDone; err != nil {
+			_ = m.cleanup(containerName)
+			return nil, err
 		}
 	}
 


### PR DESCRIPTION
## What

Game-1 win #2 from the two-digit-ms design note (#1488): the host-side jump-server account creation (useradd + authorized_keys on the daemon host, ~100–300ms) sat on the create path's critical path between container start and the network wait, even though nothing guest-side depends on it. It now runs concurrently with the guest stages that follow (network wait, package install, user seeding), so its cost is absorbed into stages that already take seconds instead of adding to the total.

## How

- `Create` launches the jump-account work (`CreateJumpServerAccount` + the additional-keys loop) in a goroutine at step 3, sending its result on a buffered channel.
- The channel is joined right before the final `GetContainer` call — after all the guest-side stages, before the create is declared successful.
- Error semantics are unchanged: a failed jump account still fails the create and cleans up the container (`m.cleanup`), just discovered at the join instead of immediately. An early error return elsewhere in `Create` skips the join deliberately — the send is buffered so the goroutine never leaks, and a host account created for a create that later fails dangles exactly as it did before (unchanged pre-existing behavior).
- `CreateJumpServerAccount` / `AddAuthorizedKey` calls move behind package-level vars (`createJumpServerAccountFn` / `addAuthorizedKeyFn`, same idiom as `waitNetPollMin` in `pkg/core/incus`) so tests can stub the host side without touching real `useradd`.

## Tests

`jump_account_concurrent_test.go`:
- **Overlap contract**: the stubbed jump-account function blocks until `WaitForNetwork` has been entered (via a channel closed from the fake backend's `WaitForNetwork`), with a 5s timeout that fails the test otherwise. This means the test actually verifies concurrency, not just "the create succeeded" — re-sequencing the code back to synchronous order makes this test time out and fail (verified locally before opening this PR).
- **Join/error contract**: a failing stubbed jump account still fails `Create`, still triggers cleanup (`DeleteContainer`), and the `jump_account` stage is still observed on the failure path while `total` is not — consistent with #1499's stage semantics.

`stageLog` (shared with #1499's tests) is now mutex-guarded since the jump-account stage reports from its own goroutine. Full `pkg/core/container` and `pkg/core/box/...` suites pass with `-race`.

## Scope

No API change. Builds on #1499 (stage instrumentation, merged) and #1501 (identity seeding collapse, merged) — this PR's diff is only the concurrency change plus its test.

Refs #1488 (Game-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
