### PR TITLE
feat(proto): SpawnService contract — agent-box resident listener (#1488 Phase 2)

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -77,6 +77,10 @@
       "description": "SandboxService is the two-digit-ms spawn path\n(docs/architecture/two-digit-ms-sandbox-spawn.md): an isolated Linux\nprocess for an agent inner loop, claimed against a pool rather than\ncreated fresh per request.\n\nA sandbox is NOT a persistent box. It has no per-tenant Linux account and\nno SSH — access is exclusively these RPCs, over a connection the daemon\nalready holds open. That is the scope cut that makes the latency target\nreachable (see the design note's \"What's in it\" section); a caller that\nneeds `ssh \u003cuser\u003e@box` wants ContainerService instead.\n\nPhase 1 (this contract's first implementation) is the cold path only —\nevery SpawnSandbox call creates a fresh container, same floor as\nContainerService.CreateContainer minus identity seeding. served_from is\nalways COLD until Phase 3 adds the warm pool; the field exists now so\nthat Phase 3 is not a breaking proto change."
     },
     {
+      "name": "SpawnService",
+      "description": "SpawnService is agent-box's resident, low-latency counterpart to\nSandboxService's per-call Incus round-trips (#1488 Phase 2). Each Incus\nexec websocket-upgrades at ~50-150ms; a warm gRPC connection straight to\nthe box does the same work in ~3ms. The daemon reaches this over a\nbind-mounted unix socket (see the design note's \"Transport\" section),\nnever over the network.\n\nThis is deliberately the only service in this package with NO\ngoogle.api.http annotations: it is not part of the public API surface —\nSandboxService is what external callers (CLI, MCP, SDK) talk to, and its\nimplementation is what will route through SpawnService once a warm pool\nexists (Phase 3). Nothing here is reachable through the REST gateway,\nand it must not be registered there.\n\nagent-box runs as PID 1 inside a pool member (see the design note's flow\ndiagram), so it owns reaping every process it forks — a design this\nservice inherits from the existing process_start/shell_exec MCP tools in\ninternal/agentbox, not a new mechanism."
+    },
+    {
       "name": "SecurityService",
       "description": "SecurityService provides container security scanning and reporting"
     },

--- a/pkg/pb/containarium/v1/sandbox.pb.go
+++ b/pkg/pb/containarium/v1/sandbox.pb.go
@@ -807,6 +807,257 @@ func (x *DeleteSandboxResponse) GetMessage() string {
 	return ""
 }
 
