### PR TITLE
feat(sandbox): pool — reconciler + claim ring (#1488 Phase 3)

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -77,6 +77,10 @@
       "description": "SandboxService is the two-digit-ms spawn path\n(docs/architecture/two-digit-ms-sandbox-spawn.md): an isolated Linux\nprocess for an agent inner loop, claimed against a pool rather than\ncreated fresh per request.\n\nA sandbox is NOT a persistent box. It has no per-tenant Linux account and\nno SSH — access is exclusively these RPCs, over a connection the daemon\nalready holds open. That is the scope cut that makes the latency target\nreachable (see the design note's \"What's in it\" section); a caller that\nneeds `ssh \u003cuser\u003e@box` wants ContainerService instead.\n\nPhase 1 (this contract's first implementation) is the cold path only —\nevery SpawnSandbox call creates a fresh container, same floor as\nContainerService.CreateContainer minus identity seeding. served_from is\nalways COLD until Phase 3 adds the warm pool; the field exists now so\nthat Phase 3 is not a breaking proto change."
     },
     {
+      "name": "SpawnService",
+      "description": "SpawnService is agent-box's resident, low-latency counterpart to\nSandboxService's per-call Incus round-trips (#1488 Phase 2). Each Incus\nexec websocket-upgrades at ~50-150ms; a warm gRPC connection straight to\nthe box does the same work in ~3ms. The daemon reaches this over a\nbind-mounted unix socket (see the design note's \"Transport\" section),\nnever over the network.\n\nThis is deliberately the only service in this package with NO\ngoogle.api.http annotations: it is not part of the public API surface —\nSandboxService is what external callers (CLI, MCP, SDK) talk to, and its\nimplementation is what will route through SpawnService once a warm pool\nexists (Phase 3). Nothing here is reachable through the REST gateway,\nand it must not be registered there.\n\nagent-box runs as PID 1 inside a pool member (see the design note's flow\ndiagram), so it owns reaping every process it forks — a design this\nservice inherits from the existing process_start/shell_exec MCP tools in\ninternal/agentbox, not a new mechanism."
+    },
+    {
       "name": "SecurityService",
       "description": "SecurityService provides container security scanning and reporting"
     },

--- a/cmd/agent-box/main.go
+++ b/cmd/agent-box/main.go
@@ -15,6 +15,13 @@
 //
 // The MCP transport is stdio; the SSH command on the user side wraps it.
 //
+// A pool member (#1488 Phase 2, not yet in production — nothing sets
+// AGENTBOX_SPAWN_SOCKET today) also serves SpawnService over a resident
+// gRPC listener on a unix socket, in parallel with stdio MCP. This
+// removes the daemon's per-call Incus round-trip (~50-150ms) for the two
+// operations a claimed sandbox needs on its hot path: spawning the task's
+// process and running commands in it.
+//
 // Tools (imperative): shell_exec, read_file, write_file, list_directory,
 // move_file, delete_file, tail_log, process_start, process_list,
 // process_kill. See internal/agentbox/server.go for the canonical list.
@@ -71,6 +78,17 @@ func main() {
 
 	agentbox.RegisterTools(mcpServer)
 	agentbox.RegisterResources(mcpServer)
+
+	// Second transport (#1488 Phase 2): opt-in via AGENTBOX_SPAWN_SOCKET,
+	// unset on every box today. Runs alongside stdio MCP, not instead of
+	// it — see the package doc comment above.
+	if socketPath := os.Getenv(agentbox.SpawnSocketEnv); socketPath != "" {
+		spawnServer, err := agentbox.StartSpawnListener(socketPath)
+		if err != nil {
+			log.Fatalf("[agent-box] failed to start SpawnService listener: %v", err)
+		}
+		defer spawnServer.GracefulStop()
+	}
 
 	log.Printf("[agent-box] starting MCP server on stdio (version %s)", version.Version)
 	if err := server.ServeStdio(mcpServer); err != nil {

--- a/internal/agentbox/agentbox_test.go
+++ b/internal/agentbox/agentbox_test.go
@@ -59,11 +59,24 @@ func TestShellExec_NonZeroExit(t *testing.T) {
 	}
 }
 
+// TestShellExec_Timeout previously only checked the output for the word
+// "timeout" — which let the command's exit be reported correctly (via
+// ctx.Err()) even though the process itself wasn't actually killed early;
+// /bin/sh -c "sleep 5" forks a genuine child rather than exec-replacing
+// itself, so killing just the shell (exec.CommandContext's default) left
+// the grandchild running and holding the stdout/stderr pipe open, and
+// Wait() blocked for the full natural 5s before returning. Asserting
+// elapsed time is what actually catches that class of bug; a bare
+// string-in-output check does not, and silently didn't for a while.
 func TestShellExec_Timeout(t *testing.T) {
+	start := time.Now()
 	out, _ := callTool(t, handleShellExec, map[string]interface{}{
 		"command":         "sleep 5",
 		"timeout_seconds": float64(1),
 	})
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Errorf("took %s, want well under the 5s sleep (timeout should kill the whole command tree around 1s)", elapsed)
+	}
 	if !strings.Contains(out, "timeout") {
 		t.Errorf("expected timeout marker in:\n%s", out)
 	}

--- a/internal/agentbox/process.go
+++ b/internal/agentbox/process.go
@@ -90,6 +90,33 @@ func handleProcessStart(_ context.Context, req mcp.CallToolRequest) (*mcp.CallTo
 	name, _ := args["name"].(string)
 	cwd, _ := args["cwd"].(string)
 
+	mp, err := spawnBackgroundProcess(name, command, cwd)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("process_start: %v", err)), nil
+	}
+
+	body := fmt.Sprintf(
+		"name: %s\npid: %d\ncommand: %s\nlog_path: %s\nstarted_at: %s\n",
+		mp.Name, mp.PID, mp.Command, mp.LogPath, mp.StartedAt.UTC().Format(time.RFC3339),
+	)
+	return mcp.NewToolResultText(body), nil
+}
+
+// spawnBackgroundProcess starts command under /bin/sh -c, detached via
+// Setsid, capturing combined stdout+stderr to a log file under
+// processLogDir, and registers it in processRegistry under name (auto-
+// generated if empty). Reaped asynchronously — a goroutine calls
+// cmd.Wait() — so it never zombies.
+//
+// Shared core between the process_start MCP tool (handleProcessStart) and
+// SpawnService.Spawn (gRPC, #1488 Phase 2): one implementation, two
+// transports, so a caller reaching agent-box over the fast local socket
+// gets identical spawn/reap semantics to one reaching it over MCP/SSH.
+func spawnBackgroundProcess(name, command, cwd string) (*managedProcess, error) {
+	if command == "" {
+		return nil, fmt.Errorf("'command' is required")
+	}
+
 	processRegistryMu.Lock()
 	defer processRegistryMu.Unlock()
 
@@ -97,13 +124,11 @@ func handleProcessStart(_ context.Context, req mcp.CallToolRequest) (*mcp.CallTo
 		name = fmt.Sprintf("proc-%d", time.Now().UnixNano())
 	}
 	if _, exists := processRegistry[name]; exists {
-		return mcp.NewToolResultError(fmt.Sprintf(
-				"process_start: a process named %q is already running; kill it first or pick a different name", name)),
-			nil
+		return nil, fmt.Errorf("a process named %q is already running; kill it first or pick a different name", name)
 	}
 
 	if err := os.MkdirAll(processLogDir, 0o750); err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("process_start: mkdir %s: %v", processLogDir, err)), nil
+		return nil, fmt.Errorf("mkdir %s: %w", processLogDir, err)
 	}
 	logPath := filepath.Join(processLogDir, sanitizeName(name)+".log")
 	// #nosec G304 -- sanitizeName strips every char outside [A-Za-z0-9_.-],
@@ -111,11 +136,11 @@ func handleProcessStart(_ context.Context, req mcp.CallToolRequest) (*mcp.CallTo
 	// not reachable from this construction.
 	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("process_start: open log %s: %v", logPath, err)), nil
+		return nil, fmt.Errorf("open log %s: %w", logPath, err)
 	}
 
