### PR TITLE
feat(sentinel): self-check the proxy pipeline, not just the backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   falling back there would install a long-lived key to paper over a
   control-plane fault and never mention it.
 
+- **Sentinel now self-checks its OWN proxy pipeline, not just the backend.**
+  `healthCheckAll` only ever proved the backend was reachable. During a live
+  incident the backend's health endpoint stayed up throughout a spot-instance
+  restart, so the sentinel never left `PROXY` state — while its own
+  ConnMux/dispatch pipeline had wedged: TCP connections were still accepted,
+  but nothing downstream ever forwarded or responded, on every port (HTTPS,
+  SSH). Cloudflare surfaced this as a 522 with no useful signal on which side
+  was actually broken. Only a by-hand `systemctl restart` of the sentinel
+  cleared it.
+
+  A new background loop (`--self-check-failure-threshold`, default 3, 0
+  disables) periodically probes the sentinel's own externally-facing HTTPS
+  listener end-to-end and treats any consecutive run of unresponsive probes as
+  a wedge, independent of what the backend health check reports. Past the
+  threshold, the sentinel exits and lets systemd's existing `Restart=always`
+  recreate it with fresh listener/dispatch state — the same fix that worked by
+  hand, now automatic. Only armed in ConnMux/hybrid mode, where the incident
+  occurred.
+
 ### Fixed
 
 - **Container nodes on a nested host no longer advertise the host's capacity,

