### PR TITLE
feat(server): wire pool.Claim/Reconcile into SandboxServer (#1488 Phase 3)

### DIFF
--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -540,11 +540,23 @@ func NewDualServer(config *DualServerConfig) (*DualServer, error) {
 	pb.RegisterVolumeServiceServer(grpcServer, NewVolumeServer())
 	log.Printf("Volume service enabled")
 
-	// Register SandboxService — ephemeral, no-SSH sandboxes (#1488 Phase 1,
-	// the two-digit-ms spawn path's cold-path implementation). Own incus
-	// client, same pattern as the other feature servers in this function.
+	// Register SandboxService — ephemeral, no-SSH sandboxes (#1488). Own
+	// incus client, same pattern as the other feature servers in this
+	// function.
+	//
+	// Pool is nil: SandboxServer can use a configured *pool.Pool (#1520)
+	// to serve spawns from a warm ring instead of always creating cold,
+	// but nothing constructs one here yet. A pool needs operator-facing
+	// config this daemon doesn't have a source for yet (min_warm per
+	// template, an image per template, the IPAM range, the NIC network)
+	// — and those need validating against a live host before they're
+	// safe defaults, which this can't do. Every spawn takes the cold
+	// path until that config lands; see SandboxServer's own type doc for
+	// why nil is also the ONLY safe default (a configured-but-empty pool
+	// would silently start rejecting every caller that hasn't set
+	// allow_cold_start=true).
 	if sandboxIncusClient, err := incus.New(); err == nil {
-		pb.RegisterSandboxServiceServer(grpcServer, NewSandboxServer(sandboxIncusClient))
+		pb.RegisterSandboxServiceServer(grpcServer, NewSandboxServer(sandboxIncusClient, nil))
 		log.Printf("Sandbox service enabled")
 	} else {
 		log.Printf("Warning: SandboxService disabled — incus client init failed: %v", err)

--- a/internal/server/sandbox_server.go
+++ b/internal/server/sandbox_server.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"log"
+	"sync"
 	"time"
 
 	"github.com/footprintai/containarium/internal/auth"
 	"github.com/footprintai/containarium/internal/safecast"
+	"github.com/footprintai/containarium/internal/sandbox/pool"
 	"github.com/footprintai/containarium/pkg/core/incus"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 	"google.golang.org/grpc/codes"
@@ -50,9 +54,9 @@ const defaultSandboxIdleTTL = 30 * time.Minute
 // equivalent wait.
 const spawnNetworkTimeout = 30 * time.Second
 
-// SandboxServer implements SandboxService (#1488 Phase 1): the two-digit-ms
-// spawn path's cold-path implementation. A sandbox has no per-tenant Linux
-// account and no SSH — these five RPCs are its entire access surface.
+// SandboxServer implements SandboxService: the two-digit-ms spawn path. A
+// sandbox has no per-tenant Linux account and no SSH — these five RPCs are
+// its entire access surface.
 //
 // Talks to incus.Backend directly rather than going through
 // pkg/core/container.Manager: Manager.Create is the full persistent-box
@@ -60,14 +64,63 @@ const spawnNetworkTimeout = 30 * time.Second
 // sandboxes are explicitly scoped to skip. Reusing it would mean threading
 // a "skip everything" option through a function whose entire shape is that
 // provisioning.
+//
+// pool is optional (#1488 Phase 3). nil means every spawn takes the cold
+// path — today's exact Phase 1 behavior, including for a caller that never
+// sets allow_cold_start (its zero value is false): admission control
+// (RESOURCE_EXHAUSTED on an exhausted pool) only ever applies when a pool
+// is actually configured. A configured-but-untargeted pool (no ready
+// member for a requested template) is indistinguishable from "no pool at
+// all" from SpawnSandbox's perspective — both fall through to cold,
+// subject to the same allow_cold_start gate.
 type SandboxServer struct {
 	pb.UnimplementedSandboxServiceServer
 	incus incus.Backend
+	pool  *pool.Pool
+
+	// claimed tracks, per pool-claimed sandbox_id, the pool.Member Claim
+	// returned — DeleteSandbox needs it to route to pool.Release (which
+	// also frees the member's IPAM address) instead of destroy() (which
+	// doesn't know about IPAM at all; a cold-path sandbox never has an
+	// address to free). In-memory only: like container_server.go's own
+	// pendingCreations, a claimed-but-not-yet-deleted sandbox's tracking
+	// doesn't survive a daemon restart — no different in kind from every
+	// other piece of this daemon's in-flight state, and sandboxes are
+	// short-lived by design.
+	claimedMu sync.Mutex
+	claimed   map[string]*pool.Member
 }
 
 // NewSandboxServer constructs a SandboxServer over the given Incus backend.
-func NewSandboxServer(backend incus.Backend) *SandboxServer {
-	return &SandboxServer{incus: backend}
+// p is optional; nil disables pool-backed spawns (see the type doc).
+func NewSandboxServer(backend incus.Backend, p *pool.Pool) *SandboxServer {
+	return &SandboxServer{incus: backend, pool: p, claimed: make(map[string]*pool.Member)}
+}
+
+// StartReconciler runs pool.Reconcile on interval until ctx is done. No-op
+// if s.pool is nil (no pool configured). Same ticker shape as this
+// package's other background loops (see startIntegrityHeartbeat in
+// dual_server.go): one immediate reconcile so a freshly-started daemon
+// doesn't wait a full interval before warming its first members, then on
+// the cadence.
+func (s *SandboxServer) StartReconciler(ctx context.Context, interval time.Duration) {
+	if s.pool == nil {
+		return
+	}
+
+	s.pool.Reconcile(ctx)
+	go func() {
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				s.pool.Reconcile(ctx)
+			}
+		}
+	}()
 }
 
 // newSandboxID generates a sandbox_id / Incus container name: sandbox- plus
@@ -109,9 +162,13 @@ func (s *SandboxServer) destroy(name string) error {
 	return s.incus.DeleteContainer(name)
 }
 
-// SpawnSandbox implements the two-digit-ms spawn path's Phase 1 cold
-// fallback: every call creates a fresh container. served_from is always
-// COLD until Phase 3 adds the warm pool.
+// SpawnSandbox tries the warm pool first (#1488 Phase 3, served_from =
+// POOL) when one is configured, and falls back to the cold path
+// (served_from = COLD) otherwise: pool disabled, or the requested
+// template's ready ring is empty and the caller set allow_cold_start. An
+// exhausted pool with allow_cold_start unset (false) returns
+// RESOURCE_EXHAUSTED instead of silently paying the cold path's cost — a
+// latency SLO whose slow path is invisible isn't an SLO.
 func (s *SandboxServer) SpawnSandbox(ctx context.Context, req *pb.SpawnSandboxRequest) (*pb.SpawnSandboxResponse, error) {
 	if err := auth.RequireScope(ctx, auth.ScopeSandboxesWrite); err != nil {
 		return nil, err
@@ -126,26 +183,38 @@ func (s *SandboxServer) SpawnSandbox(ctx context.Context, req *pb.SpawnSandboxRe
 		return nil, err
 	}
 
+	if s.pool != nil {
+		resp, err := s.claimFromPool(template, subject, req)
+		switch {
+		case err == nil:
+			return resp, nil
+		case !errors.Is(err, pool.ErrPoolExhausted):
+			// A member was actually claimed (removed from the ring) but
+			// setup failed after that — a real error, not "no pool
+			// member available." claimFromPool already unwound it.
+			return nil, err
+		case !req.AllowColdStart:
+			return nil, status.Errorf(codes.ResourceExhausted,
+				"no warm %s sandbox available; retry, or set allow_cold_start=true for the slower cold-create path", template)
+		}
+		// Exhausted, but the caller opted into the cold path — fall
+		// through to it below, exactly like a nil pool would.
+	}
+
 	id, err := newSandboxID()
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "%v", err)
 	}
 
-	ttl := time.Duration(req.IdleTtlSeconds) * time.Second
-	if ttl <= 0 {
-		ttl = defaultSandboxIdleTTL
-	}
+	ttl := sandboxTTL(req.IdleTtlSeconds)
 	now := time.Now()
 
+	extraConfig := qualifyLabels(sandboxLabelSuffixes(template, ttl))
+	extraConfig[incus.TenantLabelKey] = subject
 	config := incus.ContainerConfig{
-		Name:  id,
-		Image: image,
-		ExtraConfig: map[string]string{
-			SandboxKindLabelKey:                         SandboxKindLabelValue,
-			incus.TenantLabelKey:                        subject,
-			incus.LabelPrefix + "sandbox-template":      template.String(),
-			incus.LabelPrefix + "sandbox-idle-ttl-secs": fmt.Sprintf("%d", int64(ttl.Seconds())),
-		},
+		Name:        id,
+		Image:       image,
+		ExtraConfig: extraConfig,
 	}
 
 	if err := s.incus.CreateContainer(config); err != nil {
@@ -170,6 +239,135 @@ func (s *SandboxServer) SpawnSandbox(ctx context.Context, req *pb.SpawnSandboxRe
 			ExpiresAt:  timestamppb.New(now.Add(ttl)),
 		},
 	}, nil
+}
+
+// sandboxTTL resolves a request's idle_ttl_seconds to a concrete duration,
+// applying defaultSandboxIdleTTL when unset (<= 0).
+func sandboxTTL(idleTTLSeconds int32) time.Duration {
+	ttl := time.Duration(idleTTLSeconds) * time.Second
+	if ttl <= 0 {
+		ttl = defaultSandboxIdleTTL
+	}
+	return ttl
+}
+
+// sandboxLabelSuffixes builds the (bare, unqualified) label keys every
+// sandbox carries once fully provisioned, regardless of which path
+// created it — shared by the cold path (via qualifyLabels, below) and
+// claimFromPool's post-claim SetLabels so the two constructions can't
+// drift into stamping different keys.
+//
+// Bare because that's SetLabels' own contract — it adds incus.LabelPrefix
+// itself, so passing an already-prefixed key double-prefixes it. This
+// deliberately does NOT include incus.TenantLabelKey: that key lives
+// outside the LabelPrefix namespace entirely (SetLabels can't touch it —
+// it only clears/rewrites LabelPrefix-prefixed keys), so it's set
+// separately via SetConfig everywhere it's needed.
+func sandboxLabelSuffixes(template pb.SandboxTemplate, ttl time.Duration) map[string]string {
+	return map[string]string{
+		sandboxKindLabelSuffix:  SandboxKindLabelValue,
+		"sandbox-template":      template.String(),
+		"sandbox-idle-ttl-secs": fmt.Sprintf("%d", int64(ttl.Seconds())),
+	}
+}
+
+// qualifyLabels prefixes each key with incus.LabelPrefix, for a caller
+// (the cold path's CreateContainer ExtraConfig) that needs fully-qualified
+// keys rather than SetLabels' bare ones.
+func qualifyLabels(suffixes map[string]string) map[string]string {
+	qualified := make(map[string]string, len(suffixes))
+	for k, v := range suffixes {
+		qualified[incus.LabelPrefix+k] = v
+	}
+	return qualified
+}
+
+// claimFromPool attempts to serve a spawn from the warm pool: claim a
+// ready member, then stamp its ownership — a warmed-but-unclaimed member
+// carries none of it, since the pool has no notion of tenant — so the
+// existing ownership/lookup path (lookupOwnedSandbox) recognizes it
+// exactly like a cold-path sandbox.
+//
+// Returns pool.ErrPoolExhausted unchanged when there is simply no ready
+// member; the caller (SpawnSandbox) decides whether that's RESOURCE_EXHAUSTED
+// or a signal to fall back to the cold path. Any OTHER error means a
+// member WAS claimed (removed from the ring) but setup failed after that —
+// claimFromPool destroys it via pool.Release before returning, rather than
+// leaking a claimed member with no sandbox_id a caller could ever use to
+// clean it up: unlabeled (lookupOwnedSandbox wouldn't recognize it as a
+// sandbox at all) or unowned (info.Tenant == "" fails the ownership check
+// for everyone but an admin, including the tenant who thinks they just
+// spawned it).
+//
+// Two Incus round-trip PAIRS on the claim path — SetConfig for the tenant
+// key (outside the label namespace, see sandboxLabelSuffixes) plus
+// SetLabels for kind/template/ttl — because no existing incus.Backend
+// primitive sets both a raw config key and a batch of labels in one call.
+// This is real, and it's the piece of "two-digit ms" this integration
+// does not yet fully deliver on; a combined bulk-set primitive is a
+// legitimate follow-up once real latency numbers (Phase 3's own exit
+// criterion) show it's worth adding.
+func (s *SandboxServer) claimFromPool(template pb.SandboxTemplate, subject string, req *pb.SpawnSandboxRequest) (*pb.SpawnSandboxResponse, error) {
+	member, err := s.pool.Claim(template)
+	if err != nil {
+		return nil, err
+	}
+
+	ttl := sandboxTTL(req.IdleTtlSeconds)
+	now := time.Now()
+
+	if err := s.incus.SetConfig(member.ID, incus.TenantLabelKey, subject); err != nil {
+		s.releaseFailedClaim(member, "set tenant", err)
+		return nil, status.Errorf(codes.Internal, "claimed a warm sandbox but failed to set its owner: %v", err)
+	}
+	if err := s.incus.SetLabels(member.ID, sandboxLabelSuffixes(template, ttl)); err != nil {
+		s.releaseFailedClaim(member, "set labels", err)
+		return nil, status.Errorf(codes.Internal, "claimed a warm sandbox but failed to label it: %v", err)
+	}
+
+	s.trackClaimed(member)
+
+	return &pb.SpawnSandboxResponse{
+		Sandbox: &pb.Sandbox{
+			SandboxId:  member.ID,
+			State:      pb.SandboxState_SANDBOX_STATE_RUNNING,
+			Template:   template,
+			ServedFrom: pb.ServedFrom_SERVED_FROM_POOL,
+			CreatedAt:  timestamppb.New(member.WarmedAt),
+			ExpiresAt:  timestamppb.New(now.Add(ttl)),
+		},
+	}, nil
+}
+
+// releaseFailedClaim destroys member after a post-claim setup step
+// (naming which one, for the log) failed, so a member that can never be
+// correctly reached or owned doesn't sit around leaked instead of going
+// back through the normal destroy-on-release path. Best-effort: if the
+// release ALSO fails, there is nothing left to do but say so loudly —
+// this member is now genuinely leaked and needs an operator, not a retry.
+func (s *SandboxServer) releaseFailedClaim(m *pool.Member, step string, causeErr error) {
+	if err := s.pool.Release(m); err != nil {
+		log.Printf("[sandbox] claim %s: %s failed (%v) AND cleanup failed (%v) — this member is now leaked", m.ID, step, causeErr, err)
+	}
+}
+
+// trackClaimed records that sandbox_id came from the pool, for
+// DeleteSandbox to find later.
+func (s *SandboxServer) trackClaimed(m *pool.Member) {
+	s.claimedMu.Lock()
+	s.claimed[m.ID] = m
+	s.claimedMu.Unlock()
+}
+
+// untrackClaimed removes and returns the tracked pool.Member for id, or
+// nil if id was never claimed from the pool (a cold-path sandbox, or an
+// id this server has no record of).
+func (s *SandboxServer) untrackClaimed(id string) *pool.Member {
+	s.claimedMu.Lock()
+	defer s.claimedMu.Unlock()
+	m := s.claimed[id]
+	delete(s.claimed, id)
+	return m
 }
 
 // lookupOwnedSandbox fetches sandbox id and enforces ownership in one step:
@@ -277,7 +475,10 @@ func (s *SandboxServer) ReadFileInSandbox(ctx context.Context, req *pb.ReadFileI
 
 // DeleteSandbox destroys the sandbox immediately. Sandboxes are never reset
 // and reused (see the design note's Isolation section) — delete always
-// means destroy, never "return to a pool".
+// means destroy, never "return to a pool". A pool-claimed sandbox routes
+// through pool.Release rather than destroy() directly, since Release also
+// frees the member's IPAM-allocated address — destroy() knows nothing
+// about IPAM and a cold-path sandbox never held an allocation to free.
 func (s *SandboxServer) DeleteSandbox(ctx context.Context, req *pb.DeleteSandboxRequest) (*pb.DeleteSandboxResponse, error) {
 	if err := auth.RequireScope(ctx, auth.ScopeSandboxesWrite); err != nil {
 		return nil, err
@@ -289,7 +490,11 @@ func (s *SandboxServer) DeleteSandbox(ctx context.Context, req *pb.DeleteSandbox
 		return nil, err
 	}
 
-	if err := s.destroy(req.SandboxId); err != nil {
+	if member := s.untrackClaimed(req.SandboxId); member != nil {
+		if err := s.pool.Release(member); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to delete sandbox: %v", err)
+		}
+	} else if err := s.destroy(req.SandboxId); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to delete sandbox: %v", err)
 	}
 

--- a/internal/server/sandbox_server_pool_test.go
+++ b/internal/server/sandbox_server_pool_test.go
@@ -1,0 +1,186 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/footprintai/containarium/internal/sandbox/ipam"
+	"github.com/footprintai/containarium/internal/sandbox/pool"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// fakeSandboxBackend already implements CreateContainer/StartContainer/
+// StopContainer/DeleteContainer, which is pool.Backend's entire (narrow)
+// interface — no adapter needed to reuse it here.
+
+func TestSpawnSandbox_ClaimsFromWarmPool(t *testing.T) {
+	backend := newFakeSandboxBackend()
+	allocator, err := ipam.New("10.100.0.10", "10.100.0.250", "10.100.0.1", 0)
+	if err != nil {
+		t.Fatalf("ipam.New: %v", err)
+	}
+	p := pool.New(backend, allocator, pool.Config{
+		MinWarm:    map[pb.SandboxTemplate]int{pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE: 1},
+		Image:      map[pb.SandboxTemplate]string{pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE: "images:ubuntu/24.04"},
+		NICNetwork: "incusbr0",
+	})
+	p.Reconcile(context.Background())
+	if got := p.ReadyCount(pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE); got != 1 {
+		t.Fatalf("pool ReadyCount after warming = %d, want 1", got)
+	}
+
+	s := NewSandboxServer(backend, p)
+
+	resp, err := s.SpawnSandbox(ctxAs("alice", false), &pb.SpawnSandboxRequest{})
+	if err != nil {
+		t.Fatalf("SpawnSandbox: %v", err)
+	}
+	sb := resp.Sandbox
+	if sb.ServedFrom != pb.ServedFrom_SERVED_FROM_POOL {
+		t.Errorf("served_from = %v, want POOL", sb.ServedFrom)
+	}
+	if sb.SandboxId == "" {
+		t.Fatal("empty sandbox_id")
+	}
+	if p.ReadyCount(pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE) != 0 {
+		t.Error("pool ReadyCount after claiming the only member should be 0")
+	}
+
+	// Ownership must now be stamped correctly — proving SetConfig(tenant)
+	// + SetLabels(kind/template/ttl) together did the right thing, not
+	// just that SOME call succeeded.
+	info := backend.instances[sb.SandboxId]
+	if info.Tenant != "alice" {
+		t.Errorf("stamped tenant = %q, want alice", info.Tenant)
+	}
+	if info.Labels[sandboxKindLabelSuffix] != SandboxKindLabelValue {
+		t.Errorf("sandbox-kind label not stamped: %+v", info.Labels)
+	}
+
+	// A pool-claimed sandbox must be usable through the same ownership
+	// path as a cold-path one — exec, not just spawn, has to work.
+	if _, err := s.ExecInSandbox(ctxAs("alice", false), &pb.ExecInSandboxRequest{
+		SandboxId: sb.SandboxId, Command: []string{"true"},
+	}); err != nil {
+		t.Errorf("ExecInSandbox on a pool-claimed sandbox: %v", err)
+	}
+	if _, err := s.ExecInSandbox(ctxAs("bob", false), &pb.ExecInSandboxRequest{
+		SandboxId: sb.SandboxId, Command: []string{"true"},
+	}); status.Code(err) != codes.PermissionDenied {
+		t.Errorf("cross-tenant exec on a pool-claimed sandbox: code = %v, want PermissionDenied", status.Code(err))
+	}
+}
+
+func TestSpawnSandbox_PoolExhaustedFallsBackToColdWithAllowColdStart(t *testing.T) {
+	backend := newFakeSandboxBackend()
+	allocator, err := ipam.New("10.100.0.10", "10.100.0.250", "10.100.0.1", 0)
+	if err != nil {
+		t.Fatalf("ipam.New: %v", err)
+	}
+	// MinWarm intentionally unset (Config{}) — the pool is configured but
+	// warms nothing, matching "pool exists but has no ready member for
+	// this template" rather than "no pool at all".
+	p := pool.New(backend, allocator, pool.Config{})
+	s := NewSandboxServer(backend, p)
+
+	resp, err := s.SpawnSandbox(ctxAs("alice", false), &pb.SpawnSandboxRequest{AllowColdStart: true})
+	if err != nil {
+		t.Fatalf("SpawnSandbox: %v", err)
+	}
+	if resp.Sandbox.ServedFrom != pb.ServedFrom_SERVED_FROM_COLD {
+		t.Errorf("served_from = %v, want COLD (pool exhausted, allow_cold_start=true)", resp.Sandbox.ServedFrom)
+	}
+}
+
+func TestSpawnSandbox_PoolExhaustedReturnsResourceExhaustedWithoutAllowColdStart(t *testing.T) {
+	backend := newFakeSandboxBackend()
+	allocator, err := ipam.New("10.100.0.10", "10.100.0.250", "10.100.0.1", 0)
+	if err != nil {
+		t.Fatalf("ipam.New: %v", err)
+	}
+	p := pool.New(backend, allocator, pool.Config{})
+	s := NewSandboxServer(backend, p)
+
+	_, err = s.SpawnSandbox(ctxAs("alice", false), &pb.SpawnSandboxRequest{})
+	if got := status.Code(err); got != codes.ResourceExhausted {
+		t.Fatalf("code = %v, want ResourceExhausted (pool exhausted, allow_cold_start unset)", got)
+	}
+}
+
+func TestDeleteSandbox_PoolClaimedRoutesThroughPoolRelease(t *testing.T) {
+	backend := newFakeSandboxBackend()
+	allocator, err := ipam.New("10.100.0.10", "10.100.0.250", "10.100.0.1", 0)
+	if err != nil {
+		t.Fatalf("ipam.New: %v", err)
+	}
+	p := pool.New(backend, allocator, pool.Config{
+		MinWarm:    map[pb.SandboxTemplate]int{pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE: 1},
+		Image:      map[pb.SandboxTemplate]string{pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE: "images:ubuntu/24.04"},
+		NICNetwork: "incusbr0",
+	})
+	p.Reconcile(context.Background())
+	s := NewSandboxServer(backend, p)
+
+	resp, err := s.SpawnSandbox(ctxAs("alice", false), &pb.SpawnSandboxRequest{})
+	if err != nil {
+		t.Fatalf("SpawnSandbox: %v", err)
+	}
+	id := resp.Sandbox.SandboxId
+
+	if _, err := s.DeleteSandbox(ctxAs("alice", false), &pb.DeleteSandboxRequest{SandboxId: id}); err != nil {
+		t.Fatalf("DeleteSandbox: %v", err)
+	}
+
+	if _, ok := backend.instances[id]; ok {
+		t.Error("container still present after DeleteSandbox")
+	}
+
+	// The address must have come back through IPAM too (pool.Release's
+	// job, not destroy()'s) — reconciling a fresh warm at the same target
+	// should succeed rather than hitting an artificially-shrunk range.
+	// (This range has 241 addresses and only one was ever allocated, so
+	// this mostly documents intent; ipam's own exhaustion tests cover the
+	// release mechanics directly.)
+	p.Reconcile(context.Background())
+	if got := p.ReadyCount(pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE); got != 1 {
+		t.Errorf("ReadyCount after re-reconciling post-delete = %d, want 1", got)
+	}
+}
+
+// TestSpawnSandbox_ClaimSetupFailureDestroysTheMember pins that a claimed
+// member which fails post-claim setup doesn't leak: it must be destroyed
+// (not left claimed-but-broken, and not silently re-added to the ring —
+// this package's Isolation rule applies here too), and the caller gets a
+// real error, not a fabricated success.
+func TestSpawnSandbox_ClaimSetupFailureDestroysTheMember(t *testing.T) {
+	backend := newFakeSandboxBackend()
+	backend.setLabelsErr = errors.New("incus: simulated SetLabels failure")
+	allocator, err := ipam.New("10.100.0.10", "10.100.0.250", "10.100.0.1", 0)
+	if err != nil {
+		t.Fatalf("ipam.New: %v", err)
+	}
+	p := pool.New(backend, allocator, pool.Config{
+		MinWarm:    map[pb.SandboxTemplate]int{pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE: 1},
+		Image:      map[pb.SandboxTemplate]string{pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE: "images:ubuntu/24.04"},
+		NICNetwork: "incusbr0",
+	})
+	p.Reconcile(context.Background())
+	s := NewSandboxServer(backend, p)
+
+	_, err = s.SpawnSandbox(ctxAs("alice", false), &pb.SpawnSandboxRequest{})
+	if err == nil {
+		t.Fatal("SpawnSandbox should fail when post-claim labeling fails")
+	}
+	if got := status.Code(err); got != codes.Internal {
+		t.Errorf("code = %v, want Internal", got)
+	}
+	if got := backend.deleteCalls; got == 0 {
+		t.Error("the half-claimed member was not destroyed")
+	}
+	if got := p.ReadyCount(pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE); got != 0 {
+		t.Errorf("ReadyCount = %d, want 0 (the failed member must not be silently re-added to the ring)", got)
+	}
+}

--- a/internal/server/sandbox_server_test.go
+++ b/internal/server/sandbox_server_test.go
@@ -31,6 +31,8 @@ type fakeSandboxBackend struct {
 	deleteContainerErr error
 	deleteCalls        int
 	startErr           error
+	setLabelsErr       error
+	setConfigErr       error
 }
 
 func newFakeSandboxBackend() *fakeSandboxBackend {
@@ -109,6 +111,45 @@ func (b *fakeSandboxBackend) ReadFile(string, string) ([]byte, error) {
 	return b.readFileContent, b.readFileErr
 }
 
+// SetConfig mirrors the real client's semantics closely enough for these
+// tests: TenantLabelKey is the only raw key claimFromPool sets this way,
+// so that's the only one this fake bothers reflecting into .Tenant.
+func (b *fakeSandboxBackend) SetConfig(name, key, value string) error {
+	if b.setConfigErr != nil {
+		return b.setConfigErr
+	}
+	info, ok := b.instances[name]
+	if !ok {
+		return errors.New("not found")
+	}
+	if key == incus.TenantLabelKey {
+		info.Tenant = value
+	}
+	b.instances[name] = info
+	return nil
+}
+
+// SetLabels mirrors the real client's clear-then-replace semantics: every
+// existing label-prefixed key is dropped, then only what's in labels (bare
+// keys, per the real SetLabels contract) is re-added. Getting this
+// mirroring wrong would hide the exact double-prefix bug this fake exists
+// to catch.
+func (b *fakeSandboxBackend) SetLabels(name string, labels map[string]string) error {
+	if b.setLabelsErr != nil {
+		return b.setLabelsErr
+	}
+	info, ok := b.instances[name]
+	if !ok {
+		return errors.New("not found")
+	}
+	info.Labels = make(map[string]string, len(labels))
+	for k, v := range labels {
+		info.Labels[k] = v
+	}
+	b.instances[name] = info
+	return nil
+}
+
 func ctxAs(username string, admin bool) context.Context {
 	roles := []string{}
 	if admin {
@@ -128,7 +169,7 @@ func spawnAsAlice(t *testing.T, backend *fakeSandboxBackend, s *SandboxServer) *
 
 func TestSpawnSandbox_HappyPath(t *testing.T) {
 	backend := newFakeSandboxBackend()
-	s := NewSandboxServer(backend)
+	s := NewSandboxServer(backend, nil)
 
 	sb := spawnAsAlice(t, backend, s)
 
@@ -158,14 +199,14 @@ func TestSpawnSandbox_HappyPath(t *testing.T) {
 }
 
 func TestSpawnSandbox_UnauthenticatedRejected(t *testing.T) {
-	s := NewSandboxServer(newFakeSandboxBackend())
+	s := NewSandboxServer(newFakeSandboxBackend(), nil)
 	if _, err := s.SpawnSandbox(context.Background(), &pb.SpawnSandboxRequest{}); err == nil {
 		t.Fatal("SpawnSandbox with no subject in context should fail")
 	}
 }
 
 func TestSpawnSandbox_UnsupportedTemplateRejected(t *testing.T) {
-	s := NewSandboxServer(newFakeSandboxBackend())
+	s := NewSandboxServer(newFakeSandboxBackend(), nil)
 	_, err := s.SpawnSandbox(ctxAs("alice", false), &pb.SpawnSandboxRequest{Template: pb.SandboxTemplate(99)})
 	if err == nil {
 		t.Fatal("unsupported template should be rejected — v1 ships BASE only")
@@ -178,7 +219,7 @@ func TestSpawnSandbox_UnsupportedTemplateRejected(t *testing.T) {
 func TestSpawnSandbox_NetworkFailureCleansUp(t *testing.T) {
 	backend := newFakeSandboxBackend()
 	backend.waitNetworkErr = errors.New("no lease")
-	s := NewSandboxServer(backend)
+	s := NewSandboxServer(backend, nil)
 
 	if _, err := s.SpawnSandbox(ctxAs("alice", false), &pb.SpawnSandboxRequest{}); err == nil {
 		t.Fatal("SpawnSandbox should fail when WaitForNetwork fails")
@@ -193,7 +234,7 @@ func TestSpawnSandbox_NetworkFailureCleansUp(t *testing.T) {
 // the ownership check must run before existence can leak.
 func TestSandboxOwnership(t *testing.T) {
 	backend := newFakeSandboxBackend()
-	s := NewSandboxServer(backend)
+	s := NewSandboxServer(backend, nil)
 	sb := spawnAsAlice(t, backend, s)
 
 	t.Run("owner can exec", func(t *testing.T) {
@@ -236,7 +277,7 @@ func TestExecInSandbox_ReturnsExitCode(t *testing.T) {
 	backend.execStdout = "hello\n"
 	backend.execStderr = "warn\n"
 	backend.execExitCode = 3
-	s := NewSandboxServer(backend)
+	s := NewSandboxServer(backend, nil)
 	sb := spawnAsAlice(t, backend, s)
 
 	resp, err := s.ExecInSandbox(ctxAs("alice", false), &pb.ExecInSandboxRequest{
@@ -252,7 +293,7 @@ func TestExecInSandbox_ReturnsExitCode(t *testing.T) {
 
 func TestExecInSandbox_RequiresCommand(t *testing.T) {
 	backend := newFakeSandboxBackend()
-	s := NewSandboxServer(backend)
+	s := NewSandboxServer(backend, nil)
 	sb := spawnAsAlice(t, backend, s)
 
 	if _, err := s.ExecInSandbox(ctxAs("alice", false), &pb.ExecInSandboxRequest{SandboxId: sb.SandboxId}); err == nil {
@@ -263,7 +304,7 @@ func TestExecInSandbox_RequiresCommand(t *testing.T) {
 func TestWriteReadFileInSandbox_RoundTrip(t *testing.T) {
 	backend := newFakeSandboxBackend()
 	backend.readFileContent = []byte("round-tripped")
-	s := NewSandboxServer(backend)
+	s := NewSandboxServer(backend, nil)
 	sb := spawnAsAlice(t, backend, s)
 
 	if _, err := s.WriteFileInSandbox(ctxAs("alice", false), &pb.WriteFileInSandboxRequest{
@@ -293,7 +334,7 @@ func TestWriteReadFileInSandbox_RoundTrip(t *testing.T) {
 
 func TestDeleteSandbox_Destroys(t *testing.T) {
 	backend := newFakeSandboxBackend()
-	s := NewSandboxServer(backend)
+	s := NewSandboxServer(backend, nil)
 	sb := spawnAsAlice(t, backend, s)
 
 	if _, err := s.DeleteSandbox(ctxAs("alice", false), &pb.DeleteSandboxRequest{SandboxId: sb.SandboxId}); err != nil {
@@ -317,7 +358,7 @@ func TestDeleteSandbox_Destroys(t *testing.T) {
 func TestDeleteSandbox_DeleteErrorPropagates(t *testing.T) {
 	backend := newFakeSandboxBackend()
 	backend.deleteContainerErr = errors.New("incus: instance is busy")
-	s := NewSandboxServer(backend)
+	s := NewSandboxServer(backend, nil)
 	sb := spawnAsAlice(t, backend, s)
 
 	if _, err := s.DeleteSandbox(ctxAs("alice", false), &pb.DeleteSandboxRequest{SandboxId: sb.SandboxId}); err == nil {


### PR DESCRIPTION
## What

Wires `pool.Claim`/`pool.Reconcile` (#1520) into `SandboxServer`. `SpawnSandbox` now tries the warm pool first when one is configured, falling back to the cold path exactly as before when it isn't (nil pool) or when the requested template's ring is exhausted and the caller opted into `allow_cold_start`. An exhausted pool with `allow_cold_start` unset returns `RESOURCE_EXHAUSTED` — "a latency SLO whose slow path is invisible isn't an SLO," straight from the design note (#1488).

## Why `dual_server.go` still passes `nil`

`NewSandboxServer`'s signature grows a `*pool.Pool` parameter, but `nil` is the **only safe default** for today's actual construction: a configured-but-empty pool (no operator config exists yet for `min_warm`/image/IPAM-range/NIC-network, and none of that is safe to default without a live host to validate images and network topology against) would silently start rejecting every existing caller that has never set `allow_cold_start=true` — its proto3 zero value is `false`. `dual_server.go` keeps passing `nil`, so every current deployment's runtime behavior is byte-for-byte unchanged. This PR makes `SandboxServer` *capable* of using a configured pool, without activating one.

`StartReconciler(ctx, interval)` runs `pool.Reconcile` on a ticker (same shape as `startIntegrityHeartbeat`, this package's other background loop) but isn't called from `dual_server.go` yet, for the same reason.

## A real correctness bug, found and fixed while implementing this

My first draft reused one label-builder for both `CreateContainer`'s `ExtraConfig` (needs fully `LabelPrefix`-qualified keys) and `SetLabels` (adds `LabelPrefix` itself — passing qualified keys double-prefixes everything). Worse: `incus.TenantLabelKey` lives **outside** the `LabelPrefix` namespace entirely, so `SetLabels` can never set it correctly at all — a claimed sandbox would have been unrecognizable to `lookupOwnedSandbox` (`NotFound` on its own exec calls) and owned by nobody but an admin.

Fixed with two separate helpers: `sandboxLabelSuffixes` (bare keys — kind/template/idle-ttl) consumed directly by `SetLabels`, and `qualifyLabels` (prefixes them) for `CreateContainer`'s `ExtraConfig`. `TenantLabelKey` is set via the single-key `SetConfig`, the only primitive that can reach it.

**Verified by mutation**: reintroducing the double-prefix bug fails `TestSpawnSandbox_ClaimsFromWarmPool` immediately and exactly as predicted, then restored.

## Honest cost, not hidden

`claimFromPool` now costs **two Incus round-trip pairs** — `SetConfig` for tenant + `SetLabels` for the rest — since no existing `incus.Backend` primitive sets a raw config key and a batch of labels in one call. That's real latency this integration does not yet get under the design note's "0.5ms CAS" ideal for a claim. A combined bulk-set primitive is a legitimate follow-up once real numbers (Phase 3's own exit criterion) show it's worth adding.

## `DeleteSandbox`

Routes a pool-claimed sandbox through `pool.Release` (also frees its IPAM address) instead of `destroy()` (knows nothing about IPAM — a cold-path sandbox never held an allocation to free). Tracked via an in-memory `sandbox_id -> pool.Member` map — doesn't survive a daemon restart, no different in kind from `container_server.go`'s own `pendingCreations`, and sandboxes are short-lived by design.

## Tests

`internal/server/sandbox_server_pool_test.go`, against a real `*pool.Pool` + real `*ipam.Allocator` + the existing `fakeSandboxBackend` (already satisfies `pool.Backend`'s narrow interface — no adapter needed):

- Claiming from a warm pool: `served_from = POOL`, ring drains, ownership stamped correctly (tenant **and** kind both verified, not just "some call succeeded"), and the claimed sandbox is usable through `ExecInSandbox` — including the cross-tenant `PermissionDenied` check, proving a pool-claimed sandbox is indistinguishable from a cold-path one to every other RPC.
- Pool exhausted + `allow_cold_start=true` → falls back to `COLD`.
- Pool exhausted + unset → `ResourceExhausted`.
- `DeleteSandbox` on a pool-claimed sandbox routes through `pool.Release`.
- A post-claim setup failure destroys the half-claimed member and surfaces a real error, rather than leaking a claimed-but-broken or claimed-but-unowned container.

`fakeSandboxBackend` gained `SetConfig`/`SetLabels`, each mirroring the real client's actual semantics (`SetLabels`' clear-then-replace-only-what's-given behavior in particular) closely enough that getting the production code's contract wrong shows up as a test failure instead of passing on a fake that's more forgiving than reality.

`golangci-lint` run locally (0 issues). `go build`/`go vet` clean tree-wide. Full `internal/server` suite green with `-race`.

## Scope

Not here: `GetPoolStatus`, per-tenant rate limiting, `retry_after_ms` on `RESOURCE_EXHAUSTED` (Phase 4's admission-control refinements, deliberately out of scope), and the operator-facing pool configuration + `StartReconciler` wiring that would actually activate a pool in the running daemon — both need a live host to validate image/network settings against.

Refs #1488 (Phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