-	// #nosec G204 -- process_start's contract is to spawn agent-supplied
-	// commands; arbitrary command execution is the entire feature.
+	// #nosec G204 -- spawning agent-supplied commands is the entire
+	// feature, on both transports this function serves.
 	cmd := exec.Command("/bin/sh", "-c", command)
 	if cwd != "" {
 		cmd.Dir = cwd
@@ -128,7 +153,7 @@ func handleProcessStart(_ context.Context, req mcp.CallToolRequest) (*mcp.CallTo
 
 	if err := cmd.Start(); err != nil {
 		_ = logFile.Close()
-		return mcp.NewToolResultError(fmt.Sprintf("process_start: spawn: %v", err)), nil
+		return nil, fmt.Errorf("spawn: %w", err)
 	}
 
 	mp := &managedProcess{
@@ -149,11 +174,7 @@ func handleProcessStart(_ context.Context, req mcp.CallToolRequest) (*mcp.CallTo
 		_ = logFile.Close()
 	}()
 
-	body := fmt.Sprintf(
-		"name: %s\npid: %d\ncommand: %s\nlog_path: %s\nstarted_at: %s\n",
-		mp.Name, mp.PID, mp.Command, mp.LogPath, mp.StartedAt.UTC().Format(time.RFC3339),
-	)
-	return mcp.NewToolResultText(body), nil
+	return mp, nil
 }
 
 // ----- process_list ----------------------------------------------------

--- a/internal/agentbox/process.go
+++ b/internal/agentbox/process.go
@@ -2,6 +2,7 @@ package agentbox
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -15,6 +16,16 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
+
+// ErrProcessNameInUse is returned by spawnBackgroundProcess when name
+// already names a registered process. Sentinel (rather than a plain
+// fmt.Errorf) because SpawnService.Spawn (gRPC, #1488 Phase 2) needs to
+// map it to codes.AlreadyExists specifically — a client-correctable
+// conflict, not a server malfunction — without string-matching the
+// message. The MCP handler doesn't need to distinguish it (it only
+// surfaces the message text), so it keeps using %v/%w against this error
+// like any other.
+var ErrProcessNameInUse = errors.New("process name already in use")
 
 // Process management.
 //
@@ -124,7 +135,7 @@ func spawnBackgroundProcess(name, command, cwd string) (*managedProcess, error) 
 		name = fmt.Sprintf("proc-%d", time.Now().UnixNano())
 	}
 	if _, exists := processRegistry[name]; exists {
-		return nil, fmt.Errorf("a process named %q is already running; kill it first or pick a different name", name)
+		return nil, fmt.Errorf("%w: a process named %q is already running; kill it first or pick a different name", ErrProcessNameInUse, name)
 	}
 
 	if err := os.MkdirAll(processLogDir, 0o750); err != nil {

--- a/internal/agentbox/shell.go
+++ b/internal/agentbox/shell.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"syscall"
 	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -106,6 +107,25 @@ func runShellCommand(ctx context.Context, command, cwd string, timeout time.Dura
 	if cwd != "" {
 		cmd.Dir = cwd
 	}
+
+	// /bin/sh -c "<command>" does not reliably exec-replace itself into
+	// <command> — on this host it forks a genuine child and stays around
+	// as the parent. CommandContext's DEFAULT cancel behavior only kills
+	// cmd.Process (the shell), so on timeout the shell dies but a
+	// still-running grandchild keeps the stdout/stderr pipe's write end
+	// open, and Wait() then blocks until that grandchild exits on its
+	// own — observed hanging the full 5s of a `sleep 5` despite a 1s
+	// timeout. Setpgid puts the whole command tree in its own process
+	// group; Cancel kills the group (negative pid), not just the shell.
+	// WaitDelay is the backstop if even that leaves an orphan (e.g. a
+	// double-forked daemon that detached before the signal arrived): it
+	// bounds how long Wait() waits for the pipes to drain before force-
+	// closing them, so a pathological command still can't hang forever.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+	cmd.WaitDelay = 2 * time.Second
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &cappedWriter{buf: &stdout, limit: shellExecOutputLimit}

--- a/internal/agentbox/shell.go
+++ b/internal/agentbox/shell.go
@@ -65,13 +65,43 @@ func handleShellExec(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToo
 
 	cwd, _ := args["cwd"].(string)
 
+	res := runShellCommand(ctx, command, cwd, timeout)
+
+	// Encode result as a single text block — agents parse this readily and
+	// MCP clients render it inline. Using structured key=value sections so
+	// the agent can grep for "exit_code:" without regex over JSON escapes.
+	body := fmt.Sprintf(
+		"exit_code: %d\n"+
+			"timeout_seconds: %d\n"+
+			"--- stdout ---\n%s\n"+
+			"--- stderr ---\n%s",
+		res.ExitCode, int(timeout.Seconds()), res.Stdout, res.Stderr,
+	)
+	return mcp.NewToolResultText(body), nil
+}
+
+// shellExecResult is the outcome of running one command to completion.
+type shellExecResult struct {
+	Stdout   string
+	Stderr   string
+	ExitCode int
+}
+
+// runShellCommand runs command under /bin/sh -c with the given cwd and
+// timeout, capturing stdout/stderr up to shellExecOutputLimit each and
+// appending a note to stderr if the timeout fired.
+//
+// Shared core between the shell_exec MCP tool (handleShellExec) and
+// SpawnService.Exec (gRPC, #1488 Phase 2) — one implementation, two
+// transports.
+func runShellCommand(ctx context.Context, command, cwd string, timeout time.Duration) shellExecResult {
 	execCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	// #nosec G204 -- shell_exec's contract is to run agent-supplied shell
-	// commands; arbitrary command execution is the entire feature, not a
-	// vulnerability. Sandboxing is the operator's responsibility (run
-	// agent-box inside an LXC container with limited filesystem reach).
+	// #nosec G204 -- running agent-supplied shell commands is the entire
+	// feature, on both transports this function serves. Sandboxing is the
+	// operator's responsibility (run agent-box inside an LXC container
+	// with limited filesystem reach).
 	cmd := exec.CommandContext(execCtx, "/bin/sh", "-c", command)
 	if cwd != "" {
 		cmd.Dir = cwd
@@ -96,17 +126,7 @@ func handleShellExec(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToo
 		fmt.Fprintf(&stderr, "\n[agent-box] command exceeded timeout of %s and was killed", timeout)
 	}
 
-	// Encode result as a single text block — agents parse this readily and
-	// MCP clients render it inline. Using structured key=value sections so
-	// the agent can grep for "exit_code:" without regex over JSON escapes.
-	body := fmt.Sprintf(
-		"exit_code: %d\n"+
-			"timeout_seconds: %d\n"+
-			"--- stdout ---\n%s\n"+
-			"--- stderr ---\n%s",
-		exitCode, int(timeout.Seconds()), stdout.String(), stderr.String(),
-	)
-	return mcp.NewToolResultText(body), nil
+	return shellExecResult{Stdout: stdout.String(), Stderr: stderr.String(), ExitCode: exitCode}
 }
 
 // cappedWriter discards writes once limit bytes have landed. Used to protect

--- a/internal/agentbox/spawn_listener.go
+++ b/internal/agentbox/spawn_listener.go
@@ -1,0 +1,53 @@
+package agentbox
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"os"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"google.golang.org/grpc"
+)
+
+// SpawnSocketEnv names the environment variable that enables agent-box's
+// second transport: a SpawnService gRPC listener on a unix socket (#1488
+// Phase 2). Unset — the default, and every box today — means agent-box
+// serves MCP over stdio only, unchanged from before this feature existed.
+// A pool member's provisioning sets this once the bind-mounted socket
+// device (Phase 3) makes the path meaningful; nothing sets it yet.
+const SpawnSocketEnv = "AGENTBOX_SPAWN_SOCKET"
+
+// StartSpawnListener starts a SpawnService gRPC server listening on a unix
+// socket at socketPath, serving in a background goroutine. Returns the
+// *grpc.Server so the caller can GracefulStop it on shutdown; the error
+// return covers only setup failures (socket creation) — the serve loop's
+// own terminal error is logged, not returned, since by the time it fires
+// the caller has long since moved on.
+//
+// Removes a stale socket file at socketPath before listening: a unix
+// socket file left behind by a killed previous process blocks a fresh
+// bind with "address already in use" even though nothing is listening on
+// it anymore.
+func StartSpawnListener(socketPath string) (*grpc.Server, error) {
+	if err := os.Remove(socketPath); err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("failed to remove stale socket %s: %w", socketPath, err)
+	}
+
+	lis, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to listen on %s: %w", socketPath, err)
+	}
+
+	grpcServer := grpc.NewServer()
+	pb.RegisterSpawnServiceServer(grpcServer, NewSpawnServer())
+
+	go func() {
+		log.Printf("[agent-box] SpawnService listening on %s", socketPath)
+		if err := grpcServer.Serve(lis); err != nil {
+			log.Printf("[agent-box] SpawnService listener stopped: %v", err)
+		}
+	}()
+
+	return grpcServer, nil
+}

--- a/internal/agentbox/spawn_server.go
+++ b/internal/agentbox/spawn_server.go
@@ -1,0 +1,73 @@
+package agentbox
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/footprintai/containarium/internal/safecast"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// SpawnServer implements pb.SpawnServiceServer — agent-box's resident,
+// low-latency counterpart to the daemon's per-call Incus round-trips
+// (#1488 Phase 2). Both RPCs delegate to the same functions the
+// process_start/shell_exec MCP tools use (spawnBackgroundProcess,
+// runShellCommand): one implementation of spawn/exec/reap semantics,
+// reached over two transports (stdio MCP, this gRPC service), not two
+// parallel copies that could drift.
+type SpawnServer struct {
+	pb.UnimplementedSpawnServiceServer
+}
+
+// NewSpawnServer constructs a SpawnServer.
+func NewSpawnServer() *SpawnServer {
+	return &SpawnServer{}
+}
+
+// Spawn starts a long-running background process and returns its pid.
+func (s *SpawnServer) Spawn(_ context.Context, req *pb.SpawnRequest) (*pb.SpawnResponse, error) {
+	if req.Command == "" {
+		return nil, status.Error(codes.InvalidArgument, "command is required")
+	}
+
+	mp, err := spawnBackgroundProcess(req.Name, req.Command, req.Cwd)
+	if err != nil {
+		if errors.Is(err, ErrProcessNameInUse) {
+			return nil, status.Error(codes.AlreadyExists, err.Error())
+		}
+		return nil, status.Errorf(codes.Internal, "spawn failed: %v", err)
+	}
+
+	return &pb.SpawnResponse{
+		Name:    mp.Name,
+		Pid:     int64(mp.PID),
+		LogPath: mp.LogPath,
+	}, nil
+}
+
+// Exec runs one command to completion and returns its stdout, stderr, and
+// exit code.
+func (s *SpawnServer) Exec(ctx context.Context, req *pb.AgentExecRequest) (*pb.AgentExecResponse, error) {
+	if req.Command == "" {
+		return nil, status.Error(codes.InvalidArgument, "command is required")
+	}
+
+	timeout := shellExecDefaultTimeout
+	if req.TimeoutSeconds > 0 {
+		timeout = time.Duration(req.TimeoutSeconds) * time.Second
+		if timeout > shellExecMaxTimeout {
+			timeout = shellExecMaxTimeout
+		}
+	}
+
+	res := runShellCommand(ctx, req.Command, req.Cwd, timeout)
+
+	return &pb.AgentExecResponse{
+		Stdout:   res.Stdout,
+		Stderr:   res.Stderr,
+		ExitCode: safecast.I32(res.ExitCode),
+	}, nil
+}

--- a/internal/agentbox/spawn_server_test.go
+++ b/internal/agentbox/spawn_server_test.go
@@ -1,0 +1,216 @@
+package agentbox
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+)
+
+// These exercise SpawnServer directly (no socket) for the RPC-logic cases,
+// and go through a real StartSpawnListener + a real dialed gRPC client for
+// the contract/transport cases — no live Incus host or container needed
+// for any of it: a resident unix-socket gRPC server with real fork/exec is
+// fully testable in a plain Linux dev environment (#1488 Phase 2's own
+// scoping note).
+
+func TestSpawnServer_Spawn_ReturnsPidAndReaps(t *testing.T) {
+	t.Cleanup(func() { killAllAndReset(t) })
+	s := NewSpawnServer()
+
+	resp, err := s.Spawn(context.Background(), &pb.SpawnRequest{
+		Command: "sleep 0.05",
+		Name:    "reap-test",
+	})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	if resp.Pid <= 0 {
+		t.Fatalf("pid = %d, want > 0", resp.Pid)
+	}
+	if resp.Name != "reap-test" || resp.LogPath == "" {
+		t.Errorf("resp = %+v", resp)
+	}
+
+	// isAlive(pid) via kill(pid, 0) stays true for a zombie — a still-valid
+	// PID slot the kernel hasn't freed yet — so it flipping to false is
+	// specifically evidence cmd.Wait() completed and reaped the child, not
+	// just that the sleep finished running.
+	deadline := time.Now().Add(2 * time.Second)
+	for isAlive(int(resp.Pid)) {
+		if time.Now().After(deadline) {
+			t.Fatalf("pid %d was not reaped within 2s (still alive / zombied)", resp.Pid)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestSpawnServer_Spawn_RejectsEmptyCommand(t *testing.T) {
+	s := NewSpawnServer()
+	_, err := s.Spawn(context.Background(), &pb.SpawnRequest{Name: "no-command"})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("code = %v, want InvalidArgument", status.Code(err))
+	}
+}
+
+func TestSpawnServer_Spawn_DuplicateNameIsAlreadyExists(t *testing.T) {
+	t.Cleanup(func() { killAllAndReset(t) })
+	s := NewSpawnServer()
+
+	if _, err := s.Spawn(context.Background(), &pb.SpawnRequest{Command: "sleep 1", Name: "dup-grpc"}); err != nil {
+		t.Fatalf("first Spawn: %v", err)
+	}
+	_, err := s.Spawn(context.Background(), &pb.SpawnRequest{Command: "sleep 1", Name: "dup-grpc"})
+	if status.Code(err) != codes.AlreadyExists {
+		t.Fatalf("code = %v, want AlreadyExists", status.Code(err))
+	}
+}
+
+// TestSpawnServer_Spawn_ConcurrentSpawnsAreIndependent pins the design
+// note's own test requirement: "concurrent spawns are independent."
+func TestSpawnServer_Spawn_ConcurrentSpawnsAreIndependent(t *testing.T) {
+	t.Cleanup(func() { killAllAndReset(t) })
+	s := NewSpawnServer()
+
+	const n = 10
+	var wg sync.WaitGroup
+	pids := make([]int64, n)
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			resp, err := s.Spawn(context.Background(), &pb.SpawnRequest{
+				Command: "sleep 0.2",
+				Name:    fmt.Sprintf("concurrent-%d", i),
+			})
+			errs[i] = err
+			if resp != nil {
+				pids[i] = resp.Pid
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	seen := make(map[int64]bool, n)
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("spawn %d: %v", i, err)
+			continue
+		}
+		if pids[i] <= 0 {
+			t.Errorf("spawn %d: pid = %d", i, pids[i])
+			continue
+		}
+		if seen[pids[i]] {
+			t.Errorf("spawn %d: pid %d collided with an earlier spawn", i, pids[i])
+		}
+		seen[pids[i]] = true
+	}
+}
+
+func TestSpawnServer_Exec_CapturesOutputAndExitCode(t *testing.T) {
+	s := NewSpawnServer()
+	resp, err := s.Exec(context.Background(), &pb.AgentExecRequest{
+		Command: "echo hi; exit 3",
+	})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if resp.Stdout != "hi\n" || resp.ExitCode != 3 {
+		t.Errorf("resp = %+v, want stdout=%q exit_code=3", resp, "hi\n")
+	}
+}
+
+func TestSpawnServer_Exec_RejectsEmptyCommand(t *testing.T) {
+	s := NewSpawnServer()
+	_, err := s.Exec(context.Background(), &pb.AgentExecRequest{})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("code = %v, want InvalidArgument", status.Code(err))
+	}
+}
+
+func TestSpawnServer_Exec_RespectsTimeout(t *testing.T) {
+	s := NewSpawnServer()
+	start := time.Now()
+	resp, err := s.Exec(context.Background(), &pb.AgentExecRequest{
+		Command:        "sleep 5",
+		TimeoutSeconds: 1,
+	})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Errorf("Exec took %s, want well under the 5s sleep (timeout should have killed it around 1s)", elapsed)
+	}
+	if resp.Stderr == "" {
+		t.Error("expected a timeout note in stderr")
+	}
+}
+
+// TestStartSpawnListener_RealClientOverRealSocket is the contract test the
+// design note calls for: daemon-side client and box-side server both
+// exercised through the generated stubs, over a real unix socket in a
+// real temp dir — no mock. Proto drift here fails a test, not production.
+func TestStartSpawnListener_RealClientOverRealSocket(t *testing.T) {
+	t.Cleanup(func() { killAllAndReset(t) })
+	socketPath := filepath.Join(t.TempDir(), "spawn.sock")
+
+	srv, err := StartSpawnListener(socketPath)
+	if err != nil {
+		t.Fatalf("StartSpawnListener: %v", err)
+	}
+	t.Cleanup(srv.GracefulStop)
+
+	conn, err := grpc.NewClient("unix:"+socketPath, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	client := pb.NewSpawnServiceClient(conn)
+
+	execResp, err := client.Exec(context.Background(), &pb.AgentExecRequest{Command: "echo over-the-socket"})
+	if err != nil {
+		t.Fatalf("Exec over socket: %v", err)
+	}
+	if execResp.Stdout != "over-the-socket\n" {
+		t.Errorf("Exec stdout = %q", execResp.Stdout)
+	}
+
+	spawnResp, err := client.Spawn(context.Background(), &pb.SpawnRequest{Command: "true", Name: "socket-spawn"})
+	if err != nil {
+		t.Fatalf("Spawn over socket: %v", err)
+	}
+	if spawnResp.Pid <= 0 {
+		t.Errorf("Spawn over socket: pid = %d", spawnResp.Pid)
+	}
+}
+
+// TestStartSpawnListener_RemovesStaleSocket pins that a leftover socket
+// file from a killed previous process doesn't block a fresh bind.
+func TestStartSpawnListener_RemovesStaleSocket(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "spawn.sock")
+
+	// A real leftover socket file, the way a killed previous agent-box
+	// process would leave one behind (os.WriteFile is enough — the OS
+	// doesn't care that this isn't a real socket inode for the purpose of
+	// "a file already exists at this path").
+	if err := os.WriteFile(socketPath, nil, 0o600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	srv, err := StartSpawnListener(socketPath)
+	if err != nil {
+		t.Fatalf("StartSpawnListener should remove the stale file and succeed: %v", err)
+	}
+	srv.GracefulStop()
+}

--- a/internal/sandbox/dialer/dialer.go
+++ b/internal/sandbox/dialer/dialer.go
@@ -1,0 +1,95 @@
+// Package dialer caches gRPC connections to agent-box's resident
+// SpawnService, one per pool member's bind-mounted unix socket (#1488
+// Phase 2/3). A claim reuses an already-established connection instead of
+// paying dial cost on every spawn — the whole point of a warm pool is
+// that the connection, like the container, is already up before the
+// request arrives.
+//
+// This package deliberately does not reimplement reconnect/backoff logic:
+// grpc-go's ClientConn already manages that transparently for a cached
+// connection, and honors a call's context deadline regardless — an RPC
+// against an unready channel returns once its own ctx expires rather than
+// blocking forever, whether or not the call opts into WaitForReady. The
+// tests in dialer_test.go exist to prove reconnect-after-disconnect and
+// deadline-respecting empirically against a real local socket, not to
+// assert this package's own internal state — grpc-go's behavior is
+// exactly the contract this package depends on holding.
+package dialer
+
+import (
+	"fmt"
+	"sync"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// Dialer caches one *grpc.ClientConn per unix socket path.
+type Dialer struct {
+	mu    sync.Mutex
+	conns map[string]*grpc.ClientConn
+}
+
+// New returns an empty Dialer.
+func New() *Dialer {
+	return &Dialer{conns: make(map[string]*grpc.ClientConn)}
+}
+
+// Client returns a SpawnServiceClient for the pool member listening on
+// socketPath, dialing at most once per distinct path — a second call with
+// the same path reuses the cached connection rather than dialing again.
+//
+// grpc.NewClient is lazy: this returns immediately without blocking on the
+// socket actually being reachable. The first RPC issued through the
+// returned client is what surfaces a connection failure, bounded by that
+// call's own context deadline (per this package's doc comment) rather
+// than a retry loop in here.
+func (d *Dialer) Client(socketPath string) (pb.SpawnServiceClient, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if conn, ok := d.conns[socketPath]; ok {
+		return pb.NewSpawnServiceClient(conn), nil
+	}
+
+	conn, err := grpc.NewClient("unix:"+socketPath, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, fmt.Errorf("dial %s: %w", socketPath, err)
+	}
+	d.conns[socketPath] = conn
+	return pb.NewSpawnServiceClient(conn), nil
+}
+
+// Forget closes and evicts the cached connection for socketPath, if any.
+// Use when a pool member is being destroyed (its socket is going away
+// permanently, not just reconnecting) so the Dialer doesn't keep dialing
+// a path that will never come back — a distinct case from a transient
+// disconnect, which grpc-go's own reconnect logic already absorbs without
+// needing this.
+func (d *Dialer) Forget(socketPath string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	conn, ok := d.conns[socketPath]
+	if !ok {
+		return nil
+	}
+	delete(d.conns, socketPath)
+	return conn.Close()
+}
+
+// Close closes every cached connection. Call on daemon shutdown.
+func (d *Dialer) Close() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	var firstErr error
+	for path, conn := range d.conns {
+		if err := conn.Close(); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("close %s: %w", path, err)
+		}
+	}
+	d.conns = make(map[string]*grpc.ClientConn)
+	return firstErr
+}

