### PR TITLE
feat(sandbox): GetPoolStatus RPC for warm pool visibility (#1488 Phase 4)

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -4989,6 +4989,30 @@
         ]
       }
     },
+    "/v1/sandboxes:poolStatus": {
+      "get": {
+        "summary": "Get warm pool status",
+        "description": "Reports per-template ready/warming counts against the configured min_warm floor. Empty templates list when no pool is configured.",
+        "operationId": "SandboxService_GetPoolStatus",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/GetPoolStatusResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "tags": [
+          "Sandboxes"
+        ]
+      }
+    },
     "/v1/secrets": {
       "post": {
         "summary": "Create or update a tenant secret",
@@ -9928,6 +9952,19 @@
         }
       }
     },
+    "GetPoolStatusResponse": {
+      "type": "object",
+      "properties": {
+        "templates": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/PoolTemplateStatus"
+          },
+          "description": "One entry per template the pool is configured to warm (Config.MinWarm\nin internal/sandbox/pool). Empty when no pool is configured at all —\ndistinct from a configured-but-untargeted pool, which still reports\nits template(s) with ready = warming = 0."
+        }
+      }
+    },
     "GetRecipeResponse": {
       "type": "object",
       "properties": {
@@ -11475,6 +11512,30 @@
         }
       },
       "description": "PgConnection carries the connection parameters pg_dump / pg_restore use\n*inside the container*. Defaults target a per-container local Postgres\nreached over loopback. db_password is never logged and is passed to the\nchild process via the PGPASSWORD environment variable, not argv."
+    },
+    "PoolTemplateStatus": {
+      "type": "object",
+      "properties": {
+        "template": {
+          "$ref": "#/definitions/SandboxTemplate"
+        },
+        "ready": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Members claimable right now."
+        },
+        "warming": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Members currently being created/started/network-provisioned, not yet\nclaimable."
+        },
+        "minWarm": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The operator-configured floor ready + warming is being reconciled\ntoward."
+        }
+      },
+      "description": "PoolTemplateStatus is one template's warm-pool state."
     },
     "PrepareEncryptedMigrationBody": {
       "type": "object",

--- a/internal/client/grpc.go
+++ b/internal/client/grpc.go
@@ -948,6 +948,14 @@ func (c *GRPCClient) DeleteSandbox(sandboxID string) (*pb.DeleteSandboxResponse,
 	return c.sandboxClient.DeleteSandbox(ctx, &pb.DeleteSandboxRequest{SandboxId: sandboxID})
 }
 
+// GetPoolStatus reports the warm pool's per-template ready/warming counts
+// via gRPC (#1488 Phase 4).
+func (c *GRPCClient) GetPoolStatus() (*pb.GetPoolStatusResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	return c.sandboxClient.GetPoolStatus(ctx, &pb.GetPoolStatusRequest{})
+}
+
 // GetKMSStatus reports the active KMS backend + envelope state via gRPC.
 func (c *GRPCClient) GetKMSStatus() (*pb.GetKMSStatusResponse, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/internal/cmd/sandbox.go
+++ b/internal/cmd/sandbox.go
@@ -27,7 +27,8 @@ seeding). See docs/architecture/two-digit-ms-sandbox-spawn.md.
   containarium sandbox exec <sandbox-id> --server <host> -- echo hello
   containarium sandbox write-file <sandbox-id> /workspace/in.txt --from ./local.txt --server <host>
   containarium sandbox read-file <sandbox-id> /workspace/out.txt --server <host>
-  containarium sandbox delete <sandbox-id> --server <host>`,
+  containarium sandbox delete <sandbox-id> --server <host>
+  containarium sandbox pool-status --server <host>`,
 }
 
 var (
@@ -79,9 +80,21 @@ var sandboxDeleteCmd = &cobra.Command{
 	RunE:  runSandboxDelete,
 }
 
+var sandboxPoolStatusCmd = &cobra.Command{
+	Use:   "pool-status",
+	Short: "Show the warm pool's per-template ready/warming counts",
+	Long: `Show the warm pool's per-template ready/warming counts against the
+operator-configured min_warm floor (#1488 Phase 4).
+
+Prints "no warm pool configured" when the daemon has no pool set up
+(the current production default) — this is expected, not an error.`,
+	Args: cobra.NoArgs,
+	RunE: runSandboxPoolStatus,
+}
+
 func init() {
 	rootCmd.AddCommand(sandboxCmd)
-	sandboxCmd.AddCommand(sandboxSpawnCmd, sandboxExecCmd, sandboxWriteFileCmd, sandboxReadFileCmd, sandboxDeleteCmd)
+	sandboxCmd.AddCommand(sandboxSpawnCmd, sandboxExecCmd, sandboxWriteFileCmd, sandboxReadFileCmd, sandboxDeleteCmd, sandboxPoolStatusCmd)
 
 	sandboxSpawnCmd.Flags().Int32Var(&sandboxIdleTTLSeconds, "idle-ttl-seconds", 0, "idle TTL before the sweeper reaps an unclaimed sandbox (0 = daemon default)")
 	sandboxSpawnCmd.Flags().BoolVar(&sandboxAllowCold, "allow-cold-start", false, "fall back to the cold path instead of RESOURCE_EXHAUSTED when the warm pool is empty (no effect in Phase 1 — there is no pool yet)")
@@ -236,5 +249,27 @@ func runSandboxDelete(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	fmt.Printf("✓ %s\n", resp.Message)
+	return nil
+}
+
+func runSandboxPoolStatus(cmd *cobra.Command, args []string) error {
+	c, err := newSandboxGRPCClient()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = c.Close() }()
+
+	resp, err := c.GetPoolStatus()
+	if err != nil {
+		return err
+	}
+	if len(resp.Templates) == 0 {
+		fmt.Println("no warm pool configured")
+		return nil
+	}
+	fmt.Printf("%-28s %6s %8s %8s\n", "TEMPLATE", "READY", "WARMING", "MIN_WARM")
+	for _, t := range resp.Templates {
+		fmt.Printf("%-28s %6d %8d %8d\n", t.Template, t.Ready, t.Warming, t.MinWarm)
+	}
 	return nil
 }

--- a/internal/sandbox/pool/pool.go
+++ b/internal/sandbox/pool/pool.go
@@ -33,6 +33,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"sort"
 	"sync"
 	"time"
 
@@ -161,6 +162,47 @@ func (p *Pool) ReadyCount(template pb.SandboxTemplate) int {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return len(p.ready[template])
+}
+
+// TemplateStatus is one template's pool state, for operator visibility
+// (SandboxServer.GetPoolStatus, #1488 Phase 4). A named struct rather than
+// a positional tuple or map — see the design note's Contracts section on
+// why this package favors typed views over "was it templates[i][0] or
+// [1]?" ambiguity.
+type TemplateStatus struct {
+	Template pb.SandboxTemplate
+	// Ready is how many members are claimable right now (same count
+	// ReadyCount reports for this template).
+	Ready int
+	// Warming is how many members are being created/started/network-
+	// provisioned, not yet claimable.
+	Warming int
+	// MinWarm is the operator-configured floor Ready+Warming is being
+	// reconciled toward.
+	MinWarm int
+}
+
+// Status returns one TemplateStatus per template configured in
+// Config.MinWarm, sorted by template value for a deterministic result —
+// an operator diagnosing "why is my pool empty" needs to see the
+// configured floor even when Ready and Warming are both zero, so this
+// reports every configured template rather than only ones with current
+// ready/warming activity.
+func (p *Pool) Status() []TemplateStatus {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	statuses := make([]TemplateStatus, 0, len(p.cfg.MinWarm))
+	for template, minWarm := range p.cfg.MinWarm {
+		statuses = append(statuses, TemplateStatus{
+			Template: template,
+			Ready:    len(p.ready[template]),
+			Warming:  p.warming[template],
+			MinWarm:  minWarm,
+		})
+	}
+	sort.Slice(statuses, func(i, j int) bool { return statuses[i].Template < statuses[j].Template })
+	return statuses
 }
 
 // Reconcile brings every configured template's ready+warming count to

--- a/internal/sandbox/pool/pool_test.go
+++ b/internal/sandbox/pool/pool_test.go
@@ -462,3 +462,85 @@ func TestMember_TypedNotStringlyTyped(t *testing.T) {
 	}
 	_ = fmt.Sprintf("%+v", m)
 }
