### PR TITLE
docs(benchmark): plan + scripts for sandbox density, k8s vs Containarium

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,9 @@ internal/netbpf/*.bpf.o
 # separate checkouts living under the repo root; never commit them as embedded
 # repos (a stray `git add -A` would otherwise sweep them in).
 .worktrees/
+
+# Benchmark host-specific config (real hostnames/IPs — see
+# benchmark/*/README.md and CLAUDE.md's anonymization convention) and raw
+# per-run logs. Reviewed summaries go in benchmark/*/RESULTS.md instead.
+benchmark/*/config.env
+benchmark/*/results/

--- a/benchmark/agent-sandbox-density/README.md
+++ b/benchmark/agent-sandbox-density/README.md
@@ -8,15 +8,26 @@ before it runs out of room?
   ([kubeadm](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/))
   with the upstream
   [kubernetes-sigs/agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox)
-  controller installed, creating one `Sandbox` custom resource per unit.
-- **Experiment group** — a VM running the Containarium daemon as a plain
-  LXC/Incus "workhorse" (no Kubernetes at all), creating one box per unit via
-  `containarium create`.
+  controller installed, creating one `Sandbox` custom resource per unit
+  directly via `kubectl` — plain `runc`, no extra sandboxing layer.
+- **Experiment group** — the *same* base Kubernetes cluster setup, plus
+  gVisor and a `runsc` `RuntimeClass`, running the Containarium daemon
+  (Helm chart, `--runtime=k8s`) configured to schedule every box pod under
+  it: **pod → gVisor → containarium**. Each unit is created via
+  `containarium create`, which the daemon turns into the *same* kind of
+  `Sandbox` CR the control group creates directly — the daemon uses the
+  identical upstream controller underneath (see
+  [`docs/KIND-QUICKSTART.md`](../../docs/KIND-QUICKSTART.md)). The
+  difference under test isn't "k8s vs. no k8s" — both sides run k8s — it's
+  *raw agent-sandbox pods* vs. *Containarium-orchestrated pods with an
+  added gVisor kernel boundary*.
 
 Both VMs get **identical hard resource caps** (CPU count, memory, disk) via
