### PR TITLE
feat(cli): sandbox CLI verbs + typed client wiring (#1488 Phase 1)

### DIFF
--- a/internal/client/grpc.go
+++ b/internal/client/grpc.go
@@ -27,6 +27,7 @@ type GRPCClient struct {
 	agentClient   pb.AgentSkillServiceClient
 	crewClient    pb.CrewServiceClient
 	clusterClient pb.ClusterServiceClient
+	sandboxClient pb.SandboxServiceClient
 }
 
 // NewGRPCClient creates a new gRPC client
@@ -85,6 +86,7 @@ func NewGRPCClient(serverAddr string, certsDir string, insecureConn bool) (*GRPC
 	agentClient := pb.NewAgentSkillServiceClient(conn)
 	crewClient := pb.NewCrewServiceClient(conn)
 	clusterClient := pb.NewClusterServiceClient(conn)
+	sandboxClient := pb.NewSandboxServiceClient(conn)
 
 	return &GRPCClient{
 		conn:          conn,
@@ -98,6 +100,7 @@ func NewGRPCClient(serverAddr string, certsDir string, insecureConn bool) (*GRPC
 		agentClient:   agentClient,
 		crewClient:    crewClient,
 		clusterClient: clusterClient,
+		sandboxClient: sandboxClient,
 	}, nil
 }
 
@@ -904,6 +907,45 @@ func (c *GRPCClient) DetachVolume(volume, container string) (*pb.DetachVolumeRes
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	return c.volumeClient.DetachVolume(ctx, &pb.DetachVolumeRequest{Volume: volume, Container: container})
+}
+
+// SpawnSandbox creates an ephemeral, no-SSH sandbox via gRPC (#1488 Phase
+// 1). 60s covers the cold-path floor (image clone + boot + network wait);
+// Phase 3's warm-pool claim will be far under this.
+func (c *GRPCClient) SpawnSandbox(req *pb.SpawnSandboxRequest) (*pb.SpawnSandboxResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	return c.sandboxClient.SpawnSandbox(ctx, req)
+}
+
+// ExecInSandbox runs one command inside a sandbox via gRPC. Longer timeout
+// than the other sandbox verbs — the command itself, not the RPC
+// round-trip, is what can legitimately take a while.
+func (c *GRPCClient) ExecInSandbox(req *pb.ExecInSandboxRequest) (*pb.ExecInSandboxResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	return c.sandboxClient.ExecInSandbox(ctx, req)
+}
+
+// WriteFileInSandbox writes a file into a sandbox via gRPC.
+func (c *GRPCClient) WriteFileInSandbox(req *pb.WriteFileInSandboxRequest) (*pb.WriteFileInSandboxResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	return c.sandboxClient.WriteFileInSandbox(ctx, req)
+}
+
+// ReadFileInSandbox reads a file back out of a sandbox via gRPC.
+func (c *GRPCClient) ReadFileInSandbox(sandboxID, path string) (*pb.ReadFileInSandboxResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	return c.sandboxClient.ReadFileInSandbox(ctx, &pb.ReadFileInSandboxRequest{SandboxId: sandboxID, Path: path})
+}
+
+// DeleteSandbox destroys a sandbox immediately via gRPC.
+func (c *GRPCClient) DeleteSandbox(sandboxID string) (*pb.DeleteSandboxResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	return c.sandboxClient.DeleteSandbox(ctx, &pb.DeleteSandboxRequest{SandboxId: sandboxID})
 }
 
 // GetKMSStatus reports the active KMS backend + envelope state via gRPC.

--- a/internal/cmd/sandbox.go
+++ b/internal/cmd/sandbox.go
@@ -1,0 +1,240 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/footprintai/containarium/internal/client"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"github.com/spf13/cobra"
+)
+
+// Ephemeral, no-SSH sandboxes (#1488 Phase 1: the two-digit-ms spawn
+// path's cold-path implementation). Access is exclusively these five
+// verbs — there is no `containarium sandbox ssh`.
+
+var sandboxCmd = &cobra.Command{
+	Use:   "sandbox",
+	Short: "Manage ephemeral, no-SSH sandboxes",
+	Long: `Spawn, exec into, transfer files to/from, and delete ephemeral sandboxes.
+
+A sandbox has no per-tenant Linux account and no SSH — these verbs are its
+entire access surface. Phase 1 is the cold path: every spawn creates a
+fresh container (the same floor as a persistent box minus identity
+seeding). See docs/architecture/two-digit-ms-sandbox-spawn.md.
+
+  containarium sandbox spawn --server <host>
+  containarium sandbox exec <sandbox-id> --server <host> -- echo hello
+  containarium sandbox write-file <sandbox-id> /workspace/in.txt --from ./local.txt --server <host>
+  containarium sandbox read-file <sandbox-id> /workspace/out.txt --server <host>
+  containarium sandbox delete <sandbox-id> --server <host>`,
+}
+
+var (
+	sandboxIdleTTLSeconds int32
+	sandboxAllowCold      bool
+	sandboxWriteFrom      string
+	sandboxWriteMode      string
+	sandboxReadTo         string
+)
+
+var sandboxSpawnCmd = &cobra.Command{
+	Use:   "spawn",
+	Short: "Spawn a sandbox",
+	Args:  cobra.NoArgs,
+	RunE:  runSandboxSpawn,
+}
+
+var sandboxExecCmd = &cobra.Command{
+	Use:   "exec <sandbox-id> -- <command...>",
+	Short: "Run a command inside a sandbox",
+	Long: `Run a command inside a sandbox and print its stdout/stderr.
+
+Exits with the REMOTE command's exit code (not a generic CLI error code),
+so this composes in scripts the way a local command would:
+
+  containarium sandbox exec sandbox-abc123 --server <host> -- true; echo $?`,
+	Args: cobra.MinimumNArgs(1),
+	RunE: runSandboxExec,
+}
+
+var sandboxWriteFileCmd = &cobra.Command{
+	Use:   "write-file <sandbox-id> <remote-path>",
+	Short: "Write a local file into a sandbox",
+	Args:  cobra.ExactArgs(2),
+	RunE:  runSandboxWriteFile,
+}
+
+var sandboxReadFileCmd = &cobra.Command{
+	Use:   "read-file <sandbox-id> <remote-path>",
+	Short: "Read a file out of a sandbox (stdout, unless --to is given)",
+	Args:  cobra.ExactArgs(2),
+	RunE:  runSandboxReadFile,
+}
+
+var sandboxDeleteCmd = &cobra.Command{
+	Use:   "delete <sandbox-id>",
+	Short: "Delete a sandbox immediately",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runSandboxDelete,
+}
+
+func init() {
+	rootCmd.AddCommand(sandboxCmd)
+	sandboxCmd.AddCommand(sandboxSpawnCmd, sandboxExecCmd, sandboxWriteFileCmd, sandboxReadFileCmd, sandboxDeleteCmd)
+
+	sandboxSpawnCmd.Flags().Int32Var(&sandboxIdleTTLSeconds, "idle-ttl-seconds", 0, "idle TTL before the sweeper reaps an unclaimed sandbox (0 = daemon default)")
+	sandboxSpawnCmd.Flags().BoolVar(&sandboxAllowCold, "allow-cold-start", false, "fall back to the cold path instead of RESOURCE_EXHAUSTED when the warm pool is empty (no effect in Phase 1 — there is no pool yet)")
+
+	sandboxWriteFileCmd.Flags().StringVar(&sandboxWriteFrom, "from", "", "local file to write into the sandbox (required)")
+	sandboxWriteFileCmd.Flags().StringVar(&sandboxWriteMode, "mode", "", "file mode, e.g. 0644 (default: daemon default)")
+
+	sandboxReadFileCmd.Flags().StringVar(&sandboxReadTo, "to", "", "local file to write the content to (default: stdout)")
+}
+
+// newSandboxGRPCClient returns a gRPC client; sandbox verbs are
+// server-side only (no local box to fall back to, unlike some container
+// verbs).
+func newSandboxGRPCClient() (*client.GRPCClient, error) {
+	if serverAddr == "" {
+		return nil, fmt.Errorf("--server is required")
+	}
+	return client.NewGRPCClient(serverAddr, certsDir, insecure)
+}
+
+func runSandboxSpawn(cmd *cobra.Command, args []string) error {
+	c, err := newSandboxGRPCClient()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = c.Close() }()
+
+	resp, err := c.SpawnSandbox(&pb.SpawnSandboxRequest{
+		IdleTtlSeconds: sandboxIdleTTLSeconds,
+		AllowColdStart: sandboxAllowCold,
+	})
+	if err != nil {
+		return err
+	}
+
+	sb := resp.Sandbox
+	fmt.Printf("✓ spawned %s\n", sb.SandboxId)
+	fmt.Printf("  state:       %s\n", sb.State)
+	fmt.Printf("  template:    %s\n", sb.Template)
+	fmt.Printf("  served_from: %s\n", sb.ServedFrom)
+	if sb.ExpiresAt != nil {
+		fmt.Printf("  expires_at:  %s\n", sb.ExpiresAt.AsTime().Local().Format("2006-01-02 15:04:05 MST"))
+	}
+	return nil
+}
+
+// runSandboxExec calls os.Exit directly with the REMOTE command's exit
+// code rather than returning an error through cobra — a wrapped error
+// would both print a spurious "Error: ..." line and always exit 1
+// regardless of what the sandboxed command actually returned, breaking
+// the `sandbox exec ... ; echo $?` composability documented on the
+// command itself.
+func runSandboxExec(cmd *cobra.Command, args []string) error {
+	// args[0] is the sandbox-id regardless of where -- appears (cobra never
+	// consumes an arg for the dash itself); everything after it is the
+	// command. Recommending -- in the command's usage/examples is still the
+	// right UX (kubectl exec does the same) — without it, a command whose
+	// own arguments look like flags (e.g. `ls -la`) risks cobra trying to
+	// parse them as flags for this subcommand instead of passing them
+	// through.
+	sandboxID := args[0]
+	command := args[1:]
+	if len(command) == 0 {
+		return fmt.Errorf("a command is required, e.g.: sandbox exec %s -- echo hello", sandboxID)
+	}
+
+	c, err := newSandboxGRPCClient()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = c.Close() }()
+
+	resp, err := c.ExecInSandbox(&pb.ExecInSandboxRequest{SandboxId: sandboxID, Command: command})
+	if err != nil {
+		return err
+	}
+
+	if resp.Stdout != "" {
+		fmt.Fprint(os.Stdout, resp.Stdout)
+	}
+	if resp.Stderr != "" {
+		fmt.Fprint(os.Stderr, resp.Stderr)
+	}
+	os.Exit(int(resp.ExitCode))
+	return nil // unreachable
+}
+
+func runSandboxWriteFile(cmd *cobra.Command, args []string) error {
+	sandboxID, remotePath := args[0], args[1]
+	if sandboxWriteFrom == "" {
+		return fmt.Errorf("--from is required (local file to write into the sandbox)")
+	}
+
+	content, err := os.ReadFile(sandboxWriteFrom)
+	if err != nil {
+		return fmt.Errorf("failed to read local file %s: %w", sandboxWriteFrom, err)
+	}
+
+	c, err := newSandboxGRPCClient()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = c.Close() }()
+
+	resp, err := c.WriteFileInSandbox(&pb.WriteFileInSandboxRequest{
+		SandboxId: sandboxID,
+		Path:      remotePath,
+		Content:   content,
+		Mode:      sandboxWriteMode,
+	})
+	if err != nil {
+		return err
+	}
+	fmt.Printf("✓ %s\n", resp.Message)
+	return nil
+}
+
+func runSandboxReadFile(cmd *cobra.Command, args []string) error {
+	sandboxID, remotePath := args[0], args[1]
+
+	c, err := newSandboxGRPCClient()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = c.Close() }()
+
+	resp, err := c.ReadFileInSandbox(sandboxID, remotePath)
+	if err != nil {
+		return err
+	}
+
+	if sandboxReadTo == "" {
+		_, err := os.Stdout.Write(resp.Content)
+		return err
+	}
+	if err := os.WriteFile(sandboxReadTo, resp.Content, 0o600); err != nil {
+		return fmt.Errorf("failed to write local file %s: %w", sandboxReadTo, err)
+	}
+	fmt.Printf("✓ wrote %d byte(s) to %s\n", len(resp.Content), sandboxReadTo)
+	return nil
+}
+
+func runSandboxDelete(cmd *cobra.Command, args []string) error {
+	c, err := newSandboxGRPCClient()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = c.Close() }()
+
+	resp, err := c.DeleteSandbox(args[0])
+	if err != nil {
+		return err
+	}
+	fmt.Printf("✓ %s\n", resp.Message)
+	return nil
+}