+
+// ---- Status ---------------------------------------------------------
+
+// TestStatus_ReportsReadyWarmingAndMinWarm exercises all three
+// TemplateStatus fields at once: MinWarm=3, only 2 warmed so far because
+// the third is gated mid-warm — so Ready must be 2 and Warming must be 1,
+// not e.g. Ready=3 (which would mean a still-warming member leaked into
+// the ready count Status reports) or Warming=0 (which would mean Status
+// missed in-flight work entirely).
+func TestStatus_ReportsReadyWarmingAndMinWarm(t *testing.T) {
+	backend := newFakeBackend()
+	backend.gate = make(chan struct{})
+	p := New(backend, testAllocator(t), testConfig(3))
+
+	done := make(chan struct{})
+	go func() {
+		p.Reconcile(context.Background())
+		close(done)
+	}()
+
+	// Let 2 of the 3 warms clear the gate, then re-close it so the 3rd
+	// stays wedged — fakeBackend's gate is read-once-per-call inside
+	// CreateContainer (see newFakeBackend's doc comment / usage above),
+	// so signal exactly twice.
+	backend.gate <- struct{}{}
+	backend.gate <- struct{}{}
+	// Give the two released warms a moment to finish and update the ring
+	// before asserting — Status must not race a still-settling Reconcile.
+	deadline := time.Now().Add(2 * time.Second)
+	for p.ReadyCount(pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE) < 2 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+
+	statuses := p.Status()
+	if len(statuses) != 1 {
+		t.Fatalf("Status() returned %d entries, want 1 (one configured template)", len(statuses))
+	}
+	st := statuses[0]
+	if st.Template != pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE {
+		t.Errorf("Template = %v, want BASE", st.Template)
+	}
+	if st.MinWarm != 3 {
+		t.Errorf("MinWarm = %d, want 3 (the configured floor)", st.MinWarm)
+	}
+	if st.Ready != 2 {
+		t.Errorf("Ready = %d, want 2", st.Ready)
+	}
+	if st.Warming != 1 {
+		t.Errorf("Warming = %d, want 1 (the still-gated 3rd member)", st.Warming)
+	}
+
+	close(backend.gate)
+	<-done
+}
+
+// TestStatus_UnconfiguredTemplateReportsZeroesNotOmitted pins that Status
+// still reports a template present in Config.MinWarm even when nothing
+// has been reconciled yet — an operator diagnosing "why is my pool empty"
+// needs zero counts against the configured floor, not an empty list that
+// looks identical to "no pool configured at all".
+func TestStatus_UnconfiguredTemplateReportsZeroesNotOmitted(t *testing.T) {
+	p := New(newFakeBackend(), testAllocator(t), testConfig(5))
+
+	statuses := p.Status()
+	if len(statuses) != 1 {
+		t.Fatalf("Status() returned %d entries, want 1", len(statuses))
+	}
+	if got := statuses[0]; got.Ready != 0 || got.Warming != 0 || got.MinWarm != 5 {
+		t.Errorf("Status() before any Reconcile = %+v, want Ready=0 Warming=0 MinWarm=5", got)
+	}
+}
+
+// TestStatus_NoConfiguredTemplatesReturnsEmpty pins the other end: a pool
+// with an empty Config.MinWarm (the "pool exists but warms nothing"
+// shape SpawnSandbox's own tests already use for pool-exhausted cases)
+// reports no entries at all, not a spurious BASE row.
+func TestStatus_NoConfiguredTemplatesReturnsEmpty(t *testing.T) {
+	p := New(newFakeBackend(), testAllocator(t), Config{})
+	if statuses := p.Status(); len(statuses) != 0 {
+		t.Errorf("Status() on an unconfigured pool = %+v, want empty", statuses)
+	}
+}

--- a/internal/server/sandbox_server.go
+++ b/internal/server/sandbox_server.go
@@ -515,3 +515,33 @@ func (s *SandboxServer) DeleteSandbox(ctx context.Context, req *pb.DeleteSandbox
 
 	return &pb.DeleteSandboxResponse{Message: fmt.Sprintf("sandbox %s deleted", req.SandboxId)}, nil
 }
+
+// GetPoolStatus reports the warm pool's per-template ready/warming counts
+// against the configured min_warm floor (#1488 Phase 4: "pool exhaustion
+// is visible"). Read-only, no ownership scoping — pool state isn't
+// per-tenant data, it's operator/observability visibility into the
+// daemon's own admission-control posture. Returns an empty templates list
+// when no pool is configured (s.pool == nil, today's production default;
+// see the type doc), rather than an error — "the pool feature isn't
+// configured" is a legitimate, expected response, not a failure.
+func (s *SandboxServer) GetPoolStatus(ctx context.Context, _ *pb.GetPoolStatusRequest) (*pb.GetPoolStatusResponse, error) {
+	if err := auth.RequireScope(ctx, auth.ScopeSandboxesRead); err != nil {
+		return nil, err
+	}
+
+	if s.pool == nil {
+		return &pb.GetPoolStatusResponse{}, nil
+	}
+
+	statuses := s.pool.Status()
+	templates := make([]*pb.PoolTemplateStatus, 0, len(statuses))
+	for _, st := range statuses {
+		templates = append(templates, &pb.PoolTemplateStatus{
+			Template: st.Template,
+			Ready:    safecast.I32(st.Ready),
+			Warming:  safecast.I32(st.Warming),
+			MinWarm:  safecast.I32(st.MinWarm),
+		})
+	}
+	return &pb.GetPoolStatusResponse{Templates: templates}, nil
+}