-VirtualBox, and both sandboxes get **identical CPU/memory request+limit
-values** (see [Sandbox resource profile](#sandbox-resource-profile) below).
-The only thing that differs between the two runs is the orchestration layer.
+VirtualBox, and both sandboxes get the **same sandbox resource profile**
+(see [Sandbox resource profile](#sandbox-resource-profile) below, and
+[Fairness notes](#fairness-notes) for one documented asymmetry in how that
+profile is applied). The only thing that differs between the two runs is
+the orchestration layer and gVisor.
 
 This lives in-repo (rather than as a one-off gist) so the methodology is
 reviewable, the numbers are reproducible, and the scripts can be re-run
@@ -42,14 +53,16 @@ If Containarium loses on density, that's a real, reportable result.
 1. Provision two VirtualBox VMs on the same physical host, one at a time
    (see [Why sequential, not parallel](#why-sequential-not-parallel)), each
    given the **same** hard CPU/memory/disk cap.
-2. **Control VM:** install `kubeadm` + a CNI, raise the kubelet
-   `--max-pods` ceiling (the stock default of 110 would cap density before
-   any real resource limit does — see
-   [Kubelet max-pods](#kubelet-max-pods)), then install the upstream
-   agent-sandbox controller and CRDs.
-3. **Experiment VM:** install the Containarium daemon in its default
-   LXC/Incus "workhorse" mode (no `--runtime=k8s` — that backend targets
-   *existing* clusters, it isn't what we're measuring here).
+2. **Both VMs** get the identical base cluster (`scripts/k8s-common.sh`):
+   `kubeadm` + Calico, kubelet `--max-pods` raised (the stock default of
+   110 would cap density before any real resource limit does — see
+   [Kubelet max-pods](#kubelet-max-pods)), and the upstream agent-sandbox
+   controller + CRDs. Any drift between the two sides here would confound
+   the comparison, so this step is one shared script, not two similar ones.
+3. **Experiment VM only, on top of that base:** install gVisor
+   (`runsc` + the containerd shim), register a `runsc` `RuntimeClass`, then
+   Helm-install the Containarium daemon with `runtimeClass: runsc` so
+   every box it creates is scheduled under it.
 4. Run the matching density-loop script against each VM: create sandboxes
    one at a time with the fixed resource profile below, wait for each to
    reach a ready state, and keep going until creation starts failing for a
@@ -129,20 +142,47 @@ flag is never the thing that actually stops the run — if it is, the result
 says "kubelet's --max-pods", not "resource exhaustion", and should be
 re-run with a higher value.
 
+## gVisor access path (not needed for this benchmark)
+
+`kubectl exec`/`port-forward` straight to a `runsc`-scheduled box pod
+doesn't work — a gVisor networking characteristic, not a Containarium bug
+(kubernetes-sigs/agent-sandbox#158, this repo's #1489; see
+[`docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md`](../../docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md)
+"Hard isolation via RuntimeClass"). This benchmark only needs to know
+whether a box reached `RUNNING` — via the k8s API, which works fine
+either way — not to actually SSH into it, so `03-provision-containarium.sh`
+deliberately disables the sshpiper gateway (`gateway.namespace=""`) rather
+than standing one up for no reason. If you want to poke at a box
+afterward, re-enable the gateway per
+[`docs/KIND-QUICKSTART.md`](../../docs/KIND-QUICKSTART.md) — real
+pod-to-pod networking (which the gateway uses) is unaffected by gVisor,
+only the kubelet-mediated exec/port-forward path is.
+
 ## Fairness notes
 
-- Same physical host, same hard resource cap, same sandbox resource
-  profile, same stopping rule (`FAILURE_STREAK_TO_STOP` consecutive
-  resource-reason failures) on both sides.
-- The control group's CNI, kube-proxy, and other cluster-system pods
-  consume some of the node's capacity before a single `Sandbox` is
-  created — this is real overhead a k8s deployment actually pays, not an
-  artifact to be corrected away. It gets reported as part of the resource
-  snapshot, not subtracted from the result.
-- Containarium's own core service containers (Postgres, Caddy, the
-  otel collector, etc. — see `internal/server/core_services.go`) are the
-  equivalent fixed overhead on the experiment side, and are likewise left
-  in place and reported, not subtracted.
+- Same physical host, same hard resource cap, same base cluster setup
+  (`scripts/k8s-common.sh` — literally one script, not two hand-kept-in-sync
+  copies), same sandbox resource profile, same stopping rule
+  (`FAILURE_STREAK_TO_STOP` consecutive resource-reason failures) on both
+  sides.
+- **Documented asymmetry, not hidden:** the control group's `Sandbox`
+  pods get separate request/limit values (see the profile table below);
+  Containarium's `create --cpu/--memory` sets **both** request and limit to
+  the same (LIMIT) value — there's no separate request knob on the CLI
+  (`pkg/core/box/k8s/objects.go`). Since Kubernetes admission packs on
+  *requests*, not limits, Containarium's boxes ask the scheduler for more
+  room per unit than the control group's pods do for the same actual usage
+  ceiling. This should bias the result *against* Containarium's density,
+  not for it — worth keeping in mind reading the numbers.
+- The CNI, kube-proxy, and other cluster-system pods consume some of the
+  node's capacity before a single sandbox is created — real overhead a k8s
+  deployment actually pays on *both* sides now, not an artifact to be
+  corrected away. It gets reported as part of the resource snapshot, not
+  subtracted from the result.
+- The Containarium daemon's own pod (plus, on the experiment side only,
+  gVisor's per-pod `runsc` sandbox process overhead) is the equivalent
+  fixed cost on that side, and is likewise left in place and reported, not
+  subtracted.
 - Both density loops use the identical stopping rule and snapshot logic in
   `scripts/lib.sh`, so a methodology change (e.g. a different
   `FAILURE_STREAK_TO_STOP`) only has to be made once and applies to both
@@ -183,10 +223,11 @@ benchmark/agent-sandbox-density/
 │   └── sandbox-template.yaml    — Sandbox CR (agents.x-k8s.io/v1beta1) with the resource profile above
 └── scripts/
     ├── lib.sh                       — shared logging / resource-snapshot / stop-on-N-failures helpers
+    ├── k8s-common.sh                — shared kubeadm+CNI+agent-sandbox-controller base, used by both 01 and 03
     ├── 00-create-vm.sh              — VBoxManage: create a VM with a hard CPU/mem/disk cap
-    ├── 01-provision-k8s-control.sh  — kubeadm + CNI + raised max-pods + agent-sandbox controller
+    ├── 01-provision-k8s-control.sh  — the shared k8s base, nothing more (control group)
     ├── 02-run-density-k8s.sh        — create Sandbox CRs until the stopping rule triggers
-    ├── 03-provision-containarium.sh — containarium daemon in workhorse (LXC/Incus) mode
-    ├── 04-run-density-containarium.sh — `containarium create` until the stopping rule triggers
+    ├── 03-provision-containarium.sh — shared k8s base + gVisor/runsc RuntimeClass + Helm-installed Containarium daemon
+    ├── 04-run-density-containarium.sh — `containarium create` (pod -> gVisor -> containarium) until the stopping rule triggers
     └── 99-teardown-vm.sh            — stop + delete the VM
 ```

--- a/benchmark/agent-sandbox-density/README.md
+++ b/benchmark/agent-sandbox-density/README.md
@@ -6,32 +6,61 @@ before it runs out of room?
 
 - **Control group** — a VM running vanilla Kubernetes
   ([kubeadm](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/))
-  with the upstream
+  with gVisor installed and the upstream
   [kubernetes-sigs/agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox)
-  controller installed, creating one `Sandbox` custom resource per unit
-  directly via `kubectl` — plain `runc`, no extra sandboxing layer.
-- **Experiment group** — the *same* base Kubernetes cluster setup, plus
-  gVisor and a `runsc` `RuntimeClass`, running the Containarium daemon
+  controller running, creating one `Sandbox` custom resource per unit
+  directly via `kubectl`, its pod scheduled under a `runsc` `RuntimeClass`.
+- **Experiment group** — the *identical* base cluster (same kubeadm, same
+  gVisor install, same `RuntimeClass`), running the Containarium daemon
   (Helm chart, `--runtime=k8s`) configured to schedule every box pod under
-  it: **pod → gVisor → containarium**. Each unit is created via
-  `containarium create`, which the daemon turns into the *same* kind of
-  `Sandbox` CR the control group creates directly — the daemon uses the
-  identical upstream controller underneath (see
-  [`docs/KIND-QUICKSTART.md`](../../docs/KIND-QUICKSTART.md)). The
-  difference under test isn't "k8s vs. no k8s" — both sides run k8s — it's
-  *raw agent-sandbox pods* vs. *Containarium-orchestrated pods with an
-  added gVisor kernel boundary*.
+  that same `RuntimeClass`: **pod → gVisor → containarium**. Each unit is
+  created via `containarium create`, which the daemon turns into the
+  *same* kind of `Sandbox` CR the control group creates directly — the
+  daemon uses the identical upstream controller underneath (see
+  [`docs/KIND-QUICKSTART.md`](../../docs/KIND-QUICKSTART.md)).
 
-Both VMs get **identical hard resource caps** (CPU count, memory, disk) via
-VirtualBox, and both sandboxes get the **same sandbox resource profile**
-(see [Sandbox resource profile](#sandbox-resource-profile) below, and
+**gVisor runs on both sides on purpose** — see
+[What's actually under test](#whats-actually-under-test). Both VMs get
+**identical hard resource caps** (CPU count, memory, disk) via a KVM-backed
+Incus VM,
+and both sandboxes get the **same sandbox resource profile** (see
+[Sandbox resource profile](#sandbox-resource-profile) below, and
 [Fairness notes](#fairness-notes) for one documented asymmetry in how that
-profile is applied). The only thing that differs between the two runs is
-the orchestration layer and gVisor.
+profile is applied).
 
 This lives in-repo (rather than as a one-off gist) so the methodology is
 reviewable, the numbers are reproducible, and the scripts can be re-run
 whenever a release changes either side's footprint.
+
+## What's actually under test
+
+The obvious version of this benchmark would be "k8s vs. k8s+gVisor" — but
+that mixes two different questions into one number: *does gVisor cost
+density*, and *does Containarium's orchestration cost density*. Running
+gVisor on **both** sides removes the first question as a variable, so
+what's left to measure is narrower and more useful: given the identical
+kernel isolation boundary, what does routing sandbox creation through
+Containarium — an extra daemon hop, plus whatever resource accounting
+choices its CLI makes — actually cost, if anything, versus creating the
+same `Sandbox` CR directly?
+
+Concretely, the two things that can still differ once gVisor is held
+constant are:
+
+1. **The daemon hop.** `containarium create` → Containarium daemon →
+   `Sandbox` CR, versus `kubectl apply` → `Sandbox` CR directly. The daemon
+   itself is one extra pod's worth of fixed overhead, not a per-sandbox
+   cost — see [Fairness notes](#fairness-notes).
+2. **Request == limit.** `containarium create --cpu/--memory` sets both to
+   the same value; the control group's pods get a lower separate request.
+   Since Kubernetes admission packs on requests, this is a real,
+   per-sandbox cost multiplier — see [Fairness notes](#fairness-notes) for
+   why it should bias the result *against* Containarium, not for it.
+
+If the numbers come back close, that says Containarium's orchestration is
+close to free on top of gVisor. If they don't, the gap is attributable to
+one of the two items above, not to gVisor itself — and (2) is a fixable
+CLI gap, not an architectural one.
 
 ## Why this matters
 
@@ -50,7 +79,7 @@ If Containarium loses on density, that's a real, reportable result.
 
 ## Methodology
 
-1. Provision two VirtualBox VMs on the same physical host, one at a time
+1. Provision two Incus VMs on the same physical host, one at a time
    (see [Why sequential, not parallel](#why-sequential-not-parallel)), each
    given the **same** hard CPU/memory/disk cap.
 2. **Both VMs** get the identical base cluster (`scripts/k8s-common.sh`):
@@ -98,7 +127,7 @@ different profile, please note the profile used alongside the result in
 
 ## Hard resource caps
 
-Both VMs get the same VirtualBox-enforced hard cap, set in `config.env`:
+Both VMs get the same hard cap, set in `config.env`:
 
 ```
 VM_CPUS=<N>
@@ -106,17 +135,28 @@ VM_MEM_MB=<N>
 VM_DISK_GB=<N>
 ```
 
-`scripts/00-create-vm.sh` sets these via `VBoxManage modifyvm --cpus` /
-`--memory`, which VirtualBox enforces as a true ceiling on the guest (the
-guest OS only ever sees that much CPU/RAM — it isn't a soft cgroup limit
-inside a shared host that the guest could exceed under pressure). Pick
-values that fit comfortably within whatever's actually free on the host
-you're running on — check with `free -h` (`available`, not `free`) before
-picking a number, since some of what looks "used" may be reclaimable page
-cache. This repo intentionally does **not** hardcode a host name, IP, or
-specific machine's specs — see CLAUDE.md's anonymization convention. Fill
-in your own target host by pointing `scripts/00-create-vm.sh` at it (see
-its `--help`); it runs locally on whatever machine has VirtualBox
+`scripts/00-create-vm.sh` provisions an **Incus VM** (KVM-backed) with
+`limits.cpu`/`limits.memory` set to these — a true hardware-partitioned
+ceiling on the guest (the guest OS only ever sees that much CPU/RAM — it
+isn't a soft cgroup limit inside a shared host that the guest could exceed
+under pressure), the same guarantee a VirtualBox VM would give.
+
+**Why Incus rather than VirtualBox**, if the host already runs one: a
+second hypervisor means a second kernel module (VirtualBox's `vboxdrv`)
+loaded alongside whatever's already there. On a host already running live
+workloads under an existing KVM-based hypervisor (Incus, libvirt, etc.),
+that's an avoidable stability variable — reuse whatever hypervisor is
+already proven running on that host instead. If your host has neither, any
+KVM-backed option works the same way; the scripts just need `incus`
+(or an equivalent adapted the same way) on the host doing the provisioning.
+
+Pick values that fit comfortably within whatever's actually free on the
+host you're running on — check with `free -h` (`available`, not `free`)
+before picking a number, since some of what looks "used" may be reclaimable
+page cache. This repo intentionally does **not** hardcode a host name, IP,
+or specific machine's specs — see CLAUDE.md's anonymization convention.
+Fill in your own target host by pointing `scripts/00-create-vm.sh` at it
+(see its `--help`); it runs locally on whatever machine has Incus
 installed, so for a remote host, SSH in first and run these scripts there.
 
 ## Why sequential, not parallel
@@ -224,7 +264,7 @@ benchmark/agent-sandbox-density/
 └── scripts/
     ├── lib.sh                       — shared logging / resource-snapshot / stop-on-N-failures helpers
     ├── k8s-common.sh                — shared kubeadm+CNI+agent-sandbox-controller base, used by both 01 and 03
-    ├── 00-create-vm.sh              — VBoxManage: create a VM with a hard CPU/mem/disk cap
+    ├── 00-create-vm.sh              — Incus: create a KVM-backed VM with a hard CPU/mem/disk cap
     ├── 01-provision-k8s-control.sh  — the shared k8s base, nothing more (control group)
     ├── 02-run-density-k8s.sh        — create Sandbox CRs until the stopping rule triggers
     ├── 03-provision-containarium.sh — shared k8s base + gVisor/runsc RuntimeClass + Helm-installed Containarium daemon

--- a/benchmark/agent-sandbox-density/README.md
+++ b/benchmark/agent-sandbox-density/README.md
@@ -1,0 +1,192 @@
+# Sandbox density: k8s (agent-sandbox) vs. Containarium workhorse
+
+**Question:** given the *same* hard resource cap on the *same* class of
+machine, how many isolated agent sandboxes can each approach actually run
+before it runs out of room?
+
+- **Control group** — a VM running vanilla Kubernetes
+  ([kubeadm](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/))
+  with the upstream
+  [kubernetes-sigs/agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox)
+  controller installed, creating one `Sandbox` custom resource per unit.
+- **Experiment group** — a VM running the Containarium daemon as a plain
+  LXC/Incus "workhorse" (no Kubernetes at all), creating one box per unit via
+  `containarium create`.
+
+Both VMs get **identical hard resource caps** (CPU count, memory, disk) via
+VirtualBox, and both sandboxes get **identical CPU/memory request+limit
+values** (see [Sandbox resource profile](#sandbox-resource-profile) below).
+The only thing that differs between the two runs is the orchestration layer.
+
+This lives in-repo (rather than as a one-off gist) so the methodology is
+reviewable, the numbers are reproducible, and the scripts can be re-run
+whenever a release changes either side's footprint.
+
+## Why this matters
+
+Containarium's pitch has always been *blast-radius*, not raw density — see
+[docs/AX-COMPARISON.md](../../docs/AX-COMPARISON.md) and
+[docs/product/agent-substrate-roadmap-position.md](../../docs/product/agent-substrate-roadmap-position.md).
+This benchmark exists to find out, honestly, whether that security posture
+also happens to come with a density cost, a density win, or a wash — and to
+have a number instead of a guess the next time the question comes up.
+
+**We are not trying to make k8s look bad.** The control group runs vanilla
+`kubeadm` (not a slimmed-down edge distro) specifically so the comparison is
+against what most people actually run, and both sides get the fairest
+resource accounting we can manage (see [Fairness notes](#fairness-notes)).
+If Containarium loses on density, that's a real, reportable result.
+
+## Methodology
+
+1. Provision two VirtualBox VMs on the same physical host, one at a time
+   (see [Why sequential, not parallel](#why-sequential-not-parallel)), each
+   given the **same** hard CPU/memory/disk cap.
+2. **Control VM:** install `kubeadm` + a CNI, raise the kubelet
+   `--max-pods` ceiling (the stock default of 110 would cap density before
+   any real resource limit does — see
+   [Kubelet max-pods](#kubelet-max-pods)), then install the upstream
+   agent-sandbox controller and CRDs.
+3. **Experiment VM:** install the Containarium daemon in its default
+   LXC/Incus "workhorse" mode (no `--runtime=k8s` — that backend targets
+   *existing* clusters, it isn't what we're measuring here).
+4. Run the matching density-loop script against each VM: create sandboxes
+   one at a time with the fixed resource profile below, wait for each to
+   reach a ready state, and keep going until creation starts failing for a
+   resource reason (not a transient/config reason) for
+   `FAILURE_STREAK_TO_STOP` consecutive attempts (default 3 — see
+   `scripts/lib.sh`).
+5. Record the final count plus a resource snapshot (host `free -h`,
+   `nproc`, disk usage, and either `kubectl top nodes` or
+   `containarium list` resource totals) at the stopping point.
+6. Tear the VM down, repeat for the other side.
+
+Results get appended to [`RESULTS.md`](RESULTS.md) as an actual run
+happens — this PR ships the plan and the scripts; a follow-up records
+numbers once the benchmark has actually been executed.
+
+## Sandbox resource profile
+
+Deliberately a **fresh, minimal profile** — not a reuse of Containarium's
+own built-in per-box memory floor (`256Mi` request / `1Gi` limit, see
+`pkg/core/box/k8s/objects.go`) and not a reuse of any specific customer
+workload shape. The goal here is a density *ceiling*, not a realistic
+workload simulation:
+
+| Resource | Request | Limit |
+|---|---|---|
+| CPU | `100m` | `200m` |
+| Memory | `128Mi` | `256Mi` |
+
+Both values are overridable via `config.env` (see
+[`config.env.example`](config.env.example)) — if you re-run this against a
+different profile, please note the profile used alongside the result in
+`RESULTS.md` rather than overwriting the default row.
+
+## Hard resource caps
+
+Both VMs get the same VirtualBox-enforced hard cap, set in `config.env`:
+
+```
+VM_CPUS=<N>
+VM_MEM_MB=<N>
+VM_DISK_GB=<N>
+```
+
+`scripts/00-create-vm.sh` sets these via `VBoxManage modifyvm --cpus` /
+`--memory`, which VirtualBox enforces as a true ceiling on the guest (the
+guest OS only ever sees that much CPU/RAM — it isn't a soft cgroup limit
+inside a shared host that the guest could exceed under pressure). Pick
+values that fit comfortably within whatever's actually free on the host
+you're running on — check with `free -h` (`available`, not `free`) before
+picking a number, since some of what looks "used" may be reclaimable page
+cache. This repo intentionally does **not** hardcode a host name, IP, or
+specific machine's specs — see CLAUDE.md's anonymization convention. Fill
+in your own target host by pointing `scripts/00-create-vm.sh` at it (see
+its `--help`); it runs locally on whatever machine has VirtualBox
+installed, so for a remote host, SSH in first and run these scripts there.
+
+## Why sequential, not parallel
+
+Both VMs get the *same* hard resource cap, sized against what's actually
+free on the host. Running them side by side would mean each VM's real cap
+is the full amount, but the *host's* free capacity is split between them —
+which either forces you to halve each VM's cap (comparing two smaller
+environments, not the one you meant to compare) or overcommits the host
+(letting one run's cache pressure quietly steal from the other, which
+breaks the "hard cap" premise this whole benchmark rests on). Running one
+VM fully, tearing it down, then running the other keeps each side's
+measurement honest against the *same* full-sized cap.
+
+## Kubelet max-pods
+
+Stock kubelet defaults to `--max-pods=110` regardless of actual node
+capacity — a density benchmark that leaves this at the default is measuring
+the default, not the resource ceiling. `scripts/01-provision-k8s-control.sh`
+raises it explicitly (see `K8S_MAX_PODS` in `config.env`); pick a number
+comfortably above what you expect the memory/CPU cap to allow so the kubelet
+flag is never the thing that actually stops the run — if it is, the result
+says "kubelet's --max-pods", not "resource exhaustion", and should be
+re-run with a higher value.
+
+## Fairness notes
+
+- Same physical host, same hard resource cap, same sandbox resource
+  profile, same stopping rule (`FAILURE_STREAK_TO_STOP` consecutive
+  resource-reason failures) on both sides.
+- The control group's CNI, kube-proxy, and other cluster-system pods
+  consume some of the node's capacity before a single `Sandbox` is
+  created — this is real overhead a k8s deployment actually pays, not an
+  artifact to be corrected away. It gets reported as part of the resource
+  snapshot, not subtracted from the result.
+- Containarium's own core service containers (Postgres, Caddy, the
+  otel collector, etc. — see `internal/server/core_services.go`) are the
+  equivalent fixed overhead on the experiment side, and are likewise left
+  in place and reported, not subtracted.
+- Both density loops use the identical stopping rule and snapshot logic in
+  `scripts/lib.sh`, so a methodology change (e.g. a different
+  `FAILURE_STREAK_TO_STOP`) only has to be made once and applies to both
+  sides.
+
+## Running it
+
+```sh
+cp config.env.example config.env
+# edit config.env: VM_CPUS, VM_MEM_MB, VM_DISK_GB, and (optionally) the
+# sandbox resource profile / K8S_MAX_PODS / FAILURE_STREAK_TO_STOP
+
+# Control group
+scripts/00-create-vm.sh --name sandbox-bench-control
+scripts/01-provision-k8s-control.sh --name sandbox-bench-control
+scripts/02-run-density-k8s.sh --name sandbox-bench-control
+scripts/99-teardown-vm.sh --name sandbox-bench-control
+
+# Experiment group
+scripts/00-create-vm.sh --name sandbox-bench-containarium
+scripts/03-provision-containarium.sh --name sandbox-bench-containarium
+scripts/04-run-density-containarium.sh --name sandbox-bench-containarium
+scripts/99-teardown-vm.sh --name sandbox-bench-containarium
+```
+
+Each density script writes a timestamped results file under `results/`
+(gitignored — see `RESULTS.md` for the reviewed/committed summary format)
+and prints a one-line summary at the end.
+
+## Layout
+
+```
+benchmark/agent-sandbox-density/
+├── README.md                    — this file
+├── config.env.example           — copy to config.env, fill in your host's numbers
+├── RESULTS.md                   — reviewed summary of actual runs (template for now)
+├── manifests/
+│   └── sandbox-template.yaml    — Sandbox CR (agents.x-k8s.io/v1beta1) with the resource profile above
+└── scripts/
+    ├── lib.sh                       — shared logging / resource-snapshot / stop-on-N-failures helpers
+    ├── 00-create-vm.sh              — VBoxManage: create a VM with a hard CPU/mem/disk cap
+    ├── 01-provision-k8s-control.sh  — kubeadm + CNI + raised max-pods + agent-sandbox controller
+    ├── 02-run-density-k8s.sh        — create Sandbox CRs until the stopping rule triggers
+    ├── 03-provision-containarium.sh — containarium daemon in workhorse (LXC/Incus) mode
+    ├── 04-run-density-containarium.sh — `containarium create` until the stopping rule triggers
+    └── 99-teardown-vm.sh            — stop + delete the VM
+```

--- a/benchmark/agent-sandbox-density/README.md
+++ b/benchmark/agent-sandbox-density/README.md
@@ -214,6 +214,18 @@ only the kubelet-mediated exec/port-forward path is.
   room per unit than the control group's pods do for the same actual usage
   ceiling. This should bias the result *against* Containarium's density,
   not for it — worth keeping in mind reading the numbers.
+- **Different container images, and it's not a knob to equalize.** The
+  control group's `Sandbox` pods run a minimal `busybox:1.36`. Found live
+  that a Containarium box can't: `create`'s default image
+  (`images:ubuntu/24.04`, an LXC-style reference) isn't a valid OCI image
+  and breaks the pod outright (`InvalidImageName`) on the k8s backend, and
+  a bare `busybox` in its place crash-loops — Containarium's box runtime
+  expects its own `containarium-agent-box` image (podman-in-pod, sshd,
+  MCP server). So the experiment side runs that real, heavier image
+  instead. This is a genuine, structural difference in what each side
+  actually deploys, not a methodology gap to correct away — a Containarium
+  box IS that runtime, by product design. It gets reported (image name in
+  each run's results file), not normalized.
 - The CNI, kube-proxy, and other cluster-system pods consume some of the
   node's capacity before a single sandbox is created — real overhead a k8s
   deployment actually pays on *both* sides now, not an artifact to be

--- a/benchmark/agent-sandbox-density/RESULTS.md
+++ b/benchmark/agent-sandbox-density/RESULTS.md
@@ -6,7 +6,66 @@ timestamped file per run; see `scripts/lib.sh`'s `resource_snapshot` /
 `run_density_loop`). Copy the relevant numbers here once a run is complete
 and worth keeping as a reference point.
 
-No runs have been executed yet — this PR ships the plan and the scripts.
+### 2026-08-23 — bare-metal, AMD Ryzen 9 5900X (12c/24t), 125GB RAM host
+
+Hard cap per VM: 8 vCPU / 48GiB RAM / 200GB disk (Incus KVM VM)
+Sandbox profile: cpu 100m/200m, mem 128Mi/256Mi (control); cpu 200m mem 256Mi request==limit (Containarium — see "Fairness notes")
+Containarium version: v0.66.0    Agent-sandbox version: v0.5.1    K8s version: v1.30.14 (kubeadm)
+Both groups ran under the same `runsc` (gVisor) RuntimeClass — see README.md "What's actually under test".
+
+| | k8s + agent-sandbox (control) | Containarium (experiment) |
+|---|---|---|
+| Sandboxes reached Ready/RUNNING | **69** | **34** |
+| Attempted (incl. failures) | 72 | 37 |
+| Node CPU requests at stop | 8000m / 8000m (**100%**) | 7900m / 8000m (**98%**) |
+| Node memory at stop | 18% | 18% |
+| Wall-clock for the density loop | ~7 min | ~5 min |
+| Image | `busybox:1.36` | `containarium-agent-box:v0.66.0` (see "Fairness notes" — required, not a choice) |
+
+**Both sides were CPU-request-bound, not memory-bound** — memory sat at
+18% on both when the stopping rule triggered; the ceiling in both cases
+was Kubernetes CPU admission, confirmed via `kubectl describe node`
+"Allocated resources" at the stopping point.
+
+**The ~2x gap tracks the CPU-request asymmetry almost exactly, not
+gVisor.** Containarium's boxes request 200m each (`create --cpu/--memory`
+sets request==limit, no separate request knob); the control group's pods
+request only 100m each (limit 200m). 69 × 100m ≈ 6900m + ~1100m system
+overhead ≈ 8000m (100%); 34 × 200m = 6800m + similar system overhead ≈
+7900m (98%). Halving the control group's count (69/2 ≈ 34.5) lands almost
+exactly on Containarium's actual result (34) — consistent with the
+documented prediction in README.md's "Fairness notes" that this asymmetry
+should roughly halve Containarium's density, independent of gVisor.
+
+**gVisor confirmed live on every unit, both sides** — `uname -r` inside a
+sample pod from each group returned `4.19.0-gvisor`; the post-run
+"pods by RuntimeClass" snapshot in each run's raw log
+(`results/*.md`, gitignored) shows every `sbdens-*`/`box` pod scheduled
+under `runsc`.
+
+Notes / anomalies:
+- This was the first real end-to-end run of these scripts and surfaced
+  (and fixed, in earlier commits on this PR) several real bugs along the
+  way: the base VM image ships without sshd/cloud-init; a `kubectl wait`
+  race on Calico pods; gVisor registered under the wrong containerd
+  plugin ID on containerd v2.x; `jq`/`git` missing from the base image;
+  a Helm chart bug where `gateway.namespace=""` breaks install outright;
+  `create`'s default `--image` isn't valid on the k8s backend
+  (filed [#1524](https://github.com/FootprintAI/Containarium/issues/1524));
+  and `containarium list` is entirely broken on the k8s backend
+  (filed [#1525](https://github.com/FootprintAI/Containarium/issues/1525)).
+  The chart bug is filed as [#1526](https://github.com/FootprintAI/Containarium/issues/1526).
+  None of these affect the validity of the numbers above — all were
+  provisioning-time or CLI-ergonomics issues, worked around before the
+  density loops ran — but they're worth fixing upstream regardless of
+  this benchmark.
+- `kubectl top nodes` was unavailable (no metrics-server installed) — CPU
+  request/limit accounting from `kubectl describe node` was used instead,
+  which is what actually gates scheduling anyway.
+- Neither side hit the sandbox-resource-profile's *memory* limit at all;
+  a re-run with a much higher `VM_CPUS` (see README.md's estimation
+  discussion) would more directly isolate gVisor's own per-pod cost from
+  the CPU-admission ceiling, since CPU is the bottleneck at this VM size.
 
 ## Template
 

--- a/benchmark/agent-sandbox-density/RESULTS.md
+++ b/benchmark/agent-sandbox-density/RESULTS.md
@@ -1,0 +1,28 @@
+# Results
+
+This file holds the reviewed, committed summary of actual benchmark runs —
+not the raw per-run logs (those land under `results/`, gitignored, one
+timestamped file per run; see `scripts/lib.sh`'s `resource_snapshot` /
+`run_density_loop`). Copy the relevant numbers here once a run is complete
+and worth keeping as a reference point.
+
+No runs have been executed yet — this PR ships the plan and the scripts.
+
+## Template
+
+```
+### <date> — <host spec: CPU model, cores, RAM>
+
+Hard cap per VM: <VM_CPUS> vCPU / <VM_MEM_MB>MB RAM / <VM_DISK_GB>GB disk
+Sandbox profile: cpu <SANDBOX_CPU_REQUEST>/<SANDBOX_CPU_LIMIT>, mem <SANDBOX_MEM_REQUEST>/<SANDBOX_MEM_LIMIT>
+Containarium version: <tag>    Agent-sandbox version: <tag>    K8s version: <kubeadm version>
+
+| | k8s + agent-sandbox | Containarium workhorse |
+|---|---|---|
+| Sandboxes reached Ready/RUNNING | | |
+| Attempted (incl. failures) | | |
+| Wall-clock for the run | | |
+| Fixed overhead before sandbox #1 (kube-system pods / core containers) | | |
+
+Notes / anomalies:
+```

--- a/benchmark/agent-sandbox-density/config.env.example
+++ b/benchmark/agent-sandbox-density/config.env.example
@@ -4,11 +4,13 @@
 
 # --- VM hard resource caps (both VMs must use the SAME values — see
 #     README.md "Why sequential, not parallel") -----------------------------
+# Incus VMs (KVM-backed) — see README.md "Hard resource caps" for why
+# Incus rather than VirtualBox. limits.cpu/limits.memory are a true
+# hardware-partitioned ceiling, same guarantee a VirtualBox VM would give.
 VM_CPUS=8
 VM_MEM_MB=49152          # 48 GiB
 VM_DISK_GB=200
-VM_BASE_ISO=""           # path to an Ubuntu Server 24.04 install ISO, or a
-                          # pre-built base .vdi/.vmdk to clone from — fill in
+INCUS_IMAGE="images:ubuntu/24.04"  # stock cloud image, no manual OS install needed
 
 # --- Sandbox resource profile (see README.md "Sandbox resource profile") --
 # k8s-native quantities (Kubernetes' resource.ParseQuantity accepts these
@@ -23,24 +25,30 @@ SANDBOX_MEM_LIMIT="256Mi"
 # both. This is a documented, deliberate asymmetry vs. the control group's
 # lower REQUEST — see README.md "Fairness notes".
 
-# --- Shared k8s base (both groups — see scripts/k8s-common.sh) ------------
+# --- Shared k8s base (BOTH groups, including gVisor — see
+#     scripts/k8s-common.sh and README.md "What's actually under test") ---
 K8S_MAX_PODS=1024         # comfortably above what the resource cap should allow
 AGENT_SANDBOX_VERSION="v0.5.1"   # kubernetes-sigs/agent-sandbox release tag
+GVISOR_RUNTIME_CLASS="runsc"     # standard gVisor RuntimeClass handler name;
+                                  # used by BOTH sides — gVisor is deliberately
+                                  # not the variable under test, Containarium is
 
 # --- Experiment group (Containarium, pod -> gVisor -> containarium) -------
 CONTAINARIUM_VERSION="latest"    # FootprintAI/Containarium release tag, or "latest"
-GVISOR_RUNTIME_CLASS="runsc"     # standard gVisor RuntimeClass handler name
 
 # --- Stopping rule (shared by both density loops, scripts/lib.sh) ---------
 FAILURE_STREAK_TO_STOP=3  # consecutive resource-reason failures before stopping
 CREATE_TIMEOUT_SECONDS=60 # per-unit timeout waiting for Ready before counting it a failure
 
 # --- SSH target for the guest under test ------------------------------
-# Defaults match 00-create-vm.sh's NAT port-forward (ssh -p 2222 into the
-# VM from the same machine running VirtualBox). Point REMOTE_HOST at a
-# different address if you're driving these scripts from your own
-# workstation against a VM/host reachable some other way. Leave REMOTE_HOST
-# empty only if you're running these scripts from inside the guest itself.
-REMOTE_HOST="127.0.0.1"
-REMOTE_SSH_PORT="2222"
+# REMOTE_HOST/REMOTE_SSH_PORT are resolved dynamically per VM by
+# scripts/lib.sh's resolve_remote() (Incus VMs get a DHCP-assigned IP, not
+# a fixed port) — nothing to fill in here for those. REMOTE_SSH_USER is the
+# cloud-init default user for the Ubuntu cloud image. BENCH_SSH_PUBKEY_FILE
+# / BENCH_SSH_KEY_FILE are the host->guest keypair 00-create-vm.sh injects
+# via cloud-init and every other script authenticates with — generate one
+# dedicated to this benchmark rather than reusing your own:
+#   ssh-keygen -t ed25519 -N '' -f ~/.ssh/containarium_bench_ed25519
 REMOTE_SSH_USER="ubuntu"
+BENCH_SSH_PUBKEY_FILE="$HOME/.ssh/containarium_bench_ed25519.pub"
+BENCH_SSH_KEY_FILE="$HOME/.ssh/containarium_bench_ed25519"

--- a/benchmark/agent-sandbox-density/config.env.example
+++ b/benchmark/agent-sandbox-density/config.env.example
@@ -1,0 +1,44 @@
+# Copy to config.env (gitignored) and fill in for your target host.
+# Do NOT commit config.env with a real hostname/IP in it — this directory
+# ships in the OSS repo. See CLAUDE.md's anonymization convention.
+
+# --- VM hard resource caps (both VMs must use the SAME values — see
+#     README.md "Why sequential, not parallel") -----------------------------
+VM_CPUS=8
+VM_MEM_MB=49152          # 48 GiB
+VM_DISK_GB=200
+VM_BASE_ISO=""           # path to an Ubuntu Server 24.04 install ISO, or a
+                          # pre-built base .vdi/.vmdk to clone from — fill in
+
+# --- Sandbox resource profile (see README.md "Sandbox resource profile") --
+SANDBOX_CPU_REQUEST="100m"
+SANDBOX_CPU_LIMIT="200m"
+SANDBOX_MEM_REQUEST="128Mi"
+SANDBOX_MEM_LIMIT="256Mi"
+# LXC boxes (Containarium side) have one enforced ceiling, not a
+# request+limit pair — 04-run-density-containarium.sh uses the LIMIT
+# values above for --cpu/--memory. Disk has no k8s-side equivalent at all,
+# so it's set separately, deliberately small so disk is never what stops
+# the run (we're measuring CPU/memory density, not disk).
+SANDBOX_DISK_LIMIT="1GB"
+
+# --- Control group (k8s) ---------------------------------------------------
+K8S_MAX_PODS=1024         # comfortably above what the resource cap should allow
+AGENT_SANDBOX_VERSION="v0.5.1"   # kubernetes-sigs/agent-sandbox release tag
+
+# --- Experiment group (Containarium) ---------------------------------------
+CONTAINARIUM_VERSION="latest"    # FootprintAI/Containarium release tag, or "latest"
+
+# --- Stopping rule (shared by both density loops, scripts/lib.sh) ---------
+FAILURE_STREAK_TO_STOP=3  # consecutive resource-reason failures before stopping
+CREATE_TIMEOUT_SECONDS=60 # per-unit timeout waiting for Ready before counting it a failure
+
+# --- SSH target for the guest under test ------------------------------
+# Defaults match 00-create-vm.sh's NAT port-forward (ssh -p 2222 into the
+# VM from the same machine running VirtualBox). Point REMOTE_HOST at a
+# different address if you're driving these scripts from your own
+# workstation against a VM/host reachable some other way. Leave REMOTE_HOST
+# empty only if you're running these scripts from inside the guest itself.
+REMOTE_HOST="127.0.0.1"
+REMOTE_SSH_PORT="2222"
+REMOTE_SSH_USER="ubuntu"

--- a/benchmark/agent-sandbox-density/config.env.example
+++ b/benchmark/agent-sandbox-density/config.env.example
@@ -11,23 +11,25 @@ VM_BASE_ISO=""           # path to an Ubuntu Server 24.04 install ISO, or a
                           # pre-built base .vdi/.vmdk to clone from — fill in
 
 # --- Sandbox resource profile (see README.md "Sandbox resource profile") --
+# k8s-native quantities (Kubernetes' resource.ParseQuantity accepts these
+# directly, on both sides — see 04-run-density-containarium.sh).
 SANDBOX_CPU_REQUEST="100m"
 SANDBOX_CPU_LIMIT="200m"
 SANDBOX_MEM_REQUEST="128Mi"
 SANDBOX_MEM_LIMIT="256Mi"
-# LXC boxes (Containarium side) have one enforced ceiling, not a
-# request+limit pair — 04-run-density-containarium.sh uses the LIMIT
-# values above for --cpu/--memory. Disk has no k8s-side equivalent at all,
-# so it's set separately, deliberately small so disk is never what stops
-# the run (we're measuring CPU/memory density, not disk).
-SANDBOX_DISK_LIMIT="1GB"
+# Containarium's `create --cpu/--memory` sets BOTH request and limit to a
+# single value (pkg/core/box/k8s/objects.go) — no separate request/limit
+# knob. 04-run-density-containarium.sh uses the LIMIT values above for
+# both. This is a documented, deliberate asymmetry vs. the control group's
+# lower REQUEST — see README.md "Fairness notes".
 
-# --- Control group (k8s) ---------------------------------------------------
+# --- Shared k8s base (both groups — see scripts/k8s-common.sh) ------------
 K8S_MAX_PODS=1024         # comfortably above what the resource cap should allow
 AGENT_SANDBOX_VERSION="v0.5.1"   # kubernetes-sigs/agent-sandbox release tag
 
-# --- Experiment group (Containarium) ---------------------------------------
+# --- Experiment group (Containarium, pod -> gVisor -> containarium) -------
 CONTAINARIUM_VERSION="latest"    # FootprintAI/Containarium release tag, or "latest"
+GVISOR_RUNTIME_CLASS="runsc"     # standard gVisor RuntimeClass handler name
 
 # --- Stopping rule (shared by both density loops, scripts/lib.sh) ---------
 FAILURE_STREAK_TO_STOP=3  # consecutive resource-reason failures before stopping

--- a/benchmark/agent-sandbox-density/manifests/sandbox-template.yaml
+++ b/benchmark/agent-sandbox-density/manifests/sandbox-template.yaml
@@ -1,7 +1,11 @@
 # Sandbox CR template for the density benchmark (kubernetes-sigs/agent-sandbox,
 # agents.x-k8s.io/v1beta1). scripts/02-run-density-k8s.sh substitutes
-# __NAME__ and the resource placeholders with envsubst before `kubectl apply
-# -f -`; see config.env.example for the values.
+# __NAME__ and the resource placeholders with sed before `kubectl apply -f
+# -`; see config.env.example for the values.
+#
+# runtimeClassName is set here too — this benchmark runs BOTH sides under
+# gVisor deliberately, so gVisor itself isn't a variable in the comparison;
+# see README.md "What's actually under test".
 #
 # Deliberately minimal — no volumes, no extensions, a single small container
 # — this benchmark measures orchestration overhead, not any particular
@@ -16,6 +20,7 @@ metadata:
 spec:
   podTemplate:
     spec:
+      runtimeClassName: __GVISOR_RUNTIME_CLASS__
       containers:
         - name: sandbox
           image: busybox:1.36

--- a/benchmark/agent-sandbox-density/manifests/sandbox-template.yaml
+++ b/benchmark/agent-sandbox-density/manifests/sandbox-template.yaml
@@ -1,0 +1,30 @@
+# Sandbox CR template for the density benchmark (kubernetes-sigs/agent-sandbox,
+# agents.x-k8s.io/v1beta1). scripts/02-run-density-k8s.sh substitutes
+# __NAME__ and the resource placeholders with envsubst before `kubectl apply
+# -f -`; see config.env.example for the values.
+#
+# Deliberately minimal — no volumes, no extensions, a single small container
+# — this benchmark measures orchestration overhead, not any particular
+# sandbox image's footprint.
+apiVersion: agents.x-k8s.io/v1beta1
+kind: Sandbox
+metadata:
+  name: __NAME__
+  namespace: sandbox-density-bench
+  labels:
+    benchmark: agent-sandbox-density
+spec:
+  podTemplate:
+    spec:
+      containers:
+        - name: sandbox
+          image: busybox:1.36
+          command: ["sleep", "infinity"]
+          resources:
+            requests:
+              cpu: "__SANDBOX_CPU_REQUEST__"
+              memory: "__SANDBOX_MEM_REQUEST__"
+            limits:
+              cpu: "__SANDBOX_CPU_LIMIT__"
+              memory: "__SANDBOX_MEM_LIMIT__"
+      restartPolicy: Never

--- a/benchmark/agent-sandbox-density/scripts/00-create-vm.sh
+++ b/benchmark/agent-sandbox-density/scripts/00-create-vm.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+#
+# Create a VirtualBox VM with a hard CPU/memory/disk cap for the
+# sandbox-density benchmark. VirtualBox enforces --cpus/--memory as a true
+# ceiling on the guest (not a soft/advisory limit), which is the point —
+# see README.md "Hard resource caps".
+#
+# Two supported base-image paths, controlled by VM_BASE_ISO in config.env:
+#   - a .vdi/.vmdk disk image  -> cloned per run (fast, repeatable — the
+#     recommended path: prepare one base Ubuntu Server 24.04 image once,
+#     out of band, then run this script fresh for every benchmark run)
+#   - a .iso installer image   -> attached for a manual/interactive install;
+#     this script starts the VM and returns, it does not automate the
+#     installer
+#
+# Runs locally on whatever machine has VirtualBox installed. For a remote
+# host, SSH in yourself and run this script there — it deliberately does
+# not embed a remote host name (see CLAUDE.md's anonymization convention);
+# config.env's REMOTE_HOST is used by the *provisioning* scripts (01/03),
+# which SSH into the guest, not by this one, which needs to run where
+# VBoxManage actually is.
+#
+# Usage:
+#   scripts/00-create-vm.sh --name <vm-name>
+
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+# shellcheck source=lib.sh
+source ./lib.sh
+
+VM_NAME=""
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--name)
+		VM_NAME="$2"
+		shift 2
+		;;
+	-h | --help)
+		grep '^#' "$0" | sed 's/^# \{0,1\}//'
+		exit 0
+		;;
+	*)
+		die "unknown argument: $1"
+		;;
+	esac
+done
+[[ -n "$VM_NAME" ]] || die "usage: $0 --name <vm-name>"
+
+load_config
+require_vars VM_CPUS VM_MEM_MB VM_DISK_GB VM_BASE_ISO
+
+command -v VBoxManage >/dev/null 2>&1 || die "VBoxManage not found — install VirtualBox on this machine first"
+
+if VBoxManage list vms | grep -q "\"${VM_NAME}\""; then
+	die "a VM named '${VM_NAME}' already exists — run 99-teardown-vm.sh first, or pick a different --name"
+fi
+
+log "creating VM '${VM_NAME}' (cpus=${VM_CPUS} mem=${VM_MEM_MB}MB disk=${VM_DISK_GB}GB)"
+VBoxManage createvm --name "$VM_NAME" --ostype Ubuntu_64 --register
+
+VBoxManage modifyvm "$VM_NAME" \
+	--cpus "$VM_CPUS" \
+	--memory "$VM_MEM_MB" \
+	--nic1 nat \
+	--natpf1 "ssh,tcp,,2222,,22" \
+	--audio none \
+	--usb off
+
+VBoxManage storagectl "$VM_NAME" --name SATA --add sata --controller IntelAHCI
+
+DISK_PATH="$HOME/VirtualBox VMs/${VM_NAME}/${VM_NAME}.vdi"
+
+case "$VM_BASE_ISO" in
+*.vdi | *.vmdk)
+	log "cloning base image ${VM_BASE_ISO} -> ${DISK_PATH}"
+	VBoxManage clonemedium disk "$VM_BASE_ISO" "$DISK_PATH" --format VDI
+	VBoxManage modifymedium disk "$DISK_PATH" --resize $((VM_DISK_GB * 1024))
+	VBoxManage storageattach "$VM_NAME" --storagectl SATA --port 0 --device 0 --type hdd --medium "$DISK_PATH"
+	VBoxManage startvm "$VM_NAME" --type headless
+	log "VM '${VM_NAME}' started from cloned base image. SSH: ssh -p 2222 <user>@127.0.0.1"
+	;;
+*.iso)
+	log "creating a fresh ${VM_DISK_GB}GB disk and attaching installer ISO ${VM_BASE_ISO}"
+	VBoxManage createmedium disk --filename "$DISK_PATH" --size $((VM_DISK_GB * 1024)) --format VDI
+	VBoxManage storageattach "$VM_NAME" --storagectl SATA --port 0 --device 0 --type hdd --medium "$DISK_PATH"
+	VBoxManage storagectl "$VM_NAME" --name IDE --add ide
+	VBoxManage storageattach "$VM_NAME" --storagectl IDE --port 0 --device 0 --type dvddrive --medium "$VM_BASE_ISO"
+	VBoxManage startvm "$VM_NAME" --type headless
+	log "VM '${VM_NAME}' started with the installer ISO attached — complete the OS install manually" \
+		"(VBoxManage startvm ${VM_NAME} --type gui to see the console), then re-run without --type headless" \
+		"disabled, or just rerun the density scripts once SSH on port 2222 is reachable."
+	;;
+*)
+	die "VM_BASE_ISO must end in .vdi, .vmdk, or .iso — got '${VM_BASE_ISO}'"
+	;;
+esac
+
+log "done. Verify with: VBoxManage showvminfo '${VM_NAME}' | grep -E 'Memory size|Number of CPUs'"

--- a/benchmark/agent-sandbox-density/scripts/00-create-vm.sh
+++ b/benchmark/agent-sandbox-density/scripts/00-create-vm.sh
@@ -1,24 +1,21 @@
 #!/bin/bash
 #
-# Create a VirtualBox VM with a hard CPU/memory/disk cap for the
-# sandbox-density benchmark. VirtualBox enforces --cpus/--memory as a true
-# ceiling on the guest (not a soft/advisory limit), which is the point —
-# see README.md "Hard resource caps".
+# Create an Incus VM with a hard CPU/memory/disk cap for the
+# sandbox-density benchmark. Incus VMs are KVM-backed — limits.cpu /
+# limits.memory are a true hardware-partitioned ceiling on the guest, the
+# same guarantee a VirtualBox VM would give (see README.md "Hard resource
+# caps"). Uses Incus rather than VirtualBox deliberately: running a second
+# hypervisor's kernel module (vboxdrv) alongside an already-live KVM/Incus
+# host is an avoidable stability risk, and Incus already provides the same
+# hard-cap guarantee on a stack that's already proven on this class of
+# host.
 #
-# Two supported base-image paths, controlled by VM_BASE_ISO in config.env:
-#   - a .vdi/.vmdk disk image  -> cloned per run (fast, repeatable — the
-#     recommended path: prepare one base Ubuntu Server 24.04 image once,
-#     out of band, then run this script fresh for every benchmark run)
-#   - a .iso installer image   -> attached for a manual/interactive install;
-#     this script starts the VM and returns, it does not automate the
-#     installer
+# Boots a stock cloud image (images:ubuntu/24.04) with a generated SSH
+# keypair injected via cloud-init — no manual OS install step needed.
 #
-# Runs locally on whatever machine has VirtualBox installed. For a remote
-# host, SSH in yourself and run this script there — it deliberately does
-# not embed a remote host name (see CLAUDE.md's anonymization convention);
-# config.env's REMOTE_HOST is used by the *provisioning* scripts (01/03),
-# which SSH into the guest, not by this one, which needs to run where
-# VBoxManage actually is.
+# Runs locally on whatever machine has Incus installed. For a remote host,
+# SSH in yourself and run this script there — it deliberately does not
+# embed a remote host name (see CLAUDE.md's anonymization convention).
 #
 # Usage:
 #   scripts/00-create-vm.sh --name <vm-name>
@@ -47,52 +44,41 @@ done
 [[ -n "$VM_NAME" ]] || die "usage: $0 --name <vm-name>"
 
 load_config
-require_vars VM_CPUS VM_MEM_MB VM_DISK_GB VM_BASE_ISO
+require_vars VM_CPUS VM_MEM_MB VM_DISK_GB INCUS_IMAGE BENCH_SSH_PUBKEY_FILE
 
-command -v VBoxManage >/dev/null 2>&1 || die "VBoxManage not found — install VirtualBox on this machine first"
+command -v incus >/dev/null 2>&1 || die "incus not found — this must run on the hypervisor host"
+[[ -f "$BENCH_SSH_PUBKEY_FILE" ]] || die "BENCH_SSH_PUBKEY_FILE ($BENCH_SSH_PUBKEY_FILE) not found — generate a host->guest keypair first: ssh-keygen -t ed25519 -N '' -f <path>"
 
-if VBoxManage list vms | grep -q "\"${VM_NAME}\""; then
+if sudo incus list --format csv -c n | grep -qx "$VM_NAME"; then
 	die "a VM named '${VM_NAME}' already exists — run 99-teardown-vm.sh first, or pick a different --name"
 fi
 
-log "creating VM '${VM_NAME}' (cpus=${VM_CPUS} mem=${VM_MEM_MB}MB disk=${VM_DISK_GB}GB)"
-VBoxManage createvm --name "$VM_NAME" --ostype Ubuntu_64 --register
+PUBKEY=$(cat "$BENCH_SSH_PUBKEY_FILE")
 
-VBoxManage modifyvm "$VM_NAME" \
-	--cpus "$VM_CPUS" \
-	--memory "$VM_MEM_MB" \
-	--nic1 nat \
-	--natpf1 "ssh,tcp,,2222,,22" \
-	--audio none \
-	--usb off
+log "creating Incus VM '${VM_NAME}' (cpus=${VM_CPUS} mem=${VM_MEM_MB}MiB disk=${VM_DISK_GB}GB, image=${INCUS_IMAGE})"
+sudo incus launch "$INCUS_IMAGE" "$VM_NAME" --vm \
+	-c limits.cpu="$VM_CPUS" \
+	-c limits.memory="${VM_MEM_MB}MiB" \
+	-d root,size="${VM_DISK_GB}GB" \
+	-c cloud-init.user-data="#cloud-config
+ssh_authorized_keys:
+  - ${PUBKEY}
+package_update: true
+"
 
-VBoxManage storagectl "$VM_NAME" --name SATA --add sata --controller IntelAHCI
+log "waiting for the VM to get an IP and become SSH-reachable"
+IP=""
+for _ in $(seq 1 60); do
+	IP=$(sudo incus list "$VM_NAME" -c 4 --format csv 2>/dev/null | grep -oE '^[0-9.]+' || true)
+	[[ -n "$IP" ]] && break
+	sleep 3
+done
+[[ -n "$IP" ]] || die "VM '${VM_NAME}' never got an IP — check 'incus console ${VM_NAME}'"
 
-DISK_PATH="$HOME/VirtualBox VMs/${VM_NAME}/${VM_NAME}.vdi"
+for _ in $(seq 1 30); do
+	nc -z -w2 "$IP" 22 2>/dev/null && break
+	sleep 3
+done
 
-case "$VM_BASE_ISO" in
-*.vdi | *.vmdk)
-	log "cloning base image ${VM_BASE_ISO} -> ${DISK_PATH}"
-	VBoxManage clonemedium disk "$VM_BASE_ISO" "$DISK_PATH" --format VDI
-	VBoxManage modifymedium disk "$DISK_PATH" --resize $((VM_DISK_GB * 1024))
-	VBoxManage storageattach "$VM_NAME" --storagectl SATA --port 0 --device 0 --type hdd --medium "$DISK_PATH"
-	VBoxManage startvm "$VM_NAME" --type headless
-	log "VM '${VM_NAME}' started from cloned base image. SSH: ssh -p 2222 <user>@127.0.0.1"
-	;;
-*.iso)
-	log "creating a fresh ${VM_DISK_GB}GB disk and attaching installer ISO ${VM_BASE_ISO}"
-	VBoxManage createmedium disk --filename "$DISK_PATH" --size $((VM_DISK_GB * 1024)) --format VDI
-	VBoxManage storageattach "$VM_NAME" --storagectl SATA --port 0 --device 0 --type hdd --medium "$DISK_PATH"
-	VBoxManage storagectl "$VM_NAME" --name IDE --add ide
-	VBoxManage storageattach "$VM_NAME" --storagectl IDE --port 0 --device 0 --type dvddrive --medium "$VM_BASE_ISO"
-	VBoxManage startvm "$VM_NAME" --type headless
-	log "VM '${VM_NAME}' started with the installer ISO attached — complete the OS install manually" \
-		"(VBoxManage startvm ${VM_NAME} --type gui to see the console), then re-run without --type headless" \
-		"disabled, or just rerun the density scripts once SSH on port 2222 is reachable."
-	;;
-*)
-	die "VM_BASE_ISO must end in .vdi, .vmdk, or .iso — got '${VM_BASE_ISO}'"
-	;;
-esac
-
-log "done. Verify with: VBoxManage showvminfo '${VM_NAME}' | grep -E 'Memory size|Number of CPUs'"
+log "VM '${VM_NAME}' is up at ${IP}. Point config.env's REMOTE_HOST at it, or pass --name to the other scripts (they auto-resolve it)."
+log "Verify: sudo incus config show ${VM_NAME} | grep -E 'limits.cpu|limits.memory'"

--- a/benchmark/agent-sandbox-density/scripts/00-create-vm.sh
+++ b/benchmark/agent-sandbox-density/scripts/00-create-vm.sh
@@ -10,8 +10,14 @@
 # hard-cap guarantee on a stack that's already proven on this class of
 # host.
 #
-# Boots a stock cloud image (images:ubuntu/24.04) with a generated SSH
-# keypair injected via cloud-init — no manual OS install step needed.
+# Boots a stock VM image (images:ubuntu/24.04) and sets up SSH access
+# directly via `incus exec`/`incus file push` — NOT cloud-init. Confirmed
+# live on the first real run: the linuxcontainers.org `images:` remote's
+# ubuntu/24.04 VM image ships neither cloud-init nor openssh-server
+# installed (unlike an official Ubuntu cloud image), so a
+# cloud-init.user-data config is silently a no-op on it. incus exec/file
+# push works unconditionally against any VM the Incus agent can reach,
+# regardless of what the image does or doesn't have installed.
 #
 # Runs locally on whatever machine has Incus installed. For a remote host,
 # SSH in yourself and run this script there — it deliberately does not
@@ -44,7 +50,7 @@ done
 [[ -n "$VM_NAME" ]] || die "usage: $0 --name <vm-name>"
 
 load_config
-require_vars VM_CPUS VM_MEM_MB VM_DISK_GB INCUS_IMAGE BENCH_SSH_PUBKEY_FILE
+require_vars VM_CPUS VM_MEM_MB VM_DISK_GB INCUS_IMAGE BENCH_SSH_PUBKEY_FILE REMOTE_SSH_USER
 
 command -v incus >/dev/null 2>&1 || die "incus not found — this must run on the hypervisor host"
 [[ -f "$BENCH_SSH_PUBKEY_FILE" ]] || die "BENCH_SSH_PUBKEY_FILE ($BENCH_SSH_PUBKEY_FILE) not found — generate a host->guest keypair first: ssh-keygen -t ed25519 -N '' -f <path>"
@@ -53,20 +59,40 @@ if sudo incus list --format csv -c n | grep -qx "$VM_NAME"; then
 	die "a VM named '${VM_NAME}' already exists — run 99-teardown-vm.sh first, or pick a different --name"
 fi
 
-PUBKEY=$(cat "$BENCH_SSH_PUBKEY_FILE")
-
 log "creating Incus VM '${VM_NAME}' (cpus=${VM_CPUS} mem=${VM_MEM_MB}MiB disk=${VM_DISK_GB}GB, image=${INCUS_IMAGE})"
 sudo incus launch "$INCUS_IMAGE" "$VM_NAME" --vm \
 	-c limits.cpu="$VM_CPUS" \
 	-c limits.memory="${VM_MEM_MB}MiB" \
-	-d root,size="${VM_DISK_GB}GB" \
-	-c cloud-init.user-data="#cloud-config
-ssh_authorized_keys:
-  - ${PUBKEY}
-package_update: true
-"
+	-d root,size="${VM_DISK_GB}GB"
 
-log "waiting for the VM to get an IP and become SSH-reachable"
+log "waiting for the Incus agent to be reachable inside the guest"
+ready=0
+for _ in $(seq 1 60); do
+	if sudo incus exec "$VM_NAME" -- true 2>/dev/null; then
+		ready=1
+		break
+	fi
+	sleep 3
+done
+[[ "$ready" == 1 ]] || die "VM '${VM_NAME}' never became exec-reachable — check 'incus console ${VM_NAME}'"
+
+log "installing openssh-server and the host->guest key via incus exec (bypasses cloud-init entirely)"
+sudo incus exec "$VM_NAME" -- bash -c "
+	set -euo pipefail
+	export DEBIAN_FRONTEND=noninteractive
+	apt-get update -qq
+	apt-get install -y -qq openssh-server
+	mkdir -p /home/${REMOTE_SSH_USER}/.ssh
+	chmod 700 /home/${REMOTE_SSH_USER}/.ssh
+	chown ${REMOTE_SSH_USER}:${REMOTE_SSH_USER} /home/${REMOTE_SSH_USER}/.ssh
+	systemctl enable --now ssh
+"
+sudo incus file push "$BENCH_SSH_PUBKEY_FILE" "${VM_NAME}/home/${REMOTE_SSH_USER}/.ssh/authorized_keys" --uid 1000 --gid 1000 --mode 600
+
+log "adding passwordless sudo for ${REMOTE_SSH_USER} (provisioning scripts run as it over SSH)"
+sudo incus exec "$VM_NAME" -- bash -c "echo '${REMOTE_SSH_USER} ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/90-${REMOTE_SSH_USER}-nopasswd && chmod 440 /etc/sudoers.d/90-${REMOTE_SSH_USER}-nopasswd"
+
+log "waiting for the VM to get an IP"
 IP=""
 for _ in $(seq 1 60); do
 	IP=$(sudo incus list "$VM_NAME" -c 4 --format csv 2>/dev/null | grep -oE '^[0-9.]+' || true)
@@ -75,10 +101,18 @@ for _ in $(seq 1 60); do
 done
 [[ -n "$IP" ]] || die "VM '${VM_NAME}' never got an IP — check 'incus console ${VM_NAME}'"
 
+log "waiting for SSH to actually accept a connection"
+ssh_ready=0
 for _ in $(seq 1 30); do
-	nc -z -w2 "$IP" 22 2>/dev/null && break
+	if ssh -p 22 -o StrictHostKeyChecking=accept-new -o ConnectTimeout=5 \
+		-i "${BENCH_SSH_KEY_FILE:-${BENCH_SSH_PUBKEY_FILE%.pub}}" \
+		"${REMOTE_SSH_USER}@${IP}" true 2>/dev/null; then
+		ssh_ready=1
+		break
+	fi
 	sleep 3
 done
+[[ "$ssh_ready" == 1 ]] || die "SSH to ${IP} never became ready — check 'incus exec ${VM_NAME} -- systemctl status ssh'"
 
-log "VM '${VM_NAME}' is up at ${IP}. Point config.env's REMOTE_HOST at it, or pass --name to the other scripts (they auto-resolve it)."
+log "VM '${VM_NAME}' is up at ${IP} and SSH-ready. The other scripts auto-resolve it by --name."
 log "Verify: sudo incus config show ${VM_NAME} | grep -E 'limits.cpu|limits.memory'"

--- a/benchmark/agent-sandbox-density/scripts/01-provision-k8s-control.sh
+++ b/benchmark/agent-sandbox-density/scripts/01-provision-k8s-control.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 #
 # Provision the control-group VM: the shared base cluster (see
-# k8s-common.sh — kubeadm, CNI, raised max-pods, upstream
-# kubernetes-sigs/agent-sandbox controller) with nothing on top. The
-# control group creates `Sandbox` CRs directly via kubectl (02), with no
-# Containarium daemon and no gVisor RuntimeClass involved — plain runc.
+# k8s-common.sh — kubeadm, CNI, raised max-pods, gVisor, upstream
+# kubernetes-sigs/agent-sandbox controller) with nothing Containarium-
+# specific on top. The control group creates `Sandbox` CRs directly via
+# kubectl (02); their pods are scheduled under gVisor exactly like the
+# experiment group's (manifests/sandbox-template.yaml sets
+# runtimeClassName). See README.md "What's actually under test" — gVisor
+# is deliberately identical on both sides, so what differs is Containarium
+# the orchestrator, not gVisor.
 #
 # Usage:
 #   scripts/01-provision-k8s-control.sh --name <vm-name>
@@ -38,12 +42,14 @@ done
 [[ -n "$VM_NAME" ]] || die "usage: $0 --name <vm-name>"
 
 load_config
-require_vars K8S_MAX_PODS AGENT_SANDBOX_VERSION REMOTE_SSH_USER
+require_vars K8S_MAX_PODS AGENT_SANDBOX_VERSION GVISOR_RUNTIME_CLASS REMOTE_SSH_USER BENCH_SSH_KEY_FILE
+resolve_remote "$VM_NAME"
 
-log "provisioning k8s control group on '${VM_NAME}' (max-pods=${K8S_MAX_PODS}, agent-sandbox=${AGENT_SANDBOX_VERSION})"
+log "provisioning k8s control group on '${VM_NAME}' (max-pods=${K8S_MAX_PODS}, agent-sandbox=${AGENT_SANDBOX_VERSION}, runtime=${GVISOR_RUNTIME_CLASS})"
 provision_base_k8s
+install_gvisor
 
 log "creating benchmark namespace"
 ssh_or_local "kubectl create namespace sandbox-density-bench --dry-run=client -o yaml | kubectl apply -f -"
 
-log "provisioning complete. Verify: kubectl get nodes -o wide; kubectl -n agent-sandbox-system get pods"
+log "provisioning complete. Verify: kubectl get nodes -o wide; kubectl get runtimeclass; kubectl -n agent-sandbox-system get pods"

--- a/benchmark/agent-sandbox-density/scripts/01-provision-k8s-control.sh
+++ b/benchmark/agent-sandbox-density/scripts/01-provision-k8s-control.sh
@@ -1,25 +1,23 @@
 #!/bin/bash
 #
-# Provision the control-group VM: vanilla kubeadm single-node cluster, CNI,
-# kubelet --max-pods raised past the stock 110 default (see README.md
-# "Kubelet max-pods"), and the upstream kubernetes-sigs/agent-sandbox
-# controller + CRDs.
-#
-# Runs everything inside the guest over SSH (see lib.sh ssh_or_local) —
-# targets whatever config.env's REMOTE_HOST/REMOTE_SSH_PORT/REMOTE_SSH_USER
-# point at. --name is accepted for symmetry with the other scripts and
-# logged, but this script's actions are entirely inside the guest.
+# Provision the control-group VM: the shared base cluster (see
+# k8s-common.sh — kubeadm, CNI, raised max-pods, upstream
+# kubernetes-sigs/agent-sandbox controller) with nothing on top. The
+# control group creates `Sandbox` CRs directly via kubectl (02), with no
+# Containarium daemon and no gVisor RuntimeClass involved — plain runc.
 #
 # Usage:
 #   scripts/01-provision-k8s-control.sh --name <vm-name>
 #
-# Assumes the guest is Ubuntu Server 24.04 (matches VM_BASE_ISO guidance in
-# config.env.example) with passwordless sudo for REMOTE_SSH_USER.
+# Assumes the guest is Ubuntu Server 24.04 with passwordless sudo for
+# REMOTE_SSH_USER.
 
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
 # shellcheck source=lib.sh
 source ./lib.sh
+# shellcheck source=k8s-common.sh
+source ./k8s-common.sh
 
 VM_NAME=""
 while [[ $# -gt 0 ]]; do
@@ -43,81 +41,7 @@ load_config
 require_vars K8S_MAX_PODS AGENT_SANDBOX_VERSION REMOTE_SSH_USER
 
 log "provisioning k8s control group on '${VM_NAME}' (max-pods=${K8S_MAX_PODS}, agent-sandbox=${AGENT_SANDBOX_VERSION})"
-
-log "installing containerd + kubeadm/kubelet/kubectl"
-ssh_or_local "sudo bash -s" <<'REMOTE'
-set -euo pipefail
-export DEBIAN_FRONTEND=noninteractive
-
-apt-get update -qq
-apt-get install -y -qq apt-transport-https ca-certificates curl gpg containerd
-
-mkdir -p /etc/containerd
-containerd config default | sudo tee /etc/containerd/config.toml >/dev/null
-sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
-systemctl restart containerd
-
-install -m 0755 -d /etc/apt/keyrings
-curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.30/deb/Release.key |
-	gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /' |
-	tee /etc/apt/sources.list.d/kubernetes.list >/dev/null
-apt-get update -qq
-apt-get install -y -qq kubelet kubeadm kubectl
-apt-mark hold kubelet kubeadm kubectl
-
-swapoff -a
-sed -i '/ swap /s/^/#/' /etc/fstab
-
-cat <<EOF >/etc/modules-load.d/k8s.conf
-overlay
-br_netfilter
-EOF
-modprobe overlay
-modprobe br_netfilter
-
-cat <<EOF >/etc/sysctl.d/k8s.conf
-net.bridge.bridge-nf-call-iptables  = 1
-net.ipv4.ip_forward                 = 1
-net.bridge.bridge-nf-call-ip6tables = 1
-EOF
-sysctl --system >/dev/null
-REMOTE
-
-log "kubeadm init with maxPods=${K8S_MAX_PODS}"
-ssh_or_local "sudo bash -s" <<REMOTE
-set -euo pipefail
-cat <<KUBEADM_CFG >/tmp/kubeadm-config.yaml
-apiVersion: kubeadm.k8s.io/v1beta3
-kind: ClusterConfiguration
-networking:
-  podSubnet: "192.168.0.0/16"
----
-apiVersion: kubelet.config.k8s.io/v1beta1
-kind: KubeletConfiguration
-maxPods: ${K8S_MAX_PODS}
-KUBEADM_CFG
-
-kubeadm init --config /tmp/kubeadm-config.yaml
-
-mkdir -p /root/.kube
-cp -f /etc/kubernetes/admin.conf /root/.kube/config
-mkdir -p /home/${REMOTE_SSH_USER}/.kube
-cp -f /etc/kubernetes/admin.conf /home/${REMOTE_SSH_USER}/.kube/config
-chown -R ${REMOTE_SSH_USER}:${REMOTE_SSH_USER} /home/${REMOTE_SSH_USER}/.kube
-
-# Single-node cluster — the control-plane taint would otherwise prevent
-# any Sandbox pod from scheduling at all.
-kubectl --kubeconfig=/root/.kube/config taint nodes --all node-role.kubernetes.io/control-plane- || true
-REMOTE
-
-log "installing Calico CNI"
-ssh_or_local "kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.28.0/manifests/calico.yaml"
-ssh_or_local "kubectl wait --for=condition=ready pod -l k8s-app=calico-node -n kube-system --timeout=180s"
-
-log "installing agent-sandbox controller ${AGENT_SANDBOX_VERSION}"
-ssh_or_local "kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/${AGENT_SANDBOX_VERSION}/manifest.yaml"
-ssh_or_local "kubectl -n agent-sandbox-system wait --for=condition=available deployment/agent-sandbox-controller --timeout=180s"
+provision_base_k8s
 
 log "creating benchmark namespace"
 ssh_or_local "kubectl create namespace sandbox-density-bench --dry-run=client -o yaml | kubectl apply -f -"

--- a/benchmark/agent-sandbox-density/scripts/01-provision-k8s-control.sh
+++ b/benchmark/agent-sandbox-density/scripts/01-provision-k8s-control.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+#
+# Provision the control-group VM: vanilla kubeadm single-node cluster, CNI,
+# kubelet --max-pods raised past the stock 110 default (see README.md
+# "Kubelet max-pods"), and the upstream kubernetes-sigs/agent-sandbox
+# controller + CRDs.
+#
+# Runs everything inside the guest over SSH (see lib.sh ssh_or_local) —
+# targets whatever config.env's REMOTE_HOST/REMOTE_SSH_PORT/REMOTE_SSH_USER
+# point at. --name is accepted for symmetry with the other scripts and
+# logged, but this script's actions are entirely inside the guest.
+#
+# Usage:
+#   scripts/01-provision-k8s-control.sh --name <vm-name>
+#
+# Assumes the guest is Ubuntu Server 24.04 (matches VM_BASE_ISO guidance in
+# config.env.example) with passwordless sudo for REMOTE_SSH_USER.
+
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+# shellcheck source=lib.sh
+source ./lib.sh
+
+VM_NAME=""
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--name)
+		VM_NAME="$2"
+		shift 2
+		;;
+	-h | --help)
+		grep '^#' "$0" | sed 's/^# \{0,1\}//'
+		exit 0
+		;;
+	*)
+		die "unknown argument: $1"
+		;;
+	esac
+done
+[[ -n "$VM_NAME" ]] || die "usage: $0 --name <vm-name>"
+
+load_config
+require_vars K8S_MAX_PODS AGENT_SANDBOX_VERSION REMOTE_SSH_USER
+
+log "provisioning k8s control group on '${VM_NAME}' (max-pods=${K8S_MAX_PODS}, agent-sandbox=${AGENT_SANDBOX_VERSION})"
+
+log "installing containerd + kubeadm/kubelet/kubectl"
+ssh_or_local "sudo bash -s" <<'REMOTE'
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update -qq
+apt-get install -y -qq apt-transport-https ca-certificates curl gpg containerd
+
+mkdir -p /etc/containerd
+containerd config default | sudo tee /etc/containerd/config.toml >/dev/null
+sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
+systemctl restart containerd
+
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.30/deb/Release.key |
+	gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /' |
+	tee /etc/apt/sources.list.d/kubernetes.list >/dev/null
+apt-get update -qq
+apt-get install -y -qq kubelet kubeadm kubectl
+apt-mark hold kubelet kubeadm kubectl
+
+swapoff -a
+sed -i '/ swap /s/^/#/' /etc/fstab
+
+cat <<EOF >/etc/modules-load.d/k8s.conf
+overlay
+br_netfilter
+EOF
+modprobe overlay
+modprobe br_netfilter
+
+cat <<EOF >/etc/sysctl.d/k8s.conf
+net.bridge.bridge-nf-call-iptables  = 1
+net.ipv4.ip_forward                 = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+EOF
+sysctl --system >/dev/null
+REMOTE
+
+log "kubeadm init with maxPods=${K8S_MAX_PODS}"
+ssh_or_local "sudo bash -s" <<REMOTE
+set -euo pipefail
+cat <<KUBEADM_CFG >/tmp/kubeadm-config.yaml
+apiVersion: kubeadm.k8s.io/v1beta3
+kind: ClusterConfiguration
+networking:
+  podSubnet: "192.168.0.0/16"
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+maxPods: ${K8S_MAX_PODS}
+KUBEADM_CFG
+
+kubeadm init --config /tmp/kubeadm-config.yaml
+
+mkdir -p /root/.kube
+cp -f /etc/kubernetes/admin.conf /root/.kube/config
+mkdir -p /home/${REMOTE_SSH_USER}/.kube
+cp -f /etc/kubernetes/admin.conf /home/${REMOTE_SSH_USER}/.kube/config
+chown -R ${REMOTE_SSH_USER}:${REMOTE_SSH_USER} /home/${REMOTE_SSH_USER}/.kube
+
+# Single-node cluster — the control-plane taint would otherwise prevent
+# any Sandbox pod from scheduling at all.
+kubectl --kubeconfig=/root/.kube/config taint nodes --all node-role.kubernetes.io/control-plane- || true
+REMOTE
+
+log "installing Calico CNI"
+ssh_or_local "kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.28.0/manifests/calico.yaml"
+ssh_or_local "kubectl wait --for=condition=ready pod -l k8s-app=calico-node -n kube-system --timeout=180s"
+
+log "installing agent-sandbox controller ${AGENT_SANDBOX_VERSION}"
+ssh_or_local "kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/${AGENT_SANDBOX_VERSION}/manifest.yaml"
+ssh_or_local "kubectl -n agent-sandbox-system wait --for=condition=available deployment/agent-sandbox-controller --timeout=180s"
+
+log "creating benchmark namespace"
+ssh_or_local "kubectl create namespace sandbox-density-bench --dry-run=client -o yaml | kubectl apply -f -"
+
+log "provisioning complete. Verify: kubectl get nodes -o wide; kubectl -n agent-sandbox-system get pods"

--- a/benchmark/agent-sandbox-density/scripts/02-run-density-k8s.sh
+++ b/benchmark/agent-sandbox-density/scripts/02-run-density-k8s.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+#
+# Density loop for the control group: create Sandbox CRs (agents.x-k8s.io/
+# v1beta1) one at a time via the upstream agent-sandbox controller until the
+# shared stopping rule in lib.sh's run_density_loop triggers.
+#
+# Usage:
+#   scripts/02-run-density-k8s.sh --name <vm-name>
+#
+# NOTE: the Sandbox CR's Ready-status field is asserted here as
+# `.status.conditions[?(@.type=="Ready")].status` — the common controller
+# convention, but NOT yet verified against a live agent-sandbox-controller
+# run (this benchmark hasn't been executed yet — see README.md "Running
+# it"). On the first real run, sanity-check with
+# `kubectl get sandbox <name> -n sandbox-density-bench -o yaml` and adjust
+# `sandbox_ready` below if the actual schema differs.
+
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+# shellcheck source=lib.sh
+source ./lib.sh
+
+VM_NAME=""
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--name)
+		VM_NAME="$2"
+		shift 2
+		;;
+	-h | --help)
+		grep '^#' "$0" | sed 's/^# \{0,1\}//'
+		exit 0
+		;;
+	*)
+		die "unknown argument: $1"
+		;;
+	esac
+done
+[[ -n "$VM_NAME" ]] || die "usage: $0 --name <vm-name>"
+
+load_config
+require_vars SANDBOX_CPU_REQUEST SANDBOX_CPU_LIMIT SANDBOX_MEM_REQUEST SANDBOX_MEM_LIMIT \
+	FAILURE_STREAK_TO_STOP CREATE_TIMEOUT_SECONDS
+
+NAMESPACE="sandbox-density-bench"
+RESULTS_DIR="${BENCH_ROOT}/results"
+mkdir -p "$RESULTS_DIR"
+RESULTS_FILE="${RESULTS_DIR}/k8s-$(date -u +%Y%m%dT%H%M%SZ).md"
+
+create_sandbox() {
+	local name="$1"
+	sed \
+		-e "s/__NAME__/${name}/g" \
+		-e "s/__SANDBOX_CPU_REQUEST__/${SANDBOX_CPU_REQUEST}/g" \
+		-e "s/__SANDBOX_CPU_LIMIT__/${SANDBOX_CPU_LIMIT}/g" \
+		-e "s/__SANDBOX_MEM_REQUEST__/${SANDBOX_MEM_REQUEST}/g" \
+		-e "s/__SANDBOX_MEM_LIMIT__/${SANDBOX_MEM_LIMIT}/g" \
+		"${BENCH_ROOT}/manifests/sandbox-template.yaml" |
+		ssh_or_local "kubectl apply -f -" >/dev/null 2>&1
+}
+
+sandbox_ready() {
+	local name="$1"
+	local status
+	status=$(ssh_or_local "kubectl get sandbox ${name} -n ${NAMESPACE} -o jsonpath='{.status.conditions[?(@.type==\"Ready\")].status}' 2>/dev/null" || true)
+	[[ "$status" == "True" ]]
+}
+
+cleanup_sandbox() {
+	local name="$1"
+	ssh_or_local "kubectl delete sandbox ${name} -n ${NAMESPACE} --ignore-not-found --wait=false" >/dev/null 2>&1 || true
+}
+
+resource_snapshot "before" "$RESULTS_FILE"
+{
+	echo "profile: cpu ${SANDBOX_CPU_REQUEST}/${SANDBOX_CPU_LIMIT}, mem ${SANDBOX_MEM_REQUEST}/${SANDBOX_MEM_LIMIT}"
+	echo
+} >>"$RESULTS_FILE"
+
+run_density_loop "sbdens" create_sandbox sandbox_ready cleanup_sandbox "$RESULTS_FILE"
+
+resource_snapshot "after (${DENSITY_RESULT_COUNT} ready)" "$RESULTS_FILE"
+{
+	echo "kubectl top nodes (if metrics-server installed):"
+	echo '```'
+	ssh_or_local "kubectl top nodes 2>&1" || true
+	echo '```'
+} >>"$RESULTS_FILE"
+
+log "k8s control group result: ${DENSITY_RESULT_COUNT} sandboxes reached Ready"
+log "full log: ${RESULTS_FILE}"

--- a/benchmark/agent-sandbox-density/scripts/02-run-density-k8s.sh
+++ b/benchmark/agent-sandbox-density/scripts/02-run-density-k8s.sh
@@ -40,7 +40,8 @@ done
 
 load_config
 require_vars SANDBOX_CPU_REQUEST SANDBOX_CPU_LIMIT SANDBOX_MEM_REQUEST SANDBOX_MEM_LIMIT \
-	FAILURE_STREAK_TO_STOP CREATE_TIMEOUT_SECONDS
+	GVISOR_RUNTIME_CLASS FAILURE_STREAK_TO_STOP CREATE_TIMEOUT_SECONDS BENCH_SSH_KEY_FILE
+resolve_remote "$VM_NAME"
 
 NAMESPACE="sandbox-density-bench"
 RESULTS_DIR="${BENCH_ROOT}/results"
@@ -55,6 +56,7 @@ create_sandbox() {
 		-e "s/__SANDBOX_CPU_LIMIT__/${SANDBOX_CPU_LIMIT}/g" \
 		-e "s/__SANDBOX_MEM_REQUEST__/${SANDBOX_MEM_REQUEST}/g" \
 		-e "s/__SANDBOX_MEM_LIMIT__/${SANDBOX_MEM_LIMIT}/g" \
+		-e "s/__GVISOR_RUNTIME_CLASS__/${GVISOR_RUNTIME_CLASS}/g" \
 		"${BENCH_ROOT}/manifests/sandbox-template.yaml" |
 		ssh_or_local "kubectl apply -f -" >/dev/null 2>&1
 }
@@ -73,7 +75,7 @@ cleanup_sandbox() {
 
 resource_snapshot "before" "$RESULTS_FILE"
 {
-	echo "profile: cpu ${SANDBOX_CPU_REQUEST}/${SANDBOX_CPU_LIMIT}, mem ${SANDBOX_MEM_REQUEST}/${SANDBOX_MEM_LIMIT}"
+	echo "profile: cpu ${SANDBOX_CPU_REQUEST}/${SANDBOX_CPU_LIMIT}, mem ${SANDBOX_MEM_REQUEST}/${SANDBOX_MEM_LIMIT}, runtimeClass=${GVISOR_RUNTIME_CLASS}"
 	echo
 } >>"$RESULTS_FILE"
 
@@ -84,6 +86,10 @@ resource_snapshot "after (${DENSITY_RESULT_COUNT} ready)" "$RESULTS_FILE"
 	echo "kubectl top nodes (if metrics-server installed):"
 	echo '```'
 	ssh_or_local "kubectl top nodes 2>&1" || true
+	echo '```'
+	echo "pods by RuntimeClass (sanity check that sandboxes really landed on gVisor):"
+	echo '```'
+	ssh_or_local "kubectl get pods -n ${NAMESPACE} -o custom-columns=NAME:.metadata.name,RUNTIMECLASS:.spec.runtimeClassName 2>&1" || true
 	echo '```'
 } >>"$RESULTS_FILE"
 

--- a/benchmark/agent-sandbox-density/scripts/03-provision-containarium.sh
+++ b/benchmark/agent-sandbox-density/scripts/03-provision-containarium.sh
@@ -6,14 +6,24 @@
 # Containarium daemon (Helm chart) configured to schedule every box pod
 # under the same runsc RuntimeClass — pod -> gVisor -> containarium.
 #
-# Gateway (SSH) routing is deliberately disabled (gateway.namespace="",
-# gateway.enabled=false): this benchmark only needs to know whether a box
-# reached RUNNING, not to SSH into it, so there's no need to stand up
-# sshpiper here. If you DO want to reach the boxes afterward, note that
-# `kubectl exec`/`port-forward` straight to a gVisor-scheduled box pod does
-# not work (kubernetes-sigs/agent-sandbox#158, this repo's #1489) — see
+# Gateway (SSH) routing: sshpiper itself is disabled (gateway.enabled=
+# false) — this benchmark only needs to know whether a box reached
+# RUNNING, not to SSH into it. gateway.namespace is left at its chart
+# default ("agent-gateway") rather than cleared, though — found live that
+# charts/containarium-k8s/templates/namespace.yaml unconditionally creates
+# a Namespace resource from gateway.namespace with no enabled-guard, so an
+# empty value breaks `helm install` outright ("resource name may not be
+# empty"). The values.yaml comment's documented way to fully disable
+# gateway routing (clear `namespace`, leave the two upstream-key values
+# empty) doesn't actually work end-to-end as shipped — this works around
+# it by keeping the namespace non-empty and supplying a throwaway upstream
+# keypair instead, the same shape KIND-QUICKSTART.md documents for "Pipe
+# objects get programmed, nothing is actually watching them yet". If you
+# DO want to reach the boxes afterward, note that `kubectl exec`/
+# `port-forward` straight to a gVisor-scheduled box pod does not work
+# (kubernetes-sigs/agent-sandbox#158, this repo's #1489) — see
 # docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md "Hard isolation via RuntimeClass"
-# and re-enable the gateway per docs/KIND-QUICKSTART.md if needed.
+# and stand up a real sshpiper per docs/KIND-QUICKSTART.md if needed.
 #
 # Usage:
 #   scripts/03-provision-containarium.sh --name <vm-name>
@@ -66,7 +76,7 @@ set -euo pipefail
 # the curl|jq pipe, which then makes curl itself fail with "Failure
 # writing output to destination" — a confusing secondary symptom of the
 # real, primary cause).
-apt-get install -y -qq jq >/dev/null
+apt-get install -y -qq jq git >/dev/null
 
 TAG="${CONTAINARIUM_VERSION}"
 if [[ "\$TAG" == "latest" ]]; then
@@ -88,15 +98,34 @@ rm -rf /opt/containarium-src
 git clone --depth 1 --branch "\$TAG" https://github.com/FootprintAI/Containarium.git /opt/containarium-src
 REMOTE
 
-log "helm installing the Containarium daemon (runtimeClass=${GVISOR_RUNTIME_CLASS}, gateway disabled)"
+log "helm installing the Containarium daemon (runtimeClass=${GVISOR_RUNTIME_CLASS}, sshpiper disabled)"
 ssh_or_local "sudo bash -s" <<REMOTE
 set -euo pipefail
+# Throwaway upstream keypair — see this file's header comment for why
+# gateway.namespace stays at its default instead of being cleared. Nothing
+# ever authenticates with it since sshpiper itself isn't deployed
+# (gateway.enabled=false); it exists only so the daemon's own fail-fast
+# check (#1496: refuses to start with a non-empty gateway.namespace and no
+# upstream key configured) is satisfied.
+ssh-keygen -t ed25519 -N "" -f /tmp/sshpiper_upstream -C sshpiper-upstream <<<y >/dev/null 2>&1 || true
+PUBKEY=\$(cat /tmp/sshpiper_upstream.pub)
+
 helm install containarium /opt/containarium-src/charts/containarium-k8s \
 	--set daemon.jwtSecret="\$(openssl rand -hex 32)" \
 	--set runtimeClass=${GVISOR_RUNTIME_CLASS} \
 	--set gateway.enabled=false \
-	--set gateway.namespace="" \
+	--set gateway.upstreamKeySecret=sshpiper-upstream-key \
+	--set gateway.upstreamPublicKey="\$PUBKEY" \
 	--wait --timeout 5m
+
+# The Secret the env var above names is read lazily (only when a box is
+# actually created, not at daemon-pod startup), so it can be created
+# after helm install — which is required here, since the "agent-gateway"
+# namespace it lives in doesn't exist until this same helm install
+# creates it (namespace.yaml, unconditional on gateway.namespace).
+kubectl -n agent-gateway create secret generic sshpiper-upstream-key \
+	--from-file=ssh-privatekey=/tmp/sshpiper_upstream \
+	--dry-run=client -o yaml | kubectl apply -f -
 
 kubectl get deployment -l app.kubernetes.io/instance=containarium
 REMOTE

--- a/benchmark/agent-sandbox-density/scripts/03-provision-containarium.sh
+++ b/benchmark/agent-sandbox-density/scripts/03-provision-containarium.sh
@@ -60,6 +60,14 @@ ssh_or_local "curl -fsSL https://raw.githubusercontent.com/helm/helm/main/script
 log "resolving Containarium ${CONTAINARIUM_VERSION} and fetching the chart + CLI"
 ssh_or_local "sudo bash -s" <<REMOTE
 set -euo pipefail
+# jq is needed below to resolve "latest" — install it FIRST. Found live:
+# installing it at the end of this same block (after it's already used)
+# means "latest" resolution silently fails (jq: command not found breaks
+# the curl|jq pipe, which then makes curl itself fail with "Failure
+# writing output to destination" — a confusing secondary symptom of the
+# real, primary cause).
+apt-get install -y -qq jq >/dev/null
+
 TAG="${CONTAINARIUM_VERSION}"
 if [[ "\$TAG" == "latest" ]]; then
 	TAG=\$(curl -fsSL https://api.github.com/repos/FootprintAI/Containarium/releases/latest | jq -r .tag_name)
@@ -78,7 +86,6 @@ containarium version
 
 rm -rf /opt/containarium-src
 git clone --depth 1 --branch "\$TAG" https://github.com/FootprintAI/Containarium.git /opt/containarium-src
-apt-get install -y -qq jq >/dev/null
 REMOTE
 
 log "helm installing the Containarium daemon (runtimeClass=${GVISOR_RUNTIME_CLASS}, gateway disabled)"

--- a/benchmark/agent-sandbox-density/scripts/03-provision-containarium.sh
+++ b/benchmark/agent-sandbox-density/scripts/03-provision-containarium.sh
@@ -1,12 +1,18 @@
 #!/bin/bash
 #
-# Provision the experiment-group VM: Incus + the Containarium daemon
-# running as a plain LXC "workhorse" — the daemon's default mode, no
-# --runtime=k8s (that backend targets pods on an *existing* cluster; it
-# isn't what "workhorse" means here) and no --standalone (core service
-# containers — Postgres, Caddy, the otel collector — stay in, matching a
-# real deployment's fixed overhead, same principle as leaving the k8s
-# side's kube-system pods in place; see README.md "Fairness notes").
+# Provision the experiment-group VM: the same shared base cluster as the
+# control group (k8s-common.sh), plus gVisor + a "runsc" RuntimeClass, plus
+# the Containarium daemon (Helm chart) configured to schedule every box pod
+# under it — pod -> gVisor -> containarium.
+#
+# Gateway (SSH) routing is deliberately disabled (gateway.namespace="",
+# gateway.enabled=false): this benchmark only needs to know whether a box
+# reached RUNNING, not to SSH into it, so there's no need to stand up
+# sshpiper here. If you DO want to reach the boxes afterward, note that
+# `kubectl exec`/`port-forward` straight to a gVisor-scheduled box pod does
+# not work (kubernetes-sigs/agent-sandbox#158, this repo's #1489) — see
+# docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md "Hard isolation via RuntimeClass"
+# and re-enable the gateway per docs/KIND-QUICKSTART.md if needed.
 #
 # Usage:
 #   scripts/03-provision-containarium.sh --name <vm-name>
@@ -18,6 +24,8 @@ set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
 # shellcheck source=lib.sh
 source ./lib.sh
+# shellcheck source=k8s-common.sh
+source ./k8s-common.sh
 
 VM_NAME=""
 while [[ $# -gt 0 ]]; do
@@ -38,24 +46,43 @@ done
 [[ -n "$VM_NAME" ]] || die "usage: $0 --name <vm-name>"
 
 load_config
-require_vars CONTAINARIUM_VERSION REMOTE_SSH_USER
+require_vars K8S_MAX_PODS AGENT_SANDBOX_VERSION CONTAINARIUM_VERSION GVISOR_RUNTIME_CLASS REMOTE_SSH_USER
 
-log "provisioning Containarium workhorse on '${VM_NAME}' (version=${CONTAINARIUM_VERSION})"
+log "provisioning Containarium (pod -> gVisor -> containarium) on '${VM_NAME}'"
+provision_base_k8s
 
-log "installing Incus"
-ssh_or_local "sudo bash -s" <<'REMOTE'
+log "installing gVisor (${GVISOR_RUNTIME_CLASS})"
+ssh_or_local "sudo bash -s" <<REMOTE
 set -euo pipefail
-export DEBIAN_FRONTEND=noninteractive
+ARCH=\$(uname -m)
+URL="https://storage.googleapis.com/gvisor/releases/release/latest/\${ARCH}"
+cd /tmp
+curl -fsSLO "\${URL}/runsc" -O "\${URL}/runsc.sha512" \
+	-O "\${URL}/containerd-shim-runsc-v1" -O "\${URL}/containerd-shim-runsc-v1.sha512"
+sha512sum -c runsc.sha512 -c containerd-shim-runsc-v1.sha512
+chmod a+rx runsc containerd-shim-runsc-v1
+mv runsc containerd-shim-runsc-v1 /usr/local/bin/
 
-apt-get update -qq
-apt-get install -y -qq curl jq
-curl -fsSL https://pkgs.zabbly.com/get/incus-stable | sudo sh
+cat <<TOML >>/etc/containerd/config.toml
 
-usermod -aG incus-admin "$(logname 2>/dev/null || echo root)" || true
-incus admin init --auto
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.${GVISOR_RUNTIME_CLASS}]
+  runtime_type = "io.containerd.${GVISOR_RUNTIME_CLASS}.v1"
+TOML
+systemctl restart containerd
+
+cat <<EOF | kubectl apply -f -
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: ${GVISOR_RUNTIME_CLASS}
+handler: ${GVISOR_RUNTIME_CLASS}
+EOF
 REMOTE
 
-log "downloading containarium ${CONTAINARIUM_VERSION}"
+log "installing Helm"
+ssh_or_local "curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | sudo bash"
+
+log "resolving Containarium ${CONTAINARIUM_VERSION} and fetching the chart + CLI"
 ssh_or_local "sudo bash -s" <<REMOTE
 set -euo pipefail
 TAG="${CONTAINARIUM_VERSION}"
@@ -63,49 +90,33 @@ if [[ "\$TAG" == "latest" ]]; then
 	TAG=\$(curl -fsSL https://api.github.com/repos/FootprintAI/Containarium/releases/latest | jq -r .tag_name)
 fi
 echo "resolved tag: \$TAG"
+echo "\$TAG" >/tmp/containarium-resolved-tag
 
 BASE_URL="https://github.com/FootprintAI/Containarium/releases/download/\${TAG}"
 curl -fsSL -o /tmp/containarium "\${BASE_URL}/containarium-linux-amd64"
 curl -fsSL -o /tmp/SHA256SUMS.txt "\${BASE_URL}/SHA256SUMS.txt"
-
 EXPECTED=\$(grep 'containarium-linux-amd64\$' /tmp/SHA256SUMS.txt | awk '{print \$1}')
 ACTUAL=\$(sha256sum /tmp/containarium | awk '{print \$1}')
-[[ "\$EXPECTED" == "\$ACTUAL" ]] || {
-	echo "SHA256 mismatch: expected \$EXPECTED, got \$ACTUAL" >&2
-	exit 1
-}
-
+[[ "\$EXPECTED" == "\$ACTUAL" ]] || { echo "SHA256 mismatch: expected \$EXPECTED, got \$ACTUAL" >&2; exit 1; }
 install -m 0755 /tmp/containarium /usr/local/bin/containarium
 containarium version
+
+rm -rf /opt/containarium-src
+git clone --depth 1 --branch "\$TAG" https://github.com/FootprintAI/Containarium.git /opt/containarium-src
+apt-get install -y -qq jq >/dev/null
 REMOTE
 
-log "starting the daemon (standard mode: core services on, LXC backend)"
-ssh_or_local "sudo bash -s" <<'REMOTE'
+log "helm installing the Containarium daemon (runtimeClass=${GVISOR_RUNTIME_CLASS}, gateway disabled)"
+ssh_or_local "sudo bash -s" <<REMOTE
 set -euo pipefail
-mkdir -p /etc/containarium
-[[ -f /etc/containarium/jwt.secret ]] || openssl rand -hex 32 >/etc/containarium/jwt.secret
-chmod 0400 /etc/containarium/jwt.secret
+helm install containarium /opt/containarium-src/charts/containarium-k8s \
+	--set daemon.jwtSecret="\$(openssl rand -hex 32)" \
+	--set runtimeClass=${GVISOR_RUNTIME_CLASS} \
+	--set gateway.enabled=false \
+	--set gateway.namespace="" \
+	--wait --timeout 5m
 
-cat <<'UNIT' >/etc/systemd/system/containarium.service
-[Unit]
-Description=Containarium daemon (density benchmark workhorse)
-After=network-online.target incus.service
-Wants=network-online.target
-
-[Service]
-ExecStart=/usr/local/bin/containarium daemon --address 0.0.0.0 --rest --http-port 8080 --jwt-secret-file /etc/containarium/jwt.secret
-Restart=on-failure
-RestartSec=5s
-
-[Install]
-WantedBy=multi-user.target
-UNIT
-
-systemctl daemon-reload
-systemctl enable --now containarium
-sleep 5
-systemctl is-active containarium
-curl -fsS http://127.0.0.1:8080/healthz || echo "warning: /healthz not yet ready, check systemctl status containarium"
+kubectl get deployment -l app.kubernetes.io/instance=containarium
 REMOTE
 
-log "provisioning complete. Verify: ssh (see config.env) 'containarium list'"
+log "provisioning complete. Verify: ssh (see config.env) 'kubectl get pods -A; kubectl get runtimeclass'"

--- a/benchmark/agent-sandbox-density/scripts/03-provision-containarium.sh
+++ b/benchmark/agent-sandbox-density/scripts/03-provision-containarium.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 #
 # Provision the experiment-group VM: the same shared base cluster as the
-# control group (k8s-common.sh), plus gVisor + a "runsc" RuntimeClass, plus
-# the Containarium daemon (Helm chart) configured to schedule every box pod
-# under it — pod -> gVisor -> containarium.
+# control group, INCLUDING gVisor (k8s-common.sh — gVisor is identical on
+# both sides, see README.md "What's actually under test"), plus the
+# Containarium daemon (Helm chart) configured to schedule every box pod
+# under the same runsc RuntimeClass — pod -> gVisor -> containarium.
 #
 # Gateway (SSH) routing is deliberately disabled (gateway.namespace="",
 # gateway.enabled=false): this benchmark only needs to know whether a box
@@ -46,38 +47,12 @@ done
 [[ -n "$VM_NAME" ]] || die "usage: $0 --name <vm-name>"
 
 load_config
-require_vars K8S_MAX_PODS AGENT_SANDBOX_VERSION CONTAINARIUM_VERSION GVISOR_RUNTIME_CLASS REMOTE_SSH_USER
+require_vars K8S_MAX_PODS AGENT_SANDBOX_VERSION CONTAINARIUM_VERSION GVISOR_RUNTIME_CLASS REMOTE_SSH_USER BENCH_SSH_KEY_FILE
+resolve_remote "$VM_NAME"
 
 log "provisioning Containarium (pod -> gVisor -> containarium) on '${VM_NAME}'"
 provision_base_k8s
-
-log "installing gVisor (${GVISOR_RUNTIME_CLASS})"
-ssh_or_local "sudo bash -s" <<REMOTE
-set -euo pipefail
-ARCH=\$(uname -m)
-URL="https://storage.googleapis.com/gvisor/releases/release/latest/\${ARCH}"
-cd /tmp
-curl -fsSLO "\${URL}/runsc" -O "\${URL}/runsc.sha512" \
-	-O "\${URL}/containerd-shim-runsc-v1" -O "\${URL}/containerd-shim-runsc-v1.sha512"
-sha512sum -c runsc.sha512 -c containerd-shim-runsc-v1.sha512
-chmod a+rx runsc containerd-shim-runsc-v1
-mv runsc containerd-shim-runsc-v1 /usr/local/bin/
-
-cat <<TOML >>/etc/containerd/config.toml
-
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.${GVISOR_RUNTIME_CLASS}]
-  runtime_type = "io.containerd.${GVISOR_RUNTIME_CLASS}.v1"
-TOML
-systemctl restart containerd
-
-cat <<EOF | kubectl apply -f -
-apiVersion: node.k8s.io/v1
-kind: RuntimeClass
-metadata:
-  name: ${GVISOR_RUNTIME_CLASS}
-handler: ${GVISOR_RUNTIME_CLASS}
-EOF
-REMOTE
+install_gvisor
 
 log "installing Helm"
 ssh_or_local "curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | sudo bash"

--- a/benchmark/agent-sandbox-density/scripts/03-provision-containarium.sh
+++ b/benchmark/agent-sandbox-density/scripts/03-provision-containarium.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+#
+# Provision the experiment-group VM: Incus + the Containarium daemon
+# running as a plain LXC "workhorse" — the daemon's default mode, no
+# --runtime=k8s (that backend targets pods on an *existing* cluster; it
+# isn't what "workhorse" means here) and no --standalone (core service
+# containers — Postgres, Caddy, the otel collector — stay in, matching a
+# real deployment's fixed overhead, same principle as leaving the k8s
+# side's kube-system pods in place; see README.md "Fairness notes").
+#
+# Usage:
+#   scripts/03-provision-containarium.sh --name <vm-name>
+#
+# Assumes the guest is Ubuntu Server 24.04 with passwordless sudo for
+# REMOTE_SSH_USER, same as 01-provision-k8s-control.sh.
+
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+# shellcheck source=lib.sh
+source ./lib.sh
+
+VM_NAME=""
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--name)
+		VM_NAME="$2"
+		shift 2
+		;;
+	-h | --help)
+		grep '^#' "$0" | sed 's/^# \{0,1\}//'
+		exit 0
+		;;
+	*)
+		die "unknown argument: $1"
+		;;
+	esac
+done
+[[ -n "$VM_NAME" ]] || die "usage: $0 --name <vm-name>"
+
+load_config
+require_vars CONTAINARIUM_VERSION REMOTE_SSH_USER
+
+log "provisioning Containarium workhorse on '${VM_NAME}' (version=${CONTAINARIUM_VERSION})"
+
+log "installing Incus"
+ssh_or_local "sudo bash -s" <<'REMOTE'
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update -qq
+apt-get install -y -qq curl jq
+curl -fsSL https://pkgs.zabbly.com/get/incus-stable | sudo sh
+
+usermod -aG incus-admin "$(logname 2>/dev/null || echo root)" || true
+incus admin init --auto
+REMOTE
+
+log "downloading containarium ${CONTAINARIUM_VERSION}"
+ssh_or_local "sudo bash -s" <<REMOTE
+set -euo pipefail
+TAG="${CONTAINARIUM_VERSION}"
+if [[ "\$TAG" == "latest" ]]; then
+	TAG=\$(curl -fsSL https://api.github.com/repos/FootprintAI/Containarium/releases/latest | jq -r .tag_name)
+fi
+echo "resolved tag: \$TAG"
+
+BASE_URL="https://github.com/FootprintAI/Containarium/releases/download/\${TAG}"
+curl -fsSL -o /tmp/containarium "\${BASE_URL}/containarium-linux-amd64"
+curl -fsSL -o /tmp/SHA256SUMS.txt "\${BASE_URL}/SHA256SUMS.txt"
+
+EXPECTED=\$(grep 'containarium-linux-amd64\$' /tmp/SHA256SUMS.txt | awk '{print \$1}')
+ACTUAL=\$(sha256sum /tmp/containarium | awk '{print \$1}')
+[[ "\$EXPECTED" == "\$ACTUAL" ]] || {
+	echo "SHA256 mismatch: expected \$EXPECTED, got \$ACTUAL" >&2
+	exit 1
+}
+
+install -m 0755 /tmp/containarium /usr/local/bin/containarium
+containarium version
+REMOTE
+
+log "starting the daemon (standard mode: core services on, LXC backend)"
+ssh_or_local "sudo bash -s" <<'REMOTE'
+set -euo pipefail
+mkdir -p /etc/containarium
+[[ -f /etc/containarium/jwt.secret ]] || openssl rand -hex 32 >/etc/containarium/jwt.secret
+chmod 0400 /etc/containarium/jwt.secret
+
+cat <<'UNIT' >/etc/systemd/system/containarium.service
+[Unit]
+Description=Containarium daemon (density benchmark workhorse)
+After=network-online.target incus.service
+Wants=network-online.target
+
+[Service]
+ExecStart=/usr/local/bin/containarium daemon --address 0.0.0.0 --rest --http-port 8080 --jwt-secret-file /etc/containarium/jwt.secret
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+systemctl daemon-reload
+systemctl enable --now containarium
+sleep 5
+systemctl is-active containarium
+curl -fsS http://127.0.0.1:8080/healthz || echo "warning: /healthz not yet ready, check systemctl status containarium"
+REMOTE
+
+log "provisioning complete. Verify: ssh (see config.env) 'containarium list'"

--- a/benchmark/agent-sandbox-density/scripts/04-run-density-containarium.sh
+++ b/benchmark/agent-sandbox-density/scripts/04-run-density-containarium.sh
@@ -1,14 +1,19 @@
 #!/bin/bash
 #
 # Density loop for the experiment group: create Containarium boxes one at a
-# time via `containarium create` until the shared stopping rule in lib.sh's
+# time (each scheduled under gVisor via the runtimeClass set in
+# 03-provision-containarium.sh) until the shared stopping rule in lib.sh's
 # run_density_loop triggers.
 #
-# LXC boxes have one enforced resource ceiling per resource, not a
-# request+limit pair — this uses SANDBOX_CPU_LIMIT / SANDBOX_MEM_LIMIT
-# (converted from k8s quantities to Containarium's core-count / decimal-MB
-# units below) as the single --cpu / --memory value, and a deliberately
-# small fixed SANDBOX_DISK_LIMIT so disk is never what stops the run.
+# The k8s backend parses --cpu/--memory with Kubernetes' native quantity
+# parser (resource.ParseQuantity) and sets BOTH request and limit to that
+# same value — see pkg/core/box/k8s/objects.go. So this passes
+# SANDBOX_CPU_LIMIT/SANDBOX_MEM_LIMIT straight through, no unit conversion
+# needed (unlike the old LXC-backend version of this script). Worth noting
+# as a fairness asymmetry, not hidden: the control group's Sandbox pods
+# request the lower REQUEST value (k8s admission packs on requests, not
+# limits), while Containarium's boxes request the full LIMIT value — see
+# README.md "Fairness notes".
 #
 # Usage:
 #   scripts/04-run-density-containarium.sh --name <vm-name>
@@ -37,69 +42,47 @@ done
 [[ -n "$VM_NAME" ]] || die "usage: $0 --name <vm-name>"
 
 load_config
-require_vars SANDBOX_CPU_LIMIT SANDBOX_MEM_LIMIT SANDBOX_DISK_LIMIT \
-	FAILURE_STREAK_TO_STOP CREATE_TIMEOUT_SECONDS
+require_vars SANDBOX_CPU_LIMIT SANDBOX_MEM_LIMIT FAILURE_STREAK_TO_STOP CREATE_TIMEOUT_SECONDS
 
-# k8s CPU quantity ("100m" = 0.1 core, "1" = 1 core) -> Containarium's
-# core-count string.
-k8s_cpu_to_cores() {
-	local q="$1"
-	if [[ "$q" == *m ]]; then
-		awk -v m="${q%m}" 'BEGIN { printf "%.3f", m / 1000 }'
-	else
-		echo "$q"
-	fi
-}
-
-# k8s memory quantity (Mi/Gi, binary) -> Containarium's MB/GB (decimal)
-# string. Approximate is fine for a density benchmark; note the ~5% Mi->MB
-# gap if you're eyeballing the two sides' raw numbers against each other.
-k8s_mem_to_containarium() {
-	local q="$1"
-	if [[ "$q" == *Mi ]]; then
-		awk -v mi="${q%Mi}" 'BEGIN { printf "%dMB", mi * 1.048576 }'
-	elif [[ "$q" == *Gi ]]; then
-		awk -v gi="${q%Gi}" 'BEGIN { printf "%dGB", gi * 1.073741824 }'
-	else
-		echo "$q"
-	fi
-}
-
-CTN_CPU="$(k8s_cpu_to_cores "$SANDBOX_CPU_LIMIT")"
-CTN_MEM="$(k8s_mem_to_containarium "$SANDBOX_MEM_LIMIT")"
-CTN_DISK="$SANDBOX_DISK_LIMIT"
-
-log "sandbox profile on the Containarium side: cpu=${CTN_CPU} memory=${CTN_MEM} disk=${CTN_DISK}"
+log "sandbox profile on the Containarium side: cpu=${SANDBOX_CPU_LIMIT} memory=${SANDBOX_MEM_LIMIT} (k8s-native quantities, request==limit)"
 
 RESULTS_DIR="${BENCH_ROOT}/results"
 mkdir -p "$RESULTS_DIR"
 RESULTS_FILE="${RESULTS_DIR}/containarium-$(date -u +%Y%m%dT%H%M%SZ).md"
 
-log "minting an admin token"
-CTN_TOKEN=$(ssh_or_local "sudo containarium token generate --username bench-admin --roles admin --expiry 6h --secret-file /etc/containarium/jwt.secret --raw")
-[[ -n "$CTN_TOKEN" ]] || die "failed to mint a token — check the daemon is running (systemctl status containarium)"
+log "starting kubectl port-forward to the daemon and minting an admin token"
+ssh_or_local "pkill -f 'port-forward svc/containarium' 2>/dev/null; setsid nohup kubectl port-forward svc/containarium-containarium-k8s-daemon 8080:8080 >/tmp/port-forward.log 2>&1 < /dev/null &"
+sleep 3
+
+JWT_SECRET=$(ssh_or_local "kubectl get secret containarium-containarium-k8s-daemon -o jsonpath='{.data.jwt-secret}' | base64 -d")
+[[ -n "$JWT_SECRET" ]] || die "failed to read the daemon's jwt-secret — check helm install succeeded (03-provision-containarium.sh)"
+CTN_TOKEN=$(ssh_or_local "containarium token generate --username bench-admin --roles admin --expiry 6h --secret '${JWT_SECRET}' --raw")
+[[ -n "$CTN_TOKEN" ]] || die "failed to mint a token"
+
+CTN_SERVER="http://127.0.0.1:8080"
 
 create_box() {
 	local name="$1"
-	ssh_or_local "containarium create ${name} --no-ssh-key --cpu ${CTN_CPU} --memory ${CTN_MEM} --disk ${CTN_DISK} --server http://127.0.0.1:8080 --http --token ${CTN_TOKEN}" >/dev/null 2>&1
+	ssh_or_local "containarium create ${name} --no-ssh-key --cpu ${SANDBOX_CPU_LIMIT} --memory ${SANDBOX_MEM_LIMIT} --server ${CTN_SERVER} --http --token ${CTN_TOKEN}" >/dev/null 2>&1
 }
 
 box_ready() {
 	local name="$1"
 	local state
-	state=$(ssh_or_local "containarium list --format json --server http://127.0.0.1:8080 --http --token ${CTN_TOKEN} 2>/dev/null" |
+	state=$(ssh_or_local "containarium list --format json --server ${CTN_SERVER} --http --token ${CTN_TOKEN} 2>/dev/null" |
 		jq -r --arg n "$name" '.[] | select(.username==$n) | .state' 2>/dev/null || true)
 	[[ "$state" == "RUNNING" ]]
 }
 
 cleanup_box() {
 	local name="$1"
-	ssh_or_local "containarium delete ${name} --force --server http://127.0.0.1:8080 --http --token ${CTN_TOKEN}" >/dev/null 2>&1 || true
+	ssh_or_local "containarium delete ${name} --force --server ${CTN_SERVER} --http --token ${CTN_TOKEN}" >/dev/null 2>&1 || true
 }
 
 resource_snapshot "before" "$RESULTS_FILE"
 {
-	echo "profile: cpu ${CTN_CPU} cores, mem ${CTN_MEM}, disk ${CTN_DISK} (converted from cpu ${SANDBOX_CPU_LIMIT}, mem ${SANDBOX_MEM_LIMIT})"
+	echo "profile: cpu ${SANDBOX_CPU_LIMIT}, mem ${SANDBOX_MEM_LIMIT} (k8s-native, request==limit)"
+	echo "runtimeClass: see 03-provision-containarium.sh GVISOR_RUNTIME_CLASS"
 	echo
 } >>"$RESULTS_FILE"
 
@@ -107,11 +90,15 @@ run_density_loop "sbdens" create_box box_ready cleanup_box "$RESULTS_FILE"
 
 resource_snapshot "after (${DENSITY_RESULT_COUNT} ready)" "$RESULTS_FILE"
 {
-	echo "containarium list totals:"
+	echo "kubectl top nodes (if metrics-server installed):"
 	echo '```'
-	ssh_or_local "containarium list --server http://127.0.0.1:8080 --http --token ${CTN_TOKEN} 2>&1" || true
+	ssh_or_local "kubectl top nodes 2>&1" || true
+	echo '```'
+	echo "pods by RuntimeClass (sanity check that boxes really landed on gVisor):"
+	echo '```'
+	ssh_or_local "kubectl get pods -A -o custom-columns=NAME:.metadata.name,RUNTIMECLASS:.spec.runtimeClassName 2>&1" || true
 	echo '```'
 } >>"$RESULTS_FILE"
 
-log "Containarium workhorse result: ${DENSITY_RESULT_COUNT} boxes reached RUNNING"
+log "Containarium (gVisor) experiment group result: ${DENSITY_RESULT_COUNT} boxes reached RUNNING"
 log "full log: ${RESULTS_FILE}"

--- a/benchmark/agent-sandbox-density/scripts/04-run-density-containarium.sh
+++ b/benchmark/agent-sandbox-density/scripts/04-run-density-containarium.sh
@@ -15,6 +15,26 @@
 # limits), while Containarium's boxes request the full LIMIT value — see
 # README.md "Fairness notes".
 #
+# Two more things found live, worth knowing before reading this script:
+#
+# 1. `create`'s default --image ("images:ubuntu/24.04") is an LXC-style
+#    reference, not a valid OCI image — it 500s the k8s backend's pod with
+#    InvalidImageName. There's no backend-aware default. Explicitly passes
+#    Containarium's own agent-box image instead (the same one the Helm
+#    chart's agentBox.image value points at), version-tagged to match the
+#    daemon build (":latest" 404s on GHCR — only version tags are
+#    published) — read from /tmp/containarium-resolved-tag, which
+#    03-provision-containarium.sh's tag-resolution step writes.
+#
+# 2. `containarium list` unconditionally errors on this backend —
+#    "incus backend not available on this host" — so it can't be used for
+#    readiness or cleanup verification here. Readiness is checked directly
+#    via the k8s API instead: every box's pod is named "box" in namespace
+#    "tenant-<username>" (confirmed live), so this polls
+#    `kubectl get pod -n tenant-<name> box` for phase=Running + container
+#    ready. `containarium delete` (unlike `list`) works fine and is still
+#    used for cleanup.
+#
 # Usage:
 #   scripts/04-run-density-containarium.sh --name <vm-name>
 
@@ -51,28 +71,32 @@ RESULTS_DIR="${BENCH_ROOT}/results"
 mkdir -p "$RESULTS_DIR"
 RESULTS_FILE="${RESULTS_DIR}/containarium-$(date -u +%Y%m%dT%H%M%SZ).md"
 
-log "starting kubectl port-forward to the daemon and minting an admin token"
-ssh_or_local "pkill -f 'port-forward svc/containarium' 2>/dev/null; setsid nohup kubectl port-forward svc/containarium-containarium-k8s-daemon 8080:8080 >/tmp/port-forward.log 2>&1 < /dev/null &"
-sleep 3
+RESOLVED_TAG=$(ssh_or_local "cat /tmp/containarium-resolved-tag 2>/dev/null" || true)
+[[ -n "$RESOLVED_TAG" ]] || die "couldn't read /tmp/containarium-resolved-tag — did 03-provision-containarium.sh run first?"
+AGENT_BOX_IMAGE="ghcr.io/footprintai/containarium-agent-box:${RESOLVED_TAG}"
+log "using agent-box image ${AGENT_BOX_IMAGE}"
+
+log "resolving the daemon's ClusterIP and minting an admin token (containarium list is broken on this backend — see header — so no port-forward/list dependency here)"
+CTN_CLUSTERIP=$(ssh_or_local "kubectl get svc containarium-containarium-k8s-daemon -o jsonpath='{.spec.clusterIP}'")
+[[ -n "$CTN_CLUSTERIP" ]] || die "couldn't resolve the daemon's ClusterIP — check 'kubectl get svc' on the guest"
+CTN_SERVER="http://${CTN_CLUSTERIP}:8080"
 
 JWT_SECRET=$(ssh_or_local "kubectl get secret containarium-containarium-k8s-daemon -o jsonpath='{.data.jwt-secret}' | base64 -d")
 [[ -n "$JWT_SECRET" ]] || die "failed to read the daemon's jwt-secret — check helm install succeeded (03-provision-containarium.sh)"
 CTN_TOKEN=$(ssh_or_local "containarium token generate --username bench-admin --roles admin --expiry 6h --secret '${JWT_SECRET}' --raw")
 [[ -n "$CTN_TOKEN" ]] || die "failed to mint a token"
 
-CTN_SERVER="http://127.0.0.1:8080"
-
 create_box() {
 	local name="$1"
-	ssh_or_local "containarium create ${name} --no-ssh-key --cpu ${SANDBOX_CPU_LIMIT} --memory ${SANDBOX_MEM_LIMIT} --server ${CTN_SERVER} --http --token ${CTN_TOKEN}" >/dev/null 2>&1
+	ssh_or_local "containarium create ${name} --no-ssh-key --cpu ${SANDBOX_CPU_LIMIT} --memory ${SANDBOX_MEM_LIMIT} --image ${AGENT_BOX_IMAGE} --server ${CTN_SERVER} --http --token ${CTN_TOKEN}" >/dev/null 2>&1
 }
 
 box_ready() {
 	local name="$1"
-	local state
-	state=$(ssh_or_local "containarium list --format json --server ${CTN_SERVER} --http --token ${CTN_TOKEN} 2>/dev/null" |
-		jq -r --arg n "$name" '.[] | select(.username==$n) | .state' 2>/dev/null || true)
-	[[ "$state" == "RUNNING" ]]
+	local phase ready
+	phase=$(ssh_or_local "kubectl get pod -n tenant-${name} box -o jsonpath='{.status.phase}' 2>/dev/null" || true)
+	ready=$(ssh_or_local "kubectl get pod -n tenant-${name} box -o jsonpath='{.status.containerStatuses[0].ready}' 2>/dev/null" || true)
+	[[ "$phase" == "Running" && "$ready" == "true" ]]
 }
 
 cleanup_box() {
@@ -83,6 +107,7 @@ cleanup_box() {
 resource_snapshot "before" "$RESULTS_FILE"
 {
 	echo "profile: cpu ${SANDBOX_CPU_LIMIT}, mem ${SANDBOX_MEM_LIMIT} (k8s-native, request==limit)"
+	echo "image: ${AGENT_BOX_IMAGE}"
 	echo "runtimeClass: see 03-provision-containarium.sh GVISOR_RUNTIME_CLASS"
 	echo
 } >>"$RESULTS_FILE"

--- a/benchmark/agent-sandbox-density/scripts/04-run-density-containarium.sh
+++ b/benchmark/agent-sandbox-density/scripts/04-run-density-containarium.sh
@@ -42,7 +42,8 @@ done
 [[ -n "$VM_NAME" ]] || die "usage: $0 --name <vm-name>"
 
 load_config
-require_vars SANDBOX_CPU_LIMIT SANDBOX_MEM_LIMIT FAILURE_STREAK_TO_STOP CREATE_TIMEOUT_SECONDS
+require_vars SANDBOX_CPU_LIMIT SANDBOX_MEM_LIMIT FAILURE_STREAK_TO_STOP CREATE_TIMEOUT_SECONDS BENCH_SSH_KEY_FILE
+resolve_remote "$VM_NAME"
 
 log "sandbox profile on the Containarium side: cpu=${SANDBOX_CPU_LIMIT} memory=${SANDBOX_MEM_LIMIT} (k8s-native quantities, request==limit)"
 

--- a/benchmark/agent-sandbox-density/scripts/04-run-density-containarium.sh
+++ b/benchmark/agent-sandbox-density/scripts/04-run-density-containarium.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+#
+# Density loop for the experiment group: create Containarium boxes one at a
+# time via `containarium create` until the shared stopping rule in lib.sh's
+# run_density_loop triggers.
+#
+# LXC boxes have one enforced resource ceiling per resource, not a
+# request+limit pair — this uses SANDBOX_CPU_LIMIT / SANDBOX_MEM_LIMIT
+# (converted from k8s quantities to Containarium's core-count / decimal-MB
+# units below) as the single --cpu / --memory value, and a deliberately
+# small fixed SANDBOX_DISK_LIMIT so disk is never what stops the run.
+#
+# Usage:
+#   scripts/04-run-density-containarium.sh --name <vm-name>
+
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+# shellcheck source=lib.sh
+source ./lib.sh
+
+VM_NAME=""
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--name)
+		VM_NAME="$2"
+		shift 2
+		;;
+	-h | --help)
+		grep '^#' "$0" | sed 's/^# \{0,1\}//'
+		exit 0
+		;;
+	*)
+		die "unknown argument: $1"
+		;;
+	esac
+done
+[[ -n "$VM_NAME" ]] || die "usage: $0 --name <vm-name>"
+
+load_config
+require_vars SANDBOX_CPU_LIMIT SANDBOX_MEM_LIMIT SANDBOX_DISK_LIMIT \
+	FAILURE_STREAK_TO_STOP CREATE_TIMEOUT_SECONDS
+
+# k8s CPU quantity ("100m" = 0.1 core, "1" = 1 core) -> Containarium's
+# core-count string.
+k8s_cpu_to_cores() {
+	local q="$1"
+	if [[ "$q" == *m ]]; then
+		awk -v m="${q%m}" 'BEGIN { printf "%.3f", m / 1000 }'
+	else
+		echo "$q"
+	fi
+}
+
+# k8s memory quantity (Mi/Gi, binary) -> Containarium's MB/GB (decimal)
+# string. Approximate is fine for a density benchmark; note the ~5% Mi->MB
+# gap if you're eyeballing the two sides' raw numbers against each other.
+k8s_mem_to_containarium() {
+	local q="$1"
+	if [[ "$q" == *Mi ]]; then
+		awk -v mi="${q%Mi}" 'BEGIN { printf "%dMB", mi * 1.048576 }'
+	elif [[ "$q" == *Gi ]]; then
+		awk -v gi="${q%Gi}" 'BEGIN { printf "%dGB", gi * 1.073741824 }'
+	else
+		echo "$q"
+	fi
+}
+
+CTN_CPU="$(k8s_cpu_to_cores "$SANDBOX_CPU_LIMIT")"
+CTN_MEM="$(k8s_mem_to_containarium "$SANDBOX_MEM_LIMIT")"
+CTN_DISK="$SANDBOX_DISK_LIMIT"
+
+log "sandbox profile on the Containarium side: cpu=${CTN_CPU} memory=${CTN_MEM} disk=${CTN_DISK}"
+
+RESULTS_DIR="${BENCH_ROOT}/results"
+mkdir -p "$RESULTS_DIR"
+RESULTS_FILE="${RESULTS_DIR}/containarium-$(date -u +%Y%m%dT%H%M%SZ).md"
+
+log "minting an admin token"
+CTN_TOKEN=$(ssh_or_local "sudo containarium token generate --username bench-admin --roles admin --expiry 6h --secret-file /etc/containarium/jwt.secret --raw")
+[[ -n "$CTN_TOKEN" ]] || die "failed to mint a token — check the daemon is running (systemctl status containarium)"
+
+create_box() {
+	local name="$1"
+	ssh_or_local "containarium create ${name} --no-ssh-key --cpu ${CTN_CPU} --memory ${CTN_MEM} --disk ${CTN_DISK} --server http://127.0.0.1:8080 --http --token ${CTN_TOKEN}" >/dev/null 2>&1
+}
+
+box_ready() {
+	local name="$1"
+	local state
+	state=$(ssh_or_local "containarium list --format json --server http://127.0.0.1:8080 --http --token ${CTN_TOKEN} 2>/dev/null" |
+		jq -r --arg n "$name" '.[] | select(.username==$n) | .state' 2>/dev/null || true)
+	[[ "$state" == "RUNNING" ]]
+}
+
+cleanup_box() {
+	local name="$1"
+	ssh_or_local "containarium delete ${name} --force --server http://127.0.0.1:8080 --http --token ${CTN_TOKEN}" >/dev/null 2>&1 || true
+}
+
+resource_snapshot "before" "$RESULTS_FILE"
+{
+	echo "profile: cpu ${CTN_CPU} cores, mem ${CTN_MEM}, disk ${CTN_DISK} (converted from cpu ${SANDBOX_CPU_LIMIT}, mem ${SANDBOX_MEM_LIMIT})"
+	echo
+} >>"$RESULTS_FILE"
+
+run_density_loop "sbdens" create_box box_ready cleanup_box "$RESULTS_FILE"
+
+resource_snapshot "after (${DENSITY_RESULT_COUNT} ready)" "$RESULTS_FILE"
+{
+	echo "containarium list totals:"
+	echo '```'
+	ssh_or_local "containarium list --server http://127.0.0.1:8080 --http --token ${CTN_TOKEN} 2>&1" || true
+	echo '```'
+} >>"$RESULTS_FILE"
+
+log "Containarium workhorse result: ${DENSITY_RESULT_COUNT} boxes reached RUNNING"
+log "full log: ${RESULTS_FILE}"

--- a/benchmark/agent-sandbox-density/scripts/99-teardown-vm.sh
+++ b/benchmark/agent-sandbox-density/scripts/99-teardown-vm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Stop and delete a benchmark VM (including its disk image), freeing the
+# Stop and delete a benchmark Incus VM (including its disk), freeing the
 # host's resources for the other side's run — see README.md "Why
 # sequential, not parallel".
 #
@@ -30,18 +30,14 @@ while [[ $# -gt 0 ]]; do
 done
 [[ -n "$VM_NAME" ]] || die "usage: $0 --name <vm-name>"
 
-command -v VBoxManage >/dev/null 2>&1 || die "VBoxManage not found"
+command -v incus >/dev/null 2>&1 || die "incus not found — this must run on the hypervisor host"
 
-if ! VBoxManage list vms | grep -q "\"${VM_NAME}\""; then
+if ! sudo incus list --format csv -c n | grep -qx "$VM_NAME"; then
 	log "no VM named '${VM_NAME}' — nothing to do"
 	exit 0
 fi
 
-log "stopping '${VM_NAME}' (if running)"
-VBoxManage controlvm "$VM_NAME" poweroff 2>/dev/null || true
-sleep 2
-
-log "deleting '${VM_NAME}' and its disk(s)"
-VBoxManage unregistervm "$VM_NAME" --delete
+log "deleting Incus VM '${VM_NAME}' (force stop + delete, including its disk)"
+sudo incus delete "$VM_NAME" --force
 
 log "done"

--- a/benchmark/agent-sandbox-density/scripts/99-teardown-vm.sh
+++ b/benchmark/agent-sandbox-density/scripts/99-teardown-vm.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# Stop and delete a benchmark VM (including its disk image), freeing the
+# host's resources for the other side's run — see README.md "Why
+# sequential, not parallel".
+#
+# Usage:
+#   scripts/99-teardown-vm.sh --name <vm-name>
+
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+# shellcheck source=lib.sh
+source ./lib.sh
+
+VM_NAME=""
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--name)
+		VM_NAME="$2"
+		shift 2
+		;;
+	-h | --help)
+		grep '^#' "$0" | sed 's/^# \{0,1\}//'
+		exit 0
+		;;
+	*)
+		die "unknown argument: $1"
+		;;
+	esac
+done
+[[ -n "$VM_NAME" ]] || die "usage: $0 --name <vm-name>"
+
+command -v VBoxManage >/dev/null 2>&1 || die "VBoxManage not found"
+
+if ! VBoxManage list vms | grep -q "\"${VM_NAME}\""; then
+	log "no VM named '${VM_NAME}' — nothing to do"
+	exit 0
+fi
+
+log "stopping '${VM_NAME}' (if running)"
+VBoxManage controlvm "$VM_NAME" poweroff 2>/dev/null || true
+sleep 2
+
+log "deleting '${VM_NAME}' and its disk(s)"
+VBoxManage unregistervm "$VM_NAME" --delete
+
+log "done"

--- a/benchmark/agent-sandbox-density/scripts/k8s-common.sh
+++ b/benchmark/agent-sandbox-density/scripts/k8s-common.sh
@@ -1,13 +1,18 @@
 #!/bin/bash
 #
-# Shared kubeadm + CNI + agent-sandbox-controller provisioning. Both sides
-# of this benchmark run on Kubernetes now — the control group creates
-# `Sandbox` CRs directly, the experiment group creates them indirectly via
-# the Containarium daemon (see README.md "Experiment group") — so both
-# need the identical base cluster. This is that shared base: any drift
-# between the two sides here would confound the comparison (see README.md
-# "Fairness notes"). Sourced by 01-provision-k8s-control.sh and
-# 03-provision-containarium.sh, not executed directly.
+# Shared kubeadm + CNI + gVisor + agent-sandbox-controller provisioning.
+# Both sides of this benchmark run on Kubernetes, with gVisor installed and
+# every Sandbox pod scheduled under it — the control group creates `Sandbox`
+# CRs directly (kubectl), the experiment group creates them indirectly via
+# the Containarium daemon (see README.md "What's actually under test").
+# gVisor being present on BOTH sides is deliberate: it removes gVisor
+# itself as a variable, so what the benchmark actually isolates is
+# Containarium's own orchestration cost (the extra daemon hop, and the
+# request==limit CLI behavior — see README.md "Fairness notes"), not
+# "does gVisor cost density" mixed in with it. Any drift between the two
+# sides in this shared setup would confound that. Sourced by
+# 01-provision-k8s-control.sh and 03-provision-containarium.sh, not
+# executed directly.
 
 set -euo pipefail
 
@@ -87,4 +92,38 @@ REMOTE
 	log "installing agent-sandbox controller ${AGENT_SANDBOX_VERSION}"
 	ssh_or_local "kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/${AGENT_SANDBOX_VERSION}/manifest.yaml"
 	ssh_or_local "kubectl -n agent-sandbox-system wait --for=condition=available deployment/agent-sandbox-controller --timeout=180s"
+}
+
+# install_gvisor installs runsc + the containerd shim, registers it as a
+# containerd runtime handler, and creates the matching k8s RuntimeClass.
+# Called on BOTH sides (see the file header) so gVisor itself isn't a
+# variable between the two runs — only who's doing the scheduling is.
+install_gvisor() {
+	log "installing gVisor (${GVISOR_RUNTIME_CLASS})"
+	ssh_or_local "sudo bash -s" <<REMOTE
+set -euo pipefail
+ARCH=\$(uname -m)
+URL="https://storage.googleapis.com/gvisor/releases/release/latest/\${ARCH}"
+cd /tmp
+curl -fsSLO "\${URL}/runsc" -O "\${URL}/runsc.sha512" \
+	-O "\${URL}/containerd-shim-runsc-v1" -O "\${URL}/containerd-shim-runsc-v1.sha512"
+sha512sum -c runsc.sha512 -c containerd-shim-runsc-v1.sha512
+chmod a+rx runsc containerd-shim-runsc-v1
+mv runsc containerd-shim-runsc-v1 /usr/local/bin/
+
+cat <<TOML >>/etc/containerd/config.toml
+
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.${GVISOR_RUNTIME_CLASS}]
+  runtime_type = "io.containerd.${GVISOR_RUNTIME_CLASS}.v1"
+TOML
+systemctl restart containerd
+
+cat <<EOF | kubectl apply -f -
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: ${GVISOR_RUNTIME_CLASS}
+handler: ${GVISOR_RUNTIME_CLASS}
+EOF
+REMOTE
 }

--- a/benchmark/agent-sandbox-density/scripts/k8s-common.sh
+++ b/benchmark/agent-sandbox-density/scripts/k8s-common.sh
@@ -87,6 +87,12 @@ REMOTE
 
 	log "installing Calico CNI"
 	ssh_or_local "kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.28.0/manifests/calico.yaml"
+	# `kubectl wait` on a label selector errors immediately with "no
+	# matching resources found" if zero pods currently match — it does not
+	# wait for the DaemonSet controller to create them. Hit this live: the
+	# calico-node DaemonSet object exists right after apply, but its pods
+	# take a few seconds to appear. Poll for at least one to exist first.
+	ssh_or_local "until [ \"\$(kubectl get pods -l k8s-app=calico-node -n kube-system --no-headers 2>/dev/null | wc -l)\" -gt 0 ]; do sleep 2; done"
 	ssh_or_local "kubectl wait --for=condition=ready pod -l k8s-app=calico-node -n kube-system --timeout=180s"
 
 	log "installing agent-sandbox controller ${AGENT_SANDBOX_VERSION}"

--- a/benchmark/agent-sandbox-density/scripts/k8s-common.sh
+++ b/benchmark/agent-sandbox-density/scripts/k8s-common.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+#
+# Shared kubeadm + CNI + agent-sandbox-controller provisioning. Both sides
+# of this benchmark run on Kubernetes now — the control group creates
+# `Sandbox` CRs directly, the experiment group creates them indirectly via
+# the Containarium daemon (see README.md "Experiment group") — so both
+# need the identical base cluster. This is that shared base: any drift
+# between the two sides here would confound the comparison (see README.md
+# "Fairness notes"). Sourced by 01-provision-k8s-control.sh and
+# 03-provision-containarium.sh, not executed directly.
+
+set -euo pipefail
+
+provision_base_k8s() {
+	log "installing containerd + kubeadm/kubelet/kubectl"
+	ssh_or_local "sudo bash -s" <<'REMOTE'
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update -qq
+apt-get install -y -qq apt-transport-https ca-certificates curl gpg containerd
+
+mkdir -p /etc/containerd
+containerd config default | sudo tee /etc/containerd/config.toml >/dev/null
+sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
+systemctl restart containerd
+
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.30/deb/Release.key |
+	gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /' |
+	tee /etc/apt/sources.list.d/kubernetes.list >/dev/null
+apt-get update -qq
+apt-get install -y -qq kubelet kubeadm kubectl
+apt-mark hold kubelet kubeadm kubectl
+
+swapoff -a
+sed -i '/ swap /s/^/#/' /etc/fstab
+
+cat <<EOF >/etc/modules-load.d/k8s.conf
+overlay
+br_netfilter
+EOF
+modprobe overlay
+modprobe br_netfilter
+
+cat <<EOF >/etc/sysctl.d/k8s.conf
+net.bridge.bridge-nf-call-iptables  = 1
+net.ipv4.ip_forward                 = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+EOF
+sysctl --system >/dev/null
+REMOTE
+
+	log "kubeadm init with maxPods=${K8S_MAX_PODS}"
+	ssh_or_local "sudo bash -s" <<REMOTE
+set -euo pipefail
+cat <<KUBEADM_CFG >/tmp/kubeadm-config.yaml
+apiVersion: kubeadm.k8s.io/v1beta3
+kind: ClusterConfiguration
+networking:
+  podSubnet: "192.168.0.0/16"
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+maxPods: ${K8S_MAX_PODS}
+KUBEADM_CFG
+
+kubeadm init --config /tmp/kubeadm-config.yaml
+
+mkdir -p /root/.kube
+cp -f /etc/kubernetes/admin.conf /root/.kube/config
+mkdir -p /home/${REMOTE_SSH_USER}/.kube
+cp -f /etc/kubernetes/admin.conf /home/${REMOTE_SSH_USER}/.kube/config
+chown -R ${REMOTE_SSH_USER}:${REMOTE_SSH_USER} /home/${REMOTE_SSH_USER}/.kube
+
+# Single-node cluster — the control-plane taint would otherwise prevent
+# any pod (Sandbox-controller-owned or Containarium-owned) from
+# scheduling at all.
+kubectl --kubeconfig=/root/.kube/config taint nodes --all node-role.kubernetes.io/control-plane- || true
+REMOTE
+
+	log "installing Calico CNI"
+	ssh_or_local "kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.28.0/manifests/calico.yaml"
+	ssh_or_local "kubectl wait --for=condition=ready pod -l k8s-app=calico-node -n kube-system --timeout=180s"
+
+	log "installing agent-sandbox controller ${AGENT_SANDBOX_VERSION}"
+	ssh_or_local "kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/${AGENT_SANDBOX_VERSION}/manifest.yaml"
+	ssh_or_local "kubectl -n agent-sandbox-system wait --for=condition=available deployment/agent-sandbox-controller --timeout=180s"
+}

--- a/benchmark/agent-sandbox-density/scripts/k8s-common.sh
+++ b/benchmark/agent-sandbox-density/scripts/k8s-common.sh
@@ -119,10 +119,21 @@ mv runsc containerd-shim-runsc-v1 /usr/local/bin/
 
 cat <<TOML >>/etc/containerd/config.toml
 
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.${GVISOR_RUNTIME_CLASS}]
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.${GVISOR_RUNTIME_CLASS}]
   runtime_type = "io.containerd.${GVISOR_RUNTIME_CLASS}.v1"
 TOML
 systemctl restart containerd
+sleep 2
+# Confirm the CRI plugin actually picked up the new runtime handler before
+# moving on — found live that the wrong plugin ID (an older containerd
+# v1-era path, io.containerd.grpc.v1.cri) silently creates an inert config
+# tree on containerd v2.x: no error, no warning, just "no runtime for
+# \"${GVISOR_RUNTIME_CLASS}\" is configured" at first pod creation, several
+# steps later. containerd 2.x's actual CRI plugin id is
+# io.containerd.cri.v1.runtime (see the existing runc entry
+# \`containerd config default\` already generates, in the same file).
+crictl info 2>/dev/null | grep -q "\"${GVISOR_RUNTIME_CLASS}\"" ||
+	{ echo "containerd did not pick up the ${GVISOR_RUNTIME_CLASS} runtime handler after restart" >&2; exit 1; }
 
 cat <<EOF | kubectl apply -f -
 apiVersion: node.k8s.io/v1

--- a/benchmark/agent-sandbox-density/scripts/lib.sh
+++ b/benchmark/agent-sandbox-density/scripts/lib.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+#
+# Shared helpers for the sandbox-density benchmark scripts. Sourced, not
+# executed directly.
+#
+# Keeping the stopping rule and the resource-snapshot format here (instead
+# of duplicated in 02-run-density-k8s.sh and 04-run-density-containarium.sh)
+# is what makes the two sides comparable — a change to the methodology only
+# has to be made once. See README.md "Fairness notes".
+
+set -euo pipefail
+
+BENCH_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+log() {
+	echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*" >&2
+}
+
+die() {
+	log "ERROR: $*"
+	exit 1
+}
+
+# load_config sources config.env (created from config.env.example) and
+# fails loudly if it's missing, rather than silently running with unset
+# variables.
+load_config() {
+	local config_file="${BENCH_ROOT}/config.env"
+	[[ -f "$config_file" ]] || die "missing $config_file — copy config.env.example to config.env and fill it in first"
+	# shellcheck source=/dev/null
+	source "$config_file"
+}
+
+# require_vars checks that every named variable is non-empty, failing
+# loudly and naming which one is missing rather than proceeding with an
+# empty value that fails confusingly three steps later.
+require_vars() {
+	local missing=()
+	local var
+	for var in "$@"; do
+		if [[ -z "${!var:-}" ]]; then
+			missing+=("$var")
+		fi
+	done
+	if [[ ${#missing[@]} -gt 0 ]]; then
+		die "required config value(s) not set: ${missing[*]} (check config.env)"
+	fi
+}
+
+# ssh_or_local runs a command inside the guest under test — over SSH to
+# REMOTE_HOST:REMOTE_SSH_PORT (defaults in config.env.example match the VM
+# NAT port-forward 00-create-vm.sh sets up: 127.0.0.1:2222), or directly via
+# bash if REMOTE_HOST is left empty (e.g. running these scripts from inside
+# the guest itself). Every provisioning/density script goes through this so
+# there's exactly one place that knows how to reach the guest.
+ssh_or_local() {
+	if [[ -n "${REMOTE_HOST:-}" ]]; then
+		ssh -p "${REMOTE_SSH_PORT:-22}" -o StrictHostKeyChecking=accept-new \
+			"${REMOTE_SSH_USER:+$REMOTE_SSH_USER@}${REMOTE_HOST}" "$@"
+	else
+		bash -c "$*"
+	fi
+}
+
+# resource_snapshot appends a labeled host resource snapshot to the given
+# results file — memory, CPU count, and disk, using `free`'s "available"
+# column rather than "free" (available accounts for reclaimable page
+# cache; free doesn't, and undercounts real headroom — see the density
+# README's host-sizing note).
+resource_snapshot() {
+	local label="$1" results_file="$2"
+	{
+		echo "### snapshot: ${label} ($(date -u +%Y-%m-%dT%H:%M:%SZ))"
+		echo '```'
+		ssh_or_local "free -h; echo; nproc; echo; df -h /" 2>&1
+		echo '```'
+		echo
+	} >>"$results_file"
+}
+
+# run_density_loop drives the shared "create one more unit, check if it
+# became ready, stop after N consecutive resource-reason failures" logic.
+# Both density scripts (02, 04) pass in their own create/check/cleanup
+# functions by name so the loop itself — and therefore the stopping rule —
+# is identical on both sides.
+#
+# Args:
+#   $1 - name prefix for created units (e.g. "sbdens" -> sbdens-0001, ...)
+#   $2 - name of a function: create_fn <unit-name>  -> returns 0 on accepted, non-zero on rejected
+#   $3 - name of a function: ready_fn <unit-name>   -> returns 0 once ready, non-zero while pending
+#   $4 - name of a function: cleanup_fn <unit-name> -> best-effort teardown of a failed/half-created unit
+#   $5 - results file to append the run log to
+#
+# On return, sets DENSITY_RESULT_COUNT to the number of units that reached
+# ready state before the stopping rule triggered.
+run_density_loop() {
+	local prefix="$1" create_fn="$2" ready_fn="$3" cleanup_fn="$4" results_file="$5"
+	local i=0 ready_count=0 fail_streak=0
+	local unit_name start_ts
+
+	log "starting density loop: prefix=${prefix} stop-after=${FAILURE_STREAK_TO_STOP} consecutive failures, per-unit timeout=${CREATE_TIMEOUT_SECONDS}s"
+	echo "## density run: ${prefix} ($(date -u +%Y-%m-%dT%H:%M:%SZ))" >>"$results_file"
+
+	while true; do
+		i=$((i + 1))
+		unit_name="${prefix}-$(printf '%04d' "$i")"
+		start_ts=$(date +%s)
+
+		if ! "$create_fn" "$unit_name"; then
+			fail_streak=$((fail_streak + 1))
+			log "create rejected for ${unit_name} (failure streak: ${fail_streak}/${FAILURE_STREAK_TO_STOP})"
+			"$cleanup_fn" "$unit_name" || true
+			if [[ $fail_streak -ge $FAILURE_STREAK_TO_STOP ]]; then
+				log "stopping: ${FAILURE_STREAK_TO_STOP} consecutive create failures"
+				break
+			fi
+			continue
+		fi
+
+		local became_ready=0
+		while [[ $(($(date +%s) - start_ts)) -lt $CREATE_TIMEOUT_SECONDS ]]; do
+			if "$ready_fn" "$unit_name"; then
+				became_ready=1
+				break
+			fi
+			sleep 2
+		done
+
+		if [[ $became_ready -eq 1 ]]; then
+			ready_count=$((ready_count + 1))
+			fail_streak=0
+			log "${unit_name} ready (total ready: ${ready_count})"
+		else
+			fail_streak=$((fail_streak + 1))
+			log "${unit_name} never became ready within ${CREATE_TIMEOUT_SECONDS}s (failure streak: ${fail_streak}/${FAILURE_STREAK_TO_STOP})"
+			"$cleanup_fn" "$unit_name" || true
+			if [[ $fail_streak -ge $FAILURE_STREAK_TO_STOP ]]; then
+				log "stopping: ${FAILURE_STREAK_TO_STOP} consecutive not-ready timeouts"
+				break
+			fi
+		fi
+	done
+
+	log "final count: ${ready_count} ready units (${i} attempted)"
+	{
+		echo "- attempted: ${i}"
+		echo "- reached ready: ${ready_count}"
+		echo
+	} >>"$results_file"
+
+	DENSITY_RESULT_COUNT=$ready_count
+}

--- a/benchmark/agent-sandbox-density/scripts/lib.sh
+++ b/benchmark/agent-sandbox-density/scripts/lib.sh
@@ -62,6 +62,24 @@ resolve_remote() {
 	REMOTE_HOST="$ip"
 	REMOTE_SSH_PORT="22"
 	log "resolved ${vm_name} -> ${REMOTE_HOST}"
+
+	# A TCP port being open (what 00-create-vm.sh's own readiness check
+	# uses) doesn't mean sshd will accept a real login yet — cloud-init can
+	# still be mid-way through injecting the authorized key, and sshd is
+	# sometimes bounced by a later cloud-init stage after the port first
+	# opens. Retry an actual command instead of trusting the port alone;
+	# hit this exact race live during the first real run.
+	log "waiting for SSH to actually accept connections (cloud-init can still be settling)"
+	local i
+	for i in $(seq 1 40); do
+		if ssh -p "$REMOTE_SSH_PORT" -o StrictHostKeyChecking=accept-new -o ConnectTimeout=5 \
+			${BENCH_SSH_KEY_FILE:+-i "$BENCH_SSH_KEY_FILE"} \
+			"${REMOTE_SSH_USER:+$REMOTE_SSH_USER@}${REMOTE_HOST}" true 2>/dev/null; then
+			return 0
+		fi
+		sleep 5
+	done
+	die "SSH to ${REMOTE_HOST} never became ready after ~200s"
 }
 
 # ssh_or_local runs a command inside the guest under test — over SSH to

--- a/benchmark/agent-sandbox-density/scripts/lib.sh
+++ b/benchmark/agent-sandbox-density/scripts/lib.sh
@@ -47,15 +47,36 @@ require_vars() {
 	fi
 }
 
+# resolve_remote looks up the live IP of an Incus VM by name and points
+# REMOTE_HOST/REMOTE_SSH_PORT/REMOTE_SSH_USER at it, overriding whatever
+# static values config.env has. Incus VMs get a DHCP-assigned bridge IP,
+# not a fixed NAT-forwarded port, so there's nothing meaningful to put in
+# config.env ahead of time — the provisioning/density scripts all take
+# --name and call this instead. REMOTE_SSH_USER/BENCH_SSH_KEY_FILE still
+# come from config.env (the cloud-init user and the matching private key).
+resolve_remote() {
+	local vm_name="$1"
+	local ip
+	ip=$(sudo incus list "$vm_name" -c 4 --format csv 2>/dev/null | grep -oE '^[0-9.]+' || true)
+	[[ -n "$ip" ]] || die "couldn't resolve an IP for Incus VM '${vm_name}' — is it running? (incus list)"
+	REMOTE_HOST="$ip"
+	REMOTE_SSH_PORT="22"
+	log "resolved ${vm_name} -> ${REMOTE_HOST}"
+}
+
 # ssh_or_local runs a command inside the guest under test — over SSH to
-# REMOTE_HOST:REMOTE_SSH_PORT (defaults in config.env.example match the VM
-# NAT port-forward 00-create-vm.sh sets up: 127.0.0.1:2222), or directly via
-# bash if REMOTE_HOST is left empty (e.g. running these scripts from inside
-# the guest itself). Every provisioning/density script goes through this so
-# there's exactly one place that knows how to reach the guest.
+# REMOTE_HOST:REMOTE_SSH_PORT, using BENCH_SSH_KEY_FILE (the private half
+# of the keypair 00-create-vm.sh injects via cloud-init; see config.env's
+# BENCH_SSH_PUBKEY_FILE). REMOTE_HOST/REMOTE_SSH_PORT are set per-VM by
+# resolve_remote, not config.env — Incus VMs get a DHCP-assigned IP, not a
+# fixed port. Empty REMOTE_HOST runs directly via bash instead (e.g.
+# running these scripts from inside the guest itself). Every provisioning/
+# density script goes through this so there's exactly one place that knows
+# how to reach the guest.
 ssh_or_local() {
 	if [[ -n "${REMOTE_HOST:-}" ]]; then
 		ssh -p "${REMOTE_SSH_PORT:-22}" -o StrictHostKeyChecking=accept-new \
+			${BENCH_SSH_KEY_FILE:+-i "$BENCH_SSH_KEY_FILE"} \
 			"${REMOTE_SSH_USER:+$REMOTE_SSH_USER@}${REMOTE_HOST}" "$@"
 	else
 		bash -c "$*"


### PR DESCRIPTION
## Summary
- Adds `benchmark/agent-sandbox-density/`: plan (`README.md`), reproducible scripts, and **real, executed results** (`RESULTS.md`) comparing sandbox density between:
  - **Control group:** vanilla `kubeadm` + upstream `kubernetes-sigs/agent-sandbox` controller, `Sandbox` CRs created directly via `kubectl`.
  - **Experiment group:** the *same* base cluster, plus a `runsc` (gVisor) RuntimeClass, running the Containarium daemon (`--runtime=k8s`, Helm chart) — **pod → gVisor → containarium**.
- Both sides run under gVisor deliberately (see README "What's actually under test") — isolates Containarium's own orchestration cost from gVisor's cost, rather than conflating the two.
- **Result: 69 sandboxes (control) vs. 34 boxes (Containarium), both CPU-request-bound.** The ~2x gap tracks almost exactly with a documented CLI asymmetry (Containarium's `create` sets request==limit; the control group's pods get a lower separate request), not gVisor overhead — see `RESULTS.md` for the full breakdown.
- VM provisioning uses **Incus VMs**, not VirtualBox — the target host already runs live workloads under Incus/KVM, and loading a second hypervisor's kernel module there is an avoidable stability risk.
- **Six real bugs found and fixed while getting this to actually run** (all as separate, reviewable commits on this branch): missing sshd/cloud-init on the base VM image, a `kubectl wait` race on Calico pods, gVisor registered under the wrong containerd plugin ID on containerd v2.x, missing `jq`/`git` on the base image, and a Helm chart bug (`gateway.namespace=""` breaks install). Plus **three product bugs filed independently** of this benchmark's validity: #1524 (`create`'s default `--image` is invalid on the k8s backend), #1525 (`containarium list` is broken on the k8s backend), #1526 (the chart bug above).
- Tracked in #1521 (now closed out with the result recorded).

## Test plan
- [x] `bash -n` + `shellcheck -x` on every script (clean)
- [x] Grepped the whole diff for concrete instance names/IPs (none)
- [x] **Actually executed end-to-end** on real hardware: both density loops ran to completion, gVisor confirmed live via `uname -r` → `4.19.0-gvisor` on sampled pods from both groups, CPU-admission ceiling confirmed via `kubectl describe node` at both stopping points
- [x] Host left clean afterward (no leftover VMs, verified via `incus list`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)