--- a/internal/cmd/sandbox_test.go
+++ b/internal/cmd/sandbox_test.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// These pin the fail-fast validation that runs BEFORE newSandboxGRPCClient
+// dials anything, so they need no server and no --server flag.
+
+func TestRunSandboxExec_RequiresCommand(t *testing.T) {
+	if err := runSandboxExec(sandboxExecCmd, []string{"sandbox-abc123"}); err == nil {
+		t.Fatal("exec with no command should fail before dialing a server")
+	}
+}
+
+func TestRunSandboxWriteFile_RequiresFrom(t *testing.T) {
+	old := sandboxWriteFrom
+	sandboxWriteFrom = ""
+	defer func() { sandboxWriteFrom = old }()
+
+	if err := runSandboxWriteFile(sandboxWriteFileCmd, []string{"sandbox-abc123", "/workspace/out.txt"}); err == nil {
+		t.Fatal("write-file with no --from should fail before dialing a server")
+	}
+}
+
+func TestRunSandboxWriteFile_MissingLocalFile(t *testing.T) {
+	old := sandboxWriteFrom
+	sandboxWriteFrom = filepath.Join(t.TempDir(), "does-not-exist")
+	defer func() { sandboxWriteFrom = old }()
+
+	err := runSandboxWriteFile(sandboxWriteFileCmd, []string{"sandbox-abc123", "/workspace/out.txt"})
+	if err == nil {
+		t.Fatal("write-file with a nonexistent --from path should fail before dialing a server")
+	}
+}
+
+// TestRunSandboxWriteFile_ReadsLocalFileBeforeDialing pins that the local
+// file IS actually read (not just existence-checked) before any network
+// call — a --server flag is deliberately left unset here, so if this
+// reached newSandboxGRPCClient it would fail on "--server is required"
+// instead, which os.ReadFile's own error would not resemble.
+func TestRunSandboxWriteFile_ReadsLocalFileBeforeDialing(t *testing.T) {
+	oldFrom, oldServer := sandboxWriteFrom, serverAddr
+	dir := t.TempDir()
+	path := filepath.Join(dir, "local.txt")
+	if err := os.WriteFile(path, []byte("hello"), 0o600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	sandboxWriteFrom = path
+	serverAddr = ""
+	defer func() { sandboxWriteFrom, serverAddr = oldFrom, oldServer }()
+
+	err := runSandboxWriteFile(sandboxWriteFileCmd, []string{"sandbox-abc123", "/workspace/out.txt"})
+	if err == nil || err.Error() != "--server is required" {
+		t.Fatalf("err = %v, want the newSandboxGRPCClient --server error (local file read must have succeeded to reach it)", err)
+	}
+}


### PR DESCRIPTION
## What

Step 5 — the last step — of the CLAUDE.md proto-first workflow. Closes Phase 1's exit criterion from the two-digit-ms sandbox spawn design note (#1488): `containarium sandbox spawn/exec/write-file/read-file/delete` works end-to-end, via #1506's contract and #1508's server implementation.

## Client wiring (`internal/client/grpc.go`)

`sandboxClient` field + five typed wrapper methods (`SpawnSandbox`, `ExecInSandbox`, `WriteFileInSandbox`, `ReadFileInSandbox`, `DeleteSandbox`) — same shape as the existing `volumeClient` methods, own context timeout per call.

## CLI verbs (`internal/cmd/sandbox.go`)

- **`spawn`** — prints `sandbox_id`, state, template, `served_from`, `expires_at`.
- **`exec <id> -- <command...>`** — `sandbox-id` is always `args[0]` regardless of where `--` lands (cobra never consumes an arg for the dash itself); recommending `--` in the docs is still the right UX so a command whose own args look like flags (`ls -la`) doesn't get parsed as flags for this subcommand. **Exits with the remote command's exit code via `os.Exit`**, not a wrapped cobra error — a normal `RunE` error would both print a spurious `Error: ...` line and always exit 1 regardless of what the sandboxed command actually returned, breaking `sandbox exec ... ; echo $?` composability.
- **`write-file` / `read-file`** — `--from` / `--to` read/write local files; `read-file` defaults to stdout when `--to` is omitted.
- **`delete`** — destroys immediately, matching the server's own semantics (sandboxes are never reset and reused).

## No MCP tool in this PR

`VolumeService` has none either (checked `internal/mcp/tools.go`) — this isn't a new gap against existing precedent. Sandboxes are more obviously agent-facing than volumes, though, so an MCP wrapper is a reasonable near-term follow-up; kept out of this PR to keep it reviewable.

## Tests

Cover the fail-fast validation that runs *before* `newSandboxGRPCClient` dials anything — empty exec command, missing `--from`, a nonexistent `--from` path — plus one that pins the local file is actually **read**, not just existence-checked, before any network call, by asserting the specific `--server is required` error rather than a generic failure.

Matches this package's existing test scope: `volume_test.go` covers pure/pre-network logic only, and end-to-end command behavior isn't unit-tested per command anywhere in this codebase.

`golangci-lint` run locally against both changed packages: 0 issues (learned that lesson from #1508's CI-only gosec catch). `go build`/`go vet` clean tree-wide; `internal/cmd` and `internal/client` suites pass.

Refs #1488 (Phase 1, part 3 of 3 — closes the phase's exit criterion once merged alongside #1506 and #1508).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