--- a/internal/sandbox/dialer/dialer_test.go
+++ b/internal/sandbox/dialer/dialer_test.go
@@ -1,0 +1,254 @@
+package dialer
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/footprintai/containarium/internal/agentbox"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// These run against a real agent-box SpawnService listener on a real unix
+// socket in a temp dir — per the design note's own scoping for this
+// package's tests, no live Incus/container host is needed: the thing
+// under test is socket/connection behavior, which a plain local process
+// exercises just as faithfully as a container would.
+
+func TestDialer_ReusesConnectionAcrossCalls(t *testing.T) {
+	d := New()
+	t.Cleanup(func() { _ = d.Close() })
+
+	socketPath := filepath.Join(t.TempDir(), "spawn.sock")
+	srv, err := agentbox.StartSpawnListener(socketPath)
+	if err != nil {
+		t.Fatalf("StartSpawnListener: %v", err)
+	}
+	t.Cleanup(srv.GracefulStop)
+
+	const n = 5
+	for i := 0; i < n; i++ {
+		if _, err := d.Client(socketPath); err != nil {
+			t.Fatalf("Client call %d: %v", i, err)
+		}
+	}
+
+	d.mu.Lock()
+	got := len(d.conns)
+	d.mu.Unlock()
+	if got != 1 {
+		t.Errorf("cached connections for one path = %d, want 1 (dialed once, reused across %d calls)", got, n)
+	}
+}
+
+func TestDialer_KeysByPath(t *testing.T) {
+	d := New()
+	t.Cleanup(func() { _ = d.Close() })
+
+	pathA := filepath.Join(t.TempDir(), "a.sock")
+	pathB := filepath.Join(t.TempDir(), "b.sock")
+	srvA, err := agentbox.StartSpawnListener(pathA)
+	if err != nil {
+		t.Fatalf("StartSpawnListener a: %v", err)
+	}
+	t.Cleanup(srvA.GracefulStop)
+	srvB, err := agentbox.StartSpawnListener(pathB)
+	if err != nil {
+		t.Fatalf("StartSpawnListener b: %v", err)
+	}
+	t.Cleanup(srvB.GracefulStop)
+
+	if _, err := d.Client(pathA); err != nil {
+		t.Fatalf("Client a: %v", err)
+	}
+	if _, err := d.Client(pathB); err != nil {
+		t.Fatalf("Client b: %v", err)
+	}
+
+	d.mu.Lock()
+	got := len(d.conns)
+	d.mu.Unlock()
+	if got != 2 {
+		t.Errorf("cached connections for two distinct paths = %d, want 2", got)
+	}
+}
+
+func TestDialer_ClientWorksAgainstRealSocket(t *testing.T) {
+	d := New()
+	t.Cleanup(func() { _ = d.Close() })
+
+	socketPath := filepath.Join(t.TempDir(), "spawn.sock")
+	srv, err := agentbox.StartSpawnListener(socketPath)
+	if err != nil {
+		t.Fatalf("StartSpawnListener: %v", err)
+	}
+	t.Cleanup(srv.GracefulStop)
+
+	client, err := d.Client(socketPath)
+	if err != nil {
+		t.Fatalf("Client: %v", err)
+	}
+	resp, err := client.Exec(context.Background(), &pb.AgentExecRequest{Command: "echo via-dialer"})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if resp.Stdout != "via-dialer\n" {
+		t.Errorf("stdout = %q", resp.Stdout)
+	}
+}
+
+// TestDialer_DeadSocketReconnects pins the design note's own test
+// requirement: "dead socket -> reconnect and succeed." The Dialer's cached
+// *grpc.ClientConn survives the original listener going away; a second
+// agent-box process taking over the same socket path is enough for a call
+// through the SAME cached client to eventually succeed again — this is
+// grpc-go's own reconnect behavior working through the cache, not custom
+// retry logic in this package.
+func TestDialer_DeadSocketReconnects(t *testing.T) {
+	d := New()
+	t.Cleanup(func() { _ = d.Close() })
+
+	socketPath := filepath.Join(t.TempDir(), "spawn.sock")
+	srv1, err := agentbox.StartSpawnListener(socketPath)
+	if err != nil {
+		t.Fatalf("StartSpawnListener (1st): %v", err)
+	}
+
+	client, err := d.Client(socketPath)
+	if err != nil {
+		t.Fatalf("Client: %v", err)
+	}
+	if _, err := client.Exec(context.Background(), &pb.AgentExecRequest{Command: "true"}); err != nil {
+		t.Fatalf("Exec against 1st listener: %v", err)
+	}
+
+	srv1.GracefulStop()
+
+	srv2, err := agentbox.StartSpawnListener(socketPath)
+	if err != nil {
+		t.Fatalf("StartSpawnListener (2nd, same path): %v", err)
+	}
+	t.Cleanup(srv2.GracefulStop)
+
+	// grpc-go's reconnect backoff isn't instant — poll instead of asserting
+	// on the first attempt.
+	deadline := time.Now().Add(5 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		_, lastErr = client.Exec(ctx, &pb.AgentExecRequest{Command: "true"})
+		cancel()
+		if lastErr == nil {
+			return // reconnected and succeeded — test passes
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("did not reconnect through the same cached client within 5s; last error: %v", lastErr)
+}
+
+// TestDialer_RespectsCallerDeadlineAgainstUnreachableSocket pins the
+// design note's other test requirement: "reconnect budget bounded so a
+// wedged member cannot consume the caller's deadline." Nothing is
+// listening on socketPath at all — a call through it must return within
+// the caller's own context deadline, not hang waiting indefinitely for a
+// connection that will never come.
+//
+// Verified by mutation: adding grpc.WithDefaultCallOptions(WaitForReady
+// (true)) to Client() does NOT make this test fail — grpc-go still honors
+// the call's context deadline either way, waiting-and-retrying up to it
+// rather than failing on the first unready state. That's the real
+// guarantee this package depends on and this test protects: the caller's
+// deadline is always respected, not that failure is instantaneous.
+func TestDialer_RespectsCallerDeadlineAgainstUnreachableSocket(t *testing.T) {
+	d := New()
+	t.Cleanup(func() { _ = d.Close() })
+
+	socketPath := filepath.Join(t.TempDir(), "nothing-listening.sock")
+	client, err := d.Client(socketPath)
+	if err != nil {
+		t.Fatalf("Client: %v", err) // dialing itself is lazy and must not fail here
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, execErr := client.Exec(ctx, &pb.AgentExecRequest{Command: "true"})
+	elapsed := time.Since(start)
+
+	if execErr == nil {
+		t.Fatal("Exec against an unreachable socket unexpectedly succeeded")
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("Exec took %s to fail, want well under the caller's ~500ms deadline budget (a wedged/unreachable member must not consume more than that)", elapsed)
+	}
+}
+
+func TestDialer_Forget_ClosesAndEvicts(t *testing.T) {
+	d := New()
+	t.Cleanup(func() { _ = d.Close() })
+
+	socketPath := filepath.Join(t.TempDir(), "spawn.sock")
+	srv, err := agentbox.StartSpawnListener(socketPath)
+	if err != nil {
+		t.Fatalf("StartSpawnListener: %v", err)
+	}
+	t.Cleanup(srv.GracefulStop)
+
+	if _, err := d.Client(socketPath); err != nil {
+		t.Fatalf("Client: %v", err)
+	}
+	if err := d.Forget(socketPath); err != nil {
+		t.Fatalf("Forget: %v", err)
+	}
+
+	d.mu.Lock()
+	_, stillCached := d.conns[socketPath]
+	d.mu.Unlock()
+	if stillCached {
+		t.Error("connection still cached after Forget")
+	}
+
+	// Forgetting an already-forgotten (or never-dialed) path is a no-op,
+	// not an error — a caller destroying a pool member shouldn't have to
+	// track whether it ever actually claimed a connection.
+	if err := d.Forget(socketPath); err != nil {
+		t.Errorf("Forget on an absent entry returned %v, want nil", err)
+	}
+}
+
+func TestDialer_Close_ClosesAllAndResets(t *testing.T) {
+	d := New()
+
+	pathA := filepath.Join(t.TempDir(), "a.sock")
+	pathB := filepath.Join(t.TempDir(), "b.sock")
+	srvA, err := agentbox.StartSpawnListener(pathA)
+	if err != nil {
+		t.Fatalf("StartSpawnListener a: %v", err)
+	}
+	t.Cleanup(srvA.GracefulStop)
+	srvB, err := agentbox.StartSpawnListener(pathB)
+	if err != nil {
+		t.Fatalf("StartSpawnListener b: %v", err)
+	}
+	t.Cleanup(srvB.GracefulStop)
+
+	if _, err := d.Client(pathA); err != nil {
+		t.Fatalf("Client a: %v", err)
+	}
+	if _, err := d.Client(pathB); err != nil {
+		t.Fatalf("Client b: %v", err)
+	}
+
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	d.mu.Lock()
+	got := len(d.conns)
+	d.mu.Unlock()
+	if got != 0 {
+		t.Errorf("cached connections after Close = %d, want 0", got)
+	}
+}

--- a/internal/sandbox/ipam/ipam.go
+++ b/internal/sandbox/ipam/ipam.go
@@ -1,0 +1,166 @@
+// Package ipam allocates static IPv4 addresses for pool members (#1488
+// Phase 3): "Pool members get a statically allocated IP from a per-host
+// IPAM range at warm time... The lease wait happens during warm-up, where
+// it is free. WaitForNetwork disappears from the claim path entirely
+// rather than being made faster."
+//
+// Pure in-memory bookkeeping — no Incus, no host networking, no live
+// container needed to build or test this package. What it hands out is a
+// candidate address; actually wiring it onto a NIC (config.NIC.IPv4Address
+// on the bridged device, already present in pkg/core/incus) is the pool
+// reconciler's job at warm time, not this package's.
+package ipam
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+)
+
+// ErrExhausted is returned by Allocate when no address in the range is
+// free (accounting for the quarantine window on recently released ones).
+var ErrExhausted = errors.New("ipam: address range exhausted")
+
+// ErrNotAllocated is returned by Release for an address this Allocator
+// never handed out (or already released).
+var ErrNotAllocated = errors.New("ipam: address not currently allocated")
+
+// Allocator hands out unique IPv4 addresses from a fixed inclusive range.
+// Safe for concurrent use.
+type Allocator struct {
+	mu sync.Mutex
+
+	start, end uint32 // inclusive range, host byte order
+	quarantine time.Duration
+
+	allocated map[uint32]struct{}  // currently held
+	released  map[uint32]time.Time // ip -> release time; still quarantined until +quarantine
+	cursor    uint32               // next candidate to scan from (round-robin, spreads reuse across the range)
+}
+
+// New builds an Allocator over the inclusive range [startIP, endIP].
+// hostIP is the interface address the range's own bridge/gateway already
+// occupies (e.g. incusbr0's address) — New refuses a range that contains
+// it, since handing that address to a sandbox would collide with the
+// host itself. quarantine bounds how long a released address stays
+// unavailable for reuse before Allocate will hand it out again; 0 means
+// immediate reuse is fine.
+//
+// A released IP with a live ARP/neighbor-cache entry elsewhere on the
+// bridge is a cross-sandbox routing bug waiting to happen — quarantine
+// exists to let that cache entry age out before the address is reused by
+// someone else.
+func New(startIP, endIP, hostIP string, quarantine time.Duration) (*Allocator, error) {
+	start, err := parseIPv4(startIP)
+	if err != nil {
+		return nil, fmt.Errorf("start: %w", err)
+	}
+	end, err := parseIPv4(endIP)
+	if err != nil {
+		return nil, fmt.Errorf("end: %w", err)
+	}
+	if start > end {
+		return nil, fmt.Errorf("start %s is after end %s", startIP, endIP)
+	}
+	host, err := parseIPv4(hostIP)
+	if err != nil {
+		return nil, fmt.Errorf("host: %w", err)
+	}
+	if host >= start && host <= end {
+		return nil, fmt.Errorf("range %s-%s overlaps the host's own address %s", startIP, endIP, hostIP)
+	}
+	if quarantine < 0 {
+		return nil, fmt.Errorf("quarantine must not be negative, got %s", quarantine)
+	}
+
+	return &Allocator{
+		start:      start,
+		end:        end,
+		quarantine: quarantine,
+		allocated:  make(map[uint32]struct{}),
+		released:   make(map[uint32]time.Time),
+		cursor:     start,
+	}, nil
+}
+
+// Allocate claims and returns the next free address in the range,
+// skipping anything currently held or still within its quarantine
+// window. Returns ErrExhausted if none qualifies.
+func (a *Allocator) Allocate() (net.IP, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	now := time.Now()
+	total := a.end - a.start + 1
+	for i := uint32(0); i < total; i++ {
+		candidate := a.start + (a.cursor-a.start+i)%total
+		if a.isFreeLocked(candidate, now) {
+			a.allocated[candidate] = struct{}{}
+			delete(a.released, candidate)
+			a.cursor = candidate + 1
+			return ipFromUint32(candidate), nil
+		}
+	}
+	return nil, ErrExhausted
+}
+
+func (a *Allocator) isFreeLocked(ip uint32, now time.Time) bool {
+	if _, held := a.allocated[ip]; held {
+		return false
+	}
+	if releasedAt, wasReleased := a.released[ip]; wasReleased {
+		if now.Sub(releasedAt) < a.quarantine {
+			return false
+		}
+	}
+	return true
+}
+
+// Release returns ip to the pool, starting its quarantine window (if
+// any) from now. Returns ErrNotAllocated if ip isn't currently held by
+// this Allocator.
+func (a *Allocator) Release(ip net.IP) error {
+	v, err := ipToUint32(ip)
+	if err != nil {
+		return err
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if _, held := a.allocated[v]; !held {
+		return fmt.Errorf("%w: %s", ErrNotAllocated, ip)
+	}
+	delete(a.allocated, v)
+	a.released[v] = time.Now()
+	return nil
+}
+
+func parseIPv4(s string) (uint32, error) {
+	ip := net.ParseIP(s)
+	if ip == nil {
+		return 0, fmt.Errorf("invalid IP %q", s)
+	}
+	v4 := ip.To4()
+	if v4 == nil {
+		return 0, fmt.Errorf("%q is not an IPv4 address", s)
+	}
+	return binary.BigEndian.Uint32(v4), nil
+}
+
+func ipToUint32(ip net.IP) (uint32, error) {
+	v4 := ip.To4()
+	if v4 == nil {
+		return 0, fmt.Errorf("invalid IPv4 address %v", ip)
+	}
+	return binary.BigEndian.Uint32(v4), nil
+}
+
+func ipFromUint32(v uint32) net.IP {
+	b := make(net.IP, 4)
+	binary.BigEndian.PutUint32(b, v)
+	return b
+}

--- a/internal/sandbox/ipam/ipam_test.go
+++ b/internal/sandbox/ipam/ipam_test.go
@@ -1,0 +1,228 @@
+package ipam
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestNew_RejectsInvalidRanges(t *testing.T) {
+	cases := []struct {
+		name             string
+		start, end, host string
+		quarantine       time.Duration
+		wantErrSubstring string
+	}{
+		{"start after end", "10.0.0.20", "10.0.0.10", "10.0.0.1", 0, "after"},
+		{"malformed start", "not-an-ip", "10.0.0.10", "10.0.0.1", 0, "start"},
+		{"malformed end", "10.0.0.10", "not-an-ip", "10.0.0.1", 0, "end"},
+		{"malformed host", "10.0.0.10", "10.0.0.20", "not-an-ip", 0, "host"},
+		{"host inside range", "10.0.0.10", "10.0.0.20", "10.0.0.15", 0, "overlaps"},
+		{"host equals start", "10.0.0.10", "10.0.0.20", "10.0.0.10", 0, "overlaps"},
+		{"host equals end", "10.0.0.10", "10.0.0.20", "10.0.0.20", 0, "overlaps"},
+		{"negative quarantine", "10.0.0.10", "10.0.0.20", "10.0.0.1", -time.Second, "negative"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := New(c.start, c.end, c.host, c.quarantine)
+			if err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+			if !strings.Contains(err.Error(), c.wantErrSubstring) {
+				t.Errorf("error = %q, want it to contain %q", err.Error(), c.wantErrSubstring)
+			}
+		})
+	}
+}
+
+func TestNew_AcceptsHostOutsideRange(t *testing.T) {
+	if _, err := New("10.0.0.10", "10.0.0.20", "10.0.0.1", 0); err != nil {
+		t.Fatalf("New: %v", err)
+	}
+}
+
+func TestAllocate_UniqueAcrossConcurrentCallers(t *testing.T) {
+	a, err := New("10.0.0.1", "10.0.0.100", "10.0.0.254", 0)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	const n = 100 // exactly the range size — every address must be claimed exactly once
+	var wg sync.WaitGroup
+	ips := make([]net.IP, n)
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			ips[i], errs[i] = a.Allocate()
+		}(i)
+	}
+	wg.Wait()
+
+	seen := make(map[string]int, n)
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("Allocate %d: %v", i, err)
+		}
+		seen[ips[i].String()]++
+	}
+	if len(seen) != n {
+		t.Fatalf("got %d distinct addresses, want %d", len(seen), n)
+	}
+	for ip, count := range seen {
+		if count != 1 {
+			t.Errorf("address %s allocated %d times", ip, count)
+		}
+	}
+}
+
+func TestAllocate_ExhaustedRangeReturnsTypedError(t *testing.T) {
+	a, err := New("10.0.0.1", "10.0.0.2", "10.0.0.254", 0)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if _, err := a.Allocate(); err != nil {
+		t.Fatalf("Allocate 1: %v", err)
+	}
+	if _, err := a.Allocate(); err != nil {
+		t.Fatalf("Allocate 2: %v", err)
+	}
+	_, err = a.Allocate()
+	if !errors.Is(err, ErrExhausted) {
+		t.Fatalf("Allocate 3 (exhausted) = %v, want ErrExhausted", err)
+	}
+}
+
+func TestAllocate_SkipsQuarantinedAddressUntilItExpires(t *testing.T) {
+	// A 2-address range makes the quarantine unambiguous: after releasing
+	// the first address, the ONLY way Allocate can succeed a second time
+	// while the first is quarantined is by handing out the second address
+	// — and once the quarantine elapses, the freed one becomes available
+	// again.
+	const quarantine = 60 * time.Millisecond
+	a, err := New("10.0.0.1", "10.0.0.2", "10.0.0.254", quarantine)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	first, err := a.Allocate()
+	if err != nil {
+		t.Fatalf("Allocate 1: %v", err)
+	}
+	second, err := a.Allocate()
+	if err != nil {
+		t.Fatalf("Allocate 2: %v", err)
+	}
+	if first.Equal(second) {
+		t.Fatalf("Allocate returned the same address twice: %s", first)
+	}
+
+	if err := a.Release(first); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+
+	// Range is now fully exhausted except for `first`, which is
+	// quarantined — Allocate must fail, not silently ignore quarantine.
+	if _, err := a.Allocate(); !errors.Is(err, ErrExhausted) {
+		t.Fatalf("Allocate immediately after release = %v, want ErrExhausted (quarantine not yet elapsed)", err)
+	}
+
+	time.Sleep(quarantine + 20*time.Millisecond)
+
+	got, err := a.Allocate()
+	if err != nil {
+		t.Fatalf("Allocate after quarantine elapsed: %v", err)
+	}
+	if !got.Equal(first) {
+		t.Errorf("Allocate after quarantine = %s, want the released address %s back", got, first)
+	}
+}
+
+func TestAllocate_ZeroQuarantineAllowsImmediateReuse(t *testing.T) {
+	a, err := New("10.0.0.1", "10.0.0.1", "10.0.0.254", 0)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ip, err := a.Allocate()
+	if err != nil {
+		t.Fatalf("Allocate 1: %v", err)
+	}
+	if err := a.Release(ip); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	if _, err := a.Allocate(); err != nil {
+		t.Fatalf("Allocate 2 (immediate reuse, quarantine=0): %v", err)
+	}
+}
+
+func TestRelease_RejectsAddressNotCurrentlyAllocated(t *testing.T) {
+	a, err := New("10.0.0.1", "10.0.0.10", "10.0.0.254", 0)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	err = a.Release(net.ParseIP("10.0.0.5"))
+	if !errors.Is(err, ErrNotAllocated) {
+		t.Fatalf("Release of a never-allocated address = %v, want ErrNotAllocated", err)
+	}
+
+	ip, err := a.Allocate()
+	if err != nil {
+		t.Fatalf("Allocate: %v", err)
+	}
+	if err := a.Release(ip); err != nil {
+		t.Fatalf("first Release: %v", err)
+	}
+	if err := a.Release(ip); !errors.Is(err, ErrNotAllocated) {
+		t.Fatalf("double Release = %v, want ErrNotAllocated", err)
+	}
+}
+
+func TestAllocate_RoundRobinsAcrossTheRange(t *testing.T) {
+	// Not a strict requirement of the design note, but pins the actual
+	// scan behavior: sequential Allocate/Release/Allocate cycles spread
+	// reuse across the range (cursor-based) rather than always handing
+	// back the lowest free address — the shape that makes ARP-quarantine
+	// meaningful in the first place (constantly reusing the same handful
+	// of addresses would defeat the point of quarantining at all).
+	a, err := New("10.0.0.1", "10.0.0.3", "10.0.0.254", 0)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	var got []string
+	for i := 0; i < 3; i++ {
+		ip, err := a.Allocate()
+		if err != nil {
+			t.Fatalf("Allocate %d: %v", i, err)
+		}
+		got = append(got, ip.String())
+	}
+	want := []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("allocation order = %v, want %v", got, want)
+			break
+		}
+	}
+}
+
+func ExampleAllocator() {
+	a, err := New("10.100.0.10", "10.100.0.20", "10.100.0.1", time.Minute)
+	if err != nil {
+		panic(err)
+	}
+	ip, err := a.Allocate()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(ip)
+	// Output: 10.100.0.10
+}

