### PR TITLE
perf(incus): fetch ListContainers details concurrently instead of sequentially

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.45.0
 	golang.org/x/crypto v0.55.0
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
 	google.golang.org/api v0.293.0
@@ -140,7 +141,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/net v0.57.0 // indirect
-	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/text v0.41.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.5.0 // indirect

--- a/pkg/core/incus/client.go
+++ b/pkg/core/incus/client.go
@@ -19,6 +19,7 @@ import (
 	"github.com/footprintai/containarium/internal/safecast"
 	incus "github.com/lxc/incus/v6/client"
 	"github.com/lxc/incus/v6/shared/api"
+	"golang.org/x/sync/errgroup"
 )
 
 // detectZFSContainersDataset checks if the "incus-local/containers" ZFS dataset exists.
@@ -921,6 +922,18 @@ func (c *Client) DeleteContainer(name string) error {
 }
 
 // ListContainers lists all containers
+// listContainersConcurrency bounds how many containers' details
+// (GetInstance + GetInstanceState) ListContainers fetches from Incus at
+// once. Found live (#1532): fetching sequentially — one GetInstance plus
+// one GetInstanceState round-trip per container, one after another — made
+// `containarium list` itself exceed a 10s client deadline past ~180
+// containers on one host (roughly 2 round-trips x 180 = 360 sequential
+// Incus API calls). 32 is generous headroom over Incus's own local
+// unix-socket API, which is designed for concurrent HTTP-style access;
+// pick a number that keeps `list` well under a second at a few hundred
+// containers without hammering the Incus daemon.
+const listContainersConcurrency = 32
+
 func (c *Client) ListContainers() ([]ContainerInfo, error) {
 	// Get list of instance names (both containers and VMs)
 	names, err := c.server.GetInstanceNames(api.InstanceTypeAny)
@@ -928,12 +941,53 @@ func (c *Client) ListContainers() ([]ContainerInfo, error) {
 		return nil, fmt.Errorf("failed to list containers: %w", err)
 	}
 
-	var containers []ContainerInfo
-	for _, name := range names {
+	return fetchAllConcurrently(names, listContainersConcurrency, c.fetchContainerInfo), nil
+}
+
+// fetchAllConcurrently runs fetch(name) for every name with at most
+// concurrency in flight at once, returning only the results fetch reported
+// ok for (in no particular order — callers that need a stable order sort
+// afterward). Split out from ListContainers, real Incus calls injected only
+// via fetch, so the fan-out/skip logic is testable without a live Incus
+// server — same "generic loop, production function injected by the caller"
+// shape as waitForIP in wait_network.go.
+func fetchAllConcurrently[T any](names []string, concurrency int, fetch func(name string) (T, bool)) []T {
+	results := make([]T, len(names))
+	found := make([]bool, len(names))
+
+	var g errgroup.Group
+	g.SetLimit(concurrency)
+	for i, name := range names {
+		i, name := i, name
+		g.Go(func() error {
+			v, ok := fetch(name)
+			results[i] = v
+			found[i] = ok
+			return nil
+		})
+	}
+	_ = g.Wait() // fetch never returns an error of its own; per-item failures are dropped via found[i]
+
+	out := make([]T, 0, len(names))
+	for i, ok := range found {
+		if ok {
+			out = append(out, results[i])
+		}
+	}
+	return out
+}
+
+// fetchContainerInfo fetches one container's full ListContainers entry.
+// The second return is false when the container's details couldn't be
+// fetched (e.g. deleted between GetInstanceNames and GetInstance) — the
+// same "skip it" behavior ListContainers had inline before this was
+// split out for concurrent use.
+func (c *Client) fetchContainerInfo(name string) (ContainerInfo, bool) {
+	{
 		// Get full instance details for each container
 		inst, _, err := c.server.GetInstance(name)
 		if err != nil {
-			continue // Skip containers we can't get details for
+			return ContainerInfo{}, false // Skip containers we can't get details for
 		}
 
 		info := ContainerInfo{
@@ -1052,10 +1106,8 @@ func (c *Client) ListContainers() ([]ContainerInfo, error) {
 			}
 		}
 
-		containers = append(containers, info)
+		return info, true
 	}
-
-	return containers, nil
 }
 
 // GetContainer gets information about a specific container

--- a/pkg/core/incus/list_concurrency_test.go
+++ b/pkg/core/incus/list_concurrency_test.go
@@ -1,0 +1,80 @@
+package incus
+
+import (
+	"sort"
+	"sync/atomic"
+	"testing"
+)
+
+// TestFetchAllConcurrently_SkipsNotOk is the regression test for
+// ListContainers's "skip containers we can't get details for" behavior
+// (#1532's refactor from a sequential loop to a bounded worker pool must not
+// change what gets returned, only how fast).
+func TestFetchAllConcurrently_SkipsNotOk(t *testing.T) {
+	names := []string{"a", "b", "c", "d", "e"}
+	skip := map[string]bool{"b": true, "d": true}
+
+	got := fetchAllConcurrently(names, 4, func(name string) (string, bool) {
+		if skip[name] {
+			return "", false
+		}
+		return name, true
+	})
+
+	sort.Strings(got)
+	want := []string{"a", "c", "e"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+}
+
+// TestFetchAllConcurrently_RespectsConcurrencyLimit is the regression test
+// for #1532 itself: ListContainers used to make every GetInstance +
+// GetInstanceState round-trip one after another, which made `containarium
+// list` exceed its client deadline past ~180 containers on one host. This
+// asserts the fan-out actually bounds in-flight work rather than firing
+// everything at once (which would just move the same serialization problem
+// onto Incus's own request queue).
+func TestFetchAllConcurrently_RespectsConcurrencyLimit(t *testing.T) {
+	const limit = 3
+	names := make([]string, 50)
+	for i := range names {
+		names[i] = "x"
+	}
+
+	var inFlight, maxObserved int64
+	release := make(chan struct{})
+	go func() {
+		// Let the pool actually saturate to `limit` before releasing —
+		// otherwise a fast test run could finish before concurrency ever
+		// peaks, making the assertion vacuously true.
+		for atomic.LoadInt64(&inFlight) < limit {
+		}
+		close(release)
+	}()
+
+	fetchAllConcurrently(names, limit, func(string) (struct{}, bool) {
+		n := atomic.AddInt64(&inFlight, 1)
+		for {
+			old := atomic.LoadInt64(&maxObserved)
+			if n <= old || atomic.CompareAndSwapInt64(&maxObserved, old, n) {
+				break
+			}
+		}
+		<-release
+		atomic.AddInt64(&inFlight, -1)
+		return struct{}{}, true
+	})
+
+	if maxObserved > limit {
+		t.Fatalf("max concurrent in-flight = %d, want <= %d", maxObserved, limit)
+	}
+	if maxObserved < limit {
+		t.Fatalf("max concurrent in-flight = %d, want == %d (pool never saturated — test is not exercising the limit)", maxObserved, limit)
+	}
+}


### PR DESCRIPTION
## Summary
- `ListContainers` made 2 sequential Incus API round-trips per container (`GetInstance` + `GetInstanceState`)
- Past ~180 containers on one host, `containarium list` itself started intermittently exceeding a 10s client deadline — closes #1532
- Fans the per-container fetch out over a bounded worker pool (32 concurrent) instead of one-after-another

## Why

Found live while running `benchmark/agent-sandbox-density`'s third scenario (native LXC backend, density loop up to ~180 tenant containers on one host). The density loop polls `containarium list` to confirm each new container reached `RUNNING` — once `list` itself started taking >10s, units were misreported as "never became ready" even though the underlying container was confirmed `RUNNING` via direct `incus list`. Root cause: `ListContainers` fetches every container's details strictly sequentially — at 180 containers that's ~360 sequential round-trips to Incus's local API.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./pkg/core/incus/...`
- [x] `go test ./pkg/core/incus/... ./pkg/core/container/... ./internal/server/...`
- [x] New unit tests (`list_concurrency_test.go`): skip-on-failure semantics preserved, concurrency limit actually bounds in-flight work
- [ ] Live re-verification against the real 181-container benchmark host (in progress)