### PR TITLE
fix(cluster): let a delete batch make progress when part of it is already gone (#1505)

### DIFF
--- a/internal/server/ca_provider_server.go
+++ b/internal/server/ca_provider_server.go
@@ -199,10 +199,55 @@ func (s *CAProviderServer) NodeGroupDeleteNodes(ctx context.Context, req *capb.N
 			inGroup[n.VMName] = true
 		}
 	}
-	// Validate the whole batch before deleting anything.
+	// Validate the whole batch before deleting anything, and work out
+	// which of its nodes there is still anything to do about (#1505).
+	//
+	// The check used to reject the entire request if any named node
+	// was missing from the store. But the delete loop below aborts on
+	// the first error AFTER removing earlier nodes and their rows, so
+	// a batch [A, B] where A succeeds and B fails left every retry
+	// naming A refused outright — and B could never be removed. A
+	// retry naming A is the likely case, not a corner: nothing here
+	// deletes A's Kubernetes Node object, and upstream
+	// cluster-autoscaler derives its retry set from Node objects.
+	//
+	// So a node absent from this group's rows is now two different
+	// situations, told apart by the host:
+	//
+	//   - absent from the host too — already gone. Skipped, because
+	//     the end state the caller asked for already holds.
+	//   - still present on the host — NOT gone. Refused, because this
+	//     is a caller naming the wrong group (or store drift), and
+	//     reporting success would leave a running instance nobody
+	//     accounts for. That is what the original check was worth, and
+	//     it is kept.
+	//
+	// A host we cannot see refuses, as before: "already gone" is a
+	// claim, and an unobservable host cannot support it.
+	observed, obsErr := s.mgr.Observe(owner, name)
+	onHost := make(map[string]bool)
+	if obsErr == nil {
+		if observed.CP != nil {
+			onHost[observed.CP.Name] = true
+		}
+		for _, ws := range observed.Workers {
+			for _, w := range ws {
+				onHost[w.Name] = true
+			}
+		}
+	}
+	toDelete := make([]string, 0, len(req.Nodes))
 	for _, n := range req.Nodes {
-		if !inGroup[n.GetName()] {
-			return nil, status.Errorf(codes.NotFound, "node %q is not in group %q", n.GetName(), g.Name)
+		switch {
+		case inGroup[n.GetName()]:
+			toDelete = append(toDelete, n.GetName())
+		case obsErr != nil:
+			return nil, status.Errorf(codes.NotFound,
+				"node %q is not in group %q, and the host could not be observed to confirm it is gone: %v",
+				n.GetName(), g.Name, obsErr)
+		case onHost[n.GetName()]:
+			return nil, status.Errorf(codes.NotFound,
+				"node %q is not in group %q but still exists on the host", n.GetName(), g.Name)
 		}
 	}
 	// The target is lowered BEFORE anything is destroyed (#1498).
@@ -238,7 +283,7 @@ func (s *CAProviderServer) NodeGroupDeleteNodes(ctx context.Context, req *capb.N
 			inGroupCount++
 		}
 	}
-	target := inGroupCount - int32(len(req.Nodes)) //nolint:gosec // batch length is bounded by the group's int32 max_nodes (validated above)
+	target := inGroupCount - int32(len(toDelete)) //nolint:gosec // batch length is bounded by the group's int32 max_nodes (validated above)
 	if target < g.MinNodes {
 		target = g.MinNodes
 	}
@@ -246,24 +291,30 @@ func (s *CAProviderServer) NodeGroupDeleteNodes(ctx context.Context, req *capb.N
 		return nil, err
 	}
 	var staleSecrets []string
