### PR TITLE
feat(cmd): add 'containarium get <username>' for O(1) single-container lookup

### DIFF
--- a/internal/cmd/get.go
+++ b/internal/cmd/get.go
@@ -1,0 +1,111 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/footprintai/containarium/internal/client"
+	"github.com/footprintai/containarium/pkg/core/container"
+	"github.com/footprintai/containarium/pkg/core/incus"
+	"github.com/spf13/cobra"
+)
+
+var containerGetFormat string
+
+var getCmd = &cobra.Command{
+	Use:   "get <username>",
+	Short: "Get one container's current state",
+	Long: `Look up a single container by username — the O(1) counterpart to
+'containarium list', which always fetches and filters every container on
+the backend even when only one is wanted.
+
+Found live (#1541): a script polling readiness with 'list' in a tight loop
+makes the backend do 2 Incus API round-trips per EXISTING container on
+every single poll, regardless of how many containers the caller actually
+cares about — at a few hundred containers this becomes real load on the
+Incus daemon itself. 'get' costs exactly one round-trip, for the one
+container asked about, no matter how many others exist. Prefer it over
+'list --user <name>' for polling loops and any other single-container
+lookup.
+
+Examples:
+  containarium get alice
+  containarium get alice --format json`,
+	Args: cobra.ExactArgs(1),
+	RunE: runGet,
+}
+
+func init() {
+	rootCmd.AddCommand(getCmd)
+	getCmd.Flags().StringVarP(&containerGetFormat, "format", "f", "table", "Output format: table, json, yaml")
+}
+
+func runGet(cmd *cobra.Command, args []string) error {
+	username := args[0]
+
+	var info *incus.ContainerInfo
+	var err error
+
+	switch {
+	case httpMode && serverAddr != "":
+		info, err = getRemoteHTTP(username)
+	case serverAddr != "":
+		info, err = getRemote(username)
+	default:
+		info, err = getLocal(username)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get container %q: %w", username, err)
+	}
+	if info == nil {
+		return fmt.Errorf("container %q not found", username)
+	}
+
+	containers := []incus.ContainerInfo{*info}
+	switch containerGetFormat {
+	case "table":
+		printTableFormat(containers, boolToCount(info.State == "Running"), boolToCount(info.State != "Running"), false)
+	case "json":
+		return printJSONFormat(containers)
+	case "yaml":
+		printYAMLFormat(containers)
+	default:
+		return fmt.Errorf("unknown format: %s (use: table, json, yaml)", containerGetFormat)
+	}
+	return nil
+}
+
+// boolToCount turns a single container's running/not-running check into the
+// running/stopped counts printTableFormat's footer expects, without
+// duplicating that footer logic for a one-item list.
+func boolToCount(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+func getLocal(username string) (*incus.ContainerInfo, error) {
+	mgr, err := container.New()
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to Incus: %w (is Incus running?)", err)
+	}
+	return mgr.Get(username)
+}
+
+func getRemote(username string) (*incus.ContainerInfo, error) {
+	grpcClient, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = grpcClient.Close() }()
+	return grpcClient.GetContainer(username)
+}
+
+func getRemoteHTTP(username string) (*incus.ContainerInfo, error) {
+	httpClient, err := client.NewHTTPClient(serverAddr, authToken)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = httpClient.Close() }()
+	return httpClient.GetContainer(username)
+}


### PR DESCRIPTION
## Summary
- Adds `containarium get <username>`, an O(1) single-container lookup (one Incus round-trip, no state/network lookup) — the O(1) counterpart to `list`, which always fetches and filters every container on the backend
- Wraps the existing `GetContainer` RPC, which already had gRPC/HTTP client wrappers (used internally by `debug`/`connect`) but no CLI subcommand of its own

## Why — relates to #1541

While investigating #1541 (Incus daemon CPU overhead at ~570 containers, load average ~117 on a 20-core host), found a likely major contributor on the *Containarium* side, not necessarily an inherent Incus limitation: `benchmark/agent-sandbox-density`'s readiness-polling loop calls `containarium list` roughly every 2 seconds while waiting for each unit to become ready. Even after #1533's concurrency fix (which made each individual `list` call *fast*), it's still 2 sequential-per-container Incus API round-trips *in aggregate* — at N containers, every single poll does O(N) Incus-side work regardless of how many the caller actually cares about (one). A tight polling loop against a growing container count compounds this badly.

`get` costs exactly one round-trip for the one container being asked about, independent of how many others exist — the right tool for a readiness-polling loop or any other single-container check.

This PR is the product-side fix (the CLI command). A follow-up will point the benchmark's own `box_ready()` at it and re-verify against a live host whether this materially changes #1541's observed load.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/cmd/...`
- [x] `go test ./internal/cmd/...`
- [x] `containarium get --help` smoke-checked locally