### PR TITLE
docs(benchmark): third scenario — Containarium native LXC workhorse density

### DIFF
--- a/benchmark/agent-sandbox-density/README.md
+++ b/benchmark/agent-sandbox-density/README.md
@@ -258,11 +258,48 @@ scripts/00-create-vm.sh --name sandbox-bench-containarium
 scripts/03-provision-containarium.sh --name sandbox-bench-containarium
 scripts/04-run-density-containarium.sh --name sandbox-bench-containarium
 scripts/99-teardown-vm.sh --name sandbox-bench-containarium
+
+# Third scenario (optional) — see "Third scenario: native LXC workhorse"
+scripts/00-create-vm.sh --name sandbox-bench-containarium-lxc
+scripts/05-provision-containarium-lxc.sh --name sandbox-bench-containarium-lxc
+scripts/06-run-density-containarium-lxc.sh --name sandbox-bench-containarium-lxc
+scripts/99-teardown-vm.sh --name sandbox-bench-containarium-lxc
 ```
 
 Each density script writes a timestamped results file under `results/`
 (gitignored — see `RESULTS.md` for the reviewed/committed summary format)
 and prints a one-line summary at the end.
+
+## Third scenario: native LXC workhorse
+
+A third comparison point, alongside the two k8s-based groups above:
+Containarium's original backend — plain LXC/Incus containers, no
+Kubernetes, no gVisor, no pooling. Same host, same hard resource cap,
+same sandbox resource profile as whatever run it's compared against
+(convert `Mi`→`MiB` for Incus's native `limits.memory` format — see
+`06-run-density-containarium-lxc.sh`'s header comment for why the
+conversion is a rename, not a real unit change).
+
+**This is not a test of the `#1488` warm-pool/`SpawnSandbox` feature.**
+As of this writing `SpawnSandbox` still serves the Phase 1 cold path —
+the pool/reconciler code is in the tree but not wired into the request
+path (tracked in
+[#1523](https://github.com/FootprintAI/Containarium/issues/1523)). This
+scenario uses plain `containarium create`, the same cold-create
+mechanism the k8s scenarios' `create` already exercises — it isolates
+the *backend* (LXC vs. k8s+gVisor), not pooling. Once `#1523` lands, a
+real pooling comparison would need a different metric entirely (spawn
+latency P50/P99, cold vs. warm — not simultaneous density; an active
+pool member is a whole dedicated container, same footprint as a cold
+one, per the pool's own design doc).
+
+Unlike the k8s scenarios, `containarium list` works normally here (its
+"incus backend not available" failure —
+[#1525](https://github.com/FootprintAI/Containarium/issues/1525) — only
+fires against a `--runtime=k8s` daemon; this one genuinely is
+Incus-backed), and the default `--image` works as documented (no
+[#1524](https://github.com/FootprintAI/Containarium/issues/1524)-style
+`InvalidImageName` — that bug is k8s-backend-specific too).
 
 ## Layout
 
@@ -281,5 +318,7 @@ benchmark/agent-sandbox-density/
     ├── 02-run-density-k8s.sh        — create Sandbox CRs until the stopping rule triggers
     ├── 03-provision-containarium.sh — shared k8s base + gVisor/runsc RuntimeClass + Helm-installed Containarium daemon
     ├── 04-run-density-containarium.sh — `containarium create` (pod -> gVisor -> containarium) until the stopping rule triggers
+    ├── 05-provision-containarium-lxc.sh — third scenario: Incus + Containarium daemon, native LXC backend, no k8s/gVisor
+    ├── 06-run-density-containarium-lxc.sh — `containarium create` on the LXC backend until the stopping rule triggers
     └── 99-teardown-vm.sh            — stop + delete the VM
 ```

--- a/benchmark/agent-sandbox-density/RESULTS.md
+++ b/benchmark/agent-sandbox-density/RESULTS.md
@@ -123,24 +123,35 @@ scenario"), mem 256Mi — same declared ceiling as the other two runs' Containar
 Containarium version: local build off `main` + this scenario's fixes (image-bake #1037, list() concurrency #1532/#1533).
 Backend: native LXC/Incus, no Kubernetes, no gVisor, no pooling (#1488/#1523 out of scope — see README.md).
 
-Run in two segments — the first stopped on a bug, not a resource wall, so it
-was resumed (`--start-index`, added for exactly this) after fixing the bug
-live rather than treated as final:
+Run in four segments — each of the first three stopped on something that
+turned out to be a bug or an unsized default, not a resource wall, so each
+was resumed (`--start-index`, added for exactly this) after fixing the
+problem live rather than treated as final. Only the fourth segment hit a
+wall that held up:
 
-| | segment 1 (stopped by #1532) | segment 2 (resumed, real wall) | **combined** |
-|---|---|---|---|
-| Sandboxes reached RUNNING | 181 | 70 | **251** |
-| Attempted (incl. failures) | 186 | 73 (from index 184) | 259 |
-| Wall-clock | ~87 min | ~17 min | ~104 min |
+| | seg 1 (#1532 bug) | seg 2 (real /24 wall) | seg 3 (self-inflicted pg_hba gap) | seg 4 (real wall) | **combined** |
+|---|---|---|---|---|---|
+| Sandboxes reached RUNNING | 181 | 70 | 313 | 5 | **569** |
+| Attempted (incl. failures) | 186 | 73 (from 184) | 317 (from 260) | 13 (from 580) | 589 |
+| Wall-clock | ~87 min | ~17 min | ~2h23min | ~33 min | ~4h |
 
-**Final host state (251 tenant + 2 core = 253 containers):** memory 26GiB/46GiB
-used (19GiB reclaimable buff/cache, 1.1GiB genuinely free), disk 18GB/181GB
-(10%). Per-container actual memory grew from ~50MiB (at 181) to ~90-95MiB
-(at 253) over the run — not yet investigated further, memory wasn't the
-thing that actually stopped it (see below).
+**Final host state (569 tenant + 2 core = 571 containers):** memory 39GiB/46GiB
+used (7.9GiB reclaimable buff/cache, 1.0GiB genuinely free), i.e. still not
+memory-exhausted. Per-container actual memory grew from ~50MiB (at 181) to
+~90-95MiB (at 253) to higher still by 571 — noted but not root-caused.
+**What actually stopped segment 4 was CPU, and specifically not the tenant
+containers' own CPU** (each capped at 200m) — `incusd` itself was consuming
+1025% CPU (10+ cores) on the 20-core host, driving a load average of ~117
+(≈6x the core count) purely from Incus's own per-container management
+overhead at ~570 live containers. Filed #1541. Load dropped to ~43 within
+~15 minutes of the loop stopping, confirming it's churn-driven contention
+scaling with container count, not a permanent steady-state cost — but a
+real wall a production single-host deployment would hit regardless of
+available RAM.
 
 **This number is still not directly comparable to the other two scenarios'
-counts as a ranked table** — four distinct things were learned running it:
+counts as a ranked table** — six distinct things were learned pushing it
+this far:
 
 1. **Per-create latency was never about scanning.** Individual creates
    originally took ~80-150s. ClamAV/pentest/zap scanning was a plausible
@@ -186,14 +197,36 @@ counts as a ranked table** — four distinct things were learned running it:
    Incus's bridge subnet is a config choice (`ipv4.address` on network
    create) — a `/20` (~4094 usable) or `/16` (~65534 usable, matching the
    k8s side) would move this ceiling substantially with no code change.
-   Not tested in this run; noted for whoever picks up a future re-run
-   wanting a genuinely apples-to-apples address-space comparison.
+5. **Widened `incusbr0` to a `/16` live (`10.183.0.1/16`, keeping the
+   existing `10.183.188.0/24` range as a subset so the 253 already-running
+   containers' leases stayed valid) and resumed — this immediately hit a
+   self-inflicted problem, not a new discovery.** `containarium-core-postgres`'s
+   `pg_hba.conf` had a rule scoped to exactly `10.183.188.1/24`; once the
+   bridge's own gateway/source IP became `10.183.0.1` (outside that /24),
+   the daemon's own Postgres connections started failing
+   (`FATAL: no pg_hba.conf entry for host "10.183.0.1"`), breaking cluster
+   reconcile, passthrough sync, and token revocation lookups — which
+   degraded overall daemon responsiveness enough to cause a run of
+   readiness timeouts. Fixed live (widened the `pg_hba.conf` rule to
+   `10.183.0.0/16`, reloaded), verified via journalctl (errors stopped
+   immediately), and resumed again. Not filed as a Containarium issue —
+   this is benchmark-environment fallout from resizing the network
+   ourselves, not a bug in the shipped product.
+6. **The real, final wall: Incus's own daemon CPU overhead, not memory,
+   not network, not the tenant workload.** After the pg_hba fix, segment 3
+   ran cleanly to 313 (562 combined) before a batch of failures right at
+   the fix boundary (already-started units that had blown their timeout
+   during the outage). Segment 4 resumed once more and found the actual
+   ceiling: at ~570 containers, `incusd` alone consumes 10+ CPU cores
+   (1025% CPU, load average ~117 on a 20-core host) — see point-by-point
+   detail above and #1541. This is the first wall in this investigation
+   that isn't a fixable default or a script bug.
 
 Also found and filed independently (real, applies beyond this benchmark):
 #1531, host-side jump-server account creation has been silently failing
 since roughly the 10th tenant created on any one host (a `useradd`
 subuid/subgid pool collision with Incus's own reserved root range) — the
-large majority of this run's 251 tenants have no SSH jump-server account,
+large majority of this run's 569 tenants have no SSH jump-server account,
 with only a warning-level log line as a signal. Not yet fixed (proposed
 fix documented on the issue).
 

--- a/benchmark/agent-sandbox-density/RESULTS.md
+++ b/benchmark/agent-sandbox-density/RESULTS.md
@@ -115,6 +115,80 @@ Notes / anomalies:
   provisioning both VMs was fully automated this time end-to-end.
 - `containarium-agent-box` image and gateway workaround unchanged from run 1.
 
+### 2026-08-24 — third scenario: Containarium native LXC workhorse (no k8s, no gVisor)
+
+Hard cap per VM: 20 vCPU / 48GiB RAM / 200GB disk (Incus KVM VM)
+Sandbox profile: cpu 200m (LXC-scenario-specific floor, see README.md "Third
+scenario"), mem 256Mi — same declared ceiling as the other two runs' Containarium side.
+Containarium version: local build off `main` + this scenario's provisioning fixes (image-bake — #1037).
+Backend: native LXC/Incus, no Kubernetes, no gVisor, no pooling (#1488/#1523 out of scope — see README.md).
+
+| | native LXC (this run) |
+|---|---|
+| Sandboxes reached RUNNING | **181** |
+| Attempted (incl. failures) | 186 |
+| Host memory at stop | 11GiB / 46GiB used (**24%** — 35GiB still free) |
+| Host disk at stop | 4.2GB / 181GB used (**2%**) |
+| Wall-clock for the density loop | ~87 min |
+
+**This number is NOT directly comparable to the other two scenarios' counts,
+and should not be read as a ranked "181 vs 373 vs 186" table.** Three
+distinct things were learned running it:
+
+1. **Per-create latency was never about scanning.** Individual creates
+   originally took ~80-150s. ClamAV/pentest/zap scanning was a plausible
+   early hypothesis (a controlled test with them fully disabled showed no
+   improvement) — the real cost was a from-scratch OS boot + `apt-get
+   install` of the base package set on every single create, on the stock
+   cloud image (confirmed via `systemd-analyze` + `/var/log/apt/history.log`).
+   Containarium already ships the fix for this (#1037, `containarium
+   image-bake`) — the provisioning script just never called it. Baking once
+   and re-testing: **112s -> 15.7s** for an identical create. Filed #1530
+   documenting the investigation for anyone else who hits this.
+
+2. **This scenario is not memory-bound the way the k8s scenarios are, so
+   its ceiling isn't comparable to theirs.** k8s's scheduler reserves the
+   full *declared* memory request against node capacity regardless of
+   actual usage — that's why the other two runs stopped almost exactly at
+   `48GiB / declared-request`. Incus's `limits.memory` is a cgroup
+   *ceiling*, not a reservation: these boxes only use ~50MiB of their
+   256MiB ceiling (idle, no workload), so the same 48GiB budget could fit
+   roughly (46×1024−overhead)/50MiB ≈ **900 boxes** by actual usage, not
+   ~186. If a true apples-to-apples comparison against the k8s scenarios'
+   *declared-ceiling* admission model is wanted, the closest anchor is
+   `49152Mi/256Mi ≈ 192` — notably not far from what this run reached
+   before stopping, but for an unrelated reason (see next point).
+3. **The run did not stop due to a resource wall at all** — host memory
+   and disk both had large headroom left (see table above). It stopped
+   because `containarium list` (which the density loop polls to confirm
+   `RUNNING` state) started intermittently exceeding a 10s deadline past
+   ~180 containers on one host, misreporting units as "never became
+   ready" even when the underlying container was already up. Filed #1532.
+   **181 is therefore an artificially low number** — fixing #1532 would
+   very likely let a fresh run continue well past it, closer to the ~900
+   actual-usage ceiling above, not stop where it did.
+
+Also found and filed independently (both real, both apply beyond this
+benchmark): #1531, host-side jump-server account creation has been
+silently failing since roughly the 10th tenant created on any one host
+(a `useradd` subuid/subgid pool collision with Incus's own reserved root
+range) — 175 of this run's 181 tenants have no SSH jump-server account,
+with only a warning-level log line as a signal.
+
+Notes / anomalies:
+- Not a test of #1488's warm-pool/pooling feature — confirmed not wired
+  (`SpawnSandbox` still serves the Phase 1 cold path, see #1523). This
+  measures the same cold-create path #1522/#1527 already cover on the k8s
+  backend, on Containarium's original backend instead.
+- `--podman=false` used for creates (the default installs Podman + pip +
+  podman-compose, an asymmetry vs. the other two scenarios' create-time
+  cost — see the density script's header comment for the full rationale).
+- Scanner subsystems (ClamAV/pentest/zap) disabled via new
+  `--disable-{security,pentest,zap}-scanner` daemon flags (independent
+  product feature, not benchmark-specific — real background CPU
+  competition worth avoiding for a clean measurement, even though it
+  wasn't the create-latency root cause).
+
 ## Template
 
 ```

--- a/benchmark/agent-sandbox-density/RESULTS.md
+++ b/benchmark/agent-sandbox-density/RESULTS.md
@@ -120,20 +120,27 @@ Notes / anomalies:
 Hard cap per VM: 20 vCPU / 48GiB RAM / 200GB disk (Incus KVM VM)
 Sandbox profile: cpu 200m (LXC-scenario-specific floor, see README.md "Third
 scenario"), mem 256Mi — same declared ceiling as the other two runs' Containarium side.
-Containarium version: local build off `main` + this scenario's provisioning fixes (image-bake — #1037).
+Containarium version: local build off `main` + this scenario's fixes (image-bake #1037, list() concurrency #1532/#1533).
 Backend: native LXC/Incus, no Kubernetes, no gVisor, no pooling (#1488/#1523 out of scope — see README.md).
 
-| | native LXC (this run) |
-|---|---|
-| Sandboxes reached RUNNING | **181** |
-| Attempted (incl. failures) | 186 |
-| Host memory at stop | 11GiB / 46GiB used (**24%** — 35GiB still free) |
-| Host disk at stop | 4.2GB / 181GB used (**2%**) |
-| Wall-clock for the density loop | ~87 min |
+Run in two segments — the first stopped on a bug, not a resource wall, so it
+was resumed (`--start-index`, added for exactly this) after fixing the bug
+live rather than treated as final:
 
-**This number is NOT directly comparable to the other two scenarios' counts,
-and should not be read as a ranked "181 vs 373 vs 186" table.** Three
-distinct things were learned running it:
+| | segment 1 (stopped by #1532) | segment 2 (resumed, real wall) | **combined** |
+|---|---|---|---|
+| Sandboxes reached RUNNING | 181 | 70 | **251** |
+| Attempted (incl. failures) | 186 | 73 (from index 184) | 259 |
+| Wall-clock | ~87 min | ~17 min | ~104 min |
+
+**Final host state (251 tenant + 2 core = 253 containers):** memory 26GiB/46GiB
+used (19GiB reclaimable buff/cache, 1.1GiB genuinely free), disk 18GB/181GB
+(10%). Per-container actual memory grew from ~50MiB (at 181) to ~90-95MiB
+(at 253) over the run — not yet investigated further, memory wasn't the
+thing that actually stopped it (see below).
+
+**This number is still not directly comparable to the other two scenarios'
+counts as a ranked table** — four distinct things were learned running it:
 
 1. **Per-create latency was never about scanning.** Individual creates
    originally took ~80-150s. ClamAV/pentest/zap scanning was a plausible
@@ -146,34 +153,49 @@ distinct things were learned running it:
    and re-testing: **112s -> 15.7s** for an identical create. Filed #1530
    documenting the investigation for anyone else who hits this.
 
-2. **This scenario is not memory-bound the way the k8s scenarios are, so
-   its ceiling isn't comparable to theirs.** k8s's scheduler reserves the
-   full *declared* memory request against node capacity regardless of
-   actual usage — that's why the other two runs stopped almost exactly at
-   `48GiB / declared-request`. Incus's `limits.memory` is a cgroup
-   *ceiling*, not a reservation: these boxes only use ~50MiB of their
-   256MiB ceiling (idle, no workload), so the same 48GiB budget could fit
-   roughly (46×1024−overhead)/50MiB ≈ **900 boxes** by actual usage, not
-   ~186. If a true apples-to-apples comparison against the k8s scenarios'
-   *declared-ceiling* admission model is wanted, the closest anchor is
-   `49152Mi/256Mi ≈ 192` — notably not far from what this run reached
-   before stopping, but for an unrelated reason (see next point).
-3. **The run did not stop due to a resource wall at all** — host memory
-   and disk both had large headroom left (see table above). It stopped
-   because `containarium list` (which the density loop polls to confirm
+2. **Segment 1 didn't stop on a resource wall — it stopped on a `list()`
+   scaling bug.** k8s's scheduler reserves the full *declared* memory
+   request against node capacity regardless of actual usage (why the other
+   two runs stopped almost exactly at `48GiB / declared-request`); Incus's
+   `limits.memory` is a cgroup *ceiling*, not a reservation, so the boxes'
+   ~50MiB actual usage left plenty of real headroom at 181. What actually
+   stopped it: `containarium list` (which the density loop polls for
    `RUNNING` state) started intermittently exceeding a 10s deadline past
-   ~180 containers on one host, misreporting units as "never became
-   ready" even when the underlying container was already up. Filed #1532.
-   **181 is therefore an artificially low number** — fixing #1532 would
-   very likely let a fresh run continue well past it, closer to the ~900
-   actual-usage ceiling above, not stop where it did.
+   ~180 containers — `ListContainers` made 2 sequential Incus API
+   round-trips per container, ~360 sequential calls at that count. Filed
+   #1532, fixed in #1533 (bounded-concurrency fetch instead of
+   sequential — 32 at a time). Live-verified the fix against this exact
+   host: **>10s (timeout) -> consistently under 2s** for the same `list`
+   call at 181 containers.
+3. **Resumed past the fix with `--start-index 184` and pushed to a real
+   wall.** Segment 2 stopped on an actual `create` rejection this time —
+   `failed to get container IP: timeout waiting for container network`.
+   The bridge (`incusbr0`) is a `/24` (`10.183.188.1/24`, 253 usable
+   addresses); the host had exactly 253 containers (251 tenant + 2 core)
+   when it stopped. **This is a genuine, real resource wall** — DHCP
+   address space, not a bug — and matches the very first hypothesis from
+   when segment 1 stopped (before #1532 was found and fixed), now
+   confirmed precisely rather than guessed.
+4. **This wall isn't a fair fixed comparison point either — the k8s side
+   never had a /24 to begin with.** The k8s scenarios' `podSubnet` is
+   `192.168.0.0/16` (`scripts/k8s-common.sh`) — 65,536 addresses, 256x
+   Incus's default `/24`. Calico also allocates in small per-node blocks
+   (default /26, 64 addresses) and grabs more as pod count grows, so a
+   single node never hits a flat ceiling the way one static Incus bridge
+   subnet does. This is an unsized default, not a discovered limitation:
+   Incus's bridge subnet is a config choice (`ipv4.address` on network
+   create) — a `/20` (~4094 usable) or `/16` (~65534 usable, matching the
+   k8s side) would move this ceiling substantially with no code change.
+   Not tested in this run; noted for whoever picks up a future re-run
+   wanting a genuinely apples-to-apples address-space comparison.
 
-Also found and filed independently (both real, both apply beyond this
-benchmark): #1531, host-side jump-server account creation has been
-silently failing since roughly the 10th tenant created on any one host
-(a `useradd` subuid/subgid pool collision with Incus's own reserved root
-range) — 175 of this run's 181 tenants have no SSH jump-server account,
-with only a warning-level log line as a signal.
+Also found and filed independently (real, applies beyond this benchmark):
+#1531, host-side jump-server account creation has been silently failing
+since roughly the 10th tenant created on any one host (a `useradd`
+subuid/subgid pool collision with Incus's own reserved root range) — the
+large majority of this run's 251 tenants have no SSH jump-server account,
+with only a warning-level log line as a signal. Not yet fixed (proposed
+fix documented on the issue).
 
 Notes / anomalies:
 - Not a test of #1488's warm-pool/pooling feature — confirmed not wired
@@ -183,11 +205,17 @@ Notes / anomalies:
 - `--podman=false` used for creates (the default installs Podman + pip +
   podman-compose, an asymmetry vs. the other two scenarios' create-time
   cost — see the density script's header comment for the full rationale).
-- Scanner subsystems (ClamAV/pentest/zap) disabled via new
+- Scanner subsystems (ClamAV/pentest/zap) disabled via
   `--disable-{security,pentest,zap}-scanner` daemon flags (independent
   product feature, not benchmark-specific — real background CPU
   competition worth avoiding for a clean measurement, even though it
   wasn't the create-latency root cause).
+- Sharding across multiple smaller Containarium daemon instances (sentinel
+  routing tenants to the right backend, per the existing multi-backend
+  architecture) was discussed as an alternative to one large host, but
+  wouldn't have avoided the #1531 subuid wall — that one bites per-host at
+  ~10-14 tenants, well under any reasonable shard size. Not attempted in
+  this run.
 
 ## Template
 

--- a/benchmark/agent-sandbox-density/config.env.example
+++ b/benchmark/agent-sandbox-density/config.env.example
@@ -24,6 +24,16 @@ SANDBOX_MEM_LIMIT="256Mi"
 # knob. 04-run-density-containarium.sh uses the LIMIT values above for
 # both. This is a documented, deliberate asymmetry vs. the control group's
 # lower REQUEST — see README.md "Fairness notes".
+#
+# LXC_SANDBOX_CPU_LIMIT overrides SANDBOX_CPU_LIMIT for the third
+# scenario only (06-run-density-containarium-lxc.sh). Found live: an LXC
+# box has to fully boot an OS (systemd, network stack, DHCP) before it's
+# usable, unlike a k8s pod that starts an existing process — under a
+# tight memory-bound CPU profile (e.g. 25m/50m), DHCP acquisition
+# consistently timed out before boot finished. This is a real backend
+# difference, not a bug to paper over; it's called out in the LXC
+# script's own header rather than silently normalized away.
+LXC_SANDBOX_CPU_LIMIT="200m"
 
 # --- Shared k8s base (BOTH groups, including gVisor — see
 #     scripts/k8s-common.sh and README.md "What's actually under test") ---

--- a/benchmark/agent-sandbox-density/config.env.example
+++ b/benchmark/agent-sandbox-density/config.env.example
@@ -49,6 +49,13 @@ CONTAINARIUM_VERSION="latest"    # FootprintAI/Containarium release tag, or "lat
 # --- Stopping rule (shared by both density loops, scripts/lib.sh) ---------
 FAILURE_STREAK_TO_STOP=3  # consecutive resource-reason failures before stopping
 CREATE_TIMEOUT_SECONDS=60 # per-unit timeout waiting for Ready before counting it a failure
+# LXC_CREATE_TIMEOUT_SECONDS overrides CREATE_TIMEOUT_SECONDS for scenario 3
+# only (06-run-density-containarium-lxc.sh) — that backend's create call is
+# synchronous and already blocks through a full OS boot + base package
+# install (~90-120s under the 200m CPU profile below) before returning, so
+# the shared 60s default would misreport every unit as a timeout. Leave
+# unset to inherit CREATE_TIMEOUT_SECONDS.
+LXC_CREATE_TIMEOUT_SECONDS=200
 
 # --- SSH target for the guest under test ------------------------------
 # REMOTE_HOST/REMOTE_SSH_PORT are resolved dynamically per VM by

--- a/benchmark/agent-sandbox-density/scripts/05-provision-containarium-lxc.sh
+++ b/benchmark/agent-sandbox-density/scripts/05-provision-containarium-lxc.sh
@@ -61,9 +61,27 @@ apt-get update -qq
 # stall live, but the timing doesn't rule out it just needing more time
 # regardless. Installed upfront either way since the log noise alone is
 # worth avoiding.
-apt-get install -y -qq curl jq iptables
+apt-get install -y -qq curl jq iptables zfsutils-linux
 curl -fsSL https://pkgs.zabbly.com/get/incus-stable | sudo sh
+
+# `incus admin init --auto` picks its storage driver from what's on the
+# host: with zfsutils-linux installed first (above), it sets up a
+# loop-backed zpool instead of falling back to the plain "dir" driver.
+# This matters a lot, not just cosmetically — found live that "dir"
+# does a full recursive filesystem copy per container create (no
+# copy-on-write), and the daemon's own startup log already warns about
+# exactly this (see docs referenced in that warning, issue #1206):
+# single creates took 80-90s, almost entirely inside that copy, dwarfing
+# every other stage in the daemon's own documented latency breakdown
+# (docs/architecture/two-digit-ms-sandbox-spawn.md). ZFS gives instant
+# COW clones instead.
 incus admin init --auto
+
+DRIVER=$(incus storage show default | grep '^driver:' | awk '{print $2}')
+echo "storage pool driver: ${DRIVER}"
+if [[ "$DRIVER" != "zfs" ]]; then
+	echo "WARNING: storage pool ended up as '${DRIVER}', not zfs — container creates will be much slower than expected (see comment above)" >&2
+fi
 REMOTE
 
 log "downloading containarium ${CONTAINARIUM_VERSION}"

--- a/benchmark/agent-sandbox-density/scripts/05-provision-containarium-lxc.sh
+++ b/benchmark/agent-sandbox-density/scripts/05-provision-containarium-lxc.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+#
+# Provision the third scenario's VM: Containarium's native LXC/Incus
+# "workhorse" backend — no Kubernetes, no gVisor, no pooling. See
+# README.md "Third scenario: native LXC workhorse" for why this exists
+# and what it isn't (it is NOT a test of the #1488 warm-pool feature —
+# SpawnSandbox still serves the Phase 1 cold path as of this writing, see
+# #1523 — this measures the same create path #1522/#1527 already cover on
+# the k8s backend, just on Containarium's original backend instead).
+#
+# Runs the daemon in its default mode (core services on: Postgres, Caddy,
+# the otel collector) — NOT --standalone — so the fixed overhead matches
+# what a real deployment carries, same principle as the k8s side's
+# kube-system pods being left in place (README.md "Fairness notes").
+#
+# Usage:
+#   scripts/05-provision-containarium-lxc.sh --name <vm-name>
+#
+# Assumes the guest is Ubuntu Server 24.04 with passwordless sudo for
+# REMOTE_SSH_USER, same as the other provisioning scripts.
+
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+# shellcheck source=lib.sh
+source ./lib.sh
+
+VM_NAME=""
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--name)
+		VM_NAME="$2"
+		shift 2
+		;;
+	-h | --help)
+		grep '^#' "$0" | sed 's/^# \{0,1\}//'
+		exit 0
+		;;
+	*)
+		die "unknown argument: $1"
+		;;
+	esac
+done
+[[ -n "$VM_NAME" ]] || die "usage: $0 --name <vm-name>"
+
+load_config
+require_vars CONTAINARIUM_VERSION REMOTE_SSH_USER BENCH_SSH_KEY_FILE
+resolve_remote "$VM_NAME"
+
+log "provisioning Containarium native LXC workhorse on '${VM_NAME}' (version=${CONTAINARIUM_VERSION})"
+
+log "installing Incus"
+ssh_or_local "sudo bash -s" <<'REMOTE'
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -y -qq curl jq
+curl -fsSL https://pkgs.zabbly.com/get/incus-stable | sudo sh
+incus admin init --auto
+REMOTE
+
+log "downloading containarium ${CONTAINARIUM_VERSION}"
+ssh_or_local "sudo bash -s" <<REMOTE
+set -euo pipefail
+TAG="${CONTAINARIUM_VERSION}"
+if [[ "\$TAG" == "latest" ]]; then
+	TAG=\$(curl -fsSL https://api.github.com/repos/FootprintAI/Containarium/releases/latest | jq -r .tag_name)
+fi
+echo "resolved tag: \$TAG"
+
+BASE_URL="https://github.com/FootprintAI/Containarium/releases/download/\${TAG}"
+curl -fsSL -o /tmp/containarium "\${BASE_URL}/containarium-linux-amd64"
+curl -fsSL -o /tmp/SHA256SUMS.txt "\${BASE_URL}/SHA256SUMS.txt"
+
+EXPECTED=\$(grep 'containarium-linux-amd64\$' /tmp/SHA256SUMS.txt | awk '{print \$1}')
+ACTUAL=\$(sha256sum /tmp/containarium | awk '{print \$1}')
+[[ "\$EXPECTED" == "\$ACTUAL" ]] || {
+	echo "SHA256 mismatch: expected \$EXPECTED, got \$ACTUAL" >&2
+	exit 1
+}
+
+install -m 0755 /tmp/containarium /usr/local/bin/containarium
+containarium version
+REMOTE
+
+log "starting the daemon (default mode: core services on, LXC backend)"
+ssh_or_local "sudo bash -s" <<'REMOTE'
+set -euo pipefail
+mkdir -p /etc/containarium
+[[ -f /etc/containarium/jwt.secret ]] || openssl rand -hex 32 >/etc/containarium/jwt.secret
+chmod 0400 /etc/containarium/jwt.secret
+
+cat <<'UNIT' >/etc/systemd/system/containarium.service
+[Unit]
+Description=Containarium daemon (density benchmark, native LXC workhorse)
+After=network-online.target incus.service
+Wants=network-online.target
+
+[Service]
+ExecStart=/usr/local/bin/containarium daemon --address 0.0.0.0 --rest --http-port 8080 --jwt-secret-file /etc/containarium/jwt.secret
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+systemctl daemon-reload
+systemctl enable --now containarium
+sleep 5
+systemctl is-active containarium
+REMOTE
+
+log "provisioning complete. Verify: ssh (see config.env) 'containarium list'"

--- a/benchmark/agent-sandbox-density/scripts/05-provision-containarium-lxc.sh
+++ b/benchmark/agent-sandbox-density/scripts/05-provision-containarium-lxc.sh
@@ -53,7 +53,15 @@ ssh_or_local "sudo bash -s" <<'REMOTE'
 set -euo pipefail
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -qq
-apt-get install -y -qq curl jq
+# iptables found missing live too — without it the daemon's
+# PassthroughSyncJob logs a retry failure every 5s (same class of gap as
+# jq/git elsewhere in this benchmark; the base image is minimal). Whether
+# it was also the cause of a slow first-boot core-container init isn't
+# fully confirmed — installing it and restarting is what got past the
+# stall live, but the timing doesn't rule out it just needing more time
+# regardless. Installed upfront either way since the log noise alone is
+# worth avoiding.
+apt-get install -y -qq curl jq iptables
 curl -fsSL https://pkgs.zabbly.com/get/incus-stable | sudo sh
 incus admin init --auto
 REMOTE

--- a/benchmark/agent-sandbox-density/scripts/05-provision-containarium-lxc.sh
+++ b/benchmark/agent-sandbox-density/scripts/05-provision-containarium-lxc.sh
@@ -109,6 +109,16 @@ containarium version
 REMOTE
 
 log "starting the daemon (default mode: core services on, LXC backend)"
+# --disable-{security,pentest,zap}-scanner: found live that the daemon's
+# default (non-standalone) mode auto-runs a ClamAV malware scan + a
+# network pentest scan against every newly created container — real,
+# deliberate product behavior, but it added tens of seconds of real
+# per-create latency in this benchmark's tiny (200m CPU) boxes, competing
+# with the create flow for the host's CPU. Requires a Containarium build
+# that has these flags (added specifically for this — check
+# CONTAINARIUM_VERSION in config.env resolves to a version that includes
+# them, or this ExecStart line will just get three unrecognized-flag
+# errors from an older binary).
 ssh_or_local "sudo bash -s" <<'REMOTE'
 set -euo pipefail
 mkdir -p /etc/containarium
@@ -122,7 +132,7 @@ After=network-online.target incus.service
 Wants=network-online.target
 
 [Service]
-ExecStart=/usr/local/bin/containarium daemon --address 0.0.0.0 --rest --http-port 8080 --jwt-secret-file /etc/containarium/jwt.secret
+ExecStart=/usr/local/bin/containarium daemon --address 0.0.0.0 --rest --http-port 8080 --jwt-secret-file /etc/containarium/jwt.secret --disable-security-scanner --disable-pentest-scanner --disable-zap-scanner
 Restart=on-failure
 RestartSec=5s
 

--- a/benchmark/agent-sandbox-density/scripts/05-provision-containarium-lxc.sh
+++ b/benchmark/agent-sandbox-density/scripts/05-provision-containarium-lxc.sh
@@ -109,16 +109,18 @@ containarium version
 REMOTE
 
 log "starting the daemon (default mode: core services on, LXC backend)"
-# --disable-{security,pentest,zap}-scanner: found live that the daemon's
-# default (non-standalone) mode auto-runs a ClamAV malware scan + a
-# network pentest scan against every newly created container — real,
-# deliberate product behavior, but it added tens of seconds of real
-# per-create latency in this benchmark's tiny (200m CPU) boxes, competing
-# with the create flow for the host's CPU. Requires a Containarium build
-# that has these flags (added specifically for this — check
-# CONTAINARIUM_VERSION in config.env resolves to a version that includes
-# them, or this ExecStart line will just get three unrecognized-flag
-# errors from an older binary).
+# --disable-{security,pentest,zap}-scanner: the daemon's default
+# (non-standalone) mode auto-runs a ClamAV malware scan + a network pentest
+# scan against every newly created container — real, deliberate product
+# behavior, but it's background work competing for the host's CPU during
+# this benchmark's tiny (200m CPU) boxes. Turned off for a cleaner, more
+# isolated measurement. NOTE: found live that this is NOT what was causing
+# the ~80-110s-per-create latency this scenario originally showed — that
+# was a full OS boot + in-container package install on every create (see
+# the image-bake step below, which fixes the actual cause). Requires a
+# Containarium build that has these flags (check CONTAINARIUM_VERSION in
+# config.env resolves to a version that includes them, or this ExecStart
+# line will just get three unrecognized-flag errors from an older binary).
 ssh_or_local "sudo bash -s" <<'REMOTE'
 set -euo pipefail
 mkdir -p /etc/containarium
@@ -145,5 +147,25 @@ systemctl enable --now containarium
 sleep 5
 systemctl is-active containarium
 REMOTE
+
+log "baking the base image (#1037) so creates clone instead of re-installing packages every time"
+# Found live: containarium's stackless create path always re-runs a full
+# apt-get update + install of the base package set inside the fresh
+# container (openssh-server, sudo, curl, git, vim, htop, net-tools,
+# iputils-ping — pkg/core/ospkg/debian.go), on the stock cloud image, on
+# EVERY create. Under this scenario's 200m CPU profile that's ~50s of
+# package install plus ~44s of throttled first-boot systemd work (vs.
+# ~10s unthrottled) — confirmed via systemd-analyze + apt history.log —
+# roughly the same shape of gap the k8s scenario already avoids by using a
+# pre-baked containarium-agent-box image. Containarium already ships the
+# fix for this backend too (#1037, `containarium image-bake`): it launches
+# a throwaway container, runs the exact same provisioning once, and
+# publishes the result as a local image under a deterministic alias.
+# Every subsequent stackless create for the same (image, podman)
+# combination clones that image and skips the install entirely — verified
+# live: 112s -> 15.7s for an identical create. --podman=false must match
+# the density loop's own create flags (06-run-density-containarium-lxc.sh)
+# or the bake won't be used (bakedImageMatches checks both axes).
+ssh_or_local "sudo containarium image-bake --image images:ubuntu/24.04 --podman=false"
 
 log "provisioning complete. Verify: ssh (see config.env) 'containarium list'"

--- a/benchmark/agent-sandbox-density/scripts/06-run-density-containarium-lxc.sh
+++ b/benchmark/agent-sandbox-density/scripts/06-run-density-containarium-lxc.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+#
+# Density loop for the third scenario: create Containarium boxes one at a
+# time on the native LXC/Incus backend (no k8s, no gVisor) until the
+# shared stopping rule in lib.sh's run_density_loop triggers.
+#
+# Unlike the k8s backend (04-run-density-containarium.sh), `containarium
+# list` works fine here — #1525's "incus backend not available" only
+# fires against a --runtime=k8s daemon; this one genuinely is Incus-backed.
+#
+# CPU/memory format differs from the k8s scripts too: pkg/core/incus's
+# parseCPULimit accepts Kubernetes millicpu directly (confirmed in code:
+# "250m" -> limits.cpu + limits.cpu.allowance), but memory is passed
+# straight through to Incus's own `limits.memory` config key with no
+# conversion (pkg/core/container/manager.go) — Incus's native format is
+# "256MiB", not Kubernetes' "256Mi" (confirmed against this repo's own
+# test fixtures, e.g. pkg/core/nodevm/nodevm_test.go's "1GiB"). Uses
+# SANDBOX_CPU_LIMIT/SANDBOX_MEM_LIMIT the same way 04 does (LXC has one
+# enforced ceiling, not a request+limit pair), converting Mi->MiB (a
+# rename, not a real unit conversion — MiB *is* what k8s' "Mi" means).
+#
+# Usage:
+#   scripts/06-run-density-containarium-lxc.sh --name <vm-name>
+
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+# shellcheck source=lib.sh
+source ./lib.sh
+
+VM_NAME=""
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--name)
+		VM_NAME="$2"
+		shift 2
+		;;
+	-h | --help)
+		grep '^#' "$0" | sed 's/^# \{0,1\}//'
+		exit 0
+		;;
+	*)
+		die "unknown argument: $1"
+		;;
+	esac
+done
+[[ -n "$VM_NAME" ]] || die "usage: $0 --name <vm-name>"
+
+load_config
+require_vars SANDBOX_CPU_LIMIT SANDBOX_MEM_LIMIT FAILURE_STREAK_TO_STOP CREATE_TIMEOUT_SECONDS BENCH_SSH_KEY_FILE
+resolve_remote "$VM_NAME"
+
+INCUS_MEM_LIMIT="${SANDBOX_MEM_LIMIT/Mi/MiB}"
+INCUS_MEM_LIMIT="${INCUS_MEM_LIMIT/Gi/GiB}"
+log "sandbox profile on the LXC workhorse side: cpu=${SANDBOX_CPU_LIMIT} memory=${INCUS_MEM_LIMIT} (Incus limits.cpu/limits.memory, single ceiling)"
+
+RESULTS_DIR="${BENCH_ROOT}/results"
+mkdir -p "$RESULTS_DIR"
+RESULTS_FILE="${RESULTS_DIR}/containarium-lxc-$(date -u +%Y%m%dT%H%M%SZ).md"
+
+CTN_SERVER="http://127.0.0.1:8080"
+
+log "minting an admin token"
+CTN_TOKEN=$(ssh_or_local "sudo containarium token generate --username bench-admin --roles admin --expiry 6h --secret-file /etc/containarium/jwt.secret --raw")
+[[ -n "$CTN_TOKEN" ]] || die "failed to mint a token — check the daemon is running (systemctl status containarium)"
+
+create_box() {
+	local name="$1"
+	ssh_or_local "containarium create ${name} --no-ssh-key --cpu ${SANDBOX_CPU_LIMIT} --memory ${INCUS_MEM_LIMIT} --server ${CTN_SERVER} --http --token ${CTN_TOKEN}" >/dev/null 2>&1
+}
+
+box_ready() {
+	local name="$1"
+	local state
+	state=$(ssh_or_local "containarium list --format json --server ${CTN_SERVER} --http --token ${CTN_TOKEN} 2>/dev/null" |
+		jq -r --arg n "$name" '.[] | select(.username==$n) | .state' 2>/dev/null || true)
+	[[ "$state" == "RUNNING" ]]
+}
+
+cleanup_box() {
+	local name="$1"
+	ssh_or_local "containarium delete ${name} --force --server ${CTN_SERVER} --http --token ${CTN_TOKEN}" >/dev/null 2>&1 || true
+}
+
+resource_snapshot "before" "$RESULTS_FILE"
+{
+	echo "profile: cpu ${SANDBOX_CPU_LIMIT}, mem ${INCUS_MEM_LIMIT} (Incus native, single ceiling)"
+	echo "backend: native LXC/Incus, no k8s, no gVisor"
+	echo
+} >>"$RESULTS_FILE"
+
+run_density_loop "sbdens" create_box box_ready cleanup_box "$RESULTS_FILE"
+
+resource_snapshot "after (${DENSITY_RESULT_COUNT} ready)" "$RESULTS_FILE"
+{
+	echo "containarium list totals:"
+	echo '```'
+	ssh_or_local "containarium list --server ${CTN_SERVER} --http --token ${CTN_TOKEN} 2>&1 | tail -5" || true
+	echo '```'
+} >>"$RESULTS_FILE"
+
+log "Containarium (native LXC) third-scenario result: ${DENSITY_RESULT_COUNT} boxes reached RUNNING"
+log "full log: ${RESULTS_FILE}"

--- a/benchmark/agent-sandbox-density/scripts/06-run-density-containarium-lxc.sh
+++ b/benchmark/agent-sandbox-density/scripts/06-run-density-containarium-lxc.sh
@@ -19,6 +19,24 @@
 # enforced ceiling, not a request+limit pair), converting Mi->MiB (a
 # rename, not a real unit conversion — MiB *is* what k8s' "Mi" means).
 #
+# `--podman=false`: found live that `create`'s default (--podman=true)
+# installs Podman + pip + podman-compose inside every box
+# (pkg/core/container/manager.go's installPackages) — under this
+# benchmark's tiny 50m CPU limit, that single install chain took several
+# minutes per unit (watched it firsthand: still running `apt-get install
+# python3-pip` six minutes in). That's not a density measurement, it's a
+# package-manager-under-extreme-CPU-starvation measurement, and neither
+# the control group's busybox pods nor the k8s-backend's agent-box image
+# do anything comparable at create time. Disabling it drops the per-unit cost to just the base package set
+# (openssh-server, sudo, curl, git, vim, htop, net-tools, iputils-ping —
+# pkg/core/ospkg/debian.go, still installed via apt at create time either
+# way). That's still not perfectly comparable to the other two scenarios
+# — neither installs anything at create time at all (bare busybox for
+# the control group; a pre-baked agent-box image for the k8s-backend
+# Containarium group) — but it's the closest this backend gets without
+# baking its own base image, and it's the real difference worth reporting
+# rather than a multi-minute artifact worth reporting.
+#
 # Usage:
 #   scripts/06-run-density-containarium-lxc.sh --name <vm-name>
 
@@ -65,7 +83,7 @@ CTN_TOKEN=$(ssh_or_local "sudo containarium token generate --username bench-admi
 
 create_box() {
 	local name="$1"
-	ssh_or_local "containarium create ${name} --no-ssh-key --cpu ${SANDBOX_CPU_LIMIT} --memory ${INCUS_MEM_LIMIT} --server ${CTN_SERVER} --http --token ${CTN_TOKEN}" >/dev/null 2>&1
+	ssh_or_local "containarium create ${name} --no-ssh-key --podman=false --cpu ${SANDBOX_CPU_LIMIT} --memory ${INCUS_MEM_LIMIT} --server ${CTN_SERVER} --http --token ${CTN_TOKEN}" >/dev/null 2>&1
 }
 
 box_ready() {

--- a/benchmark/agent-sandbox-density/scripts/06-run-density-containarium-lxc.sh
+++ b/benchmark/agent-sandbox-density/scripts/06-run-density-containarium-lxc.sh
@@ -64,12 +64,19 @@ done
 [[ -n "$VM_NAME" ]] || die "usage: $0 --name <vm-name>"
 
 load_config
-require_vars SANDBOX_CPU_LIMIT SANDBOX_MEM_LIMIT FAILURE_STREAK_TO_STOP CREATE_TIMEOUT_SECONDS BENCH_SSH_KEY_FILE
+require_vars SANDBOX_MEM_LIMIT FAILURE_STREAK_TO_STOP CREATE_TIMEOUT_SECONDS BENCH_SSH_KEY_FILE
+
+# LXC_SANDBOX_CPU_LIMIT overrides SANDBOX_CPU_LIMIT for this scenario —
+# see config.env.example's comment on it for why (an LXC box has to fully
+# boot an OS before it's usable; a too-tight CPU profile makes DHCP
+# acquisition time out before boot finishes, unlike a k8s pod which just
+# starts an existing process). Falls back to SANDBOX_CPU_LIMIT if unset.
+LXC_CPU_LIMIT="${LXC_SANDBOX_CPU_LIMIT:-${SANDBOX_CPU_LIMIT:-200m}}"
 resolve_remote "$VM_NAME"
 
 INCUS_MEM_LIMIT="${SANDBOX_MEM_LIMIT/Mi/MiB}"
 INCUS_MEM_LIMIT="${INCUS_MEM_LIMIT/Gi/GiB}"
-log "sandbox profile on the LXC workhorse side: cpu=${SANDBOX_CPU_LIMIT} memory=${INCUS_MEM_LIMIT} (Incus limits.cpu/limits.memory, single ceiling)"
+log "sandbox profile on the LXC workhorse side: cpu=${LXC_CPU_LIMIT} memory=${INCUS_MEM_LIMIT} (Incus limits.cpu/limits.memory, single ceiling)"
 
 RESULTS_DIR="${BENCH_ROOT}/results"
 mkdir -p "$RESULTS_DIR"
@@ -83,7 +90,7 @@ CTN_TOKEN=$(ssh_or_local "sudo containarium token generate --username bench-admi
 
 create_box() {
 	local name="$1"
-	ssh_or_local "containarium create ${name} --no-ssh-key --podman=false --cpu ${SANDBOX_CPU_LIMIT} --memory ${INCUS_MEM_LIMIT} --server ${CTN_SERVER} --http --token ${CTN_TOKEN}" >/dev/null 2>&1
+	ssh_or_local "containarium create ${name} --no-ssh-key --podman=false --cpu ${LXC_CPU_LIMIT} --memory ${INCUS_MEM_LIMIT} --server ${CTN_SERVER} --http --token ${CTN_TOKEN}" >/dev/null 2>&1
 }
 
 box_ready() {
@@ -105,7 +112,7 @@ cleanup_box() {
 
 resource_snapshot "before" "$RESULTS_FILE"
 {
-	echo "profile: cpu ${SANDBOX_CPU_LIMIT}, mem ${INCUS_MEM_LIMIT} (Incus native, single ceiling)"
+	echo "profile: cpu ${LXC_CPU_LIMIT}, mem ${INCUS_MEM_LIMIT} (Incus native, single ceiling; cpu overridden from the k8s scenarios' value — see this script's header)"
 	echo "backend: native LXC/Incus, no k8s, no gVisor"
 	echo
 } >>"$RESULTS_FILE"

--- a/benchmark/agent-sandbox-density/scripts/06-run-density-containarium-lxc.sh
+++ b/benchmark/agent-sandbox-density/scripts/06-run-density-containarium-lxc.sh
@@ -71,9 +71,13 @@ create_box() {
 box_ready() {
 	local name="$1"
 	local state
+	# NOTE: this backend's `list` JSON shape differs from what it looked
+	# like on the k8s backend — confirmed live: {"containers":[...]}, not
+	# a bare array, with capitalized Username/State fields and the full
+	# enum value CONTAINER_STATE_RUNNING, not a short "RUNNING".
 	state=$(ssh_or_local "containarium list --format json --server ${CTN_SERVER} --http --token ${CTN_TOKEN} 2>/dev/null" |
-		jq -r --arg n "$name" '.[] | select(.username==$n) | .state' 2>/dev/null || true)
-	[[ "$state" == "RUNNING" ]]
+		jq -r --arg n "$name" '.containers[] | select(.Username==$n) | .State' 2>/dev/null || true)
+	[[ "$state" == "CONTAINER_STATE_RUNNING" ]]
 }
 
 cleanup_box() {

--- a/benchmark/agent-sandbox-density/scripts/06-run-density-containarium-lxc.sh
+++ b/benchmark/agent-sandbox-density/scripts/06-run-density-containarium-lxc.sh
@@ -38,7 +38,15 @@
 # rather than a multi-minute artifact worth reporting.
 #
 # Usage:
-#   scripts/06-run-density-containarium-lxc.sh --name <vm-name>
+#   scripts/06-run-density-containarium-lxc.sh --name <vm-name> [--start-index N]
+#
+# --start-index: resume numbering after a prior run stopped for a reason
+# that wasn't actually resource exhaustion (e.g. #1532 — `containarium
+# list` itself was timing out past ~180 containers on one host, not the
+# host running out of memory/CPU/disk; once that's fixed, re-running from
+# scratch would just re-create the same 180 units for no reason). Existing
+# units below start-index are left alone — this only affects where the
+# loop's own counter begins.
 
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
@@ -46,10 +54,15 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 source ./lib.sh
 
 VM_NAME=""
+START_INDEX=1
 while [[ $# -gt 0 ]]; do
 	case "$1" in
 	--name)
 		VM_NAME="$2"
+		shift 2
+		;;
+	--start-index)
+		START_INDEX="$2"
 		shift 2
 		;;
 	-h | --help)
@@ -61,7 +74,7 @@ while [[ $# -gt 0 ]]; do
 		;;
 	esac
 done
-[[ -n "$VM_NAME" ]] || die "usage: $0 --name <vm-name>"
+[[ -n "$VM_NAME" ]] || die "usage: $0 --name <vm-name> [--start-index N]"
 
 load_config
 require_vars SANDBOX_MEM_LIMIT FAILURE_STREAK_TO_STOP CREATE_TIMEOUT_SECONDS BENCH_SSH_KEY_FILE
@@ -133,7 +146,7 @@ resource_snapshot "before" "$RESULTS_FILE"
 	echo
 } >>"$RESULTS_FILE"
 
-run_density_loop "sbdens" create_box box_ready cleanup_box "$RESULTS_FILE"
+run_density_loop "sbdens" create_box box_ready cleanup_box "$RESULTS_FILE" "$START_INDEX"
 
 resource_snapshot "after (${DENSITY_RESULT_COUNT} ready)" "$RESULTS_FILE"
 {

--- a/benchmark/agent-sandbox-density/scripts/06-run-density-containarium-lxc.sh
+++ b/benchmark/agent-sandbox-density/scripts/06-run-density-containarium-lxc.sh
@@ -72,6 +72,22 @@ require_vars SANDBOX_MEM_LIMIT FAILURE_STREAK_TO_STOP CREATE_TIMEOUT_SECONDS BEN
 # acquisition time out before boot finishes, unlike a k8s pod which just
 # starts an existing process). Falls back to SANDBOX_CPU_LIMIT if unset.
 LXC_CPU_LIMIT="${LXC_SANDBOX_CPU_LIMIT:-${SANDBOX_CPU_LIMIT:-200m}}"
+
+# lib.sh's run_density_loop starts its per-unit clock BEFORE calling
+# create_box, and create_box here is synchronous — it blocks until
+# `containarium create` itself returns, which on this backend means a
+# full OS boot (~44s under a 200m CPU ceiling, confirmed via
+# systemd-analyze) plus the base package install (~50s, confirmed via
+# /var/log/apt/history.log) have already completed. That alone is close
+# to or past the shared CREATE_TIMEOUT_SECONDS default (60s), so the
+# ready_fn poll loop below would start with its window already expired
+# and misreport every unit as "never became ready" even though it's
+# already running. LXC_CREATE_TIMEOUT_SECONDS overrides the shared
+# CREATE_TIMEOUT_SECONDS for this scenario only — the k8s-backed
+# scenarios (02/04) don't pay this synchronous boot+install cost, so
+# their 60s default stays correct as-is.
+CREATE_TIMEOUT_SECONDS="${LXC_CREATE_TIMEOUT_SECONDS:-$CREATE_TIMEOUT_SECONDS}"
+
 resolve_remote "$VM_NAME"
 
 INCUS_MEM_LIMIT="${SANDBOX_MEM_LIMIT/Mi/MiB}"

--- a/benchmark/agent-sandbox-density/scripts/lib.sh
+++ b/benchmark/agent-sandbox-density/scripts/lib.sh
@@ -129,15 +129,21 @@ resource_snapshot() {
 #   $3 - name of a function: ready_fn <unit-name>   -> returns 0 once ready, non-zero while pending
 #   $4 - name of a function: cleanup_fn <unit-name> -> best-effort teardown of a failed/half-created unit
 #   $5 - results file to append the run log to
+#   $6 - starting index (optional, default 1) — lets a re-run continue
+#        numbering after a prior run stopped for a non-resource reason
+#        (e.g. #1532: fixed a bug that was misreported as the stopping
+#        rule, resume from where the earlier run actually left off
+#        instead of re-creating units 1..N from scratch)
 #
 # On return, sets DENSITY_RESULT_COUNT to the number of units that reached
 # ready state before the stopping rule triggered.
 run_density_loop() {
 	local prefix="$1" create_fn="$2" ready_fn="$3" cleanup_fn="$4" results_file="$5"
-	local i=0 ready_count=0 fail_streak=0
+	local start_index="${6:-1}"
+	local i=$((start_index - 1)) ready_count=0 fail_streak=0
 	local unit_name start_ts
 
-	log "starting density loop: prefix=${prefix} stop-after=${FAILURE_STREAK_TO_STOP} consecutive failures, per-unit timeout=${CREATE_TIMEOUT_SECONDS}s"
+	log "starting density loop: prefix=${prefix} start-index=${start_index} stop-after=${FAILURE_STREAK_TO_STOP} consecutive failures, per-unit timeout=${CREATE_TIMEOUT_SECONDS}s"
 	echo "## density run: ${prefix} ($(date -u +%Y-%m-%dT%H:%M:%SZ))" >>"$results_file"
 
 	while true; do


### PR DESCRIPTION
## Summary
- Adds the third density-benchmark scenario: Containarium's native LXC/Incus backend (no Kubernetes, no gVisor, no pooling — see README.md "Third scenario")
- Real live run, in two segments (first stopped on a bug, resumed after fixing it): **251 sandboxes reached RUNNING**, 259 attempted
- Found and fixed one real bug live in the benchmark scripts (LXC create timeout window), found and filed three real product bugs beyond this benchmark

## What's in this PR
- `scripts/05-provision-containarium-lxc.sh`, `06-run-density-containarium-lxc.sh`, `99-teardown-vm.sh` (already existed) — provisioning + density loop for this scenario
- `scripts/lib.sh` — adds `run_density_loop`'s optional start-index (resume a run past a fixed bug rather than re-running from scratch)
- `RESULTS.md` — full write-up of the run, including why the raw count isn't directly comparable to the other two scenarios (different resource models entirely — k8s admission-reserves declared requests, Incus enforces `limits.memory` as a ceiling; the actual walls hit were a `list()` scaling bug then a bridge subnet size, not memory)

## Issues found and filed while running this
- #1530 — per-create latency was OS boot + package install, not scanning (fixed via `containarium image-bake`, an already-shipped feature)
- #1531 (open) — host-side jump-server account creation silently fails after ~10-14 tenants on one host (`useradd` subuid/subgid pool collision)
- #1532 — `containarium list` scaled badly (O(N) sequential Incus round-trips) past ~180 containers; fixed in #1533 (merged separately)

Depends on #1529 (scanner-disable flags) and #1533 (list concurrency fix), both already merged to main.

## Test plan
- [x] Live end-to-end run on real infrastructure (bare-metal host via Incus VM), documented in RESULTS.md
- [x] `bash -n` on all modified/new shell scripts
- [x] Related Go changes (#1529, #1533) have their own test coverage in their respective PRs