-	for _, n := range req.Nodes {
+	for _, vmName := range toDelete {
 		// CA has already drained the node; removing the VM is safe.
 		// ForgetNode also clears the control plane's node-password
 		// secret, without which a later node of the same name can
 		// never join (#1498).
-		if err := s.mgr.ForgetNode(owner, name, n.GetName()); err != nil {
+		if err := s.mgr.ForgetNode(owner, name, vmName); err != nil {
 			if !errors.Is(err, clustercore.ErrNodePasswordNotCleared) {
-				return nil, status.Errorf(codes.Internal, "delete %s: %v", n.GetName(), err)
+				return nil, status.Errorf(codes.Internal, "delete %s: %v", vmName, err)
 			}
 			// The instance IS gone, so the removal must not be
 			// retried — but the residue is not harmless, and a log
 			// line is not where anyone looks. Record it on the
 			// cluster's own history.
-			staleSecrets = append(staleSecrets, n.GetName())
+			staleSecrets = append(staleSecrets, vmName)
 		}
-		_ = s.store.DeleteNode(ctx, owner, name, n.GetName())
+		_ = s.store.DeleteNode(ctx, owner, name, vmName)
 	}
-	reason := fmt.Sprintf("autoscaler removed %d drained node(s); target now %d", len(req.Nodes), target)
+	if len(toDelete) == 0 {
+		// Every named node was already gone. Nothing changed, so
+		// nothing is recorded — a scale-down event for work that did
+		// not happen is noise in the one history operators read.
+		return &capb.NodeGroupDeleteNodesResponse{}, nil
+	}
+	reason := fmt.Sprintf("autoscaler removed %d drained node(s); target now %d", len(toDelete), target)
 	if len(staleSecrets) > 0 {
 		reason += fmt.Sprintf("; WARNING: node-password secret still present for %s — a future node of that name will be refused until it is removed",
 			strings.Join(staleSecrets, ", "))

--- a/internal/server/ca_provider_server_test.go
+++ b/internal/server/ca_provider_server_test.go
@@ -169,12 +169,28 @@ func TestCAProvider_DeleteNodesAndDecrease(t *testing.T) {
 	}
 	rec.ReconcileOnce(ctx) // 2 workers now
 
-	// Unknown node refused, nothing deleted.
-	_, err := client.NodeGroupDeleteNodes(caCtx("alice", "demo"), &capb.NodeGroupDeleteNodesRequest{
+	// A node that exists NOWHERE — not in the store, not on the host —
+	// is already gone, and asking for it to go is satisfied. This
+	// assertion previously expected NotFound; #1505 changed it,
+	// because the all-or-nothing rejection wedged every retry of a
+	// partially-completed batch. The refusal it was protecting —
+	// naming a node that is absent from this group but STILL RUNNING
+	// — is unchanged and covered by
+	// TestCAProvider_DeleteNodesStillRefusesANodeThatExistsOutsideTheGroup.
+	before := len(host.vms)
+	if _, err := client.NodeGroupDeleteNodes(caCtx("alice", "demo"), &capb.NodeGroupDeleteNodesRequest{
 		Id: "alice/demo/small", Nodes: []*capb.ExternalGrpcNode{{Name: "alice-k8s-demo-small-9"}},
-	})
-	if status.Code(err) != codes.NotFound {
-		t.Fatalf("unknown node delete = %v, want NotFound", err)
+	}); err != nil {
+		t.Fatalf("deleting a node that exists nowhere = %v, want success (already gone)", err)
+	}
+	if len(host.vms) != before {
+		t.Fatalf("a no-op delete removed something: %v", vmNames(host))
+	}
+	if ts, tsErr := client.NodeGroupTargetSize(caCtx("alice", "demo"),
+		&capb.NodeGroupTargetSizeRequest{Id: "alice/demo/small"}); tsErr != nil {
+		t.Fatal(tsErr)
+	} else if ts.GetTargetSize() != 2 {
+		t.Fatalf("a no-op delete moved the target to %d, want 2", ts.GetTargetSize())
 	}
 
 	// CA drains and removes one node: VM gone, row gone, target back to 1.
@@ -197,7 +213,7 @@ func TestCAProvider_DeleteNodesAndDecrease(t *testing.T) {
 	}
 
 	// DecreaseTargetSize may not go below the existing node count.
-	_, err = client.NodeGroupDecreaseTargetSize(caCtx("alice", "demo"), &capb.NodeGroupDecreaseTargetSizeRequest{Id: "alice/demo/small", Delta: -1})
+	_, err := client.NodeGroupDecreaseTargetSize(caCtx("alice", "demo"), &capb.NodeGroupDecreaseTargetSizeRequest{Id: "alice/demo/small", Delta: -1})
 	if status.Code(err) != codes.InvalidArgument {
 		t.Fatalf("decrease below existing = %v, want InvalidArgument", err)
 	}
@@ -459,5 +475,93 @@ func TestReconcilerDoesNotDecideOnAStaleTarget(t *testing.T) {
 
 	if _, ok := host.vms["alice-k8s-demo-small-2"]; ok {
 		t.Error("a scale-down landing between Observe and Decide was undone by a stale target")
+	}
+}
+
+// #1505: a delete batch must be able to make progress on a retry.
+//
+// The batch was validated all-or-nothing — any named node missing from
+// the store rejected the whole request — while the delete loop aborts
+// on the first error after having already removed earlier nodes and
+// their rows. So for [A, B] where A succeeds and B fails, every retry
+// that still names A was refused outright, and B could never be
+// removed. A retry naming A is the likely case: nothing here deletes
+// A's Kubernetes Node object, and upstream cluster-autoscaler derives
+// its retry set from Node objects.
+//
+// A node that is absent from the store AND absent from the host is
+// simply already gone — skipping it is the honest answer, because the
+// end state the caller asked for already holds.
+func TestCAProvider_DeleteNodesMakesProgressWhenPartOfTheBatchIsAlreadyGone(t *testing.T) {
+	client, srv, rec, host := caRig(t)
+	ctx := context.Background()
+	mustCreate(t, srv, tenantCtx("alice"), "demo")
+	rec.ReconcileOnce(ctx)
+	rec.ReconcileOnce(ctx)
+	if _, err := client.NodeGroupIncreaseSize(caCtx("alice", "demo"),
+		&capb.NodeGroupIncreaseSizeRequest{Id: "alice/demo/small", Delta: 2}); err != nil {
+		t.Fatal(err)
+	}
+	rec.ReconcileOnce(ctx) // three small workers
+
+	// First attempt removes small-2 and then fails on small-3.
+	host.deleteErrFor = map[string]error{"alice-k8s-demo-small-3": errors.New("incus: instance is busy")}
+	_, err := client.NodeGroupDeleteNodes(caCtx("alice", "demo"), &capb.NodeGroupDeleteNodesRequest{
+		Id: "alice/demo/small", Nodes: []*capb.ExternalGrpcNode{
+			{Name: "alice-k8s-demo-small-2"}, {Name: "alice-k8s-demo-small-3"},
+		},
+	})
+	if err == nil {
+		t.Fatal("first attempt should have failed on small-3")
+	}
+	if _, ok := host.vms["alice-k8s-demo-small-2"]; ok {
+		t.Fatal("small-2 should already be gone after the first attempt")
+	}
+
+	// The retry still names small-2, exactly as cluster-autoscaler
+	// would: its Kubernetes Node object was never deleted by us.
+	host.deleteErrFor = nil
+	if _, err := client.NodeGroupDeleteNodes(caCtx("alice", "demo"), &capb.NodeGroupDeleteNodesRequest{
+		Id: "alice/demo/small", Nodes: []*capb.ExternalGrpcNode{
+			{Name: "alice-k8s-demo-small-2"}, {Name: "alice-k8s-demo-small-3"},
+		},
+	}); err != nil {
+		t.Fatalf("retry naming an already-removed node was refused, so small-3 can never go: %v", err)
+	}
+	if _, ok := host.vms["alice-k8s-demo-small-3"]; ok {
+		t.Error("small-3 survived the retry")
+	}
+}
+
+// Idempotence must not become blindness. A node that is absent from
+// this group's rows but STILL PRESENT on the host is not "already
+// gone" — it is a caller naming the wrong group, or store drift — and
+// silently reporting success would leave a running instance nobody
+// accounts for. That is what the original all-or-nothing check was
+// actually worth, and it is kept.
+func TestCAProvider_DeleteNodesStillRefusesANodeThatExistsOutsideTheGroup(t *testing.T) {
+	client, srv, rec, host := caRig(t)
+	ctx := context.Background()
+	mustCreate(t, srv, tenantCtx("alice"), "demo")
+	rec.ReconcileOnce(ctx)
+	rec.ReconcileOnce(ctx)
+	if _, err := client.NodeGroupIncreaseSize(caCtx("alice", "demo"),
+		&capb.NodeGroupIncreaseSizeRequest{Id: "alice/demo/medium", Delta: 1}); err != nil {
+		t.Fatal(err)
+	}
+	rec.ReconcileOnce(ctx)
+	if _, ok := host.vms["alice-k8s-demo-medium-1"]; !ok {
+		t.Fatalf("setup did not produce a medium worker: %v", vmNames(host))
+	}
+
+	// A medium node named in the small group's batch.
+	_, err := client.NodeGroupDeleteNodes(caCtx("alice", "demo"), &capb.NodeGroupDeleteNodesRequest{
+		Id: "alice/demo/small", Nodes: []*capb.ExternalGrpcNode{{Name: "alice-k8s-demo-medium-1"}},
+	})
+	if status.Code(err) != codes.NotFound {
+		t.Fatalf("naming a node from another group = %v, want NotFound", err)
+	}
+	if _, ok := host.vms["alice-k8s-demo-medium-1"]; !ok {
+		t.Error("the refused node was deleted anyway")
 	}
 }

--- a/internal/server/cluster_reconciler_test.go
+++ b/internal/server/cluster_reconciler_test.go
@@ -37,6 +37,9 @@ type stateHost struct {
 	// deleteErr makes every Delete fail, so a test can drive the
 	// retry path without racing anything.
 	deleteErr error
+	// deleteErrFor fails only the named instances, so a test can make
+	// a batch succeed partway through — the state #1505 wedges on.
+	deleteErrFor map[string]error
 	// onObserve fires after ClusterVMs has read the host, so a test
 	// can land a scale-down between the observation and the decision
 	// that consumes it (#1498 review).
@@ -119,8 +122,11 @@ func (h *stateHost) Stop(name string) error {
 
 func (h *stateHost) Delete(name string) error {
 	h.mu.Lock()
-	if h.deleteErr != nil {
-		err := h.deleteErr
+	if err := h.deleteErr; err != nil {
+		h.mu.Unlock()
+		return err
+	}
+	if err := h.deleteErrFor[name]; err != nil {
 		h.mu.Unlock()
 		return err
 	}


### PR DESCRIPTION
Closes #1505. Found reviewing #1502, filed rather than fixed there because it changes a contract an existing test asserts.

## The wedge

`NodeGroupDeleteNodes` rejected the whole request if any named node was missing from the store, while the delete loop aborts on the first error **after** removing earlier nodes and their rows. For a batch `[A, B]` where A succeeds and B fails:

- A's row is gone
- B is still there
- every retry naming A is refused with `NotFound`, and **B can never be removed**

A retry naming A is the likely case, not a corner: nothing here deletes A's Kubernetes Node object, and upstream cluster-autoscaler derives its retry set from Node objects. Each attempt then fails on a *different* node's absence, which is also a confusing thing to read in a log.

## The host decides, because the store cannot

"Never existed" and "already removed" are indistinguishable in the store — nothing records that a node was removed. So a node absent from the group's rows is now two situations, told apart by observing the host:

| Absent from rows, and… | Result | Why |
| --- | --- | --- |
| absent from the host | **skipped** | already gone — the end state the caller asked for holds |
| present on the host | **`NotFound`** | not gone: wrong group, or store drift. Reporting success would leave a running instance nobody accounts for |
| host unobservable | **`NotFound`** | "already gone" is a claim, and an unobservable host cannot support it |

This is option 1 from the issue — no new state, and it keeps what the original check was actually worth.

The target is derived from the nodes **actually** removed, so a batch that skips everything moves nothing and records nothing. A scale-down event for work that did not happen is noise in the one history operators read.

## A changed assertion, deliberately

`TestCAProvider_DeleteNodesAndDecrease` asserted `NotFound` for `alice-k8s-demo-small-9` — a node that exists nowhere. **That assertion is changed**, and it is the point of the issue rather than a way to get green. What it was protecting — refusing a node that is absent from the group but *still running* — is unchanged and now has its own test, which states the guarantee more sharply than the original did:

`TestCAProvider_DeleteNodesStillRefusesANodeThatExistsOutsideTheGroup` names a `medium` node in the `small` group's batch, expects `NotFound`, and asserts the refused node was not deleted anyway. That test passes **before and after** this change.

## Test evidence

| Test | Covers |
| --- | --- |
| `TestCAProvider_DeleteNodesMakesProgressWhenPartOfTheBatchIsAlreadyGone` | the wedge: first attempt removes small-2 and fails on small-3; the retry still names both, as CA would, and small-3 goes |
| `TestCAProvider_DeleteNodesStillRefusesANodeThatExistsOutsideTheGroup` | idempotence has not become blindness |
| `TestCAProvider_DeleteNodesAndDecrease` (updated) | a node that exists nowhere is a satisfied request that moves neither instances nor the target |

Both new behaviours confirmed to fail against the all-or-nothing check — reverting it reproduces `retry naming an already-removed node was refused, so small-3 can never go`.

The fake gained `deleteErrFor` (fail only named instances) so a batch can be made to succeed partway through — the state the wedge needs, which the existing all-or-nothing `deleteErr` cannot express.

🤖 Generated with [Claude Code](https://claude.com/claude-code)