### PR TITLE
feat(server): SandboxService implementation — Phase 1 cold path (#1488)

### DIFF
--- a/internal/auth/scopes.go
+++ b/internal/auth/scopes.go
@@ -121,6 +121,14 @@ const (
 	ScopeAuditRead         = "audit:read"          // audit-log query
 	ScopeNetworkPolicyRead = "network-policy:read" // NetworkPolicyService Get/List
 	ScopeTokensRead        = "tokens:read"         // token listing
+
+	// ephemeral sandboxes (SandboxServer, #1488). A sandbox has no
+	// per-tenant Linux account and no SSH — spawn/exec/file/delete is its
+	// entire access surface, and an agent's own token is what reaches it,
+	// so it's gated separately from the persistent-box containers scope
+	// rather than folded into it.
+	ScopeSandboxesRead  = "sandboxes:read"
+	ScopeSandboxesWrite = "sandboxes:write"
 )
 
 // AllScopes is the catalog of every known scope. It backs IsKnownScope so

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -448,6 +448,12 @@ func (gs *GatewayServer) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to register volume service gateway: %w", err)
 	}
 
+	// Register SandboxService gateway handler — ephemeral, no-SSH sandboxes
+	// (#1488 Phase 1).
+	if err := pb.RegisterSandboxServiceHandlerFromEndpoint(ctx, mux, gs.grpcAddress, opts); err != nil {
+		return fmt.Errorf("failed to register sandbox service gateway: %w", err)
+	}
+
 	// Register ClusterService gateway handler — managed K8s clusters (#1413)
 	if err := pb.RegisterClusterServiceHandlerFromEndpoint(ctx, mux, gs.grpcAddress, opts); err != nil {
 		return fmt.Errorf("failed to register cluster service gateway: %w", err)

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -524,6 +524,16 @@ func NewDualServer(config *DualServerConfig) (*DualServer, error) {
 	pb.RegisterVolumeServiceServer(grpcServer, NewVolumeServer())
 	log.Printf("Volume service enabled")
 
+	// Register SandboxService — ephemeral, no-SSH sandboxes (#1488 Phase 1,
+	// the two-digit-ms spawn path's cold-path implementation). Own incus
+	// client, same pattern as the other feature servers in this function.
+	if sandboxIncusClient, err := incus.New(); err == nil {
+		pb.RegisterSandboxServiceServer(grpcServer, NewSandboxServer(sandboxIncusClient))
+		log.Printf("Sandbox service enabled")
+	} else {
+		log.Printf("Warning: SandboxService disabled — incus client init failed: %v", err)
+	}
+
 	// Register ClusterService — managed Kubernetes clusters (#1413).
 	// Lifecycle state only; VM provisioning is the reconciler's job
 	// (#1414). Starts on the in-memory store and is swapped to Postgres

--- a/internal/server/sandbox_server.go
+++ b/internal/server/sandbox_server.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/internal/safecast"
 	"github.com/footprintai/containarium/pkg/core/incus"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 	"google.golang.org/grpc/codes"
@@ -225,7 +226,7 @@ func (s *SandboxServer) ExecInSandbox(ctx context.Context, req *pb.ExecInSandbox
 	return &pb.ExecInSandboxResponse{
 		Stdout:   stdout,
 		Stderr:   stderr,
-		ExitCode: int32(exitCode),
+		ExitCode: safecast.I32(exitCode),
 	}, nil
 }
 

--- a/internal/server/sandbox_server.go
+++ b/internal/server/sandbox_server.go
@@ -1,0 +1,296 @@
+package server
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/pkg/core/incus"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// sandboxKindLabelSuffix marks an Incus instance as an ephemeral sandbox
+// (SandboxService), distinct from a persistent tenant box. Listing/reaping
+// code that iterates ContainerService's tenant boxes should skip instances
+// carrying this label — not yet wired in Phase 1, since sandbox names
+// (sandbox-<id>) don't collide with the <username>-container convention
+// those paths key on, but worth flagging for whoever adds a sandbox-aware
+// sweep.
+const sandboxKindLabelSuffix = "kind"
+
+// SandboxKindLabelKey is the full Incus config key
+// (incus.LabelPrefix-qualified) written via ContainerConfig.ExtraConfig at
+// spawn time.
+const SandboxKindLabelKey = incus.LabelPrefix + sandboxKindLabelSuffix
+
+// SandboxKindLabelValue is the label's value on every sandbox.
+const SandboxKindLabelValue = "sandbox"
+
+// sandboxNamePrefix names every sandbox's Incus container: sandbox-<12 hex
+// chars>. The sandbox_id IS the Incus container name — no separate mapping
+// table, matching how a tenant's container name IS its box.BoxRef.Tenant +
+// "-container" elsewhere in this codebase.
+const sandboxNamePrefix = "sandbox-"
+
+// defaultSandboxIdleTTL applies when SpawnSandboxRequest.idle_ttl_seconds is
+// unset (0). No sweeper enforces it yet in Phase 1 (see the design note's
+// Phase 4) — expires_at is reported so a caller can see the horizon its
+// sandbox will eventually be reaped against once the sweeper exists.
+const defaultSandboxIdleTTL = 30 * time.Minute
+
+// spawnNetworkTimeout bounds how long SpawnSandbox waits for the guest's
+// network to come up. Same bound container.Manager.Create uses for the
+// equivalent wait.
+const spawnNetworkTimeout = 30 * time.Second
+
+// SandboxServer implements SandboxService (#1488 Phase 1): the two-digit-ms
+// spawn path's cold-path implementation. A sandbox has no per-tenant Linux
+// account and no SSH — these five RPCs are its entire access surface.
+//
+// Talks to incus.Backend directly rather than going through
+// pkg/core/container.Manager: Manager.Create is the full persistent-box
+// identity flow (jump-server account, in-guest user, SSH keys) that
+// sandboxes are explicitly scoped to skip. Reusing it would mean threading
+// a "skip everything" option through a function whose entire shape is that
+// provisioning.
+type SandboxServer struct {
+	pb.UnimplementedSandboxServiceServer
+	incus incus.Backend
+}
+
+// NewSandboxServer constructs a SandboxServer over the given Incus backend.
+func NewSandboxServer(backend incus.Backend) *SandboxServer {
+	return &SandboxServer{incus: backend}
+}
+
+// newSandboxID generates a sandbox_id / Incus container name: sandbox- plus
+// 12 hex characters (6 random bytes) — collision odds low enough that a
+// create-time name clash is not worth handling as anything other than the
+// CreateContainer error it would surface.
+func newSandboxID() (string, error) {
+	b := make([]byte, 6)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("failed to generate sandbox id: %w", err)
+	}
+	return sandboxNamePrefix + hex.EncodeToString(b), nil
+}
+
+// resolveTemplate maps a requested template to its guest image.
+// SANDBOX_TEMPLATE_UNSPECIFIED resolves to BASE, mirroring
+// ostype.ImageForOSType's unspecified-defaults-to-Ubuntu convention. Any
+// other value is rejected: v1 ships BASE only (see the proto's doc comment
+// on SandboxTemplate), and silently falling back would let a caller depend
+// on a template that doesn't actually exist yet.
+func resolveTemplate(t pb.SandboxTemplate) (resolved pb.SandboxTemplate, image string, err error) {
+	switch t {
+	case pb.SandboxTemplate_SANDBOX_TEMPLATE_UNSPECIFIED, pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE:
+		return pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE, "images:ubuntu/24.04", nil
+	default:
+		return t, "", status.Errorf(codes.InvalidArgument, "unsupported sandbox template %v (v1 ships SANDBOX_TEMPLATE_BASE only)", t)
+	}
+}
+
+// destroy stops (force, errors ignored — deleting a stopped or a still-
+// running instance both work) then deletes name, returning the delete
+// error. Same shape as pkg/core/container.Manager.cleanup, duplicated
+// rather than shared because SandboxServer deliberately does not depend on
+// container.Manager (see the type doc). A spawn-failure rollback discards
+// the returned error (the spawn already failed); DeleteSandbox propagates
+// it — a caller asking to delete needs to know if that didn't happen.
+func (s *SandboxServer) destroy(name string) error {
+	_ = s.incus.StopContainer(name, true)
+	return s.incus.DeleteContainer(name)
+}
+
+// SpawnSandbox implements the two-digit-ms spawn path's Phase 1 cold
+// fallback: every call creates a fresh container. served_from is always
+// COLD until Phase 3 adds the warm pool.
+func (s *SandboxServer) SpawnSandbox(ctx context.Context, req *pb.SpawnSandboxRequest) (*pb.SpawnSandboxResponse, error) {
+	if err := auth.RequireScope(ctx, auth.ScopeSandboxesWrite); err != nil {
+		return nil, err
+	}
+	subject, _, ok := auth.SubjectFromGRPCContext(ctx)
+	if !ok {
+		return nil, status.Error(codes.Unauthenticated, "no authenticated subject")
+	}
+
+	template, image, err := resolveTemplate(req.Template)
+	if err != nil {
+		return nil, err
+	}
+
+	id, err := newSandboxID()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "%v", err)
+	}
+
+	ttl := time.Duration(req.IdleTtlSeconds) * time.Second
+	if ttl <= 0 {
+		ttl = defaultSandboxIdleTTL
+	}
+	now := time.Now()
+
+	config := incus.ContainerConfig{
+		Name:  id,
+		Image: image,
+		ExtraConfig: map[string]string{
+			SandboxKindLabelKey:                         SandboxKindLabelValue,
+			incus.TenantLabelKey:                        subject,
+			incus.LabelPrefix + "sandbox-template":      template.String(),
+			incus.LabelPrefix + "sandbox-idle-ttl-secs": fmt.Sprintf("%d", int64(ttl.Seconds())),
+		},
+	}
+
+	if err := s.incus.CreateContainer(config); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to create sandbox: %v", err)
+	}
+	if err := s.incus.StartContainer(id); err != nil {
+		_ = s.incus.DeleteContainer(id)
+		return nil, status.Errorf(codes.Internal, "failed to start sandbox: %v", err)
+	}
+	if _, err := s.incus.WaitForNetwork(id, spawnNetworkTimeout); err != nil {
+		_ = s.destroy(id)
+		return nil, status.Errorf(codes.Internal, "sandbox network did not come up: %v", err)
+	}
+
+	return &pb.SpawnSandboxResponse{
+		Sandbox: &pb.Sandbox{
+			SandboxId:  id,
+			State:      pb.SandboxState_SANDBOX_STATE_RUNNING,
+			Template:   template,
+			ServedFrom: pb.ServedFrom_SERVED_FROM_COLD,
+			CreatedAt:  timestamppb.New(now),
+			ExpiresAt:  timestamppb.New(now.Add(ttl)),
+		},
+	}, nil
+}
+
+// lookupOwnedSandbox fetches sandbox id and enforces ownership in one step:
+// NotFound if it doesn't exist or isn't a sandbox, PermissionDenied if it
+// exists but belongs to a different tenant (admins bypass the comparison).
+// The ownership comparison happens immediately after the existence check,
+// in the same function, so no caller of this helper can accidentally skip
+// it or reorder it after some other early return — a cross-tenant
+// sandbox_id must always resolve to PermissionDenied, never NotFound (the
+// design note's own test list: "the ownership check must run before
+// existence leaks").
+func (s *SandboxServer) lookupOwnedSandbox(ctx context.Context, id string) (*incus.ContainerInfo, error) {
+	subject, roles, ok := auth.SubjectFromGRPCContext(ctx)
+	if !ok {
+		return nil, status.Error(codes.Unauthenticated, "no authenticated subject")
+	}
+
+	info, err := s.incus.GetContainer(id)
+	// ContainerInfo.Labels is already prefix-stripped (see
+	// extractLabelsFromConfig) — compare the suffix, not the
+	// ExtraConfig-qualified SandboxKindLabelKey.
+	if err != nil || info == nil || info.Labels[sandboxKindLabelSuffix] != SandboxKindLabelValue {
+		return nil, status.Errorf(codes.NotFound, "sandbox %q not found", id)
+	}
+
+	if !auth.HasRole(roles, auth.RoleAdmin) && info.Tenant != subject {
+		return nil, status.Errorf(codes.PermissionDenied, "sandbox %q belongs to a different tenant", id)
+	}
+
+	return info, nil
+}
+
+// ExecInSandbox runs one command inside the sandbox. The sandbox's only
+// access surface — there is no SSH.
+func (s *SandboxServer) ExecInSandbox(ctx context.Context, req *pb.ExecInSandboxRequest) (*pb.ExecInSandboxResponse, error) {
+	if err := auth.RequireScope(ctx, auth.ScopeSandboxesWrite); err != nil {
+		return nil, err
+	}
+	if req.SandboxId == "" {
+		return nil, status.Error(codes.InvalidArgument, "sandbox_id is required")
+	}
+	if len(req.Command) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "command is required")
+	}
+	if _, err := s.lookupOwnedSandbox(ctx, req.SandboxId); err != nil {
+		return nil, err
+	}
+
+	stdout, stderr, exitCode, err := s.incus.ExecWithExitCode(req.SandboxId, req.Command)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "exec failed: %v", err)
+	}
+
+	return &pb.ExecInSandboxResponse{
+		Stdout:   stdout,
+		Stderr:   stderr,
+		ExitCode: int32(exitCode),
+	}, nil
+}
+
+// WriteFileInSandbox writes a file into the sandbox via the Incus file push
+// API — never through a shell, so file content can never be interpreted as
+// a command.
+func (s *SandboxServer) WriteFileInSandbox(ctx context.Context, req *pb.WriteFileInSandboxRequest) (*pb.WriteFileInSandboxResponse, error) {
+	if err := auth.RequireScope(ctx, auth.ScopeSandboxesWrite); err != nil {
+		return nil, err
+	}
+	if req.SandboxId == "" || req.Path == "" {
+		return nil, status.Error(codes.InvalidArgument, "sandbox_id and path are required")
+	}
+	if _, err := s.lookupOwnedSandbox(ctx, req.SandboxId); err != nil {
+		return nil, err
+	}
+
+	mode := req.Mode
+	if mode == "" {
+		mode = "0644"
+	}
+	if err := s.incus.WriteFile(req.SandboxId, req.Path, req.Content, mode); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to write file: %v", err)
+	}
+
+	return &pb.WriteFileInSandboxResponse{Message: fmt.Sprintf("wrote %d byte(s) to %s", len(req.Content), req.Path)}, nil
+}
+
+// ReadFileInSandbox reads a file back out of the sandbox.
+func (s *SandboxServer) ReadFileInSandbox(ctx context.Context, req *pb.ReadFileInSandboxRequest) (*pb.ReadFileInSandboxResponse, error) {
+	if err := auth.RequireScope(ctx, auth.ScopeSandboxesRead); err != nil {
+		return nil, err
+	}
+	if req.SandboxId == "" || req.Path == "" {
+		return nil, status.Error(codes.InvalidArgument, "sandbox_id and path are required")
+	}
+	if _, err := s.lookupOwnedSandbox(ctx, req.SandboxId); err != nil {
+		return nil, err
+	}
+
+	content, err := s.incus.ReadFile(req.SandboxId, req.Path)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to read file: %v", err)
+	}
+
+	return &pb.ReadFileInSandboxResponse{Content: content}, nil
+}
+
+// DeleteSandbox destroys the sandbox immediately. Sandboxes are never reset
+// and reused (see the design note's Isolation section) — delete always
+// means destroy, never "return to a pool".
+func (s *SandboxServer) DeleteSandbox(ctx context.Context, req *pb.DeleteSandboxRequest) (*pb.DeleteSandboxResponse, error) {
+	if err := auth.RequireScope(ctx, auth.ScopeSandboxesWrite); err != nil {
+		return nil, err
+	}
+	if req.SandboxId == "" {
+		return nil, status.Error(codes.InvalidArgument, "sandbox_id is required")
+	}
+	if _, err := s.lookupOwnedSandbox(ctx, req.SandboxId); err != nil {
+		return nil, err
+	}
+
+	if err := s.destroy(req.SandboxId); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to delete sandbox: %v", err)
+	}
+
+	return &pb.DeleteSandboxResponse{Message: fmt.Sprintf("sandbox %s deleted", req.SandboxId)}, nil
+}