--- a/internal/server/sandbox_server_pool_test.go
+++ b/internal/server/sandbox_server_pool_test.go
@@ -184,3 +184,70 @@ func TestSpawnSandbox_ClaimSetupFailureDestroysTheMember(t *testing.T) {
 		t.Errorf("ReadyCount = %d, want 0 (the failed member must not be silently re-added to the ring)", got)
 	}
 }
+
+// TestGetPoolStatus_NilPoolReturnsEmptyTemplates pins the "no pool
+// configured" branch: an empty list, not an error — see the RPC's own doc
+// comment on why "the feature isn't configured" must not look like a
+// failure to a caller/CLI polling this for dashboards.
+func TestGetPoolStatus_NilPoolReturnsEmptyTemplates(t *testing.T) {
+	s := NewSandboxServer(newFakeSandboxBackend(), nil)
+
+	resp, err := s.GetPoolStatus(ctxAs("alice", false), &pb.GetPoolStatusRequest{})
+	if err != nil {
+		t.Fatalf("GetPoolStatus: %v", err)
+	}
+	if len(resp.Templates) != 0 {
+		t.Errorf("Templates = %+v, want empty (no pool configured)", resp.Templates)
+	}
+}
+
+// TestGetPoolStatus_ReportsConfiguredPoolCounts is the sibling for an
+// actually-configured pool: after Reconcile warms to min_warm and one
+// claim, GetPoolStatus must reflect the post-claim ready count (2, not
+// the original 3) plus the unchanged min_warm floor — proving the RPC
+// reads live pool.Status() state, not a value cached at spawn time.
+func TestGetPoolStatus_ReportsConfiguredPoolCounts(t *testing.T) {
+	backend := newFakeSandboxBackend()
+	allocator, err := ipam.New("10.100.0.10", "10.100.0.250", "10.100.0.1", 0)
+	if err != nil {
+		t.Fatalf("ipam.New: %v", err)
+	}
+	p := pool.New(backend, allocator, pool.Config{
+		MinWarm:    map[pb.SandboxTemplate]int{pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE: 3},
+		Image:      map[pb.SandboxTemplate]string{pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE: "images:ubuntu/24.04"},
+		NICNetwork: "incusbr0",
+	})
+	p.Reconcile(context.Background())
+	s := NewSandboxServer(backend, p)
+
+	if _, err := s.SpawnSandbox(ctxAs("alice", false), &pb.SpawnSandboxRequest{}); err != nil {
+		t.Fatalf("SpawnSandbox: %v", err)
+	}
+
+	resp, err := s.GetPoolStatus(ctxAs("alice", false), &pb.GetPoolStatusRequest{})
+	if err != nil {
+		t.Fatalf("GetPoolStatus: %v", err)
+	}
+	if len(resp.Templates) != 1 {
+		t.Fatalf("Templates = %+v, want exactly 1 entry", resp.Templates)
+	}
+	got := resp.Templates[0]
+	if got.Template != pb.SandboxTemplate_SANDBOX_TEMPLATE_BASE {
+		t.Errorf("Template = %v, want BASE", got.Template)
+	}
+	if got.Ready != 2 {
+		t.Errorf("Ready = %d, want 2 (3 warmed, 1 claimed)", got.Ready)
+	}
+	if got.MinWarm != 3 {
+		t.Errorf("MinWarm = %d, want 3", got.MinWarm)
+	}
+}
+
+// TestGetPoolStatus_RequiresReadScope pins that this is scope-gated like
+// every other sandbox RPC, not an unauthenticated status endpoint.
+func TestGetPoolStatus_RequiresReadScope(t *testing.T) {
+	s := NewSandboxServer(newFakeSandboxBackend(), nil)
+	if _, err := s.GetPoolStatus(context.Background(), &pb.GetPoolStatusRequest{}); err == nil {
+		t.Fatal("GetPoolStatus with no subject in context should fail")
+	}
+}