+type SpawnRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Shell command to run, e.g. "npm run dev". Runs under /bin/sh -c,
+	// matching process_start's existing MCP contract.
+	Command string `protobuf:"bytes,1,opt,name=command,proto3" json:"command,omitempty"`
+	// Stable identifier for later reference. Auto-generated if empty. Must
+	// be unique among this box's currently-registered processes.
+	Name string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	// Working directory. Empty = agent-box's own cwd.
+	Cwd           string `protobuf:"bytes,3,opt,name=cwd,proto3" json:"cwd,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SpawnRequest) Reset() {
+	*x = SpawnRequest{}
+	mi := &file_containarium_v1_sandbox_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SpawnRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SpawnRequest) ProtoMessage() {}
+
+func (x *SpawnRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_sandbox_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SpawnRequest.ProtoReflect.Descriptor instead.
+func (*SpawnRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_sandbox_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *SpawnRequest) GetCommand() string {
+	if x != nil {
+		return x.Command
+	}
+	return ""
+}
+
+func (x *SpawnRequest) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *SpawnRequest) GetCwd() string {
+	if x != nil {
+		return x.Cwd
+	}
+	return ""
+}
+
+type SpawnResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Name  string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Pid   int64                  `protobuf:"varint,2,opt,name=pid,proto3" json:"pid,omitempty"`
+	// Absolute path to the captured stdout+stderr log, matching
+	// process_start's existing MCP contract.
+	LogPath       string `protobuf:"bytes,3,opt,name=log_path,json=logPath,proto3" json:"log_path,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SpawnResponse) Reset() {
+	*x = SpawnResponse{}
+	mi := &file_containarium_v1_sandbox_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SpawnResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SpawnResponse) ProtoMessage() {}
+
+func (x *SpawnResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_sandbox_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SpawnResponse.ProtoReflect.Descriptor instead.
+func (*SpawnResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_sandbox_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *SpawnResponse) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *SpawnResponse) GetPid() int64 {
+	if x != nil {
+		return x.Pid
+	}
+	return 0
+}
+
+func (x *SpawnResponse) GetLogPath() string {
+	if x != nil {
+		return x.LogPath
+	}
+	return ""
+}
+
+type AgentExecRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Shell command to run under /bin/sh -c.
+	Command string `protobuf:"bytes,1,opt,name=command,proto3" json:"command,omitempty"`
+	// Working directory. Empty = agent-box's own cwd.
+	Cwd string `protobuf:"bytes,2,opt,name=cwd,proto3" json:"cwd,omitempty"`
+	// Hard timeout in seconds. 0 = agent-box's default (matches
+	// shell_exec's existing MCP contract).
+	TimeoutSeconds int32 `protobuf:"varint,3,opt,name=timeout_seconds,json=timeoutSeconds,proto3" json:"timeout_seconds,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *AgentExecRequest) Reset() {
+	*x = AgentExecRequest{}
+	mi := &file_containarium_v1_sandbox_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AgentExecRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AgentExecRequest) ProtoMessage() {}
+
+func (x *AgentExecRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_sandbox_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AgentExecRequest.ProtoReflect.Descriptor instead.
+func (*AgentExecRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_sandbox_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *AgentExecRequest) GetCommand() string {
+	if x != nil {
+		return x.Command
+	}
+	return ""
+}
+
+func (x *AgentExecRequest) GetCwd() string {
+	if x != nil {
+		return x.Cwd
+	}
+	return ""
+}
+
+func (x *AgentExecRequest) GetTimeoutSeconds() int32 {
+	if x != nil {
+		return x.TimeoutSeconds
+	}
+	return 0
+}
+
+type AgentExecResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Stdout        string                 `protobuf:"bytes,1,opt,name=stdout,proto3" json:"stdout,omitempty"`
+	Stderr        string                 `protobuf:"bytes,2,opt,name=stderr,proto3" json:"stderr,omitempty"`
+	ExitCode      int32                  `protobuf:"varint,3,opt,name=exit_code,json=exitCode,proto3" json:"exit_code,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AgentExecResponse) Reset() {
+	*x = AgentExecResponse{}
+	mi := &file_containarium_v1_sandbox_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AgentExecResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AgentExecResponse) ProtoMessage() {}
+
+func (x *AgentExecResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_sandbox_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AgentExecResponse.ProtoReflect.Descriptor instead.
+func (*AgentExecResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_sandbox_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *AgentExecResponse) GetStdout() string {
+	if x != nil {
+		return x.Stdout
+	}
+	return ""
+}
+
+func (x *AgentExecResponse) GetStderr() string {
+	if x != nil {
+		return x.Stderr
+	}
+	return ""
+}
+
+func (x *AgentExecResponse) GetExitCode() int32 {
+	if x != nil {
+		return x.ExitCode
+	}
+	return 0
+}
+
 var File_containarium_v1_sandbox_proto protoreflect.FileDescriptor
 
 const file_containarium_v1_sandbox_proto_rawDesc = "" +
@@ -856,7 +1107,23 @@ const file_containarium_v1_sandbox_proto_rawDesc = "" +
 	"\n" +
 	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\"1\n" +
 	"\x15DeleteSandboxResponse\x12\x18\n" +
-	"\amessage\x18\x01 \x01(\tR\amessage*\x96\x01\n" +
+	"\amessage\x18\x01 \x01(\tR\amessage\"N\n" +
+	"\fSpawnRequest\x12\x18\n" +
+	"\acommand\x18\x01 \x01(\tR\acommand\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x12\x10\n" +
+	"\x03cwd\x18\x03 \x01(\tR\x03cwd\"P\n" +
+	"\rSpawnResponse\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x10\n" +
+	"\x03pid\x18\x02 \x01(\x03R\x03pid\x12\x19\n" +
+	"\blog_path\x18\x03 \x01(\tR\alogPath\"g\n" +
+	"\x10AgentExecRequest\x12\x18\n" +
+	"\acommand\x18\x01 \x01(\tR\acommand\x12\x10\n" +
+	"\x03cwd\x18\x02 \x01(\tR\x03cwd\x12'\n" +
+	"\x0ftimeout_seconds\x18\x03 \x01(\x05R\x0etimeoutSeconds\"`\n" +
+	"\x11AgentExecResponse\x12\x16\n" +
+	"\x06stdout\x18\x01 \x01(\tR\x06stdout\x12\x16\n" +
+	"\x06stderr\x18\x02 \x01(\tR\x06stderr\x12\x1b\n" +
+	"\texit_code\x18\x03 \x01(\x05R\bexitCode*\x96\x01\n" +
 	"\fSandboxState\x12\x1d\n" +
 	"\x19SANDBOX_STATE_UNSPECIFIED\x10\x00\x12\x19\n" +
 	"\x15SANDBOX_STATE_PENDING\x10\x01\x12\x19\n" +
@@ -881,7 +1148,10 @@ const file_containarium_v1_sandbox_proto_rawDesc = "" +
 	"\x11ReadFileInSandbox\x12).containarium.v1.ReadFileInSandboxRequest\x1a*.containarium.v1.ReadFileInSandboxResponse\"\x97\x01\x92Al\n" +
 	"\tSandboxes\x12\x1aRead a file from a sandbox\x1aCpath is passed as a query parameter, e.g. ?path=/workspace/out.txt.\x82\xd3\xe4\x93\x02\"\x12 /v1/sandboxes/{sandbox_id}/files\x12\xa2\x01\n" +
 	"\rDeleteSandbox\x12%.containarium.v1.DeleteSandboxRequest\x1a&.containarium.v1.DeleteSandboxResponse\"B\x92A\x1d\n" +
-	"\tSandboxes\x12\x10Delete a sandbox\x82\xd3\xe4\x93\x02\x1c*\x1a/v1/sandboxes/{sandbox_id}BKZIgithub.com/footprintai/containarium/pkg/pb/containarium/v1;containariumv1b\x06proto3"
+	"\tSandboxes\x12\x10Delete a sandbox\x82\xd3\xe4\x93\x02\x1c*\x1a/v1/sandboxes/{sandbox_id}2\xa5\x01\n" +
+	"\fSpawnService\x12F\n" +
+	"\x05Spawn\x12\x1d.containarium.v1.SpawnRequest\x1a\x1e.containarium.v1.SpawnResponse\x12M\n" +
+	"\x04Exec\x12!.containarium.v1.AgentExecRequest\x1a\".containarium.v1.AgentExecResponseBKZIgithub.com/footprintai/containarium/pkg/pb/containarium/v1;containariumv1b\x06proto3"
 
 var (
 	file_containarium_v1_sandbox_proto_rawDescOnce sync.Once
@@ -896,7 +1166,7 @@ func file_containarium_v1_sandbox_proto_rawDescGZIP() []byte {
 }
 
 var file_containarium_v1_sandbox_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_containarium_v1_sandbox_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
+var file_containarium_v1_sandbox_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
 var file_containarium_v1_sandbox_proto_goTypes = []any{
 	(SandboxState)(0),                  // 0: containarium.v1.SandboxState
 	(ServedFrom)(0),                    // 1: containarium.v1.ServedFrom
@@ -912,14 +1182,18 @@ var file_containarium_v1_sandbox_proto_goTypes = []any{
 	(*ReadFileInSandboxResponse)(nil),  // 11: containarium.v1.ReadFileInSandboxResponse
 	(*DeleteSandboxRequest)(nil),       // 12: containarium.v1.DeleteSandboxRequest
 	(*DeleteSandboxResponse)(nil),      // 13: containarium.v1.DeleteSandboxResponse
-	(*timestamppb.Timestamp)(nil),      // 14: google.protobuf.Timestamp
+	(*SpawnRequest)(nil),               // 14: containarium.v1.SpawnRequest
+	(*SpawnResponse)(nil),              // 15: containarium.v1.SpawnResponse
+	(*AgentExecRequest)(nil),           // 16: containarium.v1.AgentExecRequest
+	(*AgentExecResponse)(nil),          // 17: containarium.v1.AgentExecResponse
+	(*timestamppb.Timestamp)(nil),      // 18: google.protobuf.Timestamp
 }
 var file_containarium_v1_sandbox_proto_depIdxs = []int32{
 	0,  // 0: containarium.v1.Sandbox.state:type_name -> containarium.v1.SandboxState
 	2,  // 1: containarium.v1.Sandbox.template:type_name -> containarium.v1.SandboxTemplate
 	1,  // 2: containarium.v1.Sandbox.served_from:type_name -> containarium.v1.ServedFrom
-	14, // 3: containarium.v1.Sandbox.created_at:type_name -> google.protobuf.Timestamp
-	14, // 4: containarium.v1.Sandbox.expires_at:type_name -> google.protobuf.Timestamp
+	18, // 3: containarium.v1.Sandbox.created_at:type_name -> google.protobuf.Timestamp
+	18, // 4: containarium.v1.Sandbox.expires_at:type_name -> google.protobuf.Timestamp
 	2,  // 5: containarium.v1.SpawnSandboxRequest.template:type_name -> containarium.v1.SandboxTemplate
 	3,  // 6: containarium.v1.SpawnSandboxResponse.sandbox:type_name -> containarium.v1.Sandbox
 	4,  // 7: containarium.v1.SandboxService.SpawnSandbox:input_type -> containarium.v1.SpawnSandboxRequest
@@ -927,13 +1201,17 @@ var file_containarium_v1_sandbox_proto_depIdxs = []int32{
 	8,  // 9: containarium.v1.SandboxService.WriteFileInSandbox:input_type -> containarium.v1.WriteFileInSandboxRequest
 	10, // 10: containarium.v1.SandboxService.ReadFileInSandbox:input_type -> containarium.v1.ReadFileInSandboxRequest
 	12, // 11: containarium.v1.SandboxService.DeleteSandbox:input_type -> containarium.v1.DeleteSandboxRequest
-	5,  // 12: containarium.v1.SandboxService.SpawnSandbox:output_type -> containarium.v1.SpawnSandboxResponse
-	7,  // 13: containarium.v1.SandboxService.ExecInSandbox:output_type -> containarium.v1.ExecInSandboxResponse
-	9,  // 14: containarium.v1.SandboxService.WriteFileInSandbox:output_type -> containarium.v1.WriteFileInSandboxResponse
-	11, // 15: containarium.v1.SandboxService.ReadFileInSandbox:output_type -> containarium.v1.ReadFileInSandboxResponse
-	13, // 16: containarium.v1.SandboxService.DeleteSandbox:output_type -> containarium.v1.DeleteSandboxResponse
-	12, // [12:17] is the sub-list for method output_type
-	7,  // [7:12] is the sub-list for method input_type
+	14, // 12: containarium.v1.SpawnService.Spawn:input_type -> containarium.v1.SpawnRequest
+	16, // 13: containarium.v1.SpawnService.Exec:input_type -> containarium.v1.AgentExecRequest
+	5,  // 14: containarium.v1.SandboxService.SpawnSandbox:output_type -> containarium.v1.SpawnSandboxResponse
+	7,  // 15: containarium.v1.SandboxService.ExecInSandbox:output_type -> containarium.v1.ExecInSandboxResponse
+	9,  // 16: containarium.v1.SandboxService.WriteFileInSandbox:output_type -> containarium.v1.WriteFileInSandboxResponse
+	11, // 17: containarium.v1.SandboxService.ReadFileInSandbox:output_type -> containarium.v1.ReadFileInSandboxResponse
+	13, // 18: containarium.v1.SandboxService.DeleteSandbox:output_type -> containarium.v1.DeleteSandboxResponse
+	15, // 19: containarium.v1.SpawnService.Spawn:output_type -> containarium.v1.SpawnResponse
+	17, // 20: containarium.v1.SpawnService.Exec:output_type -> containarium.v1.AgentExecResponse
+	14, // [14:21] is the sub-list for method output_type
+	7,  // [7:14] is the sub-list for method input_type
 	7,  // [7:7] is the sub-list for extension type_name
 	7,  // [7:7] is the sub-list for extension extendee
 	0,  // [0:7] is the sub-list for field type_name
@@ -950,9 +1228,9 @@ func file_containarium_v1_sandbox_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_v1_sandbox_proto_rawDesc), len(file_containarium_v1_sandbox_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   11,
+			NumMessages:   15,
 			NumExtensions: 0,
-			NumServices:   1,
+			NumServices:   2,
 		},
 		GoTypes:           file_containarium_v1_sandbox_proto_goTypes,
 		DependencyIndexes: file_containarium_v1_sandbox_proto_depIdxs,

--- a/pkg/pb/containarium/v1/sandbox.pb.gw.go
+++ b/pkg/pb/containarium/v1/sandbox.pb.gw.go
@@ -244,6 +244,60 @@ func local_request_SandboxService_DeleteSandbox_0(ctx context.Context, marshaler
 	return msg, metadata, err
 }
 
+func request_SpawnService_Spawn_0(ctx context.Context, marshaler runtime.Marshaler, client SpawnServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq SpawnRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.Spawn(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_SpawnService_Spawn_0(ctx context.Context, marshaler runtime.Marshaler, server SpawnServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq SpawnRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.Spawn(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_SpawnService_Exec_0(ctx context.Context, marshaler runtime.Marshaler, client SpawnServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq AgentExecRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.Exec(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_SpawnService_Exec_0(ctx context.Context, marshaler runtime.Marshaler, server SpawnServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq AgentExecRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.Exec(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterSandboxServiceHandlerServer registers the http handlers for service SandboxService to "mux".
 // UnaryRPC     :call SandboxServiceServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -349,6 +403,56 @@ func RegisterSandboxServiceHandlerServer(ctx context.Context, mux *runtime.Serve
 			return
 		}
 		forward_SandboxService_DeleteSandbox_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+
+	return nil
+}
+
+// RegisterSpawnServiceHandlerServer registers the http handlers for service SpawnService to "mux".
+// UnaryRPC     :call SpawnServiceServer directly.
+// StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
+// Note that using this registration option will cause many gRPC library features to stop working. Consider using RegisterSpawnServiceHandlerFromEndpoint instead.
+// GRPC interceptors will not work for this type of registration. To use interceptors, you must use the "runtime.WithMiddlewares" option in the "runtime.NewServeMux" call.
+func RegisterSpawnServiceHandlerServer(ctx context.Context, mux *runtime.ServeMux, server SpawnServiceServer) error {
+	mux.Handle(http.MethodPost, pattern_SpawnService_Spawn_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.SpawnService/Spawn", runtime.WithHTTPPathPattern("/containarium.v1.SpawnService/Spawn"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_SpawnService_Spawn_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_SpawnService_Spawn_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_SpawnService_Exec_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.SpawnService/Exec", runtime.WithHTTPPathPattern("/containarium.v1.SpawnService/Exec"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_SpawnService_Exec_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_SpawnService_Exec_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 
 	return nil
@@ -492,4 +596,87 @@ var (
 	forward_SandboxService_WriteFileInSandbox_0 = runtime.ForwardResponseMessage
 	forward_SandboxService_ReadFileInSandbox_0  = runtime.ForwardResponseMessage
 	forward_SandboxService_DeleteSandbox_0      = runtime.ForwardResponseMessage
+)
+
+// RegisterSpawnServiceHandlerFromEndpoint is same as RegisterSpawnServiceHandler but
+// automatically dials to "endpoint" and closes the connection when "ctx" gets done.
+func RegisterSpawnServiceHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) (err error) {
+	conn, err := grpc.NewClient(endpoint, opts...)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			if cerr := conn.Close(); cerr != nil {
+				grpclog.Errorf("Failed to close conn to %s: %v", endpoint, cerr)
+			}
+			return
+		}
+		go func() {
+			<-ctx.Done()
+			if cerr := conn.Close(); cerr != nil {
+				grpclog.Errorf("Failed to close conn to %s: %v", endpoint, cerr)
+			}
+		}()
+	}()
+	return RegisterSpawnServiceHandler(ctx, mux, conn)
+}
+
+// RegisterSpawnServiceHandler registers the http handlers for service SpawnService to "mux".
+// The handlers forward requests to the grpc endpoint over "conn".
+func RegisterSpawnServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {
+	return RegisterSpawnServiceHandlerClient(ctx, mux, NewSpawnServiceClient(conn))
+}
+
+// RegisterSpawnServiceHandlerClient registers the http handlers for service SpawnService
+// to "mux". The handlers forward requests to the grpc endpoint over the given implementation of "SpawnServiceClient".
+// Note: the gRPC framework executes interceptors within the gRPC handler. If the passed in "SpawnServiceClient"
+// doesn't go through the normal gRPC flow (creating a gRPC client etc.) then it will be up to the passed in
+// "SpawnServiceClient" to call the correct interceptors. This client ignores the HTTP middlewares.
+func RegisterSpawnServiceHandlerClient(ctx context.Context, mux *runtime.ServeMux, client SpawnServiceClient) error {
+	mux.Handle(http.MethodPost, pattern_SpawnService_Spawn_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.SpawnService/Spawn", runtime.WithHTTPPathPattern("/containarium.v1.SpawnService/Spawn"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_SpawnService_Spawn_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_SpawnService_Spawn_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_SpawnService_Exec_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.SpawnService/Exec", runtime.WithHTTPPathPattern("/containarium.v1.SpawnService/Exec"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_SpawnService_Exec_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_SpawnService_Exec_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	return nil
+}
+
+var (
+	pattern_SpawnService_Spawn_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"containarium.v1.SpawnService", "Spawn"}, ""))
+	pattern_SpawnService_Exec_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"containarium.v1.SpawnService", "Exec"}, ""))
+)
+
+var (
+	forward_SpawnService_Spawn_0 = runtime.ForwardResponseMessage
+	forward_SpawnService_Exec_0  = runtime.ForwardResponseMessage
 )

--- a/pkg/pb/containarium/v1/sandbox_grpc.pb.go
+++ b/pkg/pb/containarium/v1/sandbox_grpc.pb.go
@@ -327,3 +327,193 @@ var SandboxService_ServiceDesc = grpc.ServiceDesc{
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "containarium/v1/sandbox.proto",
 }
+
+const (
+	SpawnService_Spawn_FullMethodName = "/containarium.v1.SpawnService/Spawn"
+	SpawnService_Exec_FullMethodName  = "/containarium.v1.SpawnService/Exec"
+)
+
+// SpawnServiceClient is the client API for SpawnService service.
+//
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
+//
+// SpawnService is agent-box's resident, low-latency counterpart to
+// SandboxService's per-call Incus round-trips (#1488 Phase 2). Each Incus
+// exec websocket-upgrades at ~50-150ms; a warm gRPC connection straight to
+// the box does the same work in ~3ms. The daemon reaches this over a
+// bind-mounted unix socket (see the design note's "Transport" section),
+// never over the network.
+//
+// This is deliberately the only service in this package with NO
+// google.api.http annotations: it is not part of the public API surface —
+// SandboxService is what external callers (CLI, MCP, SDK) talk to, and its
+// implementation is what will route through SpawnService once a warm pool
+// exists (Phase 3). Nothing here is reachable through the REST gateway,
+// and it must not be registered there.
+//
+// agent-box runs as PID 1 inside a pool member (see the design note's flow
+// diagram), so it owns reaping every process it forks — a design this
+// service inherits from the existing process_start/shell_exec MCP tools in
+// internal/agentbox, not a new mechanism.
+type SpawnServiceClient interface {
+	// Spawn starts a long-running background process and returns immediately
+	// with its pid. The process is reaped (waited on), never left a zombie,
+	// when it exits.
+	Spawn(ctx context.Context, in *SpawnRequest, opts ...grpc.CallOption) (*SpawnResponse, error)
+	// Exec runs one command to completion and returns its stdout, stderr,
+	// and exit code — the fast-path equivalent of
+	// SandboxService.ExecInSandbox, minus the Incus round-trip.
+	Exec(ctx context.Context, in *AgentExecRequest, opts ...grpc.CallOption) (*AgentExecResponse, error)
+}
+
+type spawnServiceClient struct {
+	cc grpc.ClientConnInterface
+}
+
+func NewSpawnServiceClient(cc grpc.ClientConnInterface) SpawnServiceClient {
+	return &spawnServiceClient{cc}
+}
+
+func (c *spawnServiceClient) Spawn(ctx context.Context, in *SpawnRequest, opts ...grpc.CallOption) (*SpawnResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SpawnResponse)
+	err := c.cc.Invoke(ctx, SpawnService_Spawn_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *spawnServiceClient) Exec(ctx context.Context, in *AgentExecRequest, opts ...grpc.CallOption) (*AgentExecResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(AgentExecResponse)
+	err := c.cc.Invoke(ctx, SpawnService_Exec_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// SpawnServiceServer is the server API for SpawnService service.
+// All implementations must embed UnimplementedSpawnServiceServer
+// for forward compatibility.
+//
+// SpawnService is agent-box's resident, low-latency counterpart to
+// SandboxService's per-call Incus round-trips (#1488 Phase 2). Each Incus
+// exec websocket-upgrades at ~50-150ms; a warm gRPC connection straight to
+// the box does the same work in ~3ms. The daemon reaches this over a
+// bind-mounted unix socket (see the design note's "Transport" section),
+// never over the network.
+//
+// This is deliberately the only service in this package with NO
+// google.api.http annotations: it is not part of the public API surface —
+// SandboxService is what external callers (CLI, MCP, SDK) talk to, and its
+// implementation is what will route through SpawnService once a warm pool
+// exists (Phase 3). Nothing here is reachable through the REST gateway,
+// and it must not be registered there.
+//
+// agent-box runs as PID 1 inside a pool member (see the design note's flow
+// diagram), so it owns reaping every process it forks — a design this
+// service inherits from the existing process_start/shell_exec MCP tools in
+// internal/agentbox, not a new mechanism.
+type SpawnServiceServer interface {
+	// Spawn starts a long-running background process and returns immediately
+	// with its pid. The process is reaped (waited on), never left a zombie,
+	// when it exits.
+	Spawn(context.Context, *SpawnRequest) (*SpawnResponse, error)
+	// Exec runs one command to completion and returns its stdout, stderr,
+	// and exit code — the fast-path equivalent of
+	// SandboxService.ExecInSandbox, minus the Incus round-trip.
+	Exec(context.Context, *AgentExecRequest) (*AgentExecResponse, error)
+	mustEmbedUnimplementedSpawnServiceServer()
+}
+
+// UnimplementedSpawnServiceServer must be embedded to have
+// forward compatible implementations.
+//
+// NOTE: this should be embedded by value instead of pointer to avoid a nil
+// pointer dereference when methods are called.
+type UnimplementedSpawnServiceServer struct{}
+
+func (UnimplementedSpawnServiceServer) Spawn(context.Context, *SpawnRequest) (*SpawnResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method Spawn not implemented")
+}
+func (UnimplementedSpawnServiceServer) Exec(context.Context, *AgentExecRequest) (*AgentExecResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method Exec not implemented")
+}
+func (UnimplementedSpawnServiceServer) mustEmbedUnimplementedSpawnServiceServer() {}
+func (UnimplementedSpawnServiceServer) testEmbeddedByValue()                      {}
+
+// UnsafeSpawnServiceServer may be embedded to opt out of forward compatibility for this service.
+// Use of this interface is not recommended, as added methods to SpawnServiceServer will
+// result in compilation errors.
+type UnsafeSpawnServiceServer interface {
+	mustEmbedUnimplementedSpawnServiceServer()
+}
+
+func RegisterSpawnServiceServer(s grpc.ServiceRegistrar, srv SpawnServiceServer) {
+	// If the following call panics, it indicates UnimplementedSpawnServiceServer was
+	// embedded by pointer and is nil.  This will cause panics if an
+	// unimplemented method is ever invoked, so we test this at initialization
+	// time to prevent it from happening at runtime later due to I/O.
+	if t, ok := srv.(interface{ testEmbeddedByValue() }); ok {
+		t.testEmbeddedByValue()
+	}
+	s.RegisterService(&SpawnService_ServiceDesc, srv)
+}
+
+func _SpawnService_Spawn_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SpawnRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SpawnServiceServer).Spawn(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SpawnService_Spawn_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SpawnServiceServer).Spawn(ctx, req.(*SpawnRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _SpawnService_Exec_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(AgentExecRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SpawnServiceServer).Exec(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SpawnService_Exec_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SpawnServiceServer).Exec(ctx, req.(*AgentExecRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+// SpawnService_ServiceDesc is the grpc.ServiceDesc for SpawnService service.
+// It's only intended for direct use with grpc.RegisterService,
+// and not to be introspected or modified (even as a copy)
+var SpawnService_ServiceDesc = grpc.ServiceDesc{
+	ServiceName: "containarium.v1.SpawnService",
+	HandlerType: (*SpawnServiceServer)(nil),
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "Spawn",
+			Handler:    _SpawnService_Spawn_Handler,
+		},
+		{
+			MethodName: "Exec",
+			Handler:    _SpawnService_Exec_Handler,
+		},
+	},
+	Streams:  []grpc.StreamDesc{},
+	Metadata: "containarium/v1/sandbox.proto",
+}

--- a/proto/containarium/v1/sandbox.proto
+++ b/proto/containarium/v1/sandbox.proto
@@ -198,3 +198,68 @@ message DeleteSandboxRequest {
 message DeleteSandboxResponse {
   string message = 1;
 }
+
+// SpawnService is agent-box's resident, low-latency counterpart to
+// SandboxService's per-call Incus round-trips (#1488 Phase 2). Each Incus
+// exec websocket-upgrades at ~50-150ms; a warm gRPC connection straight to
+// the box does the same work in ~3ms. The daemon reaches this over a
+// bind-mounted unix socket (see the design note's "Transport" section),
+// never over the network.
+//
+// This is deliberately the only service in this package with NO
+// google.api.http annotations: it is not part of the public API surface —
+// SandboxService is what external callers (CLI, MCP, SDK) talk to, and its
+// implementation is what will route through SpawnService once a warm pool
+// exists (Phase 3). Nothing here is reachable through the REST gateway,
+// and it must not be registered there.
+//
+// agent-box runs as PID 1 inside a pool member (see the design note's flow
+// diagram), so it owns reaping every process it forks — a design this
+// service inherits from the existing process_start/shell_exec MCP tools in
+// internal/agentbox, not a new mechanism.
+service SpawnService {
+  // Spawn starts a long-running background process and returns immediately
+  // with its pid. The process is reaped (waited on), never left a zombie,
+  // when it exits.
+  rpc Spawn(SpawnRequest) returns (SpawnResponse);
+
+  // Exec runs one command to completion and returns its stdout, stderr,
+  // and exit code — the fast-path equivalent of
+  // SandboxService.ExecInSandbox, minus the Incus round-trip.
+  rpc Exec(AgentExecRequest) returns (AgentExecResponse);
+}
+
+message SpawnRequest {
+  // Shell command to run, e.g. "npm run dev". Runs under /bin/sh -c,
+  // matching process_start's existing MCP contract.
+  string command = 1;
+  // Stable identifier for later reference. Auto-generated if empty. Must
+  // be unique among this box's currently-registered processes.
+  string name = 2;
+  // Working directory. Empty = agent-box's own cwd.
+  string cwd = 3;
+}
+
+message SpawnResponse {
+  string name = 1;
+  int64 pid = 2;
+  // Absolute path to the captured stdout+stderr log, matching
+  // process_start's existing MCP contract.
+  string log_path = 3;
+}
+
+message AgentExecRequest {
+  // Shell command to run under /bin/sh -c.
+  string command = 1;
+  // Working directory. Empty = agent-box's own cwd.
+  string cwd = 2;
+  // Hard timeout in seconds. 0 = agent-box's default (matches
+  // shell_exec's existing MCP contract).
+  int32 timeout_seconds = 3;
+}
+
+message AgentExecResponse {
+  string stdout = 1;
+  string stderr = 2;
+  int32 exit_code = 3;
+}


### PR DESCRIPTION
## What

Phase 2 of the two-digit-ms sandbox spawn design note (#1488): the `SpawnService` proto contract — agent-box's resident, low-latency counterpart to `SandboxService`'s per-call Incus round-trips (each Incus exec websocket-upgrades at ~50–150ms; a warm gRPC connection straight to the box does the same work in ~3ms).

**Contract only**, same slicing that worked for Phase 1's #1506 — a server implementation is the natural follow-up building against this fixed target.

## The two RPCs

- **`Spawn`** — starts a long-running background process, returns immediately with its pid. Mirrors `process_start`'s existing MCP tool contract (`name`/`command`/`cwd` in, `name`/`pid`/`log_path` out) rather than inventing new semantics for the same operation `internal/agentbox` already has.
- **`Exec`** — runs one command to completion, returns stdout/stderr/exit code. Mirrors `shell_exec`'s existing MCP tool contract.

## Deliberately no REST surface

This is the only service in the package with no `google.api.http` annotations — it's not part of the public API. `SandboxService` is what external callers (CLI, MCP, SDK) talk to; `SpawnService` is the private daemon↔agent-box protocol `SandboxService`'s implementation will route through once a warm pool exists (Phase 3). The proto's own doc comment says explicitly it must not be registered on the REST gateway.

One thing worth flagging in review: `buf generate` still synthesizes gateway handler *functions* for it (a default `/containarium.v1.SpawnService/Spawn`-style path) even with no annotations — that's normal grpc-gateway codegen behavior. The generated code stays dead as long as nothing calls `RegisterSpawnServiceHandlerFromEndpoint` for it — confirmed via grep that `internal/gateway/gateway.go` doesn't reference it.

## Verification

- `buf build` — clean.
- `buf breaking --against main` — clean (new messages/service only).
- Swagger diff adds only the service's tag description, no new paths — confirmed by diffing for `Spawn`/`AgentExec` path entries specifically.
- `go build ./...` / `go vet ./...` — clean tree-wide.

## Note on what still needs a live host

This proto step, and the agent-box server implementation that follows it, need **no** live Incus host — a resident unix-socket gRPC server with real fork/exec/reap is fully unit-testable against a real local socket in this dev environment. What genuinely *does* need a live unprivileged container is the Incus-side bind-mounted disk device + idmap handling from the design note's Transport section — explicitly out of scope here, and I'll flag it clearly wherever it's picked up rather than claim it as verified.

Refs #1488 (Phase 2, part 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