--- a/internal/server/sandbox_server_test.go
+++ b/internal/server/sandbox_server_test.go
@@ -1,0 +1,326 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/pkg/core/incus"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// fakeSandboxBackend is a minimal, map-backed incus.Backend fake: real
+// enough that GetContainer after CreateContainer sees the labels/tenant
+// the create call stamped, without depending on a live Incus daemon.
+type fakeSandboxBackend struct {
+	incus.Backend
+	instances map[string]incus.ContainerInfo
+
+	waitNetworkErr     error
+	execStdout         string
+	execStderr         string
+	execExitCode       int
+	execErr            error
+	writeFileErr       error
+	readFileContent    []byte
+	readFileErr        error
+	deleteContainerErr error
+	deleteCalls        int
+	startErr           error
+}
+
+func newFakeSandboxBackend() *fakeSandboxBackend {
+	return &fakeSandboxBackend{instances: make(map[string]incus.ContainerInfo)}
+}
+
+func (b *fakeSandboxBackend) CreateContainer(c incus.ContainerConfig) error {
+	b.instances[c.Name] = incus.ContainerInfo{
+		Name:   c.Name,
+		State:  "Stopped",
+		Labels: extractTestLabels(c.ExtraConfig),
+		Tenant: c.ExtraConfig[incus.TenantLabelKey],
+		Image:  c.Image,
+	}
+	return nil
+}
+
+// extractTestLabels mirrors incus's own LabelPrefix-stripping so the fake's
+// GetContainer sees the same view a real backend would.
+func extractTestLabels(config map[string]string) map[string]string {
+	labels := make(map[string]string)
+	for k, v := range config {
+		if len(k) > len(incus.LabelPrefix) && k[:len(incus.LabelPrefix)] == incus.LabelPrefix {
+			labels[k[len(incus.LabelPrefix):]] = v
+		}
+	}
+	return labels
+}
+
+func (b *fakeSandboxBackend) StartContainer(name string) error {
+	if b.startErr != nil {
+		return b.startErr
+	}
+	if info, ok := b.instances[name]; ok {
+		info.State = "Running"
+		b.instances[name] = info
+	}
+	return nil
+}
+
+func (b *fakeSandboxBackend) StopContainer(string, bool) error { return nil }
+
+func (b *fakeSandboxBackend) DeleteContainer(name string) error {
+	b.deleteCalls++
+	if b.deleteContainerErr != nil {
+		return b.deleteContainerErr
+	}
+	delete(b.instances, name)
+	return nil
+}
+
+func (b *fakeSandboxBackend) WaitForNetwork(string, time.Duration) (string, error) {
+	if b.waitNetworkErr != nil {
+		return "", b.waitNetworkErr
+	}
+	return "203.0.113.9", nil
+}
+
+func (b *fakeSandboxBackend) GetContainer(name string) (*incus.ContainerInfo, error) {
+	info, ok := b.instances[name]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return &info, nil
+}
+
+func (b *fakeSandboxBackend) ExecWithExitCode(string, []string) (string, string, int, error) {
+	return b.execStdout, b.execStderr, b.execExitCode, b.execErr
+}
+
+func (b *fakeSandboxBackend) WriteFile(string, string, []byte, string) error {
+	return b.writeFileErr
+}
+
+func (b *fakeSandboxBackend) ReadFile(string, string) ([]byte, error) {
+	return b.readFileContent, b.readFileErr
+}
+
+func ctxAs(username string, admin bool) context.Context {
+	roles := []string{}
+	if admin {
+		roles = []string{auth.RoleAdmin}
+	}
+	return auth.ContextWithClaims(context.Background(), &auth.Claims{Username: username, Roles: roles})
+}
+
+func spawnAsAlice(t *testing.T, backend *fakeSandboxBackend, s *SandboxServer) *pb.Sandbox {
+	t.Helper()
+	resp, err := s.SpawnSandbox(ctxAs("alice", false), &pb.SpawnSandboxRequest{})
+	if err != nil {
+		t.Fatalf("SpawnSandbox: %v", err)
+	}
+	return resp.Sandbox
+}
+
+func TestSpawnSandbox_HappyPath(t *testing.T) {
+	backend := newFakeSandboxBackend()
+	s := NewSandboxServer(backend)
+
+	sb := spawnAsAlice(t, backend, s)
+
+	if sb.SandboxId == "" {
+		t.Fatal("empty sandbox_id")
+	}
+	if sb.State != pb.SandboxState_SANDBOX_STATE_RUNNING {
+		t.Errorf("state = %v, want RUNNING", sb.State)
+	}
+	if sb.Template != pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE {
+		t.Errorf("template = %v, want BASE (unspecified should resolve to BASE)", sb.Template)
+	}
+	if sb.ServedFrom != pb.ServedFrom_SERVED_FROM_COLD {
+		t.Errorf("served_from = %v, want COLD (Phase 1 has no pool)", sb.ServedFrom)
+	}
+	if sb.CreatedAt == nil || sb.ExpiresAt == nil {
+		t.Error("created_at / expires_at not set")
+	}
+
+	info := backend.instances[sb.SandboxId]
+	if info.Tenant != "alice" {
+		t.Errorf("stamped tenant = %q, want alice", info.Tenant)
+	}
+	if info.Labels[sandboxKindLabelSuffix] != SandboxKindLabelValue {
+		t.Errorf("sandbox-kind label not stamped: %+v", info.Labels)
+	}
+}
+
+func TestSpawnSandbox_UnauthenticatedRejected(t *testing.T) {
+	s := NewSandboxServer(newFakeSandboxBackend())
+	if _, err := s.SpawnSandbox(context.Background(), &pb.SpawnSandboxRequest{}); err == nil {
+		t.Fatal("SpawnSandbox with no subject in context should fail")
+	}
+}
+
+func TestSpawnSandbox_UnsupportedTemplateRejected(t *testing.T) {
+	s := NewSandboxServer(newFakeSandboxBackend())
+	_, err := s.SpawnSandbox(ctxAs("alice", false), &pb.SpawnSandboxRequest{Template: pb.SandboxTemplate(99)})
+	if err == nil {
+		t.Fatal("unsupported template should be rejected — v1 ships BASE only")
+	}
+}
+
+// TestSpawnSandbox_NetworkFailureCleansUp pins the rollback contract: a
+// spawn that fails after CreateContainer/StartContainer must not leave the
+// half-provisioned instance behind.
+func TestSpawnSandbox_NetworkFailureCleansUp(t *testing.T) {
+	backend := newFakeSandboxBackend()
+	backend.waitNetworkErr = errors.New("no lease")
+	s := NewSandboxServer(backend)
+
+	if _, err := s.SpawnSandbox(ctxAs("alice", false), &pb.SpawnSandboxRequest{}); err == nil {
+		t.Fatal("SpawnSandbox should fail when WaitForNetwork fails")
+	}
+	if backend.deleteCalls == 0 {
+		t.Error("failed spawn did not clean up the half-provisioned instance")
+	}
+}
+
+// TestSandboxOwnership pins the design note's own required contract: a
+// cross-tenant sandbox_id resolves to PermissionDenied, never NotFound —
+// the ownership check must run before existence can leak.
+func TestSandboxOwnership(t *testing.T) {
+	backend := newFakeSandboxBackend()
+	s := NewSandboxServer(backend)
+	sb := spawnAsAlice(t, backend, s)
+
+	t.Run("owner can exec", func(t *testing.T) {
+		if _, err := s.ExecInSandbox(ctxAs("alice", false), &pb.ExecInSandboxRequest{
+			SandboxId: sb.SandboxId, Command: []string{"true"},
+		}); err != nil {
+			t.Errorf("owner exec: %v", err)
+		}
+	})
+
+	t.Run("different tenant gets PermissionDenied, not NotFound", func(t *testing.T) {
+		_, err := s.ExecInSandbox(ctxAs("bob", false), &pb.ExecInSandboxRequest{
+			SandboxId: sb.SandboxId, Command: []string{"true"},
+		})
+		if got := status.Code(err); got != codes.PermissionDenied {
+			t.Errorf("code = %v, want PermissionDenied (cross-tenant access must not read as NotFound)", got)
+		}
+	})
+
+	t.Run("admin can exec any tenant's sandbox", func(t *testing.T) {
+		if _, err := s.ExecInSandbox(ctxAs("root", true), &pb.ExecInSandboxRequest{
+			SandboxId: sb.SandboxId, Command: []string{"true"},
+		}); err != nil {
+			t.Errorf("admin exec: %v", err)
+		}
+	})
+
+	t.Run("nonexistent sandbox_id is NotFound", func(t *testing.T) {
+		_, err := s.ExecInSandbox(ctxAs("alice", false), &pb.ExecInSandboxRequest{
+			SandboxId: "sandbox-does-not-exist", Command: []string{"true"},
+		})
+		if got := status.Code(err); got != codes.NotFound {
+			t.Errorf("code = %v, want NotFound", got)
+		}
+	})
+}
+
+func TestExecInSandbox_ReturnsExitCode(t *testing.T) {
+	backend := newFakeSandboxBackend()
+	backend.execStdout = "hello\n"
+	backend.execStderr = "warn\n"
+	backend.execExitCode = 3
+	s := NewSandboxServer(backend)
+	sb := spawnAsAlice(t, backend, s)
+
+	resp, err := s.ExecInSandbox(ctxAs("alice", false), &pb.ExecInSandboxRequest{
+		SandboxId: sb.SandboxId, Command: []string{"false"},
+	})
+	if err != nil {
+		t.Fatalf("ExecInSandbox: %v", err)
+	}
+	if resp.Stdout != "hello\n" || resp.Stderr != "warn\n" || resp.ExitCode != 3 {
+		t.Errorf("resp = %+v, want stdout=hello stderr=warn exit_code=3", resp)
+	}
+}
+
+func TestExecInSandbox_RequiresCommand(t *testing.T) {
+	backend := newFakeSandboxBackend()
+	s := NewSandboxServer(backend)
+	sb := spawnAsAlice(t, backend, s)
+
+	if _, err := s.ExecInSandbox(ctxAs("alice", false), &pb.ExecInSandboxRequest{SandboxId: sb.SandboxId}); err == nil {
+		t.Fatal("empty command should be rejected")
+	}
+}
+
+func TestWriteReadFileInSandbox_RoundTrip(t *testing.T) {
+	backend := newFakeSandboxBackend()
+	backend.readFileContent = []byte("round-tripped")
+	s := NewSandboxServer(backend)
+	sb := spawnAsAlice(t, backend, s)
+
+	if _, err := s.WriteFileInSandbox(ctxAs("alice", false), &pb.WriteFileInSandboxRequest{
+		SandboxId: sb.SandboxId, Path: "/workspace/out.txt", Content: []byte("data"),
+	}); err != nil {
+		t.Fatalf("WriteFileInSandbox: %v", err)
+	}
+
+	resp, err := s.ReadFileInSandbox(ctxAs("alice", false), &pb.ReadFileInSandboxRequest{
+		SandboxId: sb.SandboxId, Path: "/workspace/out.txt",
+	})
+	if err != nil {
+		t.Fatalf("ReadFileInSandbox: %v", err)
+	}
+	if string(resp.Content) != "round-tripped" {
+		t.Errorf("content = %q", resp.Content)
+	}
+
+	t.Run("cross-tenant read denied", func(t *testing.T) {
+		if _, err := s.ReadFileInSandbox(ctxAs("bob", false), &pb.ReadFileInSandboxRequest{
+			SandboxId: sb.SandboxId, Path: "/workspace/out.txt",
+		}); err == nil {
+			t.Fatal("expected PermissionDenied for a different tenant's sandbox")
+		}
+	})
+}
+
+func TestDeleteSandbox_Destroys(t *testing.T) {
+	backend := newFakeSandboxBackend()
+	s := NewSandboxServer(backend)
+	sb := spawnAsAlice(t, backend, s)
+
+	if _, err := s.DeleteSandbox(ctxAs("alice", false), &pb.DeleteSandboxRequest{SandboxId: sb.SandboxId}); err != nil {
+		t.Fatalf("DeleteSandbox: %v", err)
+	}
+	if _, ok := backend.instances[sb.SandboxId]; ok {
+		t.Error("sandbox still present after DeleteSandbox")
+	}
+
+	t.Run("second delete is NotFound, not a crash", func(t *testing.T) {
+		if _, err := s.DeleteSandbox(ctxAs("alice", false), &pb.DeleteSandboxRequest{SandboxId: sb.SandboxId}); err == nil {
+			t.Fatal("deleting an already-deleted sandbox should error")
+		}
+	})
+}
+
+// TestDeleteSandbox_DeleteErrorPropagates pins the fix over the naive
+// best-effort version: DeleteSandbox is the caller's explicit request to
+// delete, so a real DeleteContainer failure must surface, not be silently
+// swallowed the way a failed-spawn rollback discards it.
+func TestDeleteSandbox_DeleteErrorPropagates(t *testing.T) {
+	backend := newFakeSandboxBackend()
+	backend.deleteContainerErr = errors.New("incus: instance is busy")
+	s := NewSandboxServer(backend)
+	sb := spawnAsAlice(t, backend, s)
+
+	if _, err := s.DeleteSandbox(ctxAs("alice", false), &pb.DeleteSandboxRequest{SandboxId: sb.SandboxId}); err == nil {
+		t.Fatal("DeleteSandbox should surface a real DeleteContainer failure")
+	}
+}