--- a/internal/cmd/sentinel.go
+++ b/internal/cmd/sentinel.go
@@ -34,6 +34,7 @@ var (
 	sentinelForwardedPorts         string
 	sentinelHealthyThreshold       int
 	sentinelUnhealthyThreshold     int
+	sentinelSelfCheckFailThreshold int
 	sentinelBinaryPort             int
 	sentinelRecoveryTimeout        time.Duration
 	sentinelRecoveryBackoffInitial time.Duration
@@ -88,6 +89,7 @@ func init() {
 	sentinelCmd.Flags().StringVar(&sentinelForwardedPorts, "forwarded-ports", "80,443", "Comma-separated ports to DNAT forward (port 22 handled by sshpiper)")
 	sentinelCmd.Flags().IntVar(&sentinelHealthyThreshold, "healthy-threshold", 2, "Consecutive healthy checks before switching to proxy")
 	sentinelCmd.Flags().IntVar(&sentinelUnhealthyThreshold, "unhealthy-threshold", 2, "Consecutive unhealthy checks before switching to maintenance")
+	sentinelCmd.Flags().IntVar(&sentinelSelfCheckFailThreshold, "self-check-failure-threshold", 3, "Consecutive failed end-to-end self-checks of the sentinel's OWN proxy pipeline (independent of backend health) before it exits and lets systemd (Restart=always) recreate it; 0 disables")
 	sentinelCmd.Flags().IntVar(&sentinelBinaryPort, "binary-port", 8888, "Port to serve containarium binary for spot VM downloads (0 to disable)")
 	sentinelCmd.Flags().DurationVar(&sentinelRecoveryTimeout, "recovery-timeout", 10*time.Minute, "Warn if recovery takes longer than this (0 to disable)")
 	sentinelCmd.Flags().DurationVar(&sentinelRecoveryBackoffInitial, "recovery-backoff-initial", 30*time.Second, "Initial interval between StartInstance retries while a backend is down (#514)")
@@ -233,22 +235,23 @@ func runSentinel(cmd *cobra.Command, args []string) error {
 			log.Printf("[sentinel] hybrid mode: GCP + tunnel (ConnMux on port %d)", sentinelHTTPSPort)
 
 			config := sentinel.Config{
-				HealthPort:             sentinelHealthPort,
-				CheckInterval:          sentinelCheckInterval,
-				HTTPPort:               sentinelHTTPPort,
-				HTTPSPort:              sentinelHTTPSPort,
-				ForwardedPorts:         ports,
-				HealthyThreshold:       sentinelHealthyThreshold,
-				UnhealthyThreshold:     sentinelUnhealthyThreshold,
-				BinaryPort:             sentinelBinaryPort,
-				RecoveryTimeout:        sentinelRecoveryTimeout,
-				RecoveryBackoffInitial: sentinelRecoveryBackoffInitial,
-				RecoveryBackoffMax:     sentinelRecoveryBackoffMax,
-				CertSyncInterval:       sentinelCertSyncInterval,
-				KeySyncInterval:        sentinelKeySyncInterval,
-				HybridMode:             true,
-				ProxyProtocol:          sentinelProxyProtocol,
-				AlertWebhookURL:        sentinelAlertWebhookURL,
+				HealthPort:                sentinelHealthPort,
+				CheckInterval:             sentinelCheckInterval,
+				HTTPPort:                  sentinelHTTPPort,
+				HTTPSPort:                 sentinelHTTPSPort,
+				ForwardedPorts:            ports,
+				HealthyThreshold:          sentinelHealthyThreshold,
+				UnhealthyThreshold:        sentinelUnhealthyThreshold,
+				SelfCheckFailureThreshold: sentinelSelfCheckFailThreshold,
+				BinaryPort:                sentinelBinaryPort,
+				RecoveryTimeout:           sentinelRecoveryTimeout,
+				RecoveryBackoffInitial:    sentinelRecoveryBackoffInitial,
+				RecoveryBackoffMax:        sentinelRecoveryBackoffMax,
+				CertSyncInterval:          sentinelCertSyncInterval,
+				KeySyncInterval:           sentinelKeySyncInterval,
+				HybridMode:                true,
+				ProxyProtocol:             sentinelProxyProtocol,
+				AlertWebhookURL:           sentinelAlertWebhookURL,
 			}
 
 			manager := sentinel.NewManager(config, gcpProvider)
@@ -326,22 +329,23 @@ func runSentinel(cmd *cobra.Command, args []string) error {
 		provider = sentinel.NewTunnelProvider(registry, "")
 
 		config := sentinel.Config{
-			HealthPort:             sentinelHealthPort,
-			CheckInterval:          sentinelCheckInterval,
-			HTTPPort:               sentinelHTTPPort,
-			HTTPSPort:              sentinelHTTPSPort,
-			ForwardedPorts:         ports,
-			HealthyThreshold:       sentinelHealthyThreshold,
-			UnhealthyThreshold:     sentinelUnhealthyThreshold,
-			BinaryPort:             sentinelBinaryPort,
-			RecoveryTimeout:        sentinelRecoveryTimeout,
-			RecoveryBackoffInitial: sentinelRecoveryBackoffInitial,
-			RecoveryBackoffMax:     sentinelRecoveryBackoffMax,
-			CertSyncInterval:       sentinelCertSyncInterval,
-			KeySyncInterval:        sentinelKeySyncInterval,
-			TunnelMode:             true,
-			ProxyProtocol:          sentinelProxyProtocol,
-			AlertWebhookURL:        sentinelAlertWebhookURL,
+			HealthPort:                sentinelHealthPort,
+			CheckInterval:             sentinelCheckInterval,
+			HTTPPort:                  sentinelHTTPPort,
+			HTTPSPort:                 sentinelHTTPSPort,
+			ForwardedPorts:            ports,
+			HealthyThreshold:          sentinelHealthyThreshold,
+			UnhealthyThreshold:        sentinelUnhealthyThreshold,
+			SelfCheckFailureThreshold: sentinelSelfCheckFailThreshold,
+			BinaryPort:                sentinelBinaryPort,
+			RecoveryTimeout:           sentinelRecoveryTimeout,
+			RecoveryBackoffInitial:    sentinelRecoveryBackoffInitial,
+			RecoveryBackoffMax:        sentinelRecoveryBackoffMax,
+			CertSyncInterval:          sentinelCertSyncInterval,
+			KeySyncInterval:           sentinelKeySyncInterval,
+			TunnelMode:                true,
+			ProxyProtocol:             sentinelProxyProtocol,
+			AlertWebhookURL:           sentinelAlertWebhookURL,
 		}
 
 		manager := sentinel.NewManager(config, provider)
@@ -395,21 +399,22 @@ func runSentinel(cmd *cobra.Command, args []string) error {
 	}
 
 	config := sentinel.Config{
-		HealthPort:             sentinelHealthPort,
-		CheckInterval:          sentinelCheckInterval,
-		HTTPPort:               sentinelHTTPPort,
-		HTTPSPort:              sentinelHTTPSPort,
-		ForwardedPorts:         ports,
-		HealthyThreshold:       sentinelHealthyThreshold,
-		UnhealthyThreshold:     sentinelUnhealthyThreshold,
-		BinaryPort:             sentinelBinaryPort,
-		RecoveryTimeout:        sentinelRecoveryTimeout,
-		RecoveryBackoffInitial: sentinelRecoveryBackoffInitial,
-		RecoveryBackoffMax:     sentinelRecoveryBackoffMax,
-		CertSyncInterval:       sentinelCertSyncInterval,
-		KeySyncInterval:        sentinelKeySyncInterval,
-		ProxyProtocol:          sentinelProxyProtocol,
-		AlertWebhookURL:        sentinelAlertWebhookURL,
+		HealthPort:                sentinelHealthPort,
+		CheckInterval:             sentinelCheckInterval,
+		HTTPPort:                  sentinelHTTPPort,
+		HTTPSPort:                 sentinelHTTPSPort,
+		ForwardedPorts:            ports,
+		HealthyThreshold:          sentinelHealthyThreshold,
+		UnhealthyThreshold:        sentinelUnhealthyThreshold,
+		SelfCheckFailureThreshold: sentinelSelfCheckFailThreshold,
+		BinaryPort:                sentinelBinaryPort,
+		RecoveryTimeout:           sentinelRecoveryTimeout,
+		RecoveryBackoffInitial:    sentinelRecoveryBackoffInitial,
+		RecoveryBackoffMax:        sentinelRecoveryBackoffMax,
+		CertSyncInterval:          sentinelCertSyncInterval,
+		KeySyncInterval:           sentinelKeySyncInterval,
+		ProxyProtocol:             sentinelProxyProtocol,
+		AlertWebhookURL:           sentinelAlertWebhookURL,
 	}
 
 	manager := sentinel.NewManager(config, provider)

--- a/internal/sentinel/manager.go
+++ b/internal/sentinel/manager.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ed25519"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -72,6 +73,19 @@ type Config struct {
 	// alert chain (#514 follow-up). Empty disables the webhook; the
 	// /metrics endpoint (counters) is always served regardless.
 	AlertWebhookURL string
+	// SelfCheckFailureThreshold is the number of consecutive failed
+	// end-to-end self-checks (see selfCheckProxyPath) while actively
+	// proxying before the sentinel treats its OWN forwarding pipeline as
+	// wedged and exits — systemd's Restart=always (sentinel_unit.go)
+	// then recreates it with fresh listeners/dispatch state. This exists
+	// because healthCheckAll only proves the BACKEND is reachable: if the
+	// backend's health endpoint stays up throughout (as it did during a
+	// real incident) while the sentinel's own ConnMux/dispatch pipeline
+	// wedges — TCP accepts succeed, nothing downstream ever responds —
+	// nothing else here notices, and only a by-hand restart clears it.
+	// Zero disables the self-check. Only armed in ConnMux/hybrid mode
+	// (httpsDispatch != nil).
+	SelfCheckFailureThreshold int
 }
 
 // Manager is the core sentinel orchestrator.
@@ -164,6 +178,16 @@ type Manager struct {
 	// test failing. Same injection pattern as byocDial below. nil = the real
 	// method; tests substitute a stub.
 	switchToProxyFn func(*Backend) error
+
+	// selfCheckFn is the seam over selfCheckProxyPath so runSelfCheckLoop's
+	// wiring is testable without a real listener. nil = the real method
+	// (probes 127.0.0.1:HTTPSPort); tests substitute a stub. exitFn is
+	// invoked once SelfCheckFailureThreshold consecutive failures are
+	// observed; defaults to os.Exit(1) in NewManager so systemd's
+	// Restart=always recreates the process. Tests override it to observe
+	// the trigger without actually exiting.
+	selfCheckFn func() error
+	exitFn      func()
 
 	// hmacSecret is the shared HMAC secret used to sign
 	// /sentinel/peers responses (and reused for keysync/certsync
@@ -335,6 +359,7 @@ func NewManager(config Config, provider CloudProvider) *Manager {
 		byocRoutes: NewBYOCRouteRegistry(),
 		certStore:  NewCertStore(),
 		keyStore:   NewKeyStore(),
+		exitFn:     func() { os.Exit(1) },
 	}
 	if raw := os.Getenv(appconfig.EnvSentinelAuthSecret); raw != "" {
 		if len(raw) < auth.SentinelMinSecretLen {
@@ -681,6 +706,13 @@ func (m *Manager) Run(ctx context.Context) error {
 		}()
 	}
 
+	// Independent end-to-end self-check of the sentinel's OWN proxy
+	// pipeline — see runSelfCheckLoop / selfCheckProxyPath. Runs on its
+	// own goroutine/ticker rather than piggybacking on the main loop
+	// below so a wedged pipeline (the exact thing it's checking for)
+	// can't also stall event processing.
+	go m.runSelfCheckLoop(ctx)
+
 	ticker := time.NewTicker(m.config.CheckInterval)
 	defer ticker.Stop()
 
@@ -1000,6 +1032,105 @@ func (m *Manager) startHTTPSProxy(backendIP string) {
 	fallback := net.JoinHostPort(backendIP, fmt.Sprintf("%d", m.config.HTTPSPort))
 	m.httpsDispatch.SetHandler(m.buildSNIRoutingHandler(fallback))
 	log.Printf("[sentinel] HTTPS proxy started → fallback %s (SNI routing via primary registry)", fallback)
+}
+
+// selfCheckProxyPath dials the sentinel's own HTTPS listener and verifies
+// the ConnMux → dispatch → routing pipeline actually reacts within timeout.
+// It does not care WHAT the pipeline does with the probe (forward the byte,
+// fail the SNI peek, dial-timeout to a fallback and close) — only that
+// something happens. A read that hits its own deadline with no data, EOF,
+// or reset is exactly the wedge this exists to catch: the listener is alive
+// (TCP accepts succeed) but nothing downstream is servicing connections.
+func (m *Manager) selfCheckProxyPath(timeout time.Duration) error {
+	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(m.config.HTTPSPort))
+	conn, err := net.DialTimeout("tcp", addr, timeout)
+	if err != nil {
+		return fmt.Errorf("dial self %s: %w", addr, err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	_ = conn.SetDeadline(time.Now().Add(timeout))
+	// A single TLS record-layer byte (0x16) so ConnMux.route() sends this
+	// down the HTTPS path rather than mistaking it for a tunnel handshake
+	// (which starts with '{').
+	if _, err := conn.Write([]byte{0x16}); err != nil {
+		return fmt.Errorf("write probe: %w", err)
+	}
+
+	buf := make([]byte, 1)
+	if _, err := conn.Read(buf); err != nil {
+		var netErr net.Error
+		if errors.As(err, &netErr) && netErr.Timeout() {
+			return fmt.Errorf("proxy path unresponsive after %s: %w", timeout, err)
+		}
+		// Any other outcome (EOF, connection reset, a real backend
+		// response) proves the pipeline reacted within the deadline —
+		// only a hard timeout indicates the wedge.
+	}
+	return nil
+}
+
+// selfCheckOnce runs one self-check iteration given the current
+// consecutive-failure count, returning the updated count and whether the
+// threshold was reached (and exitFn invoked) this call. Split out from
+// runSelfCheckLoop so tests can drive it synchronously without a real
+// ticker, goroutine, or listener.
+func (m *Manager) selfCheckOnce(failures int) (newFailures int, triggered bool) {
+	if m.currentState() != StateProxy {
+		return 0, false
+	}
+
+	check := m.selfCheckFn
+	if check == nil {
+		check = func() error { return m.selfCheckProxyPath(20 * time.Second) }
+	}
+
+	if err := check(); err != nil {
+		failures++
+		log.Printf("[sentinel] self-check failed (%d/%d consecutive): %v",
+			failures, m.config.SelfCheckFailureThreshold, err)
+		if failures >= m.config.SelfCheckFailureThreshold {
+			log.Printf("[sentinel] self-check failed %d times in a row while the backend reports healthy — the proxy pipeline is wedged; restarting process (systemd Restart=always recreates it)", failures)
+			m.exitFn()
+			return failures, true
+		}
+		return failures, false
+	}
+	return 0, false
+}
+
+// runSelfCheckLoop periodically probes the sentinel's OWN externally-facing
+// proxy path end-to-end (selfCheckProxyPath), independent of and in
+// addition to healthCheckAll's backend-only health check. See
+// Config.SelfCheckFailureThreshold for why this exists. No-op when the
+// self-check is disabled (threshold <= 0) or the sentinel isn't running
+// ConnMux/hybrid mode (httpsDispatch == nil), since that's the pipeline
+// being probed.
+func (m *Manager) runSelfCheckLoop(ctx context.Context) {
+	if m.config.SelfCheckFailureThreshold <= 0 || m.httpsDispatch == nil {
+		return
+	}
+	interval := m.config.CheckInterval
+	if interval <= 0 {
+		interval = 15 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	failures := 0
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+
+		var triggered bool
+		failures, triggered = m.selfCheckOnce(failures)
+		if triggered {
+			return
+		}
+	}
 }
 
 // buildSNIRoutingHandler returns a connection handler that peeks SNI from

--- a/internal/sentinel/self_check_test.go
+++ b/internal/sentinel/self_check_test.go
@@ -1,0 +1,257 @@
+package sentinel
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+)
+
+// wedgedListener accepts TCP connections and never reads/writes anything —
+// simulating the exact production wedge: the listener is alive (TCP accepts
+// succeed) but nothing downstream ever services the connection.
+type wedgedListener struct {
+	ln   net.Listener
+	port int
+}
+
+func newWedgedListener(t *testing.T) *wedgedListener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	w := &wedgedListener{ln: ln, port: ln.Addr().(*net.TCPAddr).Port}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			// Deliberately never read or write — hold the connection open
+			// forever, same as a wedged dispatch pipeline.
+			_ = conn
+		}
+	}()
+	return w
+}
+
+func (w *wedgedListener) Close() error { return w.ln.Close() }
+
+// echoCloseListener accepts a connection, reads one byte (the probe), and
+// closes — simulating a pipeline that reacted (even if only to fail fast),
+// which must NOT be treated as a wedge.
+type echoCloseListener struct {
+	ln   net.Listener
+	port int
+}
+
+func newEchoCloseListener(t *testing.T) *echoCloseListener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	e := &echoCloseListener{ln: ln, port: ln.Addr().(*net.TCPAddr).Port}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			buf := make([]byte, 1)
+			_, _ = conn.Read(buf)
+			_ = conn.Close()
+		}
+	}()
+	return e
+}
+
+func (e *echoCloseListener) Close() error { return e.ln.Close() }
+
+// newSelfCheckManager builds a Manager in StateProxy with ConnMux/hybrid
+// mode armed (httpsDispatch != nil is what gates the self-check on), so
+// selfCheckOnce actually runs instead of short-circuiting.
+func newSelfCheckManager(t *testing.T, threshold int) *Manager {
+	t.Helper()
+	m := NewManager(Config{SelfCheckFailureThreshold: threshold}, &fakeRecoveryProvider{})
+	m.state.Store(StateProxy)
+	m.httpsDispatch = newDispatchListener(newChanListener(nil))
+	return m
+}
+
+func TestSelfCheck_SuccessKeepsCounterAtZero(t *testing.T) {
+	m := newSelfCheckManager(t, 3)
+	m.selfCheckFn = func() error { return nil }
+
+	failures, triggered := m.selfCheckOnce(0)
+	if triggered {
+		t.Fatal("a successful self-check must not trigger exit")
+	}
+	if failures != 0 {
+		t.Fatalf("failures = %d, want 0 after a success", failures)
+	}
+}
+
+func TestSelfCheck_FailuresBelowThresholdDoNotTrigger(t *testing.T) {
+	m := newSelfCheckManager(t, 3)
+	exited := false
+	m.exitFn = func() { exited = true }
+	m.selfCheckFn = func() error { return errors.New("proxy path unresponsive") }
+
+	failures := 0
+	var triggered bool
+	for i := 0; i < 2; i++ {
+		failures, triggered = m.selfCheckOnce(failures)
+		if triggered {
+			t.Fatalf("triggered after only %d failures, want threshold 3", i+1)
+		}
+	}
+	if failures != 2 {
+		t.Fatalf("failures = %d, want 2", failures)
+	}
+	if exited {
+		t.Fatal("exitFn must not be called before the threshold is reached")
+	}
+}
+
+func TestSelfCheck_ThresholdReachedTriggersExit(t *testing.T) {
+	m := newSelfCheckManager(t, 3)
+	exitCalls := 0
+	m.exitFn = func() { exitCalls++ }
+	m.selfCheckFn = func() error { return errors.New("proxy path unresponsive") }
+
+	failures := 0
+	var triggered bool
+	for i := 0; i < 3; i++ {
+		failures, triggered = m.selfCheckOnce(failures)
+	}
+	if !triggered {
+		t.Fatal("expected trigger on the 3rd consecutive failure")
+	}
+	if failures != 3 {
+		t.Fatalf("failures = %d, want 3", failures)
+	}
+	if exitCalls != 1 {
+		t.Fatalf("exitFn called %d times, want exactly 1", exitCalls)
+	}
+}
+
+func TestSelfCheck_SuccessAfterFailuresResetsCounter(t *testing.T) {
+	m := newSelfCheckManager(t, 3)
+	m.exitFn = func() { t.Fatal("exitFn must not be called: threshold never reached") }
+
+	failing := true
+	m.selfCheckFn = func() error {
+		if failing {
+			return errors.New("proxy path unresponsive")
+		}
+		return nil
+	}
+
+	failures, _ := m.selfCheckOnce(0)
+	failures, _ = m.selfCheckOnce(failures)
+	if failures != 2 {
+		t.Fatalf("failures = %d, want 2 before recovery", failures)
+	}
+
+	failing = false
+	failures, triggered := m.selfCheckOnce(failures)
+	if triggered {
+		t.Fatal("a recovered self-check must not trigger exit")
+	}
+	if failures != 0 {
+		t.Fatalf("failures = %d, want reset to 0 after a success", failures)
+	}
+}
+
+func TestSelfCheck_SkippedOutsideProxyState(t *testing.T) {
+	m := newSelfCheckManager(t, 1)
+	m.state.Store(StateMaintenance)
+	m.exitFn = func() { t.Fatal("exitFn must not be called while in maintenance") }
+	calls := 0
+	m.selfCheckFn = func() error { calls++; return errors.New("should not run") }
+
+	failures, triggered := m.selfCheckOnce(5) // pre-existing count from before the transition
+	if triggered {
+		t.Fatal("must not trigger while not in StateProxy")
+	}
+	if failures != 0 {
+		t.Fatalf("failures = %d, want reset to 0 outside StateProxy", failures)
+	}
+	if calls != 0 {
+		t.Fatalf("selfCheckFn called %d times, want 0 (state gate should short-circuit)", calls)
+	}
+}
+
+func TestSelfCheck_DisabledByZeroThresholdNeverStarts(t *testing.T) {
+	m := newSelfCheckManager(t, 0)
+	m.exitFn = func() { t.Fatal("exitFn must not be called: self-check disabled") }
+	m.selfCheckFn = func() error { t.Fatal("selfCheckFn must not run: self-check disabled"); return nil }
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	// runSelfCheckLoop must return immediately (threshold<=0 no-op) rather
+	// than block until ctx expires — this proves the gate is checked
+	// before any ticker/goroutine work starts.
+	done := make(chan struct{})
+	go func() {
+		m.runSelfCheckLoop(ctx)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("runSelfCheckLoop did not return promptly when disabled")
+	}
+}
+
+func TestSelfCheck_DisabledWithoutConnMux(t *testing.T) {
+	m := NewManager(Config{SelfCheckFailureThreshold: 3}, &fakeRecoveryProvider{})
+	m.state.Store(StateProxy)
+	// httpsDispatch left nil (not ConnMux/hybrid mode).
+	m.exitFn = func() { t.Fatal("exitFn must not be called: no ConnMux to check") }
+	m.selfCheckFn = func() error { t.Fatal("selfCheckFn must not run: no ConnMux to check"); return nil }
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		m.runSelfCheckLoop(ctx)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("runSelfCheckLoop did not return promptly without httpsDispatch")
+	}
+}
+
+// TestSelfCheckProxyPath_TimeoutIsAFailure exercises the real dial/probe
+// implementation against a listener that accepts but never responds — the
+// exact production signature (TCP accepts, nothing downstream ever reacts).
+// It must report a timeout error, not hang or silently succeed.
+func TestSelfCheckProxyPath_TimeoutIsAFailure(t *testing.T) {
+	ln := newWedgedListener(t)
+	defer ln.Close()
+
+	m := &Manager{config: Config{HTTPSPort: ln.port}}
+	err := m.selfCheckProxyPath(500 * time.Millisecond)
+	if err == nil {
+		t.Fatal("expected an error probing a listener that never responds")
+	}
+}
+
+// TestSelfCheckProxyPath_EOFCountsAsAlive exercises the real implementation
+// against a listener that accepts, reads the probe byte, then closes —
+// proving a reacting-but-closing pipeline is NOT treated as a wedge.
+func TestSelfCheckProxyPath_EOFCountsAsAlive(t *testing.T) {
+	ln := newEchoCloseListener(t)
+	defer ln.Close()
+
+	m := &Manager{config: Config{HTTPSPort: ln.port}}
+	if err := m.selfCheckProxyPath(2 * time.Second); err != nil {
+		t.Fatalf("expected no error from a listener that reacts and closes, got: %v", err)
+	}
+}

