### PR TITLE
fix(cluster): probe the lane's throwaway postgres over TCP, not the Unix socket (#1514)

### DIFF
--- a/scripts/cluster-e2e.sh
+++ b/scripts/cluster-e2e.sh
@@ -143,15 +143,28 @@ if [ -z "${CONTAINARIUM_POSTGRES_URL:-}" ]; then
     -e POSTGRES_USER=containarium -e POSTGRES_PASSWORD=e2e -e POSTGRES_DB=containarium \
     -p "127.0.0.1:${PG_PORT}:5432" postgres:16-alpine >/dev/null
   export CONTAINARIUM_POSTGRES_URL="postgres://containarium:e2e@127.0.0.1:${PG_PORT}/containarium?sslmode=disable"
-  # 90s, not 30s. Run 18 died here: on a cold runner the image pull is
-  # followed by initdb on contended IO, and 30s was not always enough.
-  # A flake at this line costs a full lane run (~15 min) and produces a
-  # red build that has nothing to do with the product.
+  # Probe over TCP (-h 127.0.0.1), never the Unix socket (#1514).
+  #
+  # The postgres entrypoint starts TWO servers: a temporary one for the
+  # init phase, run with listen_addresses='"'"''"'"' so it is reachable only
+  # over the Unix socket, and then -- after CREATE DATABASE and any init
+  # scripts -- it SHUTS THAT ONE DOWN and starts the real server, which
+  # is the first to listen on TCP. A default probe answers "ready"
+  # about the temporary one, so this loop broke early, the entrypoint
+  # shut that server down, and the confirming check below landed in the
+  # shutdown window: red seven seconds into a ninety-second bound.
+  #
+  # The bound was previously raised 30s -> 90s against this symptom, on
+  # the reading that a cold runner'"'"'s image pull plus initdb needed
+  # longer. It could not help: the loop never reached its bound. 90s is
+  # kept because a cold pull genuinely is slow, but the flake was never
+  # a duration problem -- it was a check that answered about the wrong
+  # server.
   for _ in $(seq 1 90); do
-    "$CONTAINER_RUNTIME" exec "$PG_CONTAINER" pg_isready -U containarium >/dev/null 2>&1 && break
+    "$CONTAINER_RUNTIME" exec "$PG_CONTAINER" pg_isready -h 127.0.0.1 -U containarium >/dev/null 2>&1 && break
     sleep 1
   done
-  if ! "$CONTAINER_RUNTIME" exec "$PG_CONTAINER" pg_isready -U containarium >/dev/null 2>&1; then
+  if ! "$CONTAINER_RUNTIME" exec "$PG_CONTAINER" pg_isready -h 127.0.0.1 -U containarium >/dev/null 2>&1; then
     # Say why, rather than just that. Without this the failure is
     # indistinguishable between "still starting", "crashed on startup"
     # and "port already bound".

--- a/test/e2e/cluster/helpers.go
+++ b/test/e2e/cluster/helpers.go
@@ -209,3 +209,27 @@ func MaxRestartDelta(before, after map[string]int32) int32 {
 	}
 	return max
 }
+
+// PostgresReadyArgs is how the lane asks whether its throwaway
+// postgres is actually up (#1514).
+//
+// `-h 127.0.0.1` is the entire point, and it is not a stylistic
+// preference. The official postgres entrypoint starts TWO servers: a
+// temporary one for the init phase, run with `listen_addresses=”` so
+// it is reachable only over the Unix socket, and then — after
+// CREATE DATABASE and any init scripts — it SHUTS THAT ONE DOWN and
+// starts the real server, which is the first to listen on TCP.
+//
+// A default `pg_isready` talks to the Unix socket, so it answers "ready"
+// about the temporary server. The lane's wait loop broke on that
+// answer, the entrypoint then shut that server down, and the
+// confirming probe landed in the shutdown window: a red build seven
+// seconds into a bound of ninety, with nothing wrong with postgres or
+// the product.
+//
+// Probing over TCP cannot see the init server at all, so it cannot
+// break early. Raising the timeout — which is what was tried before —
+// cannot help something that never reaches its timeout.
+func PostgresReadyArgs(user string) []string {
+	return []string{"pg_isready", "-h", "127.0.0.1", "-U", user}
+}