--- a/internal/sandbox/pool/pool.go
+++ b/internal/sandbox/pool/pool.go
@@ -1,0 +1,329 @@
+// Package pool implements the warm-pool reconciler and claim ring for
+// ephemeral sandboxes (#1488 Phase 3): "Pool members are created and
+// started by a background reconciler. A claim touches an instance that
+// has been running for seconds to minutes" instead of paying boot cost on
+// the request path.
+//
+// A pool member is a whole Incus container, dedicated to exactly one
+// task, destroyed on release and never reused — see Release's doc
+// comment and the design note's Isolation section for why. Ready members
+// are tracked per SandboxTemplate ("shared" means shared across tenants,
+// not across templates): v1 configures the base template only.
+//
+// This package talks to the same incus.Backend-shaped interface
+// SandboxServer (internal/server/sandbox_server.go) already uses to
+// create/destroy sandboxes directly — not pkg/core/container.Manager or
+// box.BoxBackend, both of which are built around the full persistent-box
+// identity flow (SSH keys, tenant naming) that pool members, like cold-
+// path sandboxes, explicitly skip. A pool member and a cold-path sandbox
+// should be indistinguishable in shape once claimed.
+//
+// Pure Go control-plane state plus calls to a narrow, fakeable Backend
+// interface — no live Incus host needed to build or test this package,
+// per the design note's own scoping ("pool logic tests run in
+// milliseconds with no host"). The nightly latency test against a real
+// host is Phase 3's actual exit criterion and lives elsewhere.
+package pool
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/footprintai/containarium/internal/sandbox/ipam"
+	"github.com/footprintai/containarium/pkg/core/incus"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// Backend is the subset of incus.Backend the pool reconciler needs to
+// warm and destroy members. Any concrete type satisfying incus.Backend
+// (in particular *incus.Client, the real thing) automatically satisfies
+// this narrower interface too — no adapter required — while a test fake
+// only has to implement four methods instead of incus.Backend's full
+// surface.
+type Backend interface {
+	CreateContainer(config incus.ContainerConfig) error
+	StartContainer(name string) error
+	StopContainer(name string, force bool) error
+	DeleteContainer(name string) error
+}
+
+// ErrPoolExhausted is returned by Claim when no ready member exists for
+// the requested template.
+var ErrPoolExhausted = errors.New("pool: no ready member for this template")
+
+// Member is the pool's typed view of one pool member — a named struct,
+// not the map[string]string the design note's Contracts section
+// specifically calls out as the wrong shape for this.
+type Member struct {
+	ID       string
+	Template pb.SandboxTemplate
+	IP       string
+	WarmedAt time.Time
+}
+
+// Config controls what Reconcile keeps warm.
+type Config struct {
+	// MinWarm is the target ready-member count, per template. A template
+	// with no entry (or 0) is never warmed — v1 configures BASE only.
+	MinWarm map[pb.SandboxTemplate]int
+	// Image maps a template to the guest image a warm-up clones from.
+	// Required for every template named in MinWarm.
+	Image map[pb.SandboxTemplate]string
+	// NICNetwork is the Incus bridged network warm members attach to
+	// (e.g. "incusbr0"), paired with a static IPAM-allocated address so
+	// WaitForNetwork's DHCP wait happens at warm time, not claim time.
+	NICNetwork string
+}
+
+// Pool holds the ready ring and in-flight warm counts, one per template,
+// and reconciles them against Config.MinWarm. Safe for concurrent use —
+// Claim and Reconcile share one mutex, so a claim during reconcile always
+// sees a consistent ring, never a torn one.
+type Pool struct {
+	backend Backend
+	ipam    *ipam.Allocator
+	cfg     Config
+
+	mu      sync.Mutex
+	ready   map[pb.SandboxTemplate][]*Member // FIFO ring per template
+	warming map[pb.SandboxTemplate]int       // in-flight warm count per template
+}
+
+// New builds a Pool. cfg is copied defensively (the maps are read, not
+// retained by reference) so a caller mutating its own Config after New
+// doesn't reach back into the Pool.
+func New(backend Backend, allocator *ipam.Allocator, cfg Config) *Pool {
+	minWarm := make(map[pb.SandboxTemplate]int, len(cfg.MinWarm))
+	for k, v := range cfg.MinWarm {
+		minWarm[k] = v
+	}
+	image := make(map[pb.SandboxTemplate]string, len(cfg.Image))
+	for k, v := range cfg.Image {
+		image[k] = v
+	}
+
+	return &Pool{
+		backend: backend,
+		ipam:    allocator,
+		cfg:     Config{MinWarm: minWarm, Image: image, NICNetwork: cfg.NICNetwork},
+		ready:   make(map[pb.SandboxTemplate][]*Member),
+		warming: make(map[pb.SandboxTemplate]int),
+	}
+}
+
+// Claim removes and returns the next ready member for template, O(1). A
+// claimed member leaves the pool's bookkeeping entirely — the caller owns
+// its lifecycle from here, and Release (below) is the only path back to
+// this package, which always destroys rather than re-adding it.
+func (p *Pool) Claim(template pb.SandboxTemplate) (*Member, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	ring := p.ready[template]
+	if len(ring) == 0 {
+		return nil, ErrPoolExhausted
+	}
+	m := ring[0]
+	// Keep the backing array from retaining a reference to a claimed
+	// member forever (ring[0] = nil before reslicing) — small pool
+	// sizes make this immaterial in practice, but it's free to do right.
+	ring[0] = nil
+	p.ready[template] = ring[1:]
+	return m, nil
+}
+
+// Release destroys member. This function's entire body is "destroy, full
+// stop" — a pool member is dedicated to exactly one task and is never
+// reset and returned to the ready ring (see the design note's Isolation
+// section: reuse is what turns a shared pool from isolation-equivalent-
+// to-per-tenant into a cross-tenant data-leak vector). TestDestroyOnRelease
+// exists specifically to fail loudly if anyone ever adds a reset-and-
+// reuse path here — don't.
+//
+// Unlike the reconciler's own trim (best-effort, logged, never blocks a
+// caller), Release propagates a real failure: the caller asked this
+// member destroyed and needs to know if that didn't happen.
+func (p *Pool) Release(m *Member) error {
+	return p.destroy(m)
+}
+
+// ReadyCount returns how many members are currently claimable for
+// template. For GetPoolStatus / operator visibility, not used by Claim
+// itself (which must stay a single atomic pop, not a check-then-act).
+func (p *Pool) ReadyCount(template pb.SandboxTemplate) int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.ready[template])
+}
+
+// Reconcile brings every configured template's ready+warming count to
+// Config.MinWarm: short → start warming the difference; over (ready
+// alone; in-flight warms are never aborted mid-boot) → trim the excess,
+// oldest first. Call periodically (the caller owns the schedule — this
+// package has no ticker of its own).
+//
+// State mutation (deciding what to warm/trim) happens under the mutex;
+// the actual I/O (CreateContainer, DeleteContainer, ...) happens after
+// releasing it, so a slow Incus call never blocks a concurrent Claim. A
+// warm that fails is simply not added to the ready ring — the next
+// Reconcile call sees the same shortfall and retries. That's this
+// package's entire backoff mechanism: retry cadence is the caller's
+// polling interval, not a per-member timer, so one wedged member can
+// never block reconciling any other template.
+func (p *Pool) Reconcile(ctx context.Context) {
+	if ctx.Err() != nil {
+		return
+	}
+
+	toWarm, toTrim := p.planLocked()
+
+	var wg sync.WaitGroup
+	for _, template := range toWarm {
+		wg.Add(1)
+		go func(t pb.SandboxTemplate) {
+			defer wg.Done()
+			p.warmOne(ctx, t)
+		}(template)
+	}
+	for _, m := range toTrim {
+		wg.Add(1)
+		go func(m *Member) {
+			defer wg.Done()
+			if err := p.destroy(m); err != nil {
+				log.Printf("[pool] trim of idle member %s failed (will be retried next reconcile? no — it already left the ring; logged only): %v", m.ID, err)
+			}
+		}(m)
+	}
+	wg.Wait()
+}
+
+// planLocked snapshots this tick's deltas and commits the bookkeeping
+// side of them (warming counters incremented, trimmed members removed
+// from the ring) before any I/O runs. Named *Locked per this package's
+// convention for a helper that must be called with p.mu held — it takes
+// the lock itself and returns after releasing it, so callers just call it
+// plainly; the suffix documents that it does its own locking rather than
+// assuming a lock inherited from the caller.
+func (p *Pool) planLocked() (toWarm []pb.SandboxTemplate, toTrim []*Member) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	for template, target := range p.cfg.MinWarm {
+		readyCount := len(p.ready[template])
+		total := readyCount + p.warming[template]
+
+		switch {
+		case total < target:
+			short := target - total
+			for i := 0; i < short; i++ {
+				toWarm = append(toWarm, template)
+			}
+			p.warming[template] += short
+		case readyCount > target:
+			excess := readyCount - target
+			toTrim = append(toTrim, p.ready[template][:excess]...)
+			p.ready[template] = p.ready[template][excess:]
+		}
+	}
+	return toWarm, toTrim
+}
+
+// warmOne creates, starts, and IP-provisions one new member for template,
+// adding it to the ready ring only on full success. Any failure at any
+// step unwinds what that step already did and leaves the ready ring
+// untouched — the shortfall this warm was meant to cover is picked back
+// up by the next Reconcile call.
+func (p *Pool) warmOne(ctx context.Context, template pb.SandboxTemplate) {
+	defer func() {
+		p.mu.Lock()
+		p.warming[template]--
+		p.mu.Unlock()
+	}()
+
+	image, ok := p.cfg.Image[template]
+	if !ok {
+		log.Printf("[pool] warm %v: no image configured for this template", template)
+		return
+	}
+
+	id, err := newMemberID()
+	if err != nil {
+		log.Printf("[pool] warm %v: %v", template, err)
+		return
+	}
+
+	ip, err := p.ipam.Allocate()
+	if err != nil {
+		log.Printf("[pool] warm %v (%s): ipam: %v", template, id, err)
+		return
+	}
+
+	config := incus.ContainerConfig{
+		Name:  id,
+		Image: image,
+		NIC: &incus.NICDevice{
+			Name:        "eth0",
+			Network:     p.cfg.NICNetwork,
+			IPv4Address: ip.String(),
+		},
+	}
+
+	if err := p.backend.CreateContainer(config); err != nil {
+		_ = p.ipam.Release(ip)
+		log.Printf("[pool] warm %v (%s): create: %v", template, id, err)
+		return
+	}
+	if err := p.backend.StartContainer(id); err != nil {
+		_ = p.backend.DeleteContainer(id)
+		_ = p.ipam.Release(ip)
+		log.Printf("[pool] warm %v (%s): start: %v", template, id, err)
+		return
+	}
+
+	m := &Member{ID: id, Template: template, IP: ip.String(), WarmedAt: time.Now()}
+	p.mu.Lock()
+	p.ready[template] = append(p.ready[template], m)
+	p.mu.Unlock()
+}
+
+// destroy stops (force, errors ignored) then deletes m, releasing its
+// IPAM allocation regardless of the delete outcome — a failed delete
+// shouldn't also leak the address. Returns the delete error, if any.
+func (p *Pool) destroy(m *Member) error {
+	_ = p.backend.StopContainer(m.ID, true)
+	deleteErr := p.backend.DeleteContainer(m.ID)
+
+	if ip := net.ParseIP(m.IP); ip != nil {
+		if err := p.ipam.Release(ip); err != nil {
+			log.Printf("[pool] destroy %s: ipam release: %v", m.ID, err)
+		}
+	}
+
+	if deleteErr != nil {
+		return fmt.Errorf("destroy %s: %w", m.ID, deleteErr)
+	}
+	return nil
+}
+
+// memberNamePrefix and newMemberID match sandbox_server.go's own
+// sandbox-<hex> naming exactly (duplicated, not shared, across the two
+// packages — three lines isn't worth a shared micro-package, and a pool
+// member's ID must be indistinguishable in shape from a cold-path
+// sandbox_id: once claimed, from the caller's perspective, it just is
+// one).
+const memberNamePrefix = "sandbox-"
+
+func newMemberID() (string, error) {
+	b := make([]byte, 6)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("failed to generate pool member id: %w", err)
+	}
+	return memberNamePrefix + hex.EncodeToString(b), nil
+}

