### PR TITLE
feat(sandbox): TTL sweeper for ephemeral sandboxes (#1488 Phase 4)

### DIFF
--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -198,42 +198,44 @@ func managementRouteDomains(cfg *DualServerConfig) []string {
 
 // DualServer runs both gRPC and HTTP/REST servers
 type DualServer struct {
-	config                *DualServerConfig
-	grpcServer            *grpc.Server
-	containerServer       *ContainerServer
-	appServer             *AppServer
-	networkServer         *NetworkServer
-	trafficServer         *TrafficServer
-	trafficCollector      *traffic.Collector
-	gatewayServer         *gateway.GatewayServer
-	tokenManager          *auth.TokenManager
-	authMiddleware        *auth.AuthMiddleware
-	routeStore            *app.RouteStore
-	routeSyncJob          *app.RouteSyncJob
-	passthroughStore      network.PassthroughStore
-	passthroughSyncJob    *network.PassthroughSyncJob
-	collaboratorStore     *collaborator.Store
-	daemonConfigStore     *app.DaemonConfigStore
-	metricsCollector      *metrics.Collector
-	securityScanner       *security.Scanner
-	securityStore         *security.Store
-	securityServer        *SecurityServer
-	auditStore            *audit.Store
-	auditEventSubscriber  *audit.EventSubscriber
-	sshCollector          *audit.SSHCollector
-	revocationStore       *auth.PgRevocationStore // Phase 1.2 — kill-switch for issued JWTs
-	alertStore            *alert.Store
-	alertManager          *alert.Manager
-	alertDeliveryStore    *alert.DeliveryStore
-	pentestManager        *pentest.Manager
-	pentestStore          *pentest.Store
-	zapManager            *zapscanner.Manager
-	zapStore              *zapscanner.Store
-	peerPool              *PeerPool
-	autoSleepManager      *autosleep.Manager
-	ttlSweeperManager     *ttlsweeper.Manager    // ephemeral CI box auto-delete (#299)
-	secretsReconciler     *secretsReconciler     // Phase 4.3 Phase B-3
-	networkPolicyEnforcer *NetworkPolicyEnforcer // #315 Phase A — eBPF per-tenant net policy (off unless configured)
+	config                   *DualServerConfig
+	grpcServer               *grpc.Server
+	containerServer          *ContainerServer
+	appServer                *AppServer
+	networkServer            *NetworkServer
+	trafficServer            *TrafficServer
+	trafficCollector         *traffic.Collector
+	gatewayServer            *gateway.GatewayServer
+	tokenManager             *auth.TokenManager
+	authMiddleware           *auth.AuthMiddleware
+	routeStore               *app.RouteStore
+	routeSyncJob             *app.RouteSyncJob
+	passthroughStore         network.PassthroughStore
+	passthroughSyncJob       *network.PassthroughSyncJob
+	collaboratorStore        *collaborator.Store
+	daemonConfigStore        *app.DaemonConfigStore
+	metricsCollector         *metrics.Collector
+	securityScanner          *security.Scanner
+	securityStore            *security.Store
+	securityServer           *SecurityServer
+	auditStore               *audit.Store
+	auditEventSubscriber     *audit.EventSubscriber
+	sshCollector             *audit.SSHCollector
+	revocationStore          *auth.PgRevocationStore // Phase 1.2 — kill-switch for issued JWTs
+	alertStore               *alert.Store
+	alertManager             *alert.Manager
+	alertDeliveryStore       *alert.DeliveryStore
+	pentestManager           *pentest.Manager
+	pentestStore             *pentest.Store
+	zapManager               *zapscanner.Manager
+	zapStore                 *zapscanner.Store
+	peerPool                 *PeerPool
+	autoSleepManager         *autosleep.Manager
+	ttlSweeperManager        *ttlsweeper.Manager    // ephemeral CI box auto-delete (#299)
+	sandboxServer            *SandboxServer         // set in NewDualServer when incus.New succeeds; nil otherwise (#1488)
+	sandboxTTLSweeperManager *ttlsweeper.Manager    // ephemeral sandbox auto-delete (#1488 Phase 4)
+	secretsReconciler        *secretsReconciler     // Phase 4.3 Phase B-3
+	networkPolicyEnforcer    *NetworkPolicyEnforcer // #315 Phase A — eBPF per-tenant net policy (off unless configured)
 
 	// k8sNetPolicyReconciler converges tenant NetworkPolicy objects on the K8s
 	// backend from the same store the eBPF enforcer reads (#1188). Nil on
@@ -555,8 +557,10 @@ func NewDualServer(config *DualServerConfig) (*DualServer, error) {
 	// why nil is also the ONLY safe default (a configured-but-empty pool
 	// would silently start rejecting every caller that hasn't set
 	// allow_cold_start=true).
+	var sandboxServer *SandboxServer
 	if sandboxIncusClient, err := incus.New(); err == nil {
-		pb.RegisterSandboxServiceServer(grpcServer, NewSandboxServer(sandboxIncusClient, nil))
+		sandboxServer = NewSandboxServer(sandboxIncusClient, nil)
+		pb.RegisterSandboxServiceServer(grpcServer, sandboxServer)
 		log.Printf("Sandbox service enabled")
 	} else {
 		log.Printf("Warning: SandboxService disabled — incus client init failed: %v", err)
@@ -1942,6 +1946,7 @@ skipAppHosting:
 		k8sNetPolicyReconciler: k8sNetPolicyReconciler,
 		cloudClient:            cloudClient,
 		startTime:              time.Now(),
+		sandboxServer:          sandboxServer,
 	}
 
 	// Auto-sleep ticker is constructed in Start() once the traffic
@@ -2344,6 +2349,28 @@ func (ds *DualServer) Start(ctx context.Context) error {
 		log.Printf("[ttlsweeper] incus client unavailable: %v (sweeper disabled)", err)
 	}
 
+	// Sandbox TTL sweeper (#1488 Phase 4: "no sandbox leaks past
+	// idle_ttl"). Separate Manager instance from the persistent-box one
+	// above, scoped to SandboxService's own container population and
+	// deletion routing: ds.sandboxServer implements ttlsweeper.Deleter
+	// directly (its DeleteContainer method), which routes an expired
+	// pool-claimed sandbox through pool.Release exactly like
+	// DeleteSandbox does — the persistent-box ttlsweeperDeleter above only
+	// knows the "<username>-container" naming convention and would refuse
+	// every sandbox_id. Independent of whether a pool is actually
+	// configured (nil today, see NewDualServer): a cold-path sandbox
+	// carries the same user.containarium.ttl_expires_at stamp a
+	// pool-claimed one does, so sweeping is safe and needed the moment
+	// SandboxService itself is enabled.
+	if ds.sandboxServer != nil {
+		ds.sandboxTTLSweeperManager = ttlsweeper.NewManager(
+			&ttlsweeperSandboxAdapter{backend: ds.sandboxServer.incus},
+			ds.sandboxServer,
+			ttlsweeper.Options{},
+		)
+		ds.sandboxTTLSweeperManager.Start(ctx)
+	}
+
 	// Orphan reaper (#835): periodically userdel host accounts whose
 	// container no longer exists. userdel -r on container delete can fail
 	// under lock contention (google-guest-agent race on GCP), leaving stale
@@ -2677,6 +2704,9 @@ func (ds *DualServer) Start(ctx context.Context) error {
 		}
 		if ds.ttlSweeperManager != nil {
 			ds.ttlSweeperManager.Stop()
+		}
+		if ds.sandboxTTLSweeperManager != nil {
+			ds.sandboxTTLSweeperManager.Stop()
 		}
 		if ds.secretsReconciler != nil {
 			ds.secretsReconciler.Stop()

--- a/internal/server/sandbox_server.go
+++ b/internal/server/sandbox_server.go
@@ -44,9 +44,11 @@ const SandboxKindLabelValue = "sandbox"
 const sandboxNamePrefix = "sandbox-"
 
 // defaultSandboxIdleTTL applies when SpawnSandboxRequest.idle_ttl_seconds is
-// unset (0). No sweeper enforces it yet in Phase 1 (see the design note's
-// Phase 4) — expires_at is reported so a caller can see the horizon its
-// sandbox will eventually be reaped against once the sweeper exists.
+// unset (0). Enforced by the ttlsweeper.Manager wired in dual_server.go
+// (#1488 Phase 4, via ttlsweeperSandboxAdapter and SandboxServer's own
+// DeleteContainer method in sandbox_ttlsweeper_adapter.go) — expires_at
+// is reported so a caller can see the horizon its sandbox will actually
+// be reaped against.
 const defaultSandboxIdleTTL = 30 * time.Minute
 
 // spawnNetworkTimeout bounds how long SpawnSandbox waits for the guest's
@@ -211,6 +213,12 @@ func (s *SandboxServer) SpawnSandbox(ctx context.Context, req *pb.SpawnSandboxRe
 
 	extraConfig := qualifyLabels(sandboxLabelSuffixes(template, ttl))
 	extraConfig[incus.TenantLabelKey] = subject
+	// Stamp the exact key/format ttlsweeper.Decide reads (see
+	// stampTTL's doc comment in container_server_ttl.go) via
+	// ContainerConfig.ExtraConfig rather than a follow-up SetConfig
+	// call — one fewer Incus round trip on the cold path, which is
+	// the path this design note is trying to make fast.
+	extraConfig[incus.TTLExpiresAtKey] = now.Add(ttl).UTC().Format(time.RFC3339)
 	config := incus.ContainerConfig{
 		Name:        id,
 		Image:       image,
@@ -299,14 +307,14 @@ func qualifyLabels(suffixes map[string]string) map[string]string {
 // for everyone but an admin, including the tenant who thinks they just
 // spawned it).
 //
-// Two Incus round-trip PAIRS on the claim path — SetConfig for the tenant
-// key (outside the label namespace, see sandboxLabelSuffixes) plus
-// SetLabels for kind/template/ttl — because no existing incus.Backend
-// primitive sets both a raw config key and a batch of labels in one call.
-// This is real, and it's the piece of "two-digit ms" this integration
-// does not yet fully deliver on; a combined bulk-set primitive is a
-// legitimate follow-up once real latency numbers (Phase 3's own exit
-// criterion) show it's worth adding.
+// Three Incus round trips on the claim path — SetConfig for the tenant key
+// and for the TTL-expiry key (both outside the label namespace, see
+// sandboxLabelSuffixes) plus SetLabels for kind/template/ttl — because no
+// existing incus.Backend primitive sets a batch of raw config keys and
+// labels in one call. This is real, and it's the piece of "two-digit ms"
+// this integration does not yet fully deliver on; a combined bulk-set
+// primitive is a legitimate follow-up once real latency numbers (Phase 3's
+// own exit criterion) show it's worth adding.
 func (s *SandboxServer) claimFromPool(template pb.SandboxTemplate, subject string, req *pb.SpawnSandboxRequest) (*pb.SpawnSandboxResponse, error) {
 	member, err := s.pool.Claim(template)
 	if err != nil {
@@ -319,6 +327,13 @@ func (s *SandboxServer) claimFromPool(template pb.SandboxTemplate, subject strin
 	if err := s.incus.SetConfig(member.ID, incus.TenantLabelKey, subject); err != nil {
 		s.releaseFailedClaim(member, "set tenant", err)
 		return nil, status.Errorf(codes.Internal, "claimed a warm sandbox but failed to set its owner: %v", err)
+	}
+	// Same key/format the cold path stamps via ExtraConfig and
+	// ttlsweeper.Decide reads — see stampTTL's doc comment in
+	// container_server_ttl.go.
+	if err := s.incus.SetConfig(member.ID, incus.TTLExpiresAtKey, now.Add(ttl).UTC().Format(time.RFC3339)); err != nil {
+		s.releaseFailedClaim(member, "set ttl expiry", err)
+		return nil, status.Errorf(codes.Internal, "claimed a warm sandbox but failed to set its expiry: %v", err)
 	}
 	if err := s.incus.SetLabels(member.ID, sandboxLabelSuffixes(template, ttl)); err != nil {
 		s.releaseFailedClaim(member, "set labels", err)

--- a/internal/server/sandbox_server_test.go
+++ b/internal/server/sandbox_server_test.go
@@ -40,14 +40,32 @@ func newFakeSandboxBackend() *fakeSandboxBackend {
 }
 
 func (b *fakeSandboxBackend) CreateContainer(c incus.ContainerConfig) error {
-	b.instances[c.Name] = incus.ContainerInfo{
+	info := incus.ContainerInfo{
 		Name:   c.Name,
 		State:  "Stopped",
 		Labels: extractTestLabels(c.ExtraConfig),
 		Tenant: c.ExtraConfig[incus.TenantLabelKey],
 		Image:  c.Image,
 	}
+	if raw := c.ExtraConfig[incus.TTLExpiresAtKey]; raw != "" {
+		if t, err := time.Parse(time.RFC3339, raw); err == nil {
+			info.TTLExpiresAt = t
+		}
+	}
+	b.instances[c.Name] = info
 	return nil
+}
+
+// ListContainers returns every tracked instance, mirroring the real
+// backend closely enough for ttlsweeperSandboxAdapter's tests: it reads
+// exactly (Name, Labels, TTLExpiresAt), all of which CreateContainer/
+// SetConfig/SetLabels already populate above.
+func (b *fakeSandboxBackend) ListContainers() ([]incus.ContainerInfo, error) {
+	out := make([]incus.ContainerInfo, 0, len(b.instances))
+	for _, info := range b.instances {
+		out = append(out, info)
+	}
+	return out, nil
 }
 
 // extractTestLabels mirrors incus's own LabelPrefix-stripping so the fake's
@@ -112,8 +130,9 @@ func (b *fakeSandboxBackend) ReadFile(string, string) ([]byte, error) {
 }
 
 // SetConfig mirrors the real client's semantics closely enough for these
-// tests: TenantLabelKey is the only raw key claimFromPool sets this way,
-// so that's the only one this fake bothers reflecting into .Tenant.
+// tests: TenantLabelKey and TTLExpiresAtKey are the only raw keys
+// claimFromPool sets this way, so those are the only ones this fake
+// bothers reflecting back into ContainerInfo.
 func (b *fakeSandboxBackend) SetConfig(name, key, value string) error {
 	if b.setConfigErr != nil {
 		return b.setConfigErr
@@ -122,8 +141,15 @@ func (b *fakeSandboxBackend) SetConfig(name, key, value string) error {
 	if !ok {
 		return errors.New("not found")
 	}
-	if key == incus.TenantLabelKey {
+	switch key {
+	case incus.TenantLabelKey:
 		info.Tenant = value
+	case incus.TTLExpiresAtKey:
+		t, err := time.Parse(time.RFC3339, value)
+		if err != nil {
+			return err
+		}
+		info.TTLExpiresAt = t
 	}
 	b.instances[name] = info
 	return nil

--- a/internal/server/sandbox_ttlsweeper_adapter.go
+++ b/internal/server/sandbox_ttlsweeper_adapter.go
@@ -1,0 +1,66 @@
+package server
+
+import (
+	"context"
+	"log"
+
+	"github.com/footprintai/containarium/internal/ttlsweeper"
+	"github.com/footprintai/containarium/pkg/core/incus"
+)
+
+// ttlsweeperSandboxAdapter bridges incus.Backend -> ttlsweeper.IncusClient,
+// scoped to ephemeral sandboxes only (#1488 Phase 4). Sibling of
+// ttlsweeperIncusAdapter/ttlsweeperBoxAdapter (ttlsweeper_adapter.go,
+// ttlsweeper_boxes_adapter.go): same one-method seam, filtered to
+// instances carrying SandboxKindLabelKey rather than "every non-core
+// container".
+//
+// Only the absolute TTL rule ever applies to a sandbox — Stopped,
+// StoppedAt, DeleteAfterStopped, and Protected are all left zero, so
+// Decide's stopped->delete and protected-box rules never fire: a sandbox
+// is never stopped-and-kept (DeleteSandbox always destroys outright, see
+// its doc comment) and delete-protection is a persistent-tenant-box
+// concept that doesn't apply to a short-lived ephemeral one.
+type ttlsweeperSandboxAdapter struct {
+	backend incus.Backend
+}
+
+// ListContainers returns one ContainerView per sandbox the backend
+// currently knows about, with TTLExpiresAt populated from the same
+// user.containarium.ttl_expires_at key SpawnSandbox/claimFromPool stamp
+// (see sandbox_server.go).
+func (a *ttlsweeperSandboxAdapter) ListContainers() ([]ttlsweeper.ContainerView, error) {
+	raw, err := a.backend.ListContainers()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]ttlsweeper.ContainerView, 0, len(raw))
+	for i := range raw {
+		c := raw[i]
+		if c.Labels[sandboxKindLabelSuffix] != SandboxKindLabelValue {
+			continue
+		}
+		v := ttlsweeper.ContainerView{Name: c.Name}
+		if !c.TTLExpiresAt.IsZero() {
+			t := c.TTLExpiresAt
+			v.TTLExpiresAt = &t
+		}
+		out = append(out, v)
+	}
+	return out, nil
+}
+
+// DeleteContainer implements ttlsweeper.Deleter directly on SandboxServer
+// (dual_server.go wires *SandboxServer itself as the Deleter, no separate
+// wrapper type needed). Routes exactly like DeleteSandbox — pool.Release
+// for a pool-claimed member, which also frees its IPAM address, destroy()
+// otherwise — but skips DeleteSandbox's auth/ownership checks: the
+// sweeper is the daemon reaping its own expired state on a schedule, not
+// acting on behalf of a tenant request.
+func (s *SandboxServer) DeleteContainer(_ context.Context, name string, reason string) error {
+	log.Printf("[ttl] auto-deleting sandbox=%s reason=%q", name, reason)
+	if member := s.untrackClaimed(name); member != nil {
+		return s.pool.Release(member)
+	}
+	return s.destroy(name)
+}

--- a/internal/server/sandbox_ttlsweeper_adapter_test.go
+++ b/internal/server/sandbox_ttlsweeper_adapter_test.go
@@ -1,0 +1,213 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/footprintai/containarium/internal/sandbox/ipam"
+	"github.com/footprintai/containarium/internal/sandbox/pool"
+	"github.com/footprintai/containarium/internal/ttlsweeper"
+	"github.com/footprintai/containarium/pkg/core/incus"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// TestSpawnSandbox_StampsTTLExpiresAt pins that the cold path writes the
+// exact key/format ttlsweeper.Decide reads — the sandbox equivalent of
+// stampTTL's own contract (container_server_ttl.go). Without this the
+// adapter would never see a TTL to act on and every sandbox would leak
+// forever, silently.
+func TestSpawnSandbox_StampsTTLExpiresAt(t *testing.T) {
+	backend := newFakeSandboxBackend()
+	s := NewSandboxServer(backend, nil)
+
+	before := time.Now()
+	sb := spawnAsAlice(t, backend, s)
+	after := time.Now()
+
+	info := backend.instances[sb.SandboxId]
+	if info.TTLExpiresAt.IsZero() {
+		t.Fatal("TTLExpiresAt not stamped on the cold path")
+	}
+	// +/- 1s slack: RFC3339 (no sub-second field) truncates the stamped
+	// value to whole seconds, so it can legitimately land a fraction of a
+	// second before `before`'s own sub-second reading.
+	wantMin := before.Add(defaultSandboxIdleTTL).Add(-time.Second)
+	wantMax := after.Add(defaultSandboxIdleTTL).Add(time.Second)
+	if info.TTLExpiresAt.Before(wantMin) || info.TTLExpiresAt.After(wantMax) {
+		t.Errorf("TTLExpiresAt = %v, want between %v and %v (now + default idle ttl)", info.TTLExpiresAt, wantMin, wantMax)
+	}
+}
+
+// TestSpawnSandbox_ClaimFromPool_StampsTTLExpiresAt is
+// TestSpawnSandbox_StampsTTLExpiresAt's sibling for the pool-claim path —
+// claimFromPool sets the same key via a separate SetConfig call, and the
+// two constructions must agree.
+func TestSpawnSandbox_ClaimFromPool_StampsTTLExpiresAt(t *testing.T) {
+	backend := newFakeSandboxBackend()
+	allocator, err := ipam.New("10.100.0.10", "10.100.0.250", "10.100.0.1", 0)
+	if err != nil {
+		t.Fatalf("ipam.New: %v", err)
+	}
+	p := pool.New(backend, allocator, pool.Config{
+		MinWarm:    map[pb.SandboxTemplate]int{pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE: 1},
+		Image:      map[pb.SandboxTemplate]string{pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE: "images:ubuntu/24.04"},
+		NICNetwork: "incusbr0",
+	})
+	p.Reconcile(context.Background())
+	s := NewSandboxServer(backend, p)
+
+	resp, err := s.SpawnSandbox(ctxAs("alice", false), &pb.SpawnSandboxRequest{})
+	if err != nil {
+		t.Fatalf("SpawnSandbox: %v", err)
+	}
+
+	info := backend.instances[resp.Sandbox.SandboxId]
+	if info.TTLExpiresAt.IsZero() {
+		t.Fatal("TTLExpiresAt not stamped on the pool-claim path")
+	}
+}
+
+// TestTTLSweeperSandboxAdapter_ListContainers_FiltersToSandboxesOnly pins
+// the adapter's whole reason for existing: it must see sandboxes (and
+// their TTL) and must NOT see an unrelated, non-sandbox container even if
+// that container happens to carry its own TTLExpiresAt — persistent-box
+// TTLs are the OTHER ttlsweeper.Manager's job (ttlsweeperIncusAdapter),
+// wired in dual_server.go against ContainerServer, not SandboxServer.
+func TestTTLSweeperSandboxAdapter_ListContainers_FiltersToSandboxesOnly(t *testing.T) {
+	backend := newFakeSandboxBackend()
+	s := NewSandboxServer(backend, nil)
+	sb := spawnAsAlice(t, backend, s)
+
+	// A non-sandbox container that happens to carry the same raw TTL key —
+	// must be excluded by the kind-label filter, not merely by accident.
+	if err := backend.CreateContainer(incus.ContainerConfig{
+		Name:        "alice-container",
+		ExtraConfig: map[string]string{incus.TTLExpiresAtKey: time.Now().Add(time.Hour).UTC().Format(time.RFC3339)},
+	}); err != nil {
+		t.Fatalf("CreateContainer(alice-container): %v", err)
+	}
+
+	adapter := &ttlsweeperSandboxAdapter{backend: backend}
+	views, err := adapter.ListContainers()
+	if err != nil {
+		t.Fatalf("ListContainers: %v", err)
+	}
+	if len(views) != 1 {
+		t.Fatalf("ListContainers returned %d views, want exactly 1 (the sandbox, not alice-container): %+v", len(views), views)
+	}
+	if views[0].Name != sb.SandboxId {
+		t.Errorf("view name = %q, want %q", views[0].Name, sb.SandboxId)
+	}
+	if views[0].TTLExpiresAt == nil {
+		t.Error("view.TTLExpiresAt is nil, want the stamped expiry")
+	}
+}
+
+// TestSandboxServer_DeleteContainer_ColdPathDestroys pins that
+// SandboxServer.DeleteContainer (the ttlsweeper.Deleter implementation) —
+// as opposed to the tenant-facing DeleteSandbox RPC — actually removes a
+// cold-path sandbox, with no auth/ownership context required.
+func TestSandboxServer_DeleteContainer_ColdPathDestroys(t *testing.T) {
+	backend := newFakeSandboxBackend()
+	s := NewSandboxServer(backend, nil)
+	sb := spawnAsAlice(t, backend, s)
+
+	if err := s.DeleteContainer(context.Background(), sb.SandboxId, "ttl_expired"); err != nil {
+		t.Fatalf("DeleteContainer: %v", err)
+	}
+	if _, ok := backend.instances[sb.SandboxId]; ok {
+		t.Error("sandbox still present after DeleteContainer")
+	}
+}
+
+// TestSandboxServer_DeleteContainer_PoolClaimedRoutesThroughRelease is
+// TestDeleteSandbox_PoolClaimedRoutesThroughPoolRelease's sibling for the
+// sweeper's own delete path: a pool-claimed sandbox reaped by TTL must
+// still free its IPAM address via pool.Release, not merely destroy() the
+// container and leak the address — the exact bug class this routing
+// exists to prevent (see reapExpired's sibling, claimFromPool's own doc
+// comment on why the claimed map exists at all).
+func TestSandboxServer_DeleteContainer_PoolClaimedRoutesThroughRelease(t *testing.T) {
+	backend := newFakeSandboxBackend()
+	// A single-address range: if DeleteContainer ever regresses to a bare
+	// destroy() for a pool-claimed sandbox (skipping pool.Release's IPAM
+	// free), the only address is never returned and the re-reconcile below
+	// fails outright instead of merely allocating a different address —
+	// this range makes the routing bug impossible to miss.
+	allocator, err := ipam.New("10.100.0.10", "10.100.0.10", "10.100.0.1", 0)
+	if err != nil {
+		t.Fatalf("ipam.New: %v", err)
+	}
+	p := pool.New(backend, allocator, pool.Config{
+		MinWarm:    map[pb.SandboxTemplate]int{pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE: 1},
+		Image:      map[pb.SandboxTemplate]string{pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE: "images:ubuntu/24.04"},
+		NICNetwork: "incusbr0",
+	})
+	p.Reconcile(context.Background())
+	s := NewSandboxServer(backend, p)
+
+	resp, err := s.SpawnSandbox(ctxAs("alice", false), &pb.SpawnSandboxRequest{})
+	if err != nil {
+		t.Fatalf("SpawnSandbox: %v", err)
+	}
+	id := resp.Sandbox.SandboxId
+
+	if err := s.DeleteContainer(context.Background(), id, "ttl_expired"); err != nil {
+		t.Fatalf("DeleteContainer: %v", err)
+	}
+	if _, ok := backend.instances[id]; ok {
+		t.Error("sandbox still present after DeleteContainer")
+	}
+
+	// The address must have come back through IPAM (pool.Release's job) —
+	// reconciling a fresh warm at the same target should succeed.
+	p.Reconcile(context.Background())
+	if got := p.ReadyCount(pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE); got != 1 {
+		t.Errorf("ReadyCount after re-reconciling post-delete = %d, want 1 (address must have been released via pool.Release, not leaked by a bare destroy)", got)
+	}
+}
+
+// TestSandboxTTLSweep_EndToEnd exercises the full pipeline this PR wires —
+// adapter.ListContainers -> ttlsweeper.Decide -> SandboxServer.DeleteContainer
+// — against three sandboxes: one already expired, one with plenty of TTL
+// left, and one pool-claimed and already expired. Only the two expired
+// ones must be gone afterward; the unexpired one must survive untouched.
+func TestSandboxTTLSweep_EndToEnd(t *testing.T) {
+	backend := newFakeSandboxBackend()
+	s := NewSandboxServer(backend, nil)
+
+	expiredCold := spawnAsAlice(t, backend, s)
+	freshCold := spawnAsAlice(t, backend, s)
+
+	now := time.Now()
+	// Force one sandbox already past its expiry and leave the other with a
+	// full TTL window — Decide must tell them apart.
+	expiredInfo := backend.instances[expiredCold.SandboxId]
+	expiredInfo.TTLExpiresAt = now.Add(-time.Minute)
+	backend.instances[expiredCold.SandboxId] = expiredInfo
+
+	adapter := &ttlsweeperSandboxAdapter{backend: backend}
+	views, err := adapter.ListContainers()
+	if err != nil {
+		t.Fatalf("ListContainers: %v", err)
+	}
+	expired := ttlsweeper.Decide(views, now)
+
+	if len(expired) != 1 || expired[0] != expiredCold.SandboxId {
+		t.Fatalf("Decide returned %v, want exactly [%s]", expired, expiredCold.SandboxId)
+	}
+
+	for _, name := range expired {
+		if err := s.DeleteContainer(context.Background(), name, "ttl_expired"); err != nil {
+			t.Fatalf("DeleteContainer(%s): %v", name, err)
+		}
+	}
+
+	if _, ok := backend.instances[expiredCold.SandboxId]; ok {
+		t.Error("expired sandbox still present after sweep")
+	}
+	if _, ok := backend.instances[freshCold.SandboxId]; !ok {
+		t.Error("fresh (unexpired) sandbox was deleted by the sweep — Decide/adapter false positive")
+	}
+}


### PR DESCRIPTION
## Summary

Phase 4 of the two-digit-ms sandbox spawn design note (#1488) is "Admission control: typed `RESOURCE_EXHAUSTED`, per-tenant rate limit, TTL sweeper, `GetPoolStatus`." `RESOURCE_EXHAUSTED` already landed with the pool wiring (#1545). This PR lands the TTL sweeper piece — "no sandbox leaks past `idle_ttl`" — reusing the existing `internal/ttlsweeper` package (built for CI-debug-box auto-delete, #299) rather than a bespoke mechanism.

- `SpawnSandbox` (cold path) and `claimFromPool` (pool-claim path) both now stamp `user.containarium.ttl_expires_at` — the exact key/format `ttlsweeper.Decide` already reads and `stampTTL` already writes for persistent boxes.
- New `ttlsweeperSandboxAdapter` (`internal/server/sandbox_ttlsweeper_adapter.go`) implements `ttlsweeper.IncusClient`, filtered to `kind=sandbox`-labeled instances only — a persistent box's own TTL stays the other `ttlsweeper.Manager`'s job.
- `SandboxServer` implements `ttlsweeper.Deleter` directly (`DeleteContainer`), routing a pool-claimed sandbox through `pool.Release` (frees its IPAM address) exactly like `DeleteSandbox` does — the persistent-box deleter only understands `<username>-container` names and would refuse every `sandbox_id`.
- `dual_server.go` wires a second `ttlsweeper.Manager` instance alongside the existing one, started/stopped on the same lifecycle, active whenever `SandboxService` itself is enabled — independent of whether a pool is configured (still nil in production; see the type doc on `SandboxServer`).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/server/... ./internal/ttlsweeper/... ./internal/sandbox/... -race`
- [x] `golangci-lint run ./internal/server/...` — 0 issues
- [x] `gosec ./internal/server/...` — 0 new findings (44 pre-existing, unrelated findings match `main` exactly)
- [x] Mutation-tested both new behavioral assertions by hand: reverting the pool-vs-cold delete routing, and removing the sandbox-kind label filter, each reliably fails the corresponding new test before the fix is restored.

No live Incus host in this environment — same constraint as the rest of #1488's Phase 0–3 work; everything here is buildable/testable against the existing fake-backend test harness.
