### PR TITLE
feat(daemon): independent opt-out flags for scanner subsystems

### DIFF
--- a/internal/cmd/daemon.go
+++ b/internal/cmd/daemon.go
@@ -45,6 +45,9 @@ var (
 	skipInfraInit          bool
 	requireIsolatedStorage bool
 	standaloneMode         bool
+	disableSecurityScanner bool
+	disablePentestScanner  bool
+	disableZapScanner      bool
 	enableAppHosting       bool
 	postgresConnString     string
 	baseDomain             string
@@ -139,6 +142,9 @@ func init() {
 	daemonCmd.Flags().BoolVar(&skipInfraInit, "skip-infra-init", false, "Skip automatic infrastructure initialization (storage, network, profile)")
 	daemonCmd.Flags().BoolVar(&requireIsolatedStorage, "require-isolated-storage", false, "Refuse to start on a storage pool that does not give each container its own volume. The dir driver puts every tenant rootfs on one filesystem, so they share one journal and one tenant's writeback can stall another tenant's fsync (see #1206). Off by default: a shared journal is harmless on a dev host or a single-tenant box. Turn it on for backends running mutually untrusting tenants.")
 	daemonCmd.Flags().BoolVar(&standaloneMode, "standalone", false, "Standalone mode: skip core containers (PostgreSQL, Caddy) and start immediately")
+	daemonCmd.Flags().BoolVar(&disableSecurityScanner, "disable-security-scanner", false, "Disable the ClamAV malware scanner that otherwise starts automatically whenever Postgres is configured and auto-scans every newly created container. No independent opt-out existed before this flag — it was purely gated on Postgres being present. Off by default (scanner stays on); set true to skip it, e.g. for a throughput-sensitive deployment or a benchmark where its background work would otherwise add real per-create latency.")
+	daemonCmd.Flags().BoolVar(&disablePentestScanner, "disable-pentest-scanner", false, "Disable the network pentest scanner (headers/TLS/ports/web/DNS) that otherwise starts automatically whenever Postgres is configured. Same rationale as --disable-security-scanner; independent flag since an operator may want one scanner without the other.")
+	daemonCmd.Flags().BoolVar(&disableZapScanner, "disable-zap-scanner", false, "Disable the ZAP web-app scanner that otherwise starts automatically whenever Postgres is configured. Same rationale as --disable-security-scanner.")
 
 	// App hosting settings
 	daemonCmd.Flags().BoolVar(&enableAppHosting, "app-hosting", false, "Enable app hosting feature (requires PostgreSQL)")
@@ -544,44 +550,47 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 
 	// Create dual server config
 	config := &server.DualServerConfig{
-		GRPCAddress:          daemonAddress,
-		GRPCPort:             daemonPort,
-		EnableMTLS:           enableMTLS,
-		CertsDir:             daemonCertsDir,
-		HTTPPort:             daemonHTTPPort,
-		EnableREST:           enableREST,
-		JWTSecret:            finalJWTSecret,
-		SwaggerDir:           swaggerDir,
-		EnableAppHosting:     enableAppHosting,
-		PostgresConnString:   postgresConnString,
-		BaseDomain:           baseDomain,
-		CaddyAdminURL:        caddyAdminURL,
-		HostIP:               hostIPFromCIDR(networkSubnet),
-		DaemonConfigStore:    daemonConfigStore,
-		CaddyCertDir:         caddyCertDir,
-		VictoriaMetricsURL:   victoriaMetricsURL,
-		Standalone:           standaloneMode,
-		AlertWebhookURL:      alertWebhookURL,
-		AlertWebhookSecret:   alertWebhookSecret,
-		SentinelURL:          sentinelURL,
-		SSHHost:              sshHost,
-		Peers:                peerAddrs,
-		LocalBackendID:       resolveBackendID(localBackendID),
-		Pool:                 pool,
-		Region:               region,
-		CPUOvercommitFactor:  cpuOvercommitFactor,
-		CPUOvercommitEnforce: cpuOvercommitEnforce,
-		PlacementCPUAware:    placementCPUAware,
-		PublicHostname:       publicHostname,
-		PublicAliases:        publicAliases,
-		PublicBaseDomains:    resolvePublicBaseDomains(publicBaseDomains, baseDomain),
-		PublicPort:           publicPort,
-		ProxyProtocol:        proxyProtocol,
-		ProxyProtocolTrusted: proxyProtocolTrusted,
-		OTelDropLabels:       otelDropLabels,
-		Runtime:              runtime,
-		ZFSTenantRoot:        zfsTenantRoot,
-		ZFSKeysDir:           zfsKeysDir,
+		GRPCAddress:            daemonAddress,
+		GRPCPort:               daemonPort,
+		EnableMTLS:             enableMTLS,
+		CertsDir:               daemonCertsDir,
+		HTTPPort:               daemonHTTPPort,
+		EnableREST:             enableREST,
+		JWTSecret:              finalJWTSecret,
+		SwaggerDir:             swaggerDir,
+		EnableAppHosting:       enableAppHosting,
+		PostgresConnString:     postgresConnString,
+		BaseDomain:             baseDomain,
+		CaddyAdminURL:          caddyAdminURL,
+		HostIP:                 hostIPFromCIDR(networkSubnet),
+		DaemonConfigStore:      daemonConfigStore,
+		CaddyCertDir:           caddyCertDir,
+		VictoriaMetricsURL:     victoriaMetricsURL,
+		Standalone:             standaloneMode,
+		DisableSecurityScanner: disableSecurityScanner,
+		DisablePentestScanner:  disablePentestScanner,
+		DisableZapScanner:      disableZapScanner,
+		AlertWebhookURL:        alertWebhookURL,
+		AlertWebhookSecret:     alertWebhookSecret,
+		SentinelURL:            sentinelURL,
+		SSHHost:                sshHost,
+		Peers:                  peerAddrs,
+		LocalBackendID:         resolveBackendID(localBackendID),
+		Pool:                   pool,
+		Region:                 region,
+		CPUOvercommitFactor:    cpuOvercommitFactor,
+		CPUOvercommitEnforce:   cpuOvercommitEnforce,
+		PlacementCPUAware:      placementCPUAware,
+		PublicHostname:         publicHostname,
+		PublicAliases:          publicAliases,
+		PublicBaseDomains:      resolvePublicBaseDomains(publicBaseDomains, baseDomain),
+		PublicPort:             publicPort,
+		ProxyProtocol:          proxyProtocol,
+		ProxyProtocolTrusted:   proxyProtocolTrusted,
+		OTelDropLabels:         otelDropLabels,
+		Runtime:                runtime,
+		ZFSTenantRoot:          zfsTenantRoot,
+		ZFSKeysDir:             zfsKeysDir,
 	}
 
 	// Create dual server

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -104,6 +104,22 @@ type DualServerConfig struct {
 	// Standalone mode: skip all PostgreSQL/core container dependencies
 	Standalone bool
 
+	// DisableSecurityScanner/DisablePentestScanner/DisableZapScanner turn
+	// off the three passive/active scanners that otherwise start
+	// automatically whenever PostgresConnString is set (there's no
+	// independent opt-out today — each is gated purely on Postgres being
+	// configured). All three run background work triggered by container
+	// creation (the security scanner subscribes to CONTAINER_CREATED
+	// events; ClamAV + a network pentest scan then run against every new
+	// tenant), which is real, deliberate product behavior for a
+	// production daemon but adds real per-create latency that a
+	// throughput-sensitive deployment (or a benchmark) may want to skip.
+	// Independent flags rather than one umbrella flag since an operator
+	// may want e.g. malware scanning without the network pentest scan.
+	DisableSecurityScanner bool
+	DisablePentestScanner  bool
+	DisableZapScanner      bool
+
 	// Multi-backend peer settings
 	SentinelURL    string   // URL for auto-discovering tunnel peers (e.g., "http://10.128.0.5:8081")
 	Peers          []string // Static peer addresses (e.g., ["10.128.0.5:18001"])
@@ -1338,7 +1354,7 @@ skipAppHosting:
 	var securityScanner *security.Scanner
 	var securityStore *security.Store
 	var securityServerInstance *SecurityServer
-	if postgresConnString != "" {
+	if postgresConnString != "" && !config.DisableSecurityScanner {
 		securityPool, poolErr := connectToPostgres(postgresConnString, 5, 3*time.Second)
 		if poolErr != nil {
 			log.Printf("Warning: Failed to connect to PostgreSQL for security store: %v", poolErr)
@@ -1391,7 +1407,7 @@ skipAppHosting:
 	// Setup pentest manager
 	var pentestManager *pentest.Manager
 	var pentestStore *pentest.Store
-	if postgresConnString != "" {
+	if postgresConnString != "" && !config.DisablePentestScanner {
 		pentestPool, poolErr := connectToPostgres(postgresConnString, 5, 3*time.Second)
 		if poolErr != nil {
 			log.Printf("Warning: Failed to connect to PostgreSQL for pentest store: %v", poolErr)
@@ -1427,7 +1443,7 @@ skipAppHosting:
 	// Setup ZAP scanner manager
 	var zapManager *zapscanner.Manager
 	var zapStore *zapscanner.Store
-	if postgresConnString != "" {
+	if postgresConnString != "" && !config.DisableZapScanner {
 		zapPool, poolErr := connectToPostgres(postgresConnString, 5, 3*time.Second)
 		if poolErr != nil {
 			log.Printf("Warning: Failed to connect to PostgreSQL for ZAP store: %v", poolErr)


### PR DESCRIPTION
## Summary
- Add `--disable-security-scanner`, `--disable-pentest-scanner`, `--disable-zap-scanner` flags to `containarium daemon`
- Each scanner subsystem (ClamAV malware scanner, network pentest scanner, ZAP web-app scanner) was previously gated purely on `PostgresConnString != ""`, with no independent opt-out
- All three default to `false` (scanners stay on) — no behavior change unless explicitly passed

## Why
Found live while investigating why LXC-backend container creates were taking 80-110s in `benchmark/agent-sandbox-density`'s third scenario. `journalctl` tracing showed the stall was background ClamAV + pentest scanning competing for host resources on every `CONTAINER_CREATED` event — not the storage driver (an earlier hypothesis, disproved by testing zfs vs dir directly).

This is a real, independently useful daemon capability beyond the benchmark: any throughput-sensitive deployment that runs Postgres for other reasons (billing, container metadata, etc.) but doesn't want per-create scanning overhead can now opt out per-scanner.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/cmd/... ./internal/server/...`
- [x] `go test ./internal/cmd/... ./internal/server/...`
- [ ] Live-verified on the benchmark VM that the flags eliminate the per-create latency (in progress, tracked separately in the `benchmark/lxc-workhorse-scenario` branch)