--- a/internal/sandbox/pool/pool_test.go
+++ b/internal/sandbox/pool/pool_test.go
@@ -1,0 +1,464 @@
+package pool
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/footprintai/containarium/internal/sandbox/ipam"
+	"github.com/footprintai/containarium/pkg/core/incus"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// fakeBackend is the pool.Backend test double — the "Incus layer" the
+// design note's own test list calls for, fast and deterministic, no host.
+type fakeBackend struct {
+	mu sync.Mutex
+
+	created []string
+	started []string
+	stopped []string
+	deleted []string
+
+	// createErr, when set, is returned by CreateContainer for names
+	// matching failFor (empty failFor = fail every create).
+	createErr error
+	failFor   map[string]bool // nil = fail everything if createErr != nil
+
+	// gate, if non-nil, blocks CreateContainer until closed — lets a test
+	// observe a member mid-warm before it becomes ready.
+	gate chan struct{}
+}
+
+func newFakeBackend() *fakeBackend {
+	return &fakeBackend{}
+}
+
+func (b *fakeBackend) CreateContainer(config incus.ContainerConfig) error {
+	if b.gate != nil {
+		<-b.gate
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.createErr != nil && (b.failFor == nil || b.failFor[config.Name]) {
+		return b.createErr
+	}
+	b.created = append(b.created, config.Name)
+	return nil
+}
+
+func (b *fakeBackend) StartContainer(name string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.started = append(b.started, name)
+	return nil
+}
+
+func (b *fakeBackend) StopContainer(name string, _ bool) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.stopped = append(b.stopped, name)
+	return nil
+}
+
+func (b *fakeBackend) DeleteContainer(name string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.deleted = append(b.deleted, name)
+	return nil
+}
+
+func (b *fakeBackend) deleteCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.deleted)
+}
+
+func testAllocator(t *testing.T) *ipam.Allocator {
+	t.Helper()
+	a, err := ipam.New("10.100.0.10", "10.100.0.250", "10.100.0.1", 0)
+	if err != nil {
+		t.Fatalf("ipam.New: %v", err)
+	}
+	return a
+}
+
+func testConfig(minWarm int) Config {
+	return Config{
+		MinWarm:    map[pb.SandboxTemplate]int{pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE: minWarm},
+		Image:      map[pb.SandboxTemplate]string{pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE: "images:ubuntu/24.04"},
+		NICNetwork: "incusbr0",
+	}
+}
+
+// ---- Claim -----------------------------------------------------------
+
+func TestClaim_EmptyPoolReturnsErrPoolExhausted(t *testing.T) {
+	p := New(newFakeBackend(), testAllocator(t), testConfig(0))
+
+	_, err := p.Claim(pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE)
+	if !errors.Is(err, ErrPoolExhausted) {
+		t.Fatalf("Claim on empty pool = %v, want ErrPoolExhausted", err)
+	}
+}
+
+func TestClaim_OneReadyMemberClaimedAndRemoved(t *testing.T) {
+	backend := newFakeBackend()
+	p := New(backend, testAllocator(t), testConfig(1))
+
+	p.Reconcile(context.Background())
+	if got := p.ReadyCount(pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE); got != 1 {
+		t.Fatalf("ReadyCount after warming to 1 = %d, want 1", got)
+	}
+
+	m, err := p.Claim(pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE)
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	if m.ID == "" || m.IP == "" {
+		t.Errorf("claimed member incomplete: %+v", m)
+	}
+	if got := p.ReadyCount(pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE); got != 0 {
+		t.Errorf("ReadyCount after claiming the only member = %d, want 0", got)
+	}
+
+	if _, err := p.Claim(pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE); !errors.Is(err, ErrPoolExhausted) {
+		t.Errorf("second Claim = %v, want ErrPoolExhausted", err)
+	}
+}
+
+// TestClaim_ConcurrentClaimsEachMemberExactlyOnce pins the design note's
+// own test requirement, run under -race with 100 goroutines against a
+// pool of exactly 100 ready members.
+func TestClaim_ConcurrentClaimsEachMemberExactlyOnce(t *testing.T) {
+	const n = 100
+	backend := newFakeBackend()
+	p := New(backend, testAllocator(t), testConfig(n))
+	p.Reconcile(context.Background())
+	if got := p.ReadyCount(pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE); got != n {
+		t.Fatalf("ReadyCount after warming = %d, want %d", got, n)
+	}
+
+	var wg sync.WaitGroup
+	claimed := make([]*Member, n)
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			claimed[i], errs[i] = p.Claim(pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE)
+		}(i)
+	}
+	wg.Wait()
+
+	seen := make(map[string]int, n)
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("claim %d: %v", i, err)
+		}
+		seen[claimed[i].ID]++
+	}
+	if len(seen) != n {
+		t.Fatalf("got %d distinct members claimed, want %d", len(seen), n)
+	}
+	for id, count := range seen {
+		if count != 1 {
+			t.Errorf("member %s claimed %d times", id, count)
+		}
+	}
+	if got := p.ReadyCount(pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE); got != 0 {
+		t.Errorf("ReadyCount after claiming everything = %d, want 0", got)
+	}
+}
+
+// TestClaimDuringReconcile_NoTornState hammers Claim and Reconcile
+// concurrently (run with -race) — the requirement is no data race and no
+// double-claim, not any particular interleaving outcome.
+func TestClaimDuringReconcile_NoTornState(t *testing.T) {
+	backend := newFakeBackend()
+	// A generous range: this test's claim loop never Releases what it
+	// claims (by design — it's only checking for torn state, not
+	// exercising the release path), so claimed addresses are gone for
+	// good for the test's duration. A small range would legitimately
+	// exhaust under the stress loop's address churn and spam the log
+	// with "address range exhausted" — noise, not a bug.
+	allocator, err := ipam.New("10.100.0.1", "10.100.255.254", "10.101.0.1", 0)
+	if err != nil {
+		t.Fatalf("ipam.New: %v", err)
+	}
+	p := New(backend, allocator, testConfig(20))
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	claimedIDs := make(chan string, 10000)
+
+	// Reconcile loop.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				p.Reconcile(context.Background())
+			}
+		}
+	}()
+
+	// Claim loop, several concurrent claimers.
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					if m, err := p.Claim(pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE); err == nil {
+						claimedIDs <- m.ID
+					}
+				}
+			}
+		}()
+	}
+
+	time.Sleep(200 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+	close(claimedIDs)
+
+	seen := make(map[string]bool)
+	for id := range claimedIDs {
+		if seen[id] {
+			t.Fatalf("member %s claimed more than once — torn state under concurrent Claim/Reconcile", id)
+		}
+		seen[id] = true
+	}
+}
+
+// ---- Reconcile ---------------------------------------------------------
+
+func TestReconcile_BelowMinWarmWarmsTheDifference(t *testing.T) {
+	backend := newFakeBackend()
+	p := New(backend, testAllocator(t), testConfig(3))
+
+	p.Reconcile(context.Background())
+
+	if got := p.ReadyCount(pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE); got != 3 {
+		t.Fatalf("ReadyCount = %d, want 3", got)
+	}
+	backend.mu.Lock()
+	gotCreated, gotStarted := len(backend.created), len(backend.started)
+	backend.mu.Unlock()
+	if gotCreated != 3 || gotStarted != 3 {
+		t.Errorf("created=%d started=%d, want 3/3", gotCreated, gotStarted)
+	}
+
+	// A second Reconcile at the same target is a no-op — already at
+	// min_warm, nothing more to warm.
+	p.Reconcile(context.Background())
+	backend.mu.Lock()
+	gotCreated2 := len(backend.created)
+	backend.mu.Unlock()
+	if gotCreated2 != 3 {
+		t.Errorf("created after a second Reconcile at steady state = %d, want still 3", gotCreated2)
+	}
+}
+
+func TestReconcile_AboveMinWarmTrimsIdle(t *testing.T) {
+	backend := newFakeBackend()
+	p := New(backend, testAllocator(t), testConfig(5))
+	p.Reconcile(context.Background())
+	if got := p.ReadyCount(pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE); got != 5 {
+		t.Fatalf("ReadyCount after warming to 5 = %d, want 5", got)
+	}
+
+	// Lower the target and reconcile again — the pool must trim down to
+	// the new target, destroying the excess.
+	p.cfg.MinWarm[pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE] = 2
+	p.Reconcile(context.Background())
+
+	if got := p.ReadyCount(pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE); got != 2 {
+		t.Fatalf("ReadyCount after trimming to 2 = %d, want 2", got)
+	}
+	if got := backend.deleteCount(); got != 3 {
+		t.Errorf("deleted %d members, want exactly the 3 trimmed", got)
+	}
+}
+
+// TestReconcile_WarmingMemberNeverEntersReadyRing gates CreateContainer so
+// a warm is provably still in flight, and checks ReadyCount is 0 for the
+// entire time the gate is held closed.
+func TestReconcile_WarmingMemberNeverEntersReadyRing(t *testing.T) {
+	backend := newFakeBackend()
+	backend.gate = make(chan struct{})
+	p := New(backend, testAllocator(t), testConfig(1))
+
+	done := make(chan struct{})
+	go func() {
+		p.Reconcile(context.Background())
+		close(done)
+	}()
+
+	// The warm is blocked on backend.gate — give the goroutine a moment to
+	// actually reach CreateContainer, then assert it hasn't shown up ready.
+	time.Sleep(50 * time.Millisecond)
+	if got := p.ReadyCount(pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE); got != 0 {
+		t.Fatalf("ReadyCount while warm is still gated = %d, want 0 (a WARMING member must not be claimable)", got)
+	}
+	if _, err := p.Claim(pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE); !errors.Is(err, ErrPoolExhausted) {
+		t.Errorf("Claim while warm is still gated = %v, want ErrPoolExhausted", err)
+	}
+
+	close(backend.gate)
+	<-done
+
+	if got := p.ReadyCount(pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE); got != 1 {
+		t.Errorf("ReadyCount after the gated warm completed = %d, want 1", got)
+	}
+}
+
+// TestReconcile_FailedWarmRetriedNextTick_DoesNotWedgeReconciler pins two
+// requirements at once: a failed warm doesn't block reconciling other
+// templates in the SAME tick, and is simply retried by the NEXT tick
+// rather than needing any per-member retry state.
+func TestReconcile_FailedWarmRetriedNextTick_DoesNotWedgeReconciler(t *testing.T) {
+	backend := newFakeBackend()
+	backend.createErr = errors.New("incus: simulated create failure")
+
+	p := New(backend, testAllocator(t), testConfig(2))
+	p.Reconcile(context.Background())
+
+	if got := p.ReadyCount(pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE); got != 0 {
+		t.Fatalf("ReadyCount after every warm failed = %d, want 0", got)
+	}
+
+	// Next tick: the backend recovers. Reconcile must retry the shortfall
+	// without any special "unwedge" call — this IS the retry mechanism.
+	backend.mu.Lock()
+	backend.createErr = nil
+	backend.mu.Unlock()
+	p.Reconcile(context.Background())
+
+	if got := p.ReadyCount(pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE); got != 2 {
+		t.Fatalf("ReadyCount after the retrying tick = %d, want 2", got)
+	}
+}
+
+// TestReconcile_OneTemplateFailingDoesNotBlockAnother is the "does not
+// wedge the reconciler" half of the same requirement, from the angle of
+// two templates reconciled in the same call.
+func TestReconcile_OneTemplateFailingDoesNotBlockAnother(t *testing.T) {
+	const goodTemplate = pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE
+	const badTemplate = pb.SandboxTemplate(99) // no image configured -> every warm fails fast
+
+	backend := newFakeBackend()
+	p := New(backend, testAllocator(t), Config{
+		MinWarm:    map[pb.SandboxTemplate]int{goodTemplate: 3, badTemplate: 3},
+		Image:      map[pb.SandboxTemplate]string{goodTemplate: "images:ubuntu/24.04"}, // badTemplate deliberately has none
+		NICNetwork: "incusbr0",
+	})
+
+	p.Reconcile(context.Background())
+
+	if got := p.ReadyCount(goodTemplate); got != 3 {
+		t.Errorf("good template ReadyCount = %d, want 3 (must not be blocked by the other template's failures)", got)
+	}
+	if got := p.ReadyCount(badTemplate); got != 0 {
+		t.Errorf("bad template ReadyCount = %d, want 0", got)
+	}
+}
+
+// ---- Release / isolation ------------------------------------------------
+
+// TestDestroyOnRelease is the executable form of the design note's
+// isolation argument: a released member is destroyed, never returned to
+// the ready ring. This test's job is to fail loudly if anyone ever adds
+// a reset-and-reuse path to Release.
+func TestDestroyOnRelease(t *testing.T) {
+	backend := newFakeBackend()
+	p := New(backend, testAllocator(t), testConfig(1))
+	p.Reconcile(context.Background())
+
+	m, err := p.Claim(pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE)
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+
+	if err := p.Release(m); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+
+	backend.mu.Lock()
+	deleted := append([]string(nil), backend.deleted...)
+	backend.mu.Unlock()
+	if len(deleted) != 1 || deleted[0] != m.ID {
+		t.Fatalf("deleted = %v, want exactly [%s]", deleted, m.ID)
+	}
+	if got := p.ReadyCount(pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE); got != 0 {
+		t.Fatalf("ReadyCount after Release = %d, want 0 (released member must NOT reappear in the ring)", got)
+	}
+}
+
+func TestRelease_PropagatesDeleteFailure(t *testing.T) {
+	backend := newFakeBackend()
+	p := New(backend, testAllocator(t), testConfig(1))
+	p.Reconcile(context.Background())
+	m, err := p.Claim(pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE)
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+
+	// Swap in a backend whose DeleteContainer always fails, to prove
+	// Release surfaces it rather than swallowing it (unlike the
+	// reconciler's own best-effort trim).
+	failing := &deleteFailingBackend{fakeBackend: backend, err: errors.New("incus: instance busy")}
+	p.backend = failing
+
+	if err := p.Release(m); err == nil {
+		t.Fatal("Release should surface a real DeleteContainer failure")
+	}
+}
+
+type deleteFailingBackend struct {
+	*fakeBackend
+	err error
+}
+
+func (b *deleteFailingBackend) DeleteContainer(name string) error {
+	_ = b.fakeBackend.DeleteContainer(name)
+	return b.err
+}
+
+// ---- misc ---------------------------------------------------------------
+
+func TestNew_DoesNotRetainCallersConfigMaps(t *testing.T) {
+	cfg := testConfig(1)
+	p := New(newFakeBackend(), testAllocator(t), cfg)
+
+	cfg.MinWarm[pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE] = 999
+	if p.cfg.MinWarm[pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE] != 1 {
+		t.Errorf("Pool's config was mutated by changing the caller's map after New — New must copy")
+	}
+}
+
+func TestMember_TypedNotStringlyTyped(t *testing.T) {
+	// Compile-time-flavored check that Member is a real struct, not
+	// map[string]string — this test exists mostly so a future refactor
+	// toward the wrong shape breaks a test, not just a code review.
+	m := Member{
+		ID:       "sandbox-abc123",
+		Template: pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE,
+		IP:       "10.100.0.10",
+		WarmedAt: time.Now(),
+	}
+	if m.Template != pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE {
+		t.Fatal("unreachable")
+	}
+	_ = fmt.Sprintf("%+v", m)
+}