--- a/pkg/core/incus/client.go
+++ b/pkg/core/incus/client.go
@@ -139,6 +139,13 @@ type Backend interface {
 	// Exec & file I/O
 	Exec(containerName string, command []string) error
 	ExecWithOutput(containerName string, command []string) (string, string, error)
+	// ExecWithExitCode is ExecWithOutput's sibling for a caller that needs
+	// the command's exit status as data, not folded into err (SandboxService
+	// ExecInSandbox, #1488: an agent inner loop branches on exit code as
+	// normal control flow). err is non-nil only for a genuine
+	// execution/transport failure — a non-zero exit is reported via
+	// exitCode with err == nil.
+	ExecWithExitCode(containerName string, command []string) (stdout, stderr string, exitCode int, err error)
 	WriteFile(containerName, path string, content []byte, mode string) error
 	ReadFile(containerName, path string) ([]byte, error)
 
@@ -2387,6 +2394,50 @@ func (c *Client) ExecWithOutput(containerName string, command []string) (string,
 		return nil
 	})
 	return stdout.String(), stderr.String(), err
+}
+
+// ExecWithExitCode is ExecWithOutput's sibling that reports a non-zero exit
+// as data (exitCode) rather than folding it into err. See the Backend
+// interface doc for why this exists.
+//
+// err == nil and a nonzero exitCode both mean "the command ran and exited
+// nonzero" — the same event ExecWithOutput reports as
+// fmt.Errorf("command exited with code %d", ...). Returning nil here (not
+// that error) is deliberate: execWithRetry's isTransientExecErr only
+// matches liblxc-socket-wedge error strings, so returning nil is what
+// stops the retry loop after one attempt, exactly as the folded-error
+// version did — just without inventing an error value only to immediately
+// discard its meaning into an int.
+func (c *Client) ExecWithExitCode(containerName string, command []string) (stdout, stderr string, exitCode int, err error) {
+	var stdoutBuf, stderrBuf bytes.Buffer
+
+	req := api.InstanceExecPost{
+		Command:     command,
+		WaitForWS:   true,
+		Interactive: false,
+	}
+
+	err = execWithRetry("exec "+containerName, func() error {
+		stdoutBuf.Reset()
+		stderrBuf.Reset()
+		exitCode = 0
+		args := &incus.InstanceExecArgs{Stdout: &stdoutBuf, Stderr: &stderrBuf}
+
+		op, opErr := c.server.ExecInstance(containerName, req, args)
+		if opErr != nil {
+			return fmt.Errorf("failed to execute command: %w", opErr)
+		}
+		if opErr := op.Wait(); opErr != nil {
+			return fmt.Errorf("command execution failed: %w", opErr)
+		}
+		if opMeta := op.Get(); opMeta.Metadata != nil {
+			if returnVal, ok := opMeta.Metadata["return"].(float64); ok {
+				exitCode = int(returnVal)
+			}
+		}
+		return nil
+	})
+	return stdoutBuf.String(), stderrBuf.String(), exitCode, err
 }
 
 // CleanupDisk frees disk space inside a container by removing temp files,