--- a/test/e2e/cluster/helpers_test.go
+++ b/test/e2e/cluster/helpers_test.go
@@ -1,6 +1,7 @@
 package clustere2e
 
 import (
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -355,5 +356,47 @@ func TestClusterInstanceNames(t *testing.T) {
 				t.Fatalf("ClusterInstanceNames = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// #1514: the probe must not be answerable by the entrypoint's
+// temporary init server, which listens on the Unix socket only.
+//
+// Asserted against the SCRIPT, not against a Go constant the script
+// does not read. A helper checked only against itself is decorative:
+// the bash could drift back to a socket probe and this would stay
+// green, which is the same mistake — asserting on a representation
+// instead of on what actually runs — that this sprint has now
+// collected four times.
+func TestLaneScriptProbesPostgresOverTCP(t *testing.T) {
+	raw, err := os.ReadFile("../../../scripts/cluster-e2e.sh")
+	if err != nil {
+		t.Fatalf("read lane script: %v", err)
+	}
+	script := string(raw)
+
+	var probes []string
+	for _, line := range strings.Split(script, "\n") {
+		trimmed := strings.TrimSpace(line)
+		// Comments talk ABOUT the probe; only what runs counts.
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if strings.Contains(trimmed, "pg_isready") {
+			probes = append(probes, trimmed)
+		}
+	}
+	if len(probes) == 0 {
+		t.Fatal("the lane script has no pg_isready probe at all; this test is checking nothing")
+	}
+
+	want := strings.Join(PostgresReadyArgs("containarium"), " ")
+	for _, p := range probes {
+		if !strings.Contains(p, want) {
+			t.Errorf("probe %q does not force TCP (want %q).\n"+
+				"A default pg_isready uses the Unix socket, so it answers \"ready\" about the "+
+				"entrypoint's TEMPORARY init server — which is then shut down, and the confirming "+
+				"probe fails seven seconds into a ninety-second bound (#1514).", p, want)
+		}
 	}
 }


### PR DESCRIPTION
Closes #1514. Unblocks the container lane, which this was failing at random — including on #1511.

## Not a timeout

```
07:20:46  ==> starting throwaway postgres on :15436
07:20:53  FATAL: postgres did not become ready
```

**Seven seconds, against a bound of ninety.** The loop never ran out — it broke early, on the wrong server.

## The probe answered about a server that was about to be destroyed

The official `postgres` entrypoint starts twice:

1. a **temporary** server for the init phase, run with `listen_addresses=''` — Unix socket only
2. `CREATE DATABASE` and any init scripts
3. **that server is shut down**
4. the real server starts, and is the first to listen on TCP

`pg_isready` defaults to the Unix socket, so it answered "ready" about the **step 1** server. The wait loop broke on that answer, the entrypoint reached step 3, and the confirming check immediately after the loop landed inside the shutdown window. Whether it failed was a race with step 4 — hence intermittent.

The run's own log shows the whole sequence, in order:

```
LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"   <- no TCP: the init server
LOG:  database system is ready to accept connections                  <- the loop breaks HERE
LOG:  received fast shutdown request                                  <- step 3
LOG:  database system is shut down
FATAL: postgres did not become ready
```

Probing over TCP cannot see the init server at all, so it cannot break early.

## The previous fix targeted the wrong quantity

The bound was raised 30s → 90s against this exact symptom, on the reading that a cold runner's image pull plus `initdb` on contended IO needed longer. That reasoning is still in the comment at the loop, and it invites raising the bound again — so it is corrected in place rather than left to mislead.

**A longer timeout on a check that answers about the wrong server just waits longer for the same wrong answer.** 90s is kept, because a cold pull genuinely is slow; it was simply never the problem.

## The test reads the script

`TestLaneScriptProbesPostgresOverTCP` parses `scripts/cluster-e2e.sh` and asserts every real `pg_isready` invocation forces TCP — skipping comment lines, which mention the probe without running it.

Asserting a Go helper against itself would be decorative: the bash does not consult it, so the script could drift back to a socket probe while the test stayed green. That is the same assert-on-the-representation mistake this sprint has now collected four times (#1452, #1473, #1415, and the `DeleteNodes` ordering test in #1502).

It also fails loudly if the script contains no probe at all, so deleting the check cannot look like passing. Confirmed to fail by reverting the probe to its old form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)