--- a/pkg/pb/containarium/v1/sandbox.pb.go
+++ b/pkg/pb/containarium/v1/sandbox.pb.go
@@ -807,6 +807,257 @@ func (x *DeleteSandboxResponse) GetMessage() string {
 	return ""
 }
 
+type SpawnRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Shell command to run, e.g. "npm run dev". Runs under /bin/sh -c,
+	// matching process_start's existing MCP contract.
+	Command string `protobuf:"bytes,1,opt,name=command,proto3" json:"command,omitempty"`
+	// Stable identifier for later reference. Auto-generated if empty. Must
+	// be unique among this box's currently-registered processes.
+	Name string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	// Working directory. Empty = agent-box's own cwd.
+	Cwd           string `protobuf:"bytes,3,opt,name=cwd,proto3" json:"cwd,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SpawnRequest) Reset() {
+	*x = SpawnRequest{}
+	mi := &file_containarium_v1_sandbox_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SpawnRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SpawnRequest) ProtoMessage() {}
+
+func (x *SpawnRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_sandbox_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SpawnRequest.ProtoReflect.Descriptor instead.
+func (*SpawnRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_sandbox_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *SpawnRequest) GetCommand() string {
+	if x != nil {
+		return x.Command
+	}
+	return ""
+}
+
+func (x *SpawnRequest) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *SpawnRequest) GetCwd() string {
+	if x != nil {
+		return x.Cwd
+	}
+	return ""
+}
+
+type SpawnResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Name  string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Pid   int64                  `protobuf:"varint,2,opt,name=pid,proto3" json:"pid,omitempty"`
+	// Absolute path to the captured stdout+stderr log, matching
+	// process_start's existing MCP contract.
+	LogPath       string `protobuf:"bytes,3,opt,name=log_path,json=logPath,proto3" json:"log_path,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SpawnResponse) Reset() {
+	*x = SpawnResponse{}
+	mi := &file_containarium_v1_sandbox_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SpawnResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SpawnResponse) ProtoMessage() {}
+
+func (x *SpawnResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_sandbox_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SpawnResponse.ProtoReflect.Descriptor instead.
+func (*SpawnResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_sandbox_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *SpawnResponse) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *SpawnResponse) GetPid() int64 {
+	if x != nil {
+		return x.Pid
+	}
+	return 0
+}
+
+func (x *SpawnResponse) GetLogPath() string {
+	if x != nil {
+		return x.LogPath
+	}
+	return ""
+}
+
+type AgentExecRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Shell command to run under /bin/sh -c.
+	Command string `protobuf:"bytes,1,opt,name=command,proto3" json:"command,omitempty"`
+	// Working directory. Empty = agent-box's own cwd.
+	Cwd string `protobuf:"bytes,2,opt,name=cwd,proto3" json:"cwd,omitempty"`
+	// Hard timeout in seconds. 0 = agent-box's default (matches
+	// shell_exec's existing MCP contract).
+	TimeoutSeconds int32 `protobuf:"varint,3,opt,name=timeout_seconds,json=timeoutSeconds,proto3" json:"timeout_seconds,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *AgentExecRequest) Reset() {
+	*x = AgentExecRequest{}
+	mi := &file_containarium_v1_sandbox_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AgentExecRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AgentExecRequest) ProtoMessage() {}
+
+func (x *AgentExecRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_sandbox_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AgentExecRequest.ProtoReflect.Descriptor instead.
+func (*AgentExecRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_sandbox_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *AgentExecRequest) GetCommand() string {
+	if x != nil {
+		return x.Command
+	}
+	return ""
+}
+
+func (x *AgentExecRequest) GetCwd() string {
+	if x != nil {
+		return x.Cwd
+	}
+	return ""
+}
+
+func (x *AgentExecRequest) GetTimeoutSeconds() int32 {
+	if x != nil {
+		return x.TimeoutSeconds
+	}
+	return 0
+}
+
+type AgentExecResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Stdout        string                 `protobuf:"bytes,1,opt,name=stdout,proto3" json:"stdout,omitempty"`
+	Stderr        string                 `protobuf:"bytes,2,opt,name=stderr,proto3" json:"stderr,omitempty"`
+	ExitCode      int32                  `protobuf:"varint,3,opt,name=exit_code,json=exitCode,proto3" json:"exit_code,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AgentExecResponse) Reset() {
+	*x = AgentExecResponse{}
+	mi := &file_containarium_v1_sandbox_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AgentExecResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AgentExecResponse) ProtoMessage() {}
+
+func (x *AgentExecResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_sandbox_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AgentExecResponse.ProtoReflect.Descriptor instead.
+func (*AgentExecResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_sandbox_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *AgentExecResponse) GetStdout() string {
+	if x != nil {
+		return x.Stdout
+	}
+	return ""
+}
+
+func (x *AgentExecResponse) GetStderr() string {
+	if x != nil {
+		return x.Stderr
+	}
+	return ""
+}
+
+func (x *AgentExecResponse) GetExitCode() int32 {
+	if x != nil {
+		return x.ExitCode
+	}
+	return 0
+}
+
 var File_containarium_v1_sandbox_proto protoreflect.FileDescriptor
 
 const file_containarium_v1_sandbox_proto_rawDesc = "" +
@@ -856,7 +1107,23 @@ const file_containarium_v1_sandbox_proto_rawDesc = "" +
 	"\n" +
 	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\"1\n" +
 	"\x15DeleteSandboxResponse\x12\x18\n" +
-	"\amessage\x18\x01 \x01(\tR\amessage*\x96\x01\n" +
+	"\amessage\x18\x01 \x01(\tR\amessage\"N\n" +
+	"\fSpawnRequest\x12\x18\n" +
+	"\acommand\x18\x01 \x01(\tR\acommand\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x12\x10\n" +
+	"\x03cwd\x18\x03 \x01(\tR\x03cwd\"P\n" +
+	"\rSpawnResponse\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x10\n" +
+	"\x03pid\x18\x02 \x01(\x03R\x03pid\x12\x19\n" +
+	"\blog_path\x18\x03 \x01(\tR\alogPath\"g\n" +
+	"\x10AgentExecRequest\x12\x18\n" +
+	"\acommand\x18\x01 \x01(\tR\acommand\x12\x10\n" +
+	"\x03cwd\x18\x02 \x01(\tR\x03cwd\x12'\n" +
+	"\x0ftimeout_seconds\x18\x03 \x01(\x05R\x0etimeoutSeconds\"`\n" +
+	"\x11AgentExecResponse\x12\x16\n" +
+	"\x06stdout\x18\x01 \x01(\tR\x06stdout\x12\x16\n" +
+	"\x06stderr\x18\x02 \x01(\tR\x06stderr\x12\x1b\n" +
+	"\texit_code\x18\x03 \x01(\x05R\bexitCode*\x96\x01\n" +
 	"\fSandboxState\x12\x1d\n" +
 	"\x19SANDBOX_STATE_UNSPECIFIED\x10\x00\x12\x19\n" +
 	"\x15SANDBOX_STATE_PENDING\x10\x01\x12\x19\n" +
@@ -881,7 +1148,10 @@ const file_containarium_v1_sandbox_proto_rawDesc = "" +
 	"\x11ReadFileInSandbox\x12).containarium.v1.ReadFileInSandboxRequest\x1a*.containarium.v1.ReadFileInSandboxResponse\"\x97\x01\x92Al\n" +
 	"\tSandboxes\x12\x1aRead a file from a sandbox\x1aCpath is passed as a query parameter, e.g. ?path=/workspace/out.txt.\x82\xd3\xe4\x93\x02\"\x12 /v1/sandboxes/{sandbox_id}/files\x12\xa2\x01\n" +
 	"\rDeleteSandbox\x12%.containarium.v1.DeleteSandboxRequest\x1a&.containarium.v1.DeleteSandboxResponse\"B\x92A\x1d\n" +
-	"\tSandboxes\x12\x10Delete a sandbox\x82\xd3\xe4\x93\x02\x1c*\x1a/v1/sandboxes/{sandbox_id}BKZIgithub.com/footprintai/containarium/pkg/pb/containarium/v1;containariumv1b\x06proto3"
+	"\tSandboxes\x12\x10Delete a sandbox\x82\xd3\xe4\x93\x02\x1c*\x1a/v1/sandboxes/{sandbox_id}2\xa5\x01\n" +
+	"\fSpawnService\x12F\n" +
+	"\x05Spawn\x12\x1d.containarium.v1.SpawnRequest\x1a\x1e.containarium.v1.SpawnResponse\x12M\n" +
+	"\x04Exec\x12!.containarium.v1.AgentExecRequest\x1a\".containarium.v1.AgentExecResponseBKZIgithub.com/footprintai/containarium/pkg/pb/containarium/v1;containariumv1b\x06proto3"
 
 var (
 	file_containarium_v1_sandbox_proto_rawDescOnce sync.Once
@@ -896,7 +1166,7 @@ func file_containarium_v1_sandbox_proto_rawDescGZIP() []byte {
 }
 
 var file_containarium_v1_sandbox_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_containarium_v1_sandbox_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
+var file_containarium_v1_sandbox_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
 var file_containarium_v1_sandbox_proto_goTypes = []any{
 	(SandboxState)(0),                  // 0: containarium.v1.SandboxState
 	(ServedFrom)(0),                    // 1: containarium.v1.ServedFrom
@@ -912,14 +1182,18 @@ var file_containarium_v1_sandbox_proto_goTypes = []any{
 	(*ReadFileInSandboxResponse)(nil),  // 11: containarium.v1.ReadFileInSandboxResponse
 	(*DeleteSandboxRequest)(nil),       // 12: containarium.v1.DeleteSandboxRequest
 	(*DeleteSandboxResponse)(nil),      // 13: containarium.v1.DeleteSandboxResponse
-	(*timestamppb.Timestamp)(nil),      // 14: google.protobuf.Timestamp
+	(*SpawnRequest)(nil),               // 14: containarium.v1.SpawnRequest
+	(*SpawnResponse)(nil),              // 15: containarium.v1.SpawnResponse
+	(*AgentExecRequest)(nil),           // 16: containarium.v1.AgentExecRequest
+	(*AgentExecResponse)(nil),          // 17: containarium.v1.AgentExecResponse
+	(*timestamppb.Timestamp)(nil),      // 18: google.protobuf.Timestamp
 }
 var file_containarium_v1_sandbox_proto_depIdxs = []int32{
 	0,  // 0: containarium.v1.Sandbox.state:type_name -> containarium.v1.SandboxState
 	2,  // 1: containarium.v1.Sandbox.template:type_name -> containarium.v1.SandboxTemplate
 	1,  // 2: containarium.v1.Sandbox.served_from:type_name -> containarium.v1.ServedFrom
-	14, // 3: containarium.v1.Sandbox.created_at:type_name -> google.protobuf.Timestamp
-	14, // 4: containarium.v1.Sandbox.expires_at:type_name -> google.protobuf.Timestamp
+	18, // 3: containarium.v1.Sandbox.created_at:type_name -> google.protobuf.Timestamp
+	18, // 4: containarium.v1.Sandbox.expires_at:type_name -> google.protobuf.Timestamp
 	2,  // 5: containarium.v1.SpawnSandboxRequest.template:type_name -> containarium.v1.SandboxTemplate
 	3,  // 6: containarium.v1.SpawnSandboxResponse.sandbox:type_name -> containarium.v1.Sandbox
 	4,  // 7: containarium.v1.SandboxService.SpawnSandbox:input_type -> containarium.v1.SpawnSandboxRequest
@@ -927,13 +1201,17 @@ var file_containarium_v1_sandbox_proto_depIdxs = []int32{
 	8,  // 9: containarium.v1.SandboxService.WriteFileInSandbox:input_type -> containarium.v1.WriteFileInSandboxRequest
 	10, // 10: containarium.v1.SandboxService.ReadFileInSandbox:input_type -> containarium.v1.ReadFileInSandboxRequest
 	12, // 11: containarium.v1.SandboxService.DeleteSandbox:input_type -> containarium.v1.DeleteSandboxRequest
-	5,  // 12: containarium.v1.SandboxService.SpawnSandbox:output_type -> containarium.v1.SpawnSandboxResponse
-	7,  // 13: containarium.v1.SandboxService.ExecInSandbox:output_type -> containarium.v1.ExecInSandboxResponse
-	9,  // 14: containarium.v1.SandboxService.WriteFileInSandbox:output_type -> containarium.v1.WriteFileInSandboxResponse
-	11, // 15: containarium.v1.SandboxService.ReadFileInSandbox:output_type -> containarium.v1.ReadFileInSandboxResponse
-	13, // 16: containarium.v1.SandboxService.DeleteSandbox:output_type -> containarium.v1.DeleteSandboxResponse
-	12, // [12:17] is the sub-list for method output_type
-	7,  // [7:12] is the sub-list for method input_type
+	14, // 12: containarium.v1.SpawnService.Spawn:input_type -> containarium.v1.SpawnRequest
+	16, // 13: containarium.v1.SpawnService.Exec:input_type -> containarium.v1.AgentExecRequest
+	5,  // 14: containarium.v1.SandboxService.SpawnSandbox:output_type -> containarium.v1.SpawnSandboxResponse
+	7,  // 15: containarium.v1.SandboxService.ExecInSandbox:output_type -> containarium.v1.ExecInSandboxResponse
+	9,  // 16: containarium.v1.SandboxService.WriteFileInSandbox:output_type -> containarium.v1.WriteFileInSandboxResponse
+	11, // 17: containarium.v1.SandboxService.ReadFileInSandbox:output_type -> containarium.v1.ReadFileInSandboxResponse
+	13, // 18: containarium.v1.SandboxService.DeleteSandbox:output_type -> containarium.v1.DeleteSandboxResponse
+	15, // 19: containarium.v1.SpawnService.Spawn:output_type -> containarium.v1.SpawnResponse
+	17, // 20: containarium.v1.SpawnService.Exec:output_type -> containarium.v1.AgentExecResponse
+	14, // [14:21] is the sub-list for method output_type
+	7,  // [7:14] is the sub-list for method input_type
 	7,  // [7:7] is the sub-list for extension type_name
 	7,  // [7:7] is the sub-list for extension extendee
 	0,  // [0:7] is the sub-list for field type_name
@@ -950,9 +1228,9 @@ func file_containarium_v1_sandbox_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_v1_sandbox_proto_rawDesc), len(file_containarium_v1_sandbox_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   11,
+			NumMessages:   15,
 			NumExtensions: 0,
-			NumServices:   1,
+			NumServices:   2,
 		},
 		GoTypes:           file_containarium_v1_sandbox_proto_goTypes,
 		DependencyIndexes: file_containarium_v1_sandbox_proto_depIdxs,

--- a/pkg/pb/containarium/v1/sandbox.pb.gw.go
+++ b/pkg/pb/containarium/v1/sandbox.pb.gw.go
@@ -244,6 +244,60 @@ func local_request_SandboxService_DeleteSandbox_0(ctx context.Context, marshaler
 	return msg, metadata, err
 }
 
+func request_SpawnService_Spawn_0(ctx context.Context, marshaler runtime.Marshaler, client SpawnServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq SpawnRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.Spawn(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_SpawnService_Spawn_0(ctx context.Context, marshaler runtime.Marshaler, server SpawnServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq SpawnRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.Spawn(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_SpawnService_Exec_0(ctx context.Context, marshaler runtime.Marshaler, client SpawnServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq AgentExecRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.Exec(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_SpawnService_Exec_0(ctx context.Context, marshaler runtime.Marshaler, server SpawnServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq AgentExecRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.Exec(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterSandboxServiceHandlerServer registers the http handlers for service SandboxService to "mux".
 // UnaryRPC     :call SandboxServiceServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -349,6 +403,56 @@ func RegisterSandboxServiceHandlerServer(ctx context.Context, mux *runtime.Serve
 			return
 		}
 		forward_SandboxService_DeleteSandbox_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+
+	return nil
+}
+
+// RegisterSpawnServiceHandlerServer registers the http handlers for service SpawnService to "mux".
+// UnaryRPC     :call SpawnServiceServer directly.
+// StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
+// Note that using this registration option will cause many gRPC library features to stop working. Consider using RegisterSpawnServiceHandlerFromEndpoint instead.
+// GRPC interceptors will not work for this type of registration. To use interceptors, you must use the "runtime.WithMiddlewares" option in the "runtime.NewServeMux" call.
+func RegisterSpawnServiceHandlerServer(ctx context.Context, mux *runtime.ServeMux, server SpawnServiceServer) error {
+	mux.Handle(http.MethodPost, pattern_SpawnService_Spawn_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.SpawnService/Spawn", runtime.WithHTTPPathPattern("/containarium.v1.SpawnService/Spawn"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_SpawnService_Spawn_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_SpawnService_Spawn_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_SpawnService_Exec_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.SpawnService/Exec", runtime.WithHTTPPathPattern("/containarium.v1.SpawnService/Exec"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_SpawnService_Exec_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_SpawnService_Exec_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 
 	return nil
@@ -492,4 +596,87 @@ var (
 	forward_SandboxService_WriteFileInSandbox_0 = runtime.ForwardResponseMessage
 	forward_SandboxService_ReadFileInSandbox_0  = runtime.ForwardResponseMessage
 	forward_SandboxService_DeleteSandbox_0      = runtime.ForwardResponseMessage
+)
+
+// RegisterSpawnServiceHandlerFromEndpoint is same as RegisterSpawnServiceHandler but
+// automatically dials to "endpoint" and closes the connection when "ctx" gets done.
+func RegisterSpawnServiceHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) (err error) {
+	conn, err := grpc.NewClient(endpoint, opts...)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			if cerr := conn.Close(); cerr != nil {
+				grpclog.Errorf("Failed to close conn to %s: %v", endpoint, cerr)
+			}
+			return
+		}
+		go func() {
+			<-ctx.Done()
+			if cerr := conn.Close(); cerr != nil {
+				grpclog.Errorf("Failed to close conn to %s: %v", endpoint, cerr)
+			}
+		}()
+	}()
+	return RegisterSpawnServiceHandler(ctx, mux, conn)
+}
+
+// RegisterSpawnServiceHandler registers the http handlers for service SpawnService to "mux".
+// The handlers forward requests to the grpc endpoint over "conn".
+func RegisterSpawnServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {
+	return RegisterSpawnServiceHandlerClient(ctx, mux, NewSpawnServiceClient(conn))
+}
+
+// RegisterSpawnServiceHandlerClient registers the http handlers for service SpawnService
+// to "mux". The handlers forward requests to the grpc endpoint over the given implementation of "SpawnServiceClient".
+// Note: the gRPC framework executes interceptors within the gRPC handler. If the passed in "SpawnServiceClient"
+// doesn't go through the normal gRPC flow (creating a gRPC client etc.) then it will be up to the passed in
+// "SpawnServiceClient" to call the correct interceptors. This client ignores the HTTP middlewares.
+func RegisterSpawnServiceHandlerClient(ctx context.Context, mux *runtime.ServeMux, client SpawnServiceClient) error {
+	mux.Handle(http.MethodPost, pattern_SpawnService_Spawn_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.SpawnService/Spawn", runtime.WithHTTPPathPattern("/containarium.v1.SpawnService/Spawn"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_SpawnService_Spawn_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_SpawnService_Spawn_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_SpawnService_Exec_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.SpawnService/Exec", runtime.WithHTTPPathPattern("/containarium.v1.SpawnService/Exec"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_SpawnService_Exec_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_SpawnService_Exec_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	return nil
+}
+
+var (
+	pattern_SpawnService_Spawn_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"containarium.v1.SpawnService", "Spawn"}, ""))
+	pattern_SpawnService_Exec_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"containarium.v1.SpawnService", "Exec"}, ""))
+)
+
+var (
+	forward_SpawnService_Spawn_0 = runtime.ForwardResponseMessage
+	forward_SpawnService_Exec_0  = runtime.ForwardResponseMessage
 )

--- a/pkg/pb/containarium/v1/sandbox_grpc.pb.go
+++ b/pkg/pb/containarium/v1/sandbox_grpc.pb.go
@@ -327,3 +327,193 @@ var SandboxService_ServiceDesc = grpc.ServiceDesc{
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "containarium/v1/sandbox.proto",
 }
+
+const (
+	SpawnService_Spawn_FullMethodName = "/containarium.v1.SpawnService/Spawn"
+	SpawnService_Exec_FullMethodName  = "/containarium.v1.SpawnService/Exec"
+)
+
+// SpawnServiceClient is the client API for SpawnService service.
+//
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
+//
+// SpawnService is agent-box's resident, low-latency counterpart to
+// SandboxService's per-call Incus round-trips (#1488 Phase 2). Each Incus
+// exec websocket-upgrades at ~50-150ms; a warm gRPC connection straight to
+// the box does the same work in ~3ms. The daemon reaches this over a
+// bind-mounted unix socket (see the design note's "Transport" section),
+// never over the network.
+//
+// This is deliberately the only service in this package with NO
+// google.api.http annotations: it is not part of the public API surface —
+// SandboxService is what external callers (CLI, MCP, SDK) talk to, and its
+// implementation is what will route through SpawnService once a warm pool
+// exists (Phase 3). Nothing here is reachable through the REST gateway,
+// and it must not be registered there.
+//
+// agent-box runs as PID 1 inside a pool member (see the design note's flow
+// diagram), so it owns reaping every process it forks — a design this
+// service inherits from the existing process_start/shell_exec MCP tools in
+// internal/agentbox, not a new mechanism.
+type SpawnServiceClient interface {
+	// Spawn starts a long-running background process and returns immediately
+	// with its pid. The process is reaped (waited on), never left a zombie,
+	// when it exits.
+	Spawn(ctx context.Context, in *SpawnRequest, opts ...grpc.CallOption) (*SpawnResponse, error)
+	// Exec runs one command to completion and returns its stdout, stderr,
+	// and exit code — the fast-path equivalent of
+	// SandboxService.ExecInSandbox, minus the Incus round-trip.
+	Exec(ctx context.Context, in *AgentExecRequest, opts ...grpc.CallOption) (*AgentExecResponse, error)
+}
+
+type spawnServiceClient struct {
+	cc grpc.ClientConnInterface
+}
+
+func NewSpawnServiceClient(cc grpc.ClientConnInterface) SpawnServiceClient {
+	return &spawnServiceClient{cc}
+}
+
+func (c *spawnServiceClient) Spawn(ctx context.Context, in *SpawnRequest, opts ...grpc.CallOption) (*SpawnResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SpawnResponse)
+	err := c.cc.Invoke(ctx, SpawnService_Spawn_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *spawnServiceClient) Exec(ctx context.Context, in *AgentExecRequest, opts ...grpc.CallOption) (*AgentExecResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(AgentExecResponse)
+	err := c.cc.Invoke(ctx, SpawnService_Exec_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// SpawnServiceServer is the server API for SpawnService service.
+// All implementations must embed UnimplementedSpawnServiceServer
+// for forward compatibility.
+//
+// SpawnService is agent-box's resident, low-latency counterpart to
+// SandboxService's per-call Incus round-trips (#1488 Phase 2). Each Incus
+// exec websocket-upgrades at ~50-150ms; a warm gRPC connection straight to
+// the box does the same work in ~3ms. The daemon reaches this over a
+// bind-mounted unix socket (see the design note's "Transport" section),
+// never over the network.
+//
+// This is deliberately the only service in this package with NO
+// google.api.http annotations: it is not part of the public API surface —
+// SandboxService is what external callers (CLI, MCP, SDK) talk to, and its
+// implementation is what will route through SpawnService once a warm pool
+// exists (Phase 3). Nothing here is reachable through the REST gateway,
+// and it must not be registered there.
+//
+// agent-box runs as PID 1 inside a pool member (see the design note's flow
+// diagram), so it owns reaping every process it forks — a design this
+// service inherits from the existing process_start/shell_exec MCP tools in
+// internal/agentbox, not a new mechanism.
+type SpawnServiceServer interface {
+	// Spawn starts a long-running background process and returns immediately
+	// with its pid. The process is reaped (waited on), never left a zombie,
+	// when it exits.
+	Spawn(context.Context, *SpawnRequest) (*SpawnResponse, error)
+	// Exec runs one command to completion and returns its stdout, stderr,
+	// and exit code — the fast-path equivalent of
+	// SandboxService.ExecInSandbox, minus the Incus round-trip.
+	Exec(context.Context, *AgentExecRequest) (*AgentExecResponse, error)
+	mustEmbedUnimplementedSpawnServiceServer()
+}
+
+// UnimplementedSpawnServiceServer must be embedded to have
+// forward compatible implementations.
+//
+// NOTE: this should be embedded by value instead of pointer to avoid a nil
+// pointer dereference when methods are called.
+type UnimplementedSpawnServiceServer struct{}
+
+func (UnimplementedSpawnServiceServer) Spawn(context.Context, *SpawnRequest) (*SpawnResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method Spawn not implemented")
+}
+func (UnimplementedSpawnServiceServer) Exec(context.Context, *AgentExecRequest) (*AgentExecResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method Exec not implemented")
+}
+func (UnimplementedSpawnServiceServer) mustEmbedUnimplementedSpawnServiceServer() {}
+func (UnimplementedSpawnServiceServer) testEmbeddedByValue()                      {}
+
+// UnsafeSpawnServiceServer may be embedded to opt out of forward compatibility for this service.
+// Use of this interface is not recommended, as added methods to SpawnServiceServer will
+// result in compilation errors.
+type UnsafeSpawnServiceServer interface {
+	mustEmbedUnimplementedSpawnServiceServer()
+}
+
+func RegisterSpawnServiceServer(s grpc.ServiceRegistrar, srv SpawnServiceServer) {
+	// If the following call panics, it indicates UnimplementedSpawnServiceServer was
+	// embedded by pointer and is nil.  This will cause panics if an
+	// unimplemented method is ever invoked, so we test this at initialization
+	// time to prevent it from happening at runtime later due to I/O.
+	if t, ok := srv.(interface{ testEmbeddedByValue() }); ok {
+		t.testEmbeddedByValue()
+	}
+	s.RegisterService(&SpawnService_ServiceDesc, srv)
+}
+
+func _SpawnService_Spawn_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SpawnRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SpawnServiceServer).Spawn(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SpawnService_Spawn_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SpawnServiceServer).Spawn(ctx, req.(*SpawnRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _SpawnService_Exec_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(AgentExecRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SpawnServiceServer).Exec(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SpawnService_Exec_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SpawnServiceServer).Exec(ctx, req.(*AgentExecRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+// SpawnService_ServiceDesc is the grpc.ServiceDesc for SpawnService service.
+// It's only intended for direct use with grpc.RegisterService,
+// and not to be introspected or modified (even as a copy)
+var SpawnService_ServiceDesc = grpc.ServiceDesc{
+	ServiceName: "containarium.v1.SpawnService",
+	HandlerType: (*SpawnServiceServer)(nil),
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "Spawn",
+			Handler:    _SpawnService_Spawn_Handler,
+		},
+		{
+			MethodName: "Exec",
+			Handler:    _SpawnService_Exec_Handler,
+		},
+	},
+	Streams:  []grpc.StreamDesc{},
+	Metadata: "containarium/v1/sandbox.proto",
+}

--- a/proto/containarium/v1/sandbox.proto
+++ b/proto/containarium/v1/sandbox.proto
@@ -198,3 +198,68 @@ message DeleteSandboxRequest {
 message DeleteSandboxResponse {
   string message = 1;
 }
+
+// SpawnService is agent-box's resident, low-latency counterpart to
+// SandboxService's per-call Incus round-trips (#1488 Phase 2). Each Incus
+// exec websocket-upgrades at ~50-150ms; a warm gRPC connection straight to
+// the box does the same work in ~3ms. The daemon reaches this over a
+// bind-mounted unix socket (see the design note's "Transport" section),
+// never over the network.
+//
+// This is deliberately the only service in this package with NO
+// google.api.http annotations: it is not part of the public API surface —
+// SandboxService is what external callers (CLI, MCP, SDK) talk to, and its
+// implementation is what will route through SpawnService once a warm pool
+// exists (Phase 3). Nothing here is reachable through the REST gateway,
+// and it must not be registered there.
+//
+// agent-box runs as PID 1 inside a pool member (see the design note's flow
+// diagram), so it owns reaping every process it forks — a design this
+// service inherits from the existing process_start/shell_exec MCP tools in
+// internal/agentbox, not a new mechanism.
+service SpawnService {
+  // Spawn starts a long-running background process and returns immediately
+  // with its pid. The process is reaped (waited on), never left a zombie,
+  // when it exits.
+  rpc Spawn(SpawnRequest) returns (SpawnResponse);
+
+  // Exec runs one command to completion and returns its stdout, stderr,
+  // and exit code — the fast-path equivalent of
+  // SandboxService.ExecInSandbox, minus the Incus round-trip.
+  rpc Exec(AgentExecRequest) returns (AgentExecResponse);
+}
+
+message SpawnRequest {
+  // Shell command to run, e.g. "npm run dev". Runs under /bin/sh -c,
+  // matching process_start's existing MCP contract.
+  string command = 1;
+  // Stable identifier for later reference. Auto-generated if empty. Must
+  // be unique among this box's currently-registered processes.
+  string name = 2;
+  // Working directory. Empty = agent-box's own cwd.
+  string cwd = 3;
+}
+
+message SpawnResponse {
+  string name = 1;
+  int64 pid = 2;
+  // Absolute path to the captured stdout+stderr log, matching
+  // process_start's existing MCP contract.
+  string log_path = 3;
+}
+
+message AgentExecRequest {
+  // Shell command to run under /bin/sh -c.
+  string command = 1;
+  // Working directory. Empty = agent-box's own cwd.
+  string cwd = 2;
+  // Hard timeout in seconds. 0 = agent-box's default (matches
+  // shell_exec's existing MCP contract).
+  int32 timeout_seconds = 3;
+}
+
+message AgentExecResponse {
+  string stdout = 1;
+  string stderr = 2;
+  int32 exit_code = 3;
+}


### PR DESCRIPTION
## What

Phase 3 of the two-digit-ms sandbox spawn design note (#1488): `internal/sandbox/pool`, the warm-pool reconciler and claim ring. This is the phase where two-digit ms actually lands, per the note. Stacked on #1519 (ipam) — this PR's diff narrows to just its own commit once that merges into main.

## A design choice worth flagging: `incus.Backend`, not `box.BoxBackend`

The design note's own Contracts table names `box.BoxBackend` as this package's dependency. This PR uses the same `incus.Backend`-shaped interface `SandboxServer` (#1508) already uses instead. Both `container.Manager` and `box.BoxBackend` are built around the full persistent-box identity flow (SSH keys, tenant naming) that pool members — like cold-path sandboxes — explicitly skip. A pool member and a cold-path sandbox should be indistinguishable in shape once claimed; reusing the same dependency in both places is what makes that actually true rather than just asserted. This updates the note's original sketch to match what's actually built now that #1508 already made that call for the cold path.

## Design

- **`Claim`** — O(1) pop from a FIFO ring, per template. Empty → `ErrPoolExhausted`. A claimed member leaves the pool's bookkeeping entirely — the caller owns its lifecycle from there.
- **`Release`** — destroys the member, full stop. Never resets and returns it to the ring (the design note's Isolation section: that's exactly what would turn a shared pool from isolation-equivalent-to-per-tenant into a cross-tenant leak vector). Propagates a real delete failure, matching the explicit-vs-background-cleanup distinction #1508's `DeleteSandbox` already established.
- **`Reconcile`** — per template: short of `min_warm` → warm the difference (async); over (ready count alone — an in-flight warm is never aborted mid-boot) → trim the oldest excess. A failed warm is simply not added to the ring; the *next* `Reconcile` call sees the same shortfall and retries — that's the package's entire backoff mechanism, so one wedged member can never block reconciling any other template. Warm members get a static IPAM-allocated address (#1519) at creation time, so DHCP's wait happens during warm-up, off the claim path entirely.

One mutex serializes all state mutation — `Claim` and `Reconcile`'s bookkeeping share it, so a claim during reconcile always sees a consistent ring — while the actual I/O (`CreateContainer`, `DeleteContainer`, ...) happens after releasing it, so a slow Incus call never blocks a concurrent `Claim`.

`Backend` is a narrow, fakeable interface (4 methods, not `incus.Backend`'s full surface) — any concrete type satisfying `incus.Backend`, in particular the real `*incus.Client`, automatically satisfies this narrower one too, no adapter needed.

## Tests — each verified by mutation to actually catch what it claims to

- **Claim**: empty pool → `ErrPoolExhausted`; one ready member claimed and removed; 100 concurrent claims against a 100-member pool, each claimed exactly once. Verified: removing `Claim`'s mutex crashes *immediately* under `-race` with a nil-pointer panic from a double-claimed member, not a silent flake.
- **`TestClaimDuringReconcile_NoTornState`** — `Claim` and `Reconcile` hammered concurrently for 200ms under `-race`.
- **Reconcile below/above `min_warm`** — warms/trims to target; a second `Reconcile` at steady state is a no-op.
- **`TestReconcile_WarmingMemberNeverEntersReadyRing`** — gates `CreateContainer` so a warm is provably still in flight; `ReadyCount` and `Claim` both confirm zero visibility into it until the gate releases.
- **The two halves of "does not wedge the reconciler"** — retried by the next tick with no per-member state, and one failing template never blocks another in the same tick.
- **`TestDestroyOnRelease`** — verified by mutation: swapping `Release`'s body for a reset-and-reuse stub fails the test immediately, exactly as the design note's own framing for this test intends ("fail loudly if anyone ever adds a reset-and-reuse path").
- `TestNew_DoesNotRetainCallersConfigMaps` — `New` copies its `Config` maps rather than aliasing the caller's.

`golangci-lint` run locally (0 issues). `go build`/`go vet` clean tree-wide. Package suite green with `-race`.

## Scope

Not in this PR: `GetPoolStatus`, the authz/rate-limit/`RESOURCE_EXHAUSTED` wiring in `SandboxServer`, and the actual daemon-side scheduling loop that calls `Reconcile` periodically and wires `SpawnSandbox` to `Claim` instead of always going cold — integrating this package into `SandboxServer` is the natural next slice. Phase 3's real exit criterion (nightly latency test against a real host, P50 ≤ 50ms / P99 ≤ 99ms) needs a live Incus host this environment doesn't have.

Refs #1488 (Phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