--- a/pkg/core/incus/incustest/mock.go
+++ b/pkg/core/incus/incustest/mock.go
@@ -37,6 +37,7 @@ type MockBackend struct {
 	WaitForNetworkFunc        func(containerName string, timeout time.Duration) (string, error)
 	ExecFunc                  func(containerName string, command []string) error
 	ExecWithOutputFunc        func(containerName string, command []string) (string, string, error)
+	ExecWithExitCodeFunc      func(containerName string, command []string) (string, string, int, error)
 	WriteFileFunc             func(containerName, path string, content []byte, mode string) error
 	ReadFileFunc              func(containerName, path string) ([]byte, error)
 	SetConfigFunc             func(containerName, key, value string) error
@@ -159,6 +160,13 @@ func (m *MockBackend) ExecWithOutput(containerName string, command []string) (st
 		return m.ExecWithOutputFunc(containerName, command)
 	}
 	return "", "", nil
+}
+
+func (m *MockBackend) ExecWithExitCode(containerName string, command []string) (string, string, int, error) {
+	if m.ExecWithExitCodeFunc != nil {
+		return m.ExecWithExitCodeFunc(containerName, command)
+	}
+	return "", "", 0, nil
 }
 
 func (m *MockBackend) WriteFile(containerName, path string, content []byte, mode string) error {

--- a/pkg/core/incus/unavailable.go
+++ b/pkg/core/incus/unavailable.go
@@ -46,6 +46,9 @@ func (*UnavailableBackend) Exec(string, []string) error { return ErrUnavailable 
 func (*UnavailableBackend) ExecWithOutput(string, []string) (string, string, error) {
 	return "", "", ErrUnavailable
 }
+func (*UnavailableBackend) ExecWithExitCode(string, []string) (string, string, int, error) {
+	return "", "", 0, ErrUnavailable
+}
 func (*UnavailableBackend) WriteFile(string, string, []byte, string) error { return ErrUnavailable }
 func (*UnavailableBackend) ReadFile(string, string) ([]byte, error)        { return nil, ErrUnavailable }
 func (*UnavailableBackend) SetConfig(string, string, string) error         { return ErrUnavailable }


### PR DESCRIPTION
## What

Step 4 of the CLAUDE.md proto-first workflow (proto → generate → **implement** → wire client), building on the contract landed in #1506. Implements all five `SandboxService` RPCs — Phase 1's cold path from the two-digit-ms sandbox spawn design note (#1488).

## Design choice: bypass `container.Manager`

`SandboxServer` talks to `incus.Backend` directly rather than through `pkg/core/container.Manager`. `Manager.Create` *is* the full persistent-box identity flow (jump-server account, in-guest user, SSH keys) — exactly what the design note scopes sandboxes to skip. Reusing it would mean threading a "skip everything" option through a function whose entire shape is that provisioning.

## The RPCs

- **`SpawnSandbox`** — create + start + wait-network (same floor as `ContainerService.CreateContainer` minus identity seeding). Stamps the owning tenant from the authenticated subject (`incus.TenantLabelKey` — the request itself carries no username, by design) and a sandbox-kind label. `served_from` is always `COLD`; `template` resolves `UNSPECIFIED → BASE` and rejects anything else (v1 ships one template, per #1488's post-review answer). A failed `WaitForNetwork` rolls back the half-provisioned instance.
- **`ExecInSandbox` / `Write/ReadFileInSandbox` / `DeleteSandbox`** — ownership enforced by `lookupOwnedSandbox` before any operation runs. Existence and ownership are checked in the *same function*, so a cross-tenant `sandbox_id` always resolves to `PermissionDenied`, never `NotFound` — the design note's own required test case ("the ownership check must run before existence leaks"). `DeleteSandbox` propagates a real `DeleteContainer` failure rather than swallowing it the way a failed-spawn rollback discards its own cleanup error.

## New `incus.Backend` method: `ExecWithExitCode`

`ExecWithOutput` folds a non-zero exit into an error string (`"command exited with code %d"`) — fine for its ~20 existing callers, wrong for `ExecInSandboxResponse.exit_code`: an agent inner loop needs to branch on exit code as normal control flow, not string-parse an error. Purely additive — `ExecWithOutput` and every existing caller are untouched. `UnavailableBackend` and `incustest.MockBackend` updated to implement the new interface method (both mechanical, ~3 lines each).

## Auth

Two new scopes, `sandboxes:read` / `sandboxes:write`, gating these RPCs separately from `containers:*` — matching the volumes/backups precedent of a materially different resource getting its own grant.

## Wiring

`internal/server/dual_server.go` (gRPC) and `internal/gateway/gateway.go` (REST) — same pattern as every other feature server in those files: its own `incus.New()` client, registration skipped with a warning if incus isn't reachable. Reachable today via `POST /v1/sandboxes` etc. and gRPC; CLI verbs (step 5) are the next PR.

## Tests

`internal/server/sandbox_server_test.go`, against a map-backed fake `incus.Backend`:

- Happy-path spawn: labels/tenant stamped, `served_from = COLD`, template resolution.
- Unauthenticated and unsupported-template rejection.
- Spawn-failure rollback (`WaitForNetwork` failure → the half-provisioned instance is deleted).
- **The full ownership matrix** — owner, cross-tenant, admin, nonexistent — asserting the *exact* gRPC status code via `status.Code(err)`, not just `err != nil`.
- Exec exit-code passthrough; write/read round-trip; delete + delete-error-propagation.

**One real bug caught by the ownership tests during development**: `lookupOwnedSandbox` compared against the `ExtraConfig`-qualified label key while `ContainerInfo.Labels` is already prefix-stripped, so *every* owned-sandbox lookup 404'd — every test in the ownership/exec/file/delete groups failed on first run. Fixed before this commit; `DeleteSandbox`'s error-propagation test was separately verified to fail against a deliberately-reintroduced swallowed-error version, then restored.

Full `internal/server`, `pkg/core/incus`, `pkg/core/container`, `pkg/core/box/...` suites pass. `go build ./...` and `go vet ./...` clean tree-wide.

Refs #1488 (Phase 1, part 2 of the split described in #1506).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
