### PR TITLE
fix(container): stop EnsureJumpServerAccount from exhausting the subuid pool

### DIFF
--- a/pkg/core/container/jump_server.go
+++ b/pkg/core/container/jump_server.go
@@ -196,8 +196,21 @@ func EnsureJumpServerAccount(username string) error {
 		_ = exec.Command("usermod", "-s", shellPath, username).Run()
 	} else {
 		// Create user with containarium-shell
+		// -K SUB_UID_COUNT=0 / SUB_GID_COUNT=0: this account only ever runs
+		// containarium-shell (exec into the tenant's own container) — it
+		// never needs a user-namespace subuid/subgid mapping. Without this,
+		// useradd auto-allocates one from /etc/subuid's small free window
+		// below Incus's own root reservation (#1531): found live that the
+		// window exhausts after ~10-14 accounts on a fresh host, after
+		// which every subsequent EnsureJumpServerAccount call fails outright
+		// (useradd exit 16) — not a degraded state, no jump-server account
+		// at all. retryUseraddWithLockWait (CreateJumpServerAccount's own
+		// useradd, used by the SSH-key create path) already carries these
+		// same two flags; this call site was the one gap.
 		// #nosec G204 -- username validated by isValidUsername above
 		if err := exec.Command("useradd", "-m", "-s", shellPath,
+			"-K", "SUB_UID_COUNT=0",
+			"-K", "SUB_GID_COUNT=0",
 			"-c", fmt.Sprintf("Containarium user - %s", username),
 			username).Run(); err != nil {
 			return fmt.Errorf("useradd failed: %w", err)


### PR DESCRIPTION
## Summary
- `EnsureJumpServerAccount`'s `useradd` call was missing `-K SUB_UID_COUNT=0 -K SUB_GID_COUNT=0`, which its sibling (`retryUseraddWithLockWait`, used by the SSH-key create path) already has
- Without it, `useradd` auto-allocates a subordinate UID/GID range from `/etc/subuid` for every new host account — the pool exhausts after ~10-14 accounts on a fresh host because Incus's own root reservation (for unprivileged-container ID mapping) leaves only a narrow free window
- After exhaustion, every subsequent `EnsureJumpServerAccount` call fails outright (`useradd` exit 16), logged only as a `Warning:` — no SSH jump-server account for that tenant, with no operator-visible signal beyond a log grep

Closes #1531

## Why

Found live while running `benchmark/agent-sandbox-density`'s third scenario: 175 of 181 tenant creates in that run silently had no jump-server account, starting from roughly the 10th tenant on the host. These jump-server accounts only ever run `containarium-shell` (exec into the tenant's own container) — they never need a user-namespace mapping, so there's no reason to let `useradd` allocate one.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./pkg/core/container/...`
- [x] `go test ./pkg/core/container/...`
- [ ] Live re-verification (the flags match an already-proven pattern in the same file, `retryUseraddWithLockWait`, which has run this exact fix in production create paths) — no live host currently available to re-test end-to-end, but the change is mechanically identical to that already-verified sibling call