--- a/internal/server/sandbox_server_test.go
+++ b/internal/server/sandbox_server_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -16,8 +17,16 @@ import (
 // fakeSandboxBackend is a minimal, map-backed incus.Backend fake: real
 // enough that GetContainer after CreateContainer sees the labels/tenant
 // the create call stamped, without depending on a live Incus daemon.
+//
+// mu guards instances/deleteCalls: pool.Reconcile warms multiple members
+// for the same template concurrently (one goroutine per warm, see
+// pool.go's Reconcile), so any test with min_warm > 1 drives concurrent
+// CreateContainer/StartContainer calls into this single fake — without a
+// lock that's a genuine, `-race`-catchable data race, not just a
+// theoretical one.
 type fakeSandboxBackend struct {
 	incus.Backend
+	mu        sync.Mutex
 	instances map[string]incus.ContainerInfo
 
 	waitNetworkErr     error
@@ -52,6 +61,8 @@ func (b *fakeSandboxBackend) CreateContainer(c incus.ContainerConfig) error {
 			info.TTLExpiresAt = t
 		}
 	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	b.instances[c.Name] = info
 	return nil
 }
@@ -61,6 +72,8 @@ func (b *fakeSandboxBackend) CreateContainer(c incus.ContainerConfig) error {
 // exactly (Name, Labels, TTLExpiresAt), all of which CreateContainer/
 // SetConfig/SetLabels already populate above.
 func (b *fakeSandboxBackend) ListContainers() ([]incus.ContainerInfo, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	out := make([]incus.ContainerInfo, 0, len(b.instances))
 	for _, info := range b.instances {
 		out = append(out, info)
@@ -84,6 +97,8 @@ func (b *fakeSandboxBackend) StartContainer(name string) error {
 	if b.startErr != nil {
 		return b.startErr
 	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	if info, ok := b.instances[name]; ok {
 		info.State = "Running"
 		b.instances[name] = info
@@ -94,6 +109,8 @@ func (b *fakeSandboxBackend) StartContainer(name string) error {
 func (b *fakeSandboxBackend) StopContainer(string, bool) error { return nil }
 
 func (b *fakeSandboxBackend) DeleteContainer(name string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	b.deleteCalls++
 	if b.deleteContainerErr != nil {
 		return b.deleteContainerErr
@@ -110,6 +127,8 @@ func (b *fakeSandboxBackend) WaitForNetwork(string, time.Duration) (string, erro
 }
 
 func (b *fakeSandboxBackend) GetContainer(name string) (*incus.ContainerInfo, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	info, ok := b.instances[name]
 	if !ok {
 		return nil, errors.New("not found")
@@ -137,6 +156,8 @@ func (b *fakeSandboxBackend) SetConfig(name, key, value string) error {
 	if b.setConfigErr != nil {
 		return b.setConfigErr
 	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	info, ok := b.instances[name]
 	if !ok {
 		return errors.New("not found")
@@ -164,6 +185,8 @@ func (b *fakeSandboxBackend) SetLabels(name string, labels map[string]string) er
 	if b.setLabelsErr != nil {
 		return b.setLabelsErr
 	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	info, ok := b.instances[name]
 	if !ok {
 		return errors.New("not found")

--- a/pkg/pb/containarium/v1/sandbox.pb.go
+++ b/pkg/pb/containarium/v1/sandbox.pb.go
@@ -807,6 +807,164 @@ func (x *DeleteSandboxResponse) GetMessage() string {
 	return ""
 }
 
+type GetPoolStatusRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetPoolStatusRequest) Reset() {
+	*x = GetPoolStatusRequest{}
+	mi := &file_containarium_v1_sandbox_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetPoolStatusRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetPoolStatusRequest) ProtoMessage() {}
+
+func (x *GetPoolStatusRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_sandbox_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetPoolStatusRequest.ProtoReflect.Descriptor instead.
+func (*GetPoolStatusRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_sandbox_proto_rawDescGZIP(), []int{11}
+}
+
+type GetPoolStatusResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// One entry per template the pool is configured to warm (Config.MinWarm
+	// in internal/sandbox/pool). Empty when no pool is configured at all —
+	// distinct from a configured-but-untargeted pool, which still reports
+	// its template(s) with ready = warming = 0.
+	Templates     []*PoolTemplateStatus `protobuf:"bytes,1,rep,name=templates,proto3" json:"templates,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetPoolStatusResponse) Reset() {
+	*x = GetPoolStatusResponse{}
+	mi := &file_containarium_v1_sandbox_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetPoolStatusResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetPoolStatusResponse) ProtoMessage() {}
+
+func (x *GetPoolStatusResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_sandbox_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetPoolStatusResponse.ProtoReflect.Descriptor instead.
+func (*GetPoolStatusResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_sandbox_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *GetPoolStatusResponse) GetTemplates() []*PoolTemplateStatus {
+	if x != nil {
+		return x.Templates
+	}
+	return nil
+}
+
+// PoolTemplateStatus is one template's warm-pool state.
+type PoolTemplateStatus struct {
+	state    protoimpl.MessageState `protogen:"open.v1"`
+	Template SandboxTemplate        `protobuf:"varint,1,opt,name=template,proto3,enum=containarium.v1.SandboxTemplate" json:"template,omitempty"`
+	// Members claimable right now.
+	Ready int32 `protobuf:"varint,2,opt,name=ready,proto3" json:"ready,omitempty"`
+	// Members currently being created/started/network-provisioned, not yet
+	// claimable.
+	Warming int32 `protobuf:"varint,3,opt,name=warming,proto3" json:"warming,omitempty"`
+	// The operator-configured floor ready + warming is being reconciled
+	// toward.
+	MinWarm       int32 `protobuf:"varint,4,opt,name=min_warm,json=minWarm,proto3" json:"min_warm,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PoolTemplateStatus) Reset() {
+	*x = PoolTemplateStatus{}
+	mi := &file_containarium_v1_sandbox_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PoolTemplateStatus) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PoolTemplateStatus) ProtoMessage() {}
+
+func (x *PoolTemplateStatus) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_sandbox_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PoolTemplateStatus.ProtoReflect.Descriptor instead.
+func (*PoolTemplateStatus) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_sandbox_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *PoolTemplateStatus) GetTemplate() SandboxTemplate {
+	if x != nil {
+		return x.Template
+	}
+	return SandboxTemplate_SANDBOX_TEMPLATE_UNSPECIFIED
+}
+
+func (x *PoolTemplateStatus) GetReady() int32 {
+	if x != nil {
+		return x.Ready
+	}
+	return 0
+}
+
+func (x *PoolTemplateStatus) GetWarming() int32 {
+	if x != nil {
+		return x.Warming
+	}
+	return 0
+}
+
+func (x *PoolTemplateStatus) GetMinWarm() int32 {
+	if x != nil {
+		return x.MinWarm
+	}
+	return 0
+}
+
 type SpawnRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Shell command to run, e.g. "npm run dev". Runs under /bin/sh -c,
@@ -823,7 +981,7 @@ type SpawnRequest struct {
 
 func (x *SpawnRequest) Reset() {
 	*x = SpawnRequest{}
-	mi := &file_containarium_v1_sandbox_proto_msgTypes[11]
+	mi := &file_containarium_v1_sandbox_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -835,7 +993,7 @@ func (x *SpawnRequest) String() string {
 func (*SpawnRequest) ProtoMessage() {}
 
 func (x *SpawnRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_sandbox_proto_msgTypes[11]
+	mi := &file_containarium_v1_sandbox_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -848,7 +1006,7 @@ func (x *SpawnRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SpawnRequest.ProtoReflect.Descriptor instead.
 func (*SpawnRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_sandbox_proto_rawDescGZIP(), []int{11}
+	return file_containarium_v1_sandbox_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *SpawnRequest) GetCommand() string {
@@ -885,7 +1043,7 @@ type SpawnResponse struct {
 
 func (x *SpawnResponse) Reset() {
 	*x = SpawnResponse{}
-	mi := &file_containarium_v1_sandbox_proto_msgTypes[12]
+	mi := &file_containarium_v1_sandbox_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -897,7 +1055,7 @@ func (x *SpawnResponse) String() string {
 func (*SpawnResponse) ProtoMessage() {}
 
 func (x *SpawnResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_sandbox_proto_msgTypes[12]
+	mi := &file_containarium_v1_sandbox_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -910,7 +1068,7 @@ func (x *SpawnResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SpawnResponse.ProtoReflect.Descriptor instead.
 func (*SpawnResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_sandbox_proto_rawDescGZIP(), []int{12}
+	return file_containarium_v1_sandbox_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *SpawnResponse) GetName() string {
@@ -949,7 +1107,7 @@ type AgentExecRequest struct {
 
 func (x *AgentExecRequest) Reset() {
 	*x = AgentExecRequest{}
-	mi := &file_containarium_v1_sandbox_proto_msgTypes[13]
+	mi := &file_containarium_v1_sandbox_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -961,7 +1119,7 @@ func (x *AgentExecRequest) String() string {
 func (*AgentExecRequest) ProtoMessage() {}
 
 func (x *AgentExecRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_sandbox_proto_msgTypes[13]
+	mi := &file_containarium_v1_sandbox_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -974,7 +1132,7 @@ func (x *AgentExecRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AgentExecRequest.ProtoReflect.Descriptor instead.
 func (*AgentExecRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_sandbox_proto_rawDescGZIP(), []int{13}
+	return file_containarium_v1_sandbox_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *AgentExecRequest) GetCommand() string {
@@ -1009,7 +1167,7 @@ type AgentExecResponse struct {
 
 func (x *AgentExecResponse) Reset() {
 	*x = AgentExecResponse{}
-	mi := &file_containarium_v1_sandbox_proto_msgTypes[14]
+	mi := &file_containarium_v1_sandbox_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1021,7 +1179,7 @@ func (x *AgentExecResponse) String() string {
 func (*AgentExecResponse) ProtoMessage() {}
 
 func (x *AgentExecResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_sandbox_proto_msgTypes[14]
+	mi := &file_containarium_v1_sandbox_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1034,7 +1192,7 @@ func (x *AgentExecResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AgentExecResponse.ProtoReflect.Descriptor instead.
 func (*AgentExecResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_sandbox_proto_rawDescGZIP(), []int{14}
+	return file_containarium_v1_sandbox_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *AgentExecResponse) GetStdout() string {
@@ -1107,7 +1265,15 @@ const file_containarium_v1_sandbox_proto_rawDesc = "" +
 	"\n" +
 	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\"1\n" +
 	"\x15DeleteSandboxResponse\x12\x18\n" +
-	"\amessage\x18\x01 \x01(\tR\amessage\"N\n" +
+	"\amessage\x18\x01 \x01(\tR\amessage\"\x16\n" +
+	"\x14GetPoolStatusRequest\"Z\n" +
+	"\x15GetPoolStatusResponse\x12A\n" +
+	"\ttemplates\x18\x01 \x03(\v2#.containarium.v1.PoolTemplateStatusR\ttemplates\"\x9d\x01\n" +
+	"\x12PoolTemplateStatus\x12<\n" +
+	"\btemplate\x18\x01 \x01(\x0e2 .containarium.v1.SandboxTemplateR\btemplate\x12\x14\n" +
+	"\x05ready\x18\x02 \x01(\x05R\x05ready\x12\x18\n" +
+	"\awarming\x18\x03 \x01(\x05R\awarming\x12\x19\n" +
+	"\bmin_warm\x18\x04 \x01(\x05R\aminWarm\"N\n" +
 	"\fSpawnRequest\x12\x18\n" +
 	"\acommand\x18\x01 \x01(\tR\acommand\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x10\n" +
@@ -1137,7 +1303,7 @@ const file_containarium_v1_sandbox_proto_rawDesc = "" +
 	"\x10SERVED_FROM_POOL\x10\x02*N\n" +
 	"\x0fSandboxTemplate\x12 \n" +
 	"\x1cSANDBOX_TEMPLATE_UNSPECIFIED\x10\x00\x12\x19\n" +
-	"\x15SANDBOX_TEMPLATE_BASE\x10\x012\xb4\t\n" +
+	"\x15SANDBOX_TEMPLATE_BASE\x10\x012\xe1\v\n" +
 	"\x0eSandboxService\x12\xf2\x02\n" +
 	"\fSpawnSandbox\x12$.containarium.v1.SpawnSandboxRequest\x1a%.containarium.v1.SpawnSandboxResponse\"\x94\x02\x92A\xf8\x01\n" +
 	"\tSandboxes\x12\x0fSpawn a sandbox\x1a\xd9\x01Creates an ephemeral, unauthenticated-shell-free sandbox. Phase 1: always the cold path (served_from = COLD); Phase 3+: a pool claim when a warm member is ready, else RESOURCE_EXHAUSTED unless allow_cold_start is set.\x82\xd3\xe4\x93\x02\x12:\x01*\"\r/v1/sandboxes\x12\xb8\x01\n" +
@@ -1148,7 +1314,9 @@ const file_containarium_v1_sandbox_proto_rawDesc = "" +
 	"\x11ReadFileInSandbox\x12).containarium.v1.ReadFileInSandboxRequest\x1a*.containarium.v1.ReadFileInSandboxResponse\"\x97\x01\x92Al\n" +
 	"\tSandboxes\x12\x1aRead a file from a sandbox\x1aCpath is passed as a query parameter, e.g. ?path=/workspace/out.txt.\x82\xd3\xe4\x93\x02\"\x12 /v1/sandboxes/{sandbox_id}/files\x12\xa2\x01\n" +
 	"\rDeleteSandbox\x12%.containarium.v1.DeleteSandboxRequest\x1a&.containarium.v1.DeleteSandboxResponse\"B\x92A\x1d\n" +
-	"\tSandboxes\x12\x10Delete a sandbox\x82\xd3\xe4\x93\x02\x1c*\x1a/v1/sandboxes/{sandbox_id}2\xa5\x01\n" +
+	"\tSandboxes\x12\x10Delete a sandbox\x82\xd3\xe4\x93\x02\x1c*\x1a/v1/sandboxes/{sandbox_id}\x12\xaa\x02\n" +
+	"\rGetPoolStatus\x12%.containarium.v1.GetPoolStatusRequest\x1a&.containarium.v1.GetPoolStatusResponse\"\xc9\x01\x92A\xa5\x01\n" +
+	"\tSandboxes\x12\x14Get warm pool status\x1a\x81\x01Reports per-template ready/warming counts against the configured min_warm floor. Empty templates list when no pool is configured.\x82\xd3\xe4\x93\x02\x1a\x12\x18/v1/sandboxes:poolStatus2\xa5\x01\n" +
 	"\fSpawnService\x12F\n" +
 	"\x05Spawn\x12\x1d.containarium.v1.SpawnRequest\x1a\x1e.containarium.v1.SpawnResponse\x12M\n" +
 	"\x04Exec\x12!.containarium.v1.AgentExecRequest\x1a\".containarium.v1.AgentExecResponseBKZIgithub.com/footprintai/containarium/pkg/pb/containarium/v1;containariumv1b\x06proto3"
@@ -1166,7 +1334,7 @@ func file_containarium_v1_sandbox_proto_rawDescGZIP() []byte {
 }
 
 var file_containarium_v1_sandbox_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_containarium_v1_sandbox_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
+var file_containarium_v1_sandbox_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
 var file_containarium_v1_sandbox_proto_goTypes = []any{
 	(SandboxState)(0),                  // 0: containarium.v1.SandboxState
 	(ServedFrom)(0),                    // 1: containarium.v1.ServedFrom
@@ -1182,39 +1350,46 @@ var file_containarium_v1_sandbox_proto_goTypes = []any{
 	(*ReadFileInSandboxResponse)(nil),  // 11: containarium.v1.ReadFileInSandboxResponse
 	(*DeleteSandboxRequest)(nil),       // 12: containarium.v1.DeleteSandboxRequest
 	(*DeleteSandboxResponse)(nil),      // 13: containarium.v1.DeleteSandboxResponse
-	(*SpawnRequest)(nil),               // 14: containarium.v1.SpawnRequest
-	(*SpawnResponse)(nil),              // 15: containarium.v1.SpawnResponse
-	(*AgentExecRequest)(nil),           // 16: containarium.v1.AgentExecRequest
-	(*AgentExecResponse)(nil),          // 17: containarium.v1.AgentExecResponse
-	(*timestamppb.Timestamp)(nil),      // 18: google.protobuf.Timestamp
+	(*GetPoolStatusRequest)(nil),       // 14: containarium.v1.GetPoolStatusRequest
+	(*GetPoolStatusResponse)(nil),      // 15: containarium.v1.GetPoolStatusResponse
+	(*PoolTemplateStatus)(nil),         // 16: containarium.v1.PoolTemplateStatus
+	(*SpawnRequest)(nil),               // 17: containarium.v1.SpawnRequest
+	(*SpawnResponse)(nil),              // 18: containarium.v1.SpawnResponse
+	(*AgentExecRequest)(nil),           // 19: containarium.v1.AgentExecRequest
+	(*AgentExecResponse)(nil),          // 20: containarium.v1.AgentExecResponse
+	(*timestamppb.Timestamp)(nil),      // 21: google.protobuf.Timestamp
 }
 var file_containarium_v1_sandbox_proto_depIdxs = []int32{
 	0,  // 0: containarium.v1.Sandbox.state:type_name -> containarium.v1.SandboxState
 	2,  // 1: containarium.v1.Sandbox.template:type_name -> containarium.v1.SandboxTemplate
 	1,  // 2: containarium.v1.Sandbox.served_from:type_name -> containarium.v1.ServedFrom
-	18, // 3: containarium.v1.Sandbox.created_at:type_name -> google.protobuf.Timestamp
-	18, // 4: containarium.v1.Sandbox.expires_at:type_name -> google.protobuf.Timestamp
+	21, // 3: containarium.v1.Sandbox.created_at:type_name -> google.protobuf.Timestamp
+	21, // 4: containarium.v1.Sandbox.expires_at:type_name -> google.protobuf.Timestamp
 	2,  // 5: containarium.v1.SpawnSandboxRequest.template:type_name -> containarium.v1.SandboxTemplate
 	3,  // 6: containarium.v1.SpawnSandboxResponse.sandbox:type_name -> containarium.v1.Sandbox
-	4,  // 7: containarium.v1.SandboxService.SpawnSandbox:input_type -> containarium.v1.SpawnSandboxRequest
-	6,  // 8: containarium.v1.SandboxService.ExecInSandbox:input_type -> containarium.v1.ExecInSandboxRequest
-	8,  // 9: containarium.v1.SandboxService.WriteFileInSandbox:input_type -> containarium.v1.WriteFileInSandboxRequest
-	10, // 10: containarium.v1.SandboxService.ReadFileInSandbox:input_type -> containarium.v1.ReadFileInSandboxRequest
-	12, // 11: containarium.v1.SandboxService.DeleteSandbox:input_type -> containarium.v1.DeleteSandboxRequest
-	14, // 12: containarium.v1.SpawnService.Spawn:input_type -> containarium.v1.SpawnRequest
-	16, // 13: containarium.v1.SpawnService.Exec:input_type -> containarium.v1.AgentExecRequest
-	5,  // 14: containarium.v1.SandboxService.SpawnSandbox:output_type -> containarium.v1.SpawnSandboxResponse
-	7,  // 15: containarium.v1.SandboxService.ExecInSandbox:output_type -> containarium.v1.ExecInSandboxResponse
-	9,  // 16: containarium.v1.SandboxService.WriteFileInSandbox:output_type -> containarium.v1.WriteFileInSandboxResponse
-	11, // 17: containarium.v1.SandboxService.ReadFileInSandbox:output_type -> containarium.v1.ReadFileInSandboxResponse
-	13, // 18: containarium.v1.SandboxService.DeleteSandbox:output_type -> containarium.v1.DeleteSandboxResponse
-	15, // 19: containarium.v1.SpawnService.Spawn:output_type -> containarium.v1.SpawnResponse
-	17, // 20: containarium.v1.SpawnService.Exec:output_type -> containarium.v1.AgentExecResponse
-	14, // [14:21] is the sub-list for method output_type
-	7,  // [7:14] is the sub-list for method input_type
-	7,  // [7:7] is the sub-list for extension type_name
-	7,  // [7:7] is the sub-list for extension extendee
-	0,  // [0:7] is the sub-list for field type_name
+	16, // 7: containarium.v1.GetPoolStatusResponse.templates:type_name -> containarium.v1.PoolTemplateStatus
+	2,  // 8: containarium.v1.PoolTemplateStatus.template:type_name -> containarium.v1.SandboxTemplate
+	4,  // 9: containarium.v1.SandboxService.SpawnSandbox:input_type -> containarium.v1.SpawnSandboxRequest
+	6,  // 10: containarium.v1.SandboxService.ExecInSandbox:input_type -> containarium.v1.ExecInSandboxRequest
+	8,  // 11: containarium.v1.SandboxService.WriteFileInSandbox:input_type -> containarium.v1.WriteFileInSandboxRequest
+	10, // 12: containarium.v1.SandboxService.ReadFileInSandbox:input_type -> containarium.v1.ReadFileInSandboxRequest
+	12, // 13: containarium.v1.SandboxService.DeleteSandbox:input_type -> containarium.v1.DeleteSandboxRequest
+	14, // 14: containarium.v1.SandboxService.GetPoolStatus:input_type -> containarium.v1.GetPoolStatusRequest
+	17, // 15: containarium.v1.SpawnService.Spawn:input_type -> containarium.v1.SpawnRequest
+	19, // 16: containarium.v1.SpawnService.Exec:input_type -> containarium.v1.AgentExecRequest
+	5,  // 17: containarium.v1.SandboxService.SpawnSandbox:output_type -> containarium.v1.SpawnSandboxResponse
+	7,  // 18: containarium.v1.SandboxService.ExecInSandbox:output_type -> containarium.v1.ExecInSandboxResponse
+	9,  // 19: containarium.v1.SandboxService.WriteFileInSandbox:output_type -> containarium.v1.WriteFileInSandboxResponse
+	11, // 20: containarium.v1.SandboxService.ReadFileInSandbox:output_type -> containarium.v1.ReadFileInSandboxResponse
+	13, // 21: containarium.v1.SandboxService.DeleteSandbox:output_type -> containarium.v1.DeleteSandboxResponse
+	15, // 22: containarium.v1.SandboxService.GetPoolStatus:output_type -> containarium.v1.GetPoolStatusResponse
+	18, // 23: containarium.v1.SpawnService.Spawn:output_type -> containarium.v1.SpawnResponse
+	20, // 24: containarium.v1.SpawnService.Exec:output_type -> containarium.v1.AgentExecResponse
+	17, // [17:25] is the sub-list for method output_type
+	9,  // [9:17] is the sub-list for method input_type
+	9,  // [9:9] is the sub-list for extension type_name
+	9,  // [9:9] is the sub-list for extension extendee
+	0,  // [0:9] is the sub-list for field type_name
 }
 
 func init() { file_containarium_v1_sandbox_proto_init() }
@@ -1228,7 +1403,7 @@ func file_containarium_v1_sandbox_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_v1_sandbox_proto_rawDesc), len(file_containarium_v1_sandbox_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   15,
+			NumMessages:   18,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/pkg/pb/containarium/v1/sandbox.pb.gw.go
+++ b/pkg/pb/containarium/v1/sandbox.pb.gw.go
@@ -244,6 +244,27 @@ func local_request_SandboxService_DeleteSandbox_0(ctx context.Context, marshaler
 	return msg, metadata, err
 }
 
+func request_SandboxService_GetPoolStatus_0(ctx context.Context, marshaler runtime.Marshaler, client SandboxServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq GetPoolStatusRequest
+		metadata runtime.ServerMetadata
+	)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.GetPoolStatus(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_SandboxService_GetPoolStatus_0(ctx context.Context, marshaler runtime.Marshaler, server SandboxServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq GetPoolStatusRequest
+		metadata runtime.ServerMetadata
+	)
+	msg, err := server.GetPoolStatus(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_SpawnService_Spawn_0(ctx context.Context, marshaler runtime.Marshaler, client SpawnServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq SpawnRequest
@@ -403,6 +424,26 @@ func RegisterSandboxServiceHandlerServer(ctx context.Context, mux *runtime.Serve
 			return
 		}
 		forward_SandboxService_DeleteSandbox_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_SandboxService_GetPoolStatus_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.SandboxService/GetPoolStatus", runtime.WithHTTPPathPattern("/v1/sandboxes:poolStatus"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_SandboxService_GetPoolStatus_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_SandboxService_GetPoolStatus_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 
 	return nil
@@ -579,6 +620,23 @@ func RegisterSandboxServiceHandlerClient(ctx context.Context, mux *runtime.Serve
 		}
 		forward_SandboxService_DeleteSandbox_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodGet, pattern_SandboxService_GetPoolStatus_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.SandboxService/GetPoolStatus", runtime.WithHTTPPathPattern("/v1/sandboxes:poolStatus"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_SandboxService_GetPoolStatus_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_SandboxService_GetPoolStatus_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
@@ -588,6 +646,7 @@ var (
 	pattern_SandboxService_WriteFileInSandbox_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "sandboxes", "sandbox_id", "files"}, ""))
 	pattern_SandboxService_ReadFileInSandbox_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "sandboxes", "sandbox_id", "files"}, ""))
 	pattern_SandboxService_DeleteSandbox_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "sandboxes", "sandbox_id"}, ""))
+	pattern_SandboxService_GetPoolStatus_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "sandboxes"}, "poolStatus"))
 )
 
 var (
@@ -596,6 +655,7 @@ var (
 	forward_SandboxService_WriteFileInSandbox_0 = runtime.ForwardResponseMessage
 	forward_SandboxService_ReadFileInSandbox_0  = runtime.ForwardResponseMessage
 	forward_SandboxService_DeleteSandbox_0      = runtime.ForwardResponseMessage
+	forward_SandboxService_GetPoolStatus_0      = runtime.ForwardResponseMessage
 )
 
 // RegisterSpawnServiceHandlerFromEndpoint is same as RegisterSpawnServiceHandler but

--- a/pkg/pb/containarium/v1/sandbox_grpc.pb.go
+++ b/pkg/pb/containarium/v1/sandbox_grpc.pb.go
@@ -24,6 +24,7 @@ const (
 	SandboxService_WriteFileInSandbox_FullMethodName = "/containarium.v1.SandboxService/WriteFileInSandbox"
 	SandboxService_ReadFileInSandbox_FullMethodName  = "/containarium.v1.SandboxService/ReadFileInSandbox"
 	SandboxService_DeleteSandbox_FullMethodName      = "/containarium.v1.SandboxService/DeleteSandbox"
+	SandboxService_GetPoolStatus_FullMethodName      = "/containarium.v1.SandboxService/GetPoolStatus"
 )
 
 // SandboxServiceClient is the client API for SandboxService service.
@@ -63,6 +64,17 @@ type SandboxServiceClient interface {
 	// reset and reused (see the design note's Isolation section) — delete
 	// always means destroy, never "return to a pool".
 	DeleteSandbox(ctx context.Context, in *DeleteSandboxRequest, opts ...grpc.CallOption) (*DeleteSandboxResponse, error)
+	// GetPoolStatus reports the warm pool's current state per template —
+	// how many members are ready to claim right now, how many are still
+	// warming, and the operator-configured min_warm floor each is being
+	// reconciled toward (#1488 Phase 4: "pool exhaustion is visible").
+	// Read-only operator/observability visibility, not a pre-flight check a
+	// SpawnSandbox caller needs to poll first — RESOURCE_EXHAUSTED on an
+	// actual claim attempt remains the source of truth for whether a
+	// specific call would succeed right now. Returns an empty templates
+	// list when no pool is configured (the current production default —
+	// see SandboxServer's own type doc).
+	GetPoolStatus(ctx context.Context, in *GetPoolStatusRequest, opts ...grpc.CallOption) (*GetPoolStatusResponse, error)
 }
 
 type sandboxServiceClient struct {
@@ -123,6 +135,16 @@ func (c *sandboxServiceClient) DeleteSandbox(ctx context.Context, in *DeleteSand
 	return out, nil
 }
 
+func (c *sandboxServiceClient) GetPoolStatus(ctx context.Context, in *GetPoolStatusRequest, opts ...grpc.CallOption) (*GetPoolStatusResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetPoolStatusResponse)
+	err := c.cc.Invoke(ctx, SandboxService_GetPoolStatus_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // SandboxServiceServer is the server API for SandboxService service.
 // All implementations must embed UnimplementedSandboxServiceServer
 // for forward compatibility.
@@ -160,6 +182,17 @@ type SandboxServiceServer interface {
 	// reset and reused (see the design note's Isolation section) — delete
 	// always means destroy, never "return to a pool".
 	DeleteSandbox(context.Context, *DeleteSandboxRequest) (*DeleteSandboxResponse, error)
+	// GetPoolStatus reports the warm pool's current state per template —
+	// how many members are ready to claim right now, how many are still
+	// warming, and the operator-configured min_warm floor each is being
+	// reconciled toward (#1488 Phase 4: "pool exhaustion is visible").
+	// Read-only operator/observability visibility, not a pre-flight check a
+	// SpawnSandbox caller needs to poll first — RESOURCE_EXHAUSTED on an
+	// actual claim attempt remains the source of truth for whether a
+	// specific call would succeed right now. Returns an empty templates
+	// list when no pool is configured (the current production default —
+	// see SandboxServer's own type doc).
+	GetPoolStatus(context.Context, *GetPoolStatusRequest) (*GetPoolStatusResponse, error)
 	mustEmbedUnimplementedSandboxServiceServer()
 }
 
@@ -184,6 +217,9 @@ func (UnimplementedSandboxServiceServer) ReadFileInSandbox(context.Context, *Rea
 }
 func (UnimplementedSandboxServiceServer) DeleteSandbox(context.Context, *DeleteSandboxRequest) (*DeleteSandboxResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteSandbox not implemented")
+}
+func (UnimplementedSandboxServiceServer) GetPoolStatus(context.Context, *GetPoolStatusRequest) (*GetPoolStatusResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetPoolStatus not implemented")
 }
 func (UnimplementedSandboxServiceServer) mustEmbedUnimplementedSandboxServiceServer() {}
 func (UnimplementedSandboxServiceServer) testEmbeddedByValue()                        {}
@@ -296,6 +332,24 @@ func _SandboxService_DeleteSandbox_Handler(srv interface{}, ctx context.Context,
 	return interceptor(ctx, in, info, handler)
 }
 
+func _SandboxService_GetPoolStatus_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetPoolStatusRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SandboxServiceServer).GetPoolStatus(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SandboxService_GetPoolStatus_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SandboxServiceServer).GetPoolStatus(ctx, req.(*GetPoolStatusRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // SandboxService_ServiceDesc is the grpc.ServiceDesc for SandboxService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -322,6 +376,10 @@ var SandboxService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "DeleteSandbox",
 			Handler:    _SandboxService_DeleteSandbox_Handler,
+		},
+		{
+			MethodName: "GetPoolStatus",
+			Handler:    _SandboxService_GetPoolStatus_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/proto/containarium/v1/sandbox.proto
+++ b/proto/containarium/v1/sandbox.proto
@@ -90,6 +90,27 @@ service SandboxService {
       tags: "Sandboxes";
     };
   }
+
+  // GetPoolStatus reports the warm pool's current state per template —
+  // how many members are ready to claim right now, how many are still
+  // warming, and the operator-configured min_warm floor each is being
+  // reconciled toward (#1488 Phase 4: "pool exhaustion is visible").
+  // Read-only operator/observability visibility, not a pre-flight check a
+  // SpawnSandbox caller needs to poll first — RESOURCE_EXHAUSTED on an
+  // actual claim attempt remains the source of truth for whether a
+  // specific call would succeed right now. Returns an empty templates
+  // list when no pool is configured (the current production default —
+  // see SandboxServer's own type doc).
+  rpc GetPoolStatus(GetPoolStatusRequest) returns (GetPoolStatusResponse) {
+    option (google.api.http) = {
+      get: "/v1/sandboxes:poolStatus"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Get warm pool status";
+      description: "Reports per-template ready/warming counts against the configured min_warm floor. Empty templates list when no pool is configured.";
+      tags: "Sandboxes";
+    };
+  }
 }
 
 // SandboxState is the lifecycle state of a sandbox. Deliberately smaller
@@ -197,6 +218,29 @@ message DeleteSandboxRequest {
 
 message DeleteSandboxResponse {
   string message = 1;
+}
+
+message GetPoolStatusRequest {}
+
+message GetPoolStatusResponse {
+  // One entry per template the pool is configured to warm (Config.MinWarm
+  // in internal/sandbox/pool). Empty when no pool is configured at all —
+  // distinct from a configured-but-untargeted pool, which still reports
+  // its template(s) with ready = warming = 0.
+  repeated PoolTemplateStatus templates = 1;
+}
+
+// PoolTemplateStatus is one template's warm-pool state.
+message PoolTemplateStatus {
+  SandboxTemplate template = 1;
+  // Members claimable right now.
+  int32 ready = 2;
+  // Members currently being created/started/network-provisioned, not yet
+  // claimable.
+  int32 warming = 3;
+  // The operator-configured floor ready + warming is being reconciled
+  // toward.
+  int32 min_warm = 4;
 }
 
 // SpawnService is agent-box's resident, low-latency counterpart to


### PR DESCRIPTION
## Summary

Continues #1488 Phase 4 ("Admission control: typed `RESOURCE_EXHAUSTED`, per-tenant rate limit, TTL sweeper, `GetPoolStatus`") after #1545 (`RESOURCE_EXHAUSTED`) and #1547 (TTL sweeper). This lands `GetPoolStatus`.

- `sandbox.proto`: new `GetPoolStatus` RPC + `GetPoolStatusRequest`/`GetPoolStatusResponse`/`PoolTemplateStatus` messages, `google.api.http` mapped to `GET /v1/sandboxes:poolStatus`. Regenerated via `make proto` (`pkg/pb/`, `.pb.gw.go`, swagger).
- `pool.Pool.Status()`: new method reporting `{Template, Ready, Warming, MinWarm}` per configured template, sorted for a deterministic result. Reports a configured template with zero counts (not omitted) even before any `Reconcile` has run, so "why is my pool empty" is diagnosable from the operator-configured floor, not just live activity.
- `SandboxServer.GetPoolStatus`: gated on `sandboxes:read` (no per-sandbox ownership check — pool state isn't tenant data). Returns an empty `templates` list, not an error, when `s.pool == nil` (still the production default per `dual_server.go`).
- Typed gRPC client method + `containarium sandbox pool-status` CLI verb (table output, "no warm pool configured" when empty).

## Test plan

- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./internal/server/... ./internal/sandbox/... ./internal/client/... ./internal/cmd/... -race`
- [x] `golangci-lint run` — 0 issues
- [x] `gosec` — 0 new findings (1 pre-existing, unrelated `G304` on a local-file-read CLI flag, present on `main` too)
- [x] Mutation-tested by hand: `pool.Status()`'s `Warming` field, `SandboxServer.GetPoolStatus`'s pool-status passthrough, and its scope gate — each reliably fails its corresponding test before the fix is restored.
- [x] Fixed a real pre-existing data race in the `internal/server` test fake (`fakeSandboxBackend.instances` was unguarded — `pool.Reconcile` warms multiple members concurrently, and no prior test in this package used `min_warm > 1` to trigger it). Added a mutex, matching the pattern `internal/sandbox/pool`'s own test fake already uses.

No live Incus host in this environment — same constraint as the rest of #1488.