--- a/internal/sentinel/self_check_test.go
+++ b/internal/sentinel/self_check_test.go
@@ -234,7 +234,7 @@ func TestSelfCheck_DisabledWithoutConnMux(t *testing.T) {
 // It must report a timeout error, not hang or silently succeed.
 func TestSelfCheckProxyPath_TimeoutIsAFailure(t *testing.T) {
 	ln := newWedgedListener(t)
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 
 	m := &Manager{config: Config{HTTPSPort: ln.port}}
 	err := m.selfCheckProxyPath(500 * time.Millisecond)
@@ -248,7 +248,7 @@ func TestSelfCheckProxyPath_TimeoutIsAFailure(t *testing.T) {
 // proving a reacting-but-closing pipeline is NOT treated as a wedge.
 func TestSelfCheckProxyPath_EOFCountsAsAlive(t *testing.T) {
 	ln := newEchoCloseListener(t)
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 
 	m := &Manager{config: Config{HTTPSPort: ln.port}}
 	if err := m.selfCheckProxyPath(2 * time.Second); err != nil {


### PR DESCRIPTION
## Summary
- `healthCheckAll` only ever proved the *backend* was reachable. During a live incident, the backend's health endpoint stayed up throughout a spot-instance restart, so the sentinel never left `PROXY` state — while its own ConnMux/dispatch pipeline had wedged: TCP connections were still accepted, but nothing downstream ever forwarded or responded, on any port (HTTPS, SSH). This surfaced publicly as a Cloudflare 522 with no signal on which side was actually broken. Only a by-hand `systemctl restart` of the sentinel cleared it.
- Adds a background self-check loop (`--self-check-failure-threshold`, default 3, `0` disables) that periodically probes the sentinel's own externally-facing HTTPS listener end-to-end, independent of backend health. After the threshold of consecutive unresponsive probes, the sentinel exits and lets the existing systemd `Restart=always` recreate it with fresh listener/dispatch state — the same fix that worked by hand, now automatic.
- Only armed in ConnMux/hybrid mode (`httpsDispatch != nil`), which is where the incident occurred.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/sentinel/... ./internal/cmd/...`
- [x] `go test ./internal/sentinel/... ./internal/cmd/...` (existing suite, all green)
- [x] New unit tests in `internal/sentinel/self_check_test.go`, including two against real listener sockets: one that accepts-and-never-responds (the exact production wedge signature) is correctly detected as a failure, and one that accepts-reads-closes is correctly treated as "alive" (not a false positive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)