### PR TITLE
feat(sandbox): per-tenant spawn rate limit (#1488 Phase 4)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
+	golang.org/x/time v0.15.0
 	google.golang.org/api v0.293.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20260803160001-6ac0973c030d
 	google.golang.org/grpc v1.83.1
@@ -142,7 +143,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/text v0.41.0 // indirect
-	golang.org/x/time v0.15.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.5.0 // indirect
 	google.golang.org/genproto v0.0.0-20260519071638-aa98bba5eb94 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260807164820-c8921c73eeea // indirect

--- a/internal/sandbox/ratelimit/ratelimit.go
+++ b/internal/sandbox/ratelimit/ratelimit.go
@@ -1,0 +1,116 @@
+// Package ratelimit implements the per-tenant spawn rate limiter for
+// SandboxServer.SpawnSandbox (#1488 Phase 4: "per-tenant rate limit").
+//
+// A single subject spawning far faster than any legitimate agent inner
+// loop would — a bug, a retry storm, or an abusive script — should be
+// throttled without touching any other tenant's spawn budget or the
+// shared warm pool. This package is pure in-memory Go, no live host or
+// external store needed, same scoping as this codebase's other
+// internal/sandbox siblings (ipam, pool, dialer).
+package ratelimit
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+
+	"golang.org/x/time/rate"
+)
+
+// Limiter is a per-tenant token-bucket rate limiter. The zero value is
+// NOT valid — always construct via New, Disabled, Poisoned, or
+// NewFromEnv, all of which return a ready-to-use *Limiter so a caller
+// never needs its own nil check before calling Allow.
+type Limiter struct {
+	ratePerSecond float64
+	burst         int
+
+	// configErr poisons the limiter: once set, every Allow call returns
+	// false regardless of ratePerSecond/burst — a malformed operator
+	// config must refuse spawns until fixed, not silently become
+	// "unlimited". Same fail-closed posture this codebase already uses
+	// for clusterCaps.configErr (internal/server/cluster_caps.go).
+	configErr error
+
+	mu      sync.Mutex
+	buckets map[string]*rate.Limiter
+}
+
+// New builds an enabled Limiter. ratePerSecond and burst must both be
+// positive — use Disabled for "no limiting", not New(0, 0).
+func New(ratePerSecond float64, burst int) *Limiter {
+	return &Limiter{ratePerSecond: ratePerSecond, burst: burst, buckets: make(map[string]*rate.Limiter)}
+}
+
+// Disabled returns a Limiter whose Allow always returns true — the
+// explicit "no rate limiting configured" value.
+func Disabled() *Limiter {
+	return &Limiter{}
+}
+
+// Poisoned returns a Limiter whose Allow always returns false, with err
+// available via Err — the fail-closed value for a malformed operator
+// config.
+func Poisoned(err error) *Limiter {
+	return &Limiter{configErr: err}
+}
+
+// NewFromEnv parses ratePerMinute/burst (both optional; both empty =
+// Disabled) into a ready-to-use Limiter. A malformed non-empty value
+// returns Poisoned plus the error rather than silently disabling
+// enforcement — the operator asked for a limit; a typo must not remove
+// it. burst defaults to the per-minute rate itself (rounded down, floor
+// 1) when left empty, giving a caller a reasonable one-flag config
+// (CONTAINARIUM_SANDBOX_SPAWN_RATE_PER_MINUTE alone).
+func NewFromEnv(ratePerMinute, burst string) *Limiter {
+	if ratePerMinute == "" && burst == "" {
+		return Disabled()
+	}
+	rpm, err := strconv.ParseFloat(ratePerMinute, 64)
+	if err != nil || rpm <= 0 {
+		return Poisoned(fmt.Errorf("invalid sandbox spawn rate limit %q: must be a positive number of spawns per minute", ratePerMinute))
+	}
+	b := int(rpm)
+	if b < 1 {
+		b = 1
+	}
+	if burst != "" {
+		bi, err := strconv.Atoi(burst)
+		if err != nil || bi < 1 {
+			return Poisoned(fmt.Errorf("invalid sandbox spawn burst %q: must be a positive integer", burst))
+		}
+		b = bi
+	}
+	return New(rpm/60.0, b)
+}
+
+// Allow reports whether subject may spawn right now, consuming one
+// token from its bucket if so. Always true when Disabled, always false
+// when Poisoned. Buckets are created lazily per subject and never
+// evicted — bounded in practice by the operator's tenant population
+// (subject comes from an authenticated token, not unauthenticated
+// caller-controlled input), the same non-eviction tradeoff pool.Pool
+// accepts for its own per-template maps.
+func (l *Limiter) Allow(subject string) bool {
+	if l.configErr != nil {
+		return false
+	}
+	if l.ratePerSecond <= 0 {
+		return true
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	b, ok := l.buckets[subject]
+	if !ok {
+		b = rate.NewLimiter(rate.Limit(l.ratePerSecond), l.burst)
+		l.buckets[subject] = b
+	}
+	return b.Allow()
+}
+
+// Err returns the configuration error for a Poisoned limiter, nil
+// otherwise.
+func (l *Limiter) Err() error {
+	return l.configErr
+}

--- a/internal/sandbox/ratelimit/ratelimit_test.go
+++ b/internal/sandbox/ratelimit/ratelimit_test.go
@@ -1,0 +1,101 @@
+package ratelimit
+
+import (
+	"errors"
+	"testing"
+)
+
+var errBoom = errors.New("boom")
+
+func TestDisabled_AlwaysAllows(t *testing.T) {
+	l := Disabled()
+	for i := 0; i < 100; i++ {
+		if !l.Allow("alice") {
+			t.Fatalf("Disabled limiter refused call %d, want always allowed", i)
+		}
+	}
+}
+
+func TestPoisoned_AlwaysDenies(t *testing.T) {
+	l := Poisoned(errBoom)
+	if l.Allow("alice") {
+		t.Fatal("Poisoned limiter allowed a call, want always denied")
+	}
+	if l.Err() == nil {
+		t.Fatal("Err() = nil on a Poisoned limiter, want the configuration error")
+	}
+}
+
+func TestNew_AllowsUpToBurstThenDenies(t *testing.T) {
+	// A slow rate (well under 1/sec) with burst=3 means the 4th call in
+	// the same instant must be denied — the token bucket has nothing
+	// left and refill is negligible over a test's execution time.
+	l := New(0.001, 3)
+
+	for i := 0; i < 3; i++ {
+		if !l.Allow("alice") {
+			t.Fatalf("call %d within burst was denied, want allowed", i)
+		}
+	}
+	if l.Allow("alice") {
+		t.Error("4th call beyond burst was allowed, want denied")
+	}
+}
+
+func TestNew_PerSubjectBucketsAreIndependent(t *testing.T) {
+	l := New(0.001, 1)
+
+	if !l.Allow("alice") {
+		t.Fatal("alice's first call was denied, want allowed")
+	}
+	if l.Allow("alice") {
+		t.Error("alice's second call (over her own burst of 1) was allowed, want denied")
+	}
+	// bob must not be affected by alice's exhausted bucket — a shared
+	// bucket keyed on nothing (or the wrong key) would deny this too.
+	if !l.Allow("bob") {
+		t.Error("bob's first call was denied by alice's rate limit — buckets are not independent per subject")
+	}
+}
+
+func TestNewFromEnv_BothEmptyIsDisabled(t *testing.T) {
+	l := NewFromEnv("", "")
+	if l.Err() != nil {
+		t.Fatalf("Err() = %v, want nil (both empty = disabled, not an error)", l.Err())
+	}
+	if !l.Allow("alice") {
+		t.Error("NewFromEnv(\"\", \"\") denied a call, want disabled (always allow)")
+	}
+}
+
+func TestNewFromEnv_InvalidRateIsPoisoned(t *testing.T) {
+	for _, rate := range []string{"not-a-number", "0", "-5"} {
+		l := NewFromEnv(rate, "")
+		if l.Err() == nil {
+			t.Errorf("NewFromEnv(%q, \"\").Err() = nil, want an error (invalid/non-positive rate)", rate)
+		}
+		if l.Allow("alice") {
+			t.Errorf("NewFromEnv(%q, \"\") allowed a call, want denied (poisoned)", rate)
+		}
+	}
+}
+
+func TestNewFromEnv_InvalidBurstIsPoisoned(t *testing.T) {
+	l := NewFromEnv("60", "not-a-number")
+	if l.Err() == nil {
+		t.Fatal("NewFromEnv(\"60\", \"not-a-number\").Err() = nil, want an error (invalid burst)")
+	}
+}
+
+func TestNewFromEnv_ValidRateEnablesEnforcement(t *testing.T) {
+	// 60/minute = 1/second; burst defaults to the rate (60) since burst
+	// is left empty. Well within burst, so this must be allowed — this
+	// is the "operator actually configured a working limit" happy path.
+	l := NewFromEnv("60", "")
+	if l.Err() != nil {
+		t.Fatalf("Err() = %v, want nil", l.Err())
+	}
+	if !l.Allow("alice") {
+		t.Error("a call within a freshly-configured limiter's burst was denied")
+	}
+}

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -33,6 +33,7 @@ import (
 	"github.com/footprintai/containarium/internal/modelgateway"
 	"github.com/footprintai/containarium/internal/mtls"
 	"github.com/footprintai/containarium/internal/pentest"
+	"github.com/footprintai/containarium/internal/sandbox/ratelimit"
 	secretsstore "github.com/footprintai/containarium/internal/secrets"
 	"github.com/footprintai/containarium/internal/security"
 	"github.com/footprintai/containarium/internal/traffic"
@@ -560,6 +561,24 @@ func NewDualServer(config *DualServerConfig) (*DualServer, error) {
 	var sandboxServer *SandboxServer
 	if sandboxIncusClient, err := incus.New(); err == nil {
 		sandboxServer = NewSandboxServer(sandboxIncusClient, nil)
+
+		// Per-tenant spawn rate limit (#1488 Phase 4). Off by default
+		// (ratelimit.Disabled(), same as NewSandboxServer's own zero
+		// value) — CONTAINARIUM_SANDBOX_SPAWN_RATE_PER_MINUTE opts in.
+		// A malformed value fails closed (every spawn refused, not
+		// silently unlimited) rather than aborting daemon startup —
+		// same posture as clusterCaps.configErr below, applied to a
+		// feature that's off by default instead of one with a
+		// meaningful "unset" ceiling.
+		spawnLimiter := ratelimit.NewFromEnv(
+			os.Getenv("CONTAINARIUM_SANDBOX_SPAWN_RATE_PER_MINUTE"),
+			os.Getenv("CONTAINARIUM_SANDBOX_SPAWN_BURST"),
+		)
+		if limiterErr := spawnLimiter.Err(); limiterErr != nil {
+			log.Printf("ERROR: %v — sandbox spawns will be refused until the rate limit config is fixed", limiterErr)
+		}
+		sandboxServer.SetRateLimiter(spawnLimiter)
+
 		pb.RegisterSandboxServiceServer(grpcServer, sandboxServer)
 		log.Printf("Sandbox service enabled")
 	} else {

--- a/internal/server/sandbox_server.go
+++ b/internal/server/sandbox_server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/footprintai/containarium/internal/auth"
 	"github.com/footprintai/containarium/internal/safecast"
 	"github.com/footprintai/containarium/internal/sandbox/pool"
+	"github.com/footprintai/containarium/internal/sandbox/ratelimit"
 	"github.com/footprintai/containarium/pkg/core/incus"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 	"google.golang.org/grpc/codes"
@@ -80,6 +81,12 @@ type SandboxServer struct {
 	incus incus.Backend
 	pool  *pool.Pool
 
+	// rateLimiter gates SpawnSandbox per-tenant (#1488 Phase 4). Always
+	// non-nil after NewSandboxServer (ratelimit.Disabled(): every spawn
+	// allowed) — set via SetRateLimiter to actually enforce a limit, so
+	// SpawnSandbox never needs its own nil check here.
+	rateLimiter *ratelimit.Limiter
+
 	// claimed tracks, per pool-claimed sandbox_id, the pool.Member Claim
 	// returned — DeleteSandbox needs it to route to pool.Release (which
 	// also frees the member's IPAM address) instead of destroy() (which
@@ -94,9 +101,28 @@ type SandboxServer struct {
 }
 
 // NewSandboxServer constructs a SandboxServer over the given Incus backend.
-// p is optional; nil disables pool-backed spawns (see the type doc).
+// p is optional; nil disables pool-backed spawns (see the type doc). The
+// spawn rate limiter starts disabled (ratelimit.Disabled()) — call
+// SetRateLimiter to enable one.
 func NewSandboxServer(backend incus.Backend, p *pool.Pool) *SandboxServer {
-	return &SandboxServer{incus: backend, pool: p, claimed: make(map[string]*pool.Member)}
+	return &SandboxServer{
+		incus:       backend,
+		pool:        p,
+		rateLimiter: ratelimit.Disabled(),
+		claimed:     make(map[string]*pool.Member),
+	}
+}
+
+// SetRateLimiter installs a per-tenant spawn rate limiter (#1488 Phase
+// 4). Optional — call after NewSandboxServer; passing nil restores
+// ratelimit.Disabled() rather than leaving a real nil pointer around,
+// mirroring ClusterServer.SetCaps's own optional-config-after-
+// construction shape.
+func (s *SandboxServer) SetRateLimiter(l *ratelimit.Limiter) {
+	if l == nil {
+		l = ratelimit.Disabled()
+	}
+	s.rateLimiter = l
 }
 
 // StartReconciler runs pool.Reconcile on interval until ctx is done. No-op
@@ -171,6 +197,13 @@ func (s *SandboxServer) destroy(name string) error {
 // exhausted pool with allow_cold_start unset (false) returns
 // RESOURCE_EXHAUSTED instead of silently paying the cold path's cost — a
 // latency SLO whose slow path is invisible isn't an SLO.
+//
+// Per-tenant rate limiting (#1488 Phase 4) is checked immediately after
+// authentication, before template resolution or any pool/cold work — a
+// throttled caller shouldn't pay (or cause) any of that. It gates every
+// spawn regardless of path: a caller hammering SpawnSandbox is exactly as
+// disruptive to shared pool capacity via a fast POOL claim loop as via
+// slow COLD creates, so this isn't scoped to one path or the other.
 func (s *SandboxServer) SpawnSandbox(ctx context.Context, req *pb.SpawnSandboxRequest) (*pb.SpawnSandboxResponse, error) {
 	if err := auth.RequireScope(ctx, auth.ScopeSandboxesWrite); err != nil {
 		return nil, err
@@ -178,6 +211,13 @@ func (s *SandboxServer) SpawnSandbox(ctx context.Context, req *pb.SpawnSandboxRe
 	subject, _, ok := auth.SubjectFromGRPCContext(ctx)
 	if !ok {
 		return nil, status.Error(codes.Unauthenticated, "no authenticated subject")
+	}
+
+	if !s.rateLimiter.Allow(subject) {
+		if err := s.rateLimiter.Err(); err != nil {
+			return nil, status.Errorf(codes.Internal, "sandbox spawn rate limiting misconfigured: %v", err)
+		}
+		return nil, status.Errorf(codes.ResourceExhausted, "spawn rate limit exceeded for %s; retry after a short backoff", subject)
 	}
 
 	template, image, err := resolveTemplate(req.Template)

--- a/internal/server/sandbox_server_ratelimit_test.go
+++ b/internal/server/sandbox_server_ratelimit_test.go
@@ -1,0 +1,100 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/footprintai/containarium/internal/sandbox/ratelimit"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestSpawnSandbox_DefaultRateLimiterAllowsUnbounded pins that a freshly
+// constructed SandboxServer — no SetRateLimiter call at all — never
+// throttles: NewSandboxServer's default must be ratelimit.Disabled(),
+// not a nil pointer or an implicitly-zero (and therefore enforced)
+// limiter.
+func TestSpawnSandbox_DefaultRateLimiterAllowsUnbounded(t *testing.T) {
+	backend := newFakeSandboxBackend()
+	s := NewSandboxServer(backend, nil)
+
+	for i := 0; i < 20; i++ {
+		if _, err := s.SpawnSandbox(ctxAs("alice", false), &pb.SpawnSandboxRequest{}); err != nil {
+			t.Fatalf("spawn %d with no rate limiter configured: %v", i, err)
+		}
+	}
+}
+
+// TestSpawnSandbox_RateLimitedTenantGetsResourceExhausted pins the core
+// behavior: once a tenant exhausts its burst, the NEXT spawn is refused
+// with ResourceExhausted, not silently served — an admission-control
+// check that can't ever fail proves nothing.
+func TestSpawnSandbox_RateLimitedTenantGetsResourceExhausted(t *testing.T) {
+	backend := newFakeSandboxBackend()
+	s := NewSandboxServer(backend, nil)
+	s.SetRateLimiter(ratelimit.New(0.001, 2))
+
+	for i := 0; i < 2; i++ {
+		if _, err := s.SpawnSandbox(ctxAs("alice", false), &pb.SpawnSandboxRequest{}); err != nil {
+			t.Fatalf("spawn %d within burst: %v", i, err)
+		}
+	}
+
+	_, err := s.SpawnSandbox(ctxAs("alice", false), &pb.SpawnSandboxRequest{})
+	if got := status.Code(err); got != codes.ResourceExhausted {
+		t.Fatalf("code = %v, want ResourceExhausted (burst exhausted)", got)
+	}
+}
+
+// TestSpawnSandbox_RateLimitIsPerTenant is
+// TestSpawnSandbox_RateLimitedTenantGetsResourceExhausted's sibling: a
+// DIFFERENT tenant must not be affected by alice's exhausted bucket — a
+// shared-not-per-subject limiter (or one keyed on the wrong field) would
+// fail this while still passing the single-tenant test above.
+func TestSpawnSandbox_RateLimitIsPerTenant(t *testing.T) {
+	backend := newFakeSandboxBackend()
+	s := NewSandboxServer(backend, nil)
+	s.SetRateLimiter(ratelimit.New(0.001, 1))
+
+	if _, err := s.SpawnSandbox(ctxAs("alice", false), &pb.SpawnSandboxRequest{}); err != nil {
+		t.Fatalf("alice's first spawn: %v", err)
+	}
+	if _, err := s.SpawnSandbox(ctxAs("alice", false), &pb.SpawnSandboxRequest{}); status.Code(err) != codes.ResourceExhausted {
+		t.Fatalf("alice's second spawn (over her burst of 1): code = %v, want ResourceExhausted", status.Code(err))
+	}
+	if _, err := s.SpawnSandbox(ctxAs("bob", false), &pb.SpawnSandboxRequest{}); err != nil {
+		t.Errorf("bob's first spawn was refused by alice's rate limit: %v", err)
+	}
+}
+
+// TestSpawnSandbox_PoisonedRateLimiterRefusesEveryone pins the
+// fail-closed contract for a malformed operator config: every spawn is
+// refused (Internal, distinct from a legitimate rate-limit
+// ResourceExhausted — an operator misconfiguration is not the same
+// class of error as "you're going too fast").
+func TestSpawnSandbox_PoisonedRateLimiterRefusesEveryone(t *testing.T) {
+	backend := newFakeSandboxBackend()
+	s := NewSandboxServer(backend, nil)
+	s.SetRateLimiter(ratelimit.NewFromEnv("not-a-number", ""))
+
+	_, err := s.SpawnSandbox(ctxAs("alice", false), &pb.SpawnSandboxRequest{})
+	if got := status.Code(err); got != codes.Internal {
+		t.Fatalf("code = %v, want Internal (poisoned/misconfigured rate limiter)", got)
+	}
+}
+
+// TestSpawnSandbox_SetRateLimiterNilRestoresDisabled pins that passing
+// nil to SetRateLimiter doesn't leave a real nil pointer that would
+// panic on the next spawn — it must fall back to ratelimit.Disabled().
+func TestSpawnSandbox_SetRateLimiterNilRestoresDisabled(t *testing.T) {
+	backend := newFakeSandboxBackend()
+	s := NewSandboxServer(backend, nil)
+	s.SetRateLimiter(ratelimit.New(0.001, 1))
+	s.SetRateLimiter(nil)
+
+	for i := 0; i < 5; i++ {
+		if _, err := s.SpawnSandbox(ctxAs("alice", false), &pb.SpawnSandboxRequest{}); err != nil {
+			t.Fatalf("spawn %d after SetRateLimiter(nil): %v", i, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Lands the last piece of #1488 Phase 4 ("Admission control: typed `RESOURCE_EXHAUSTED`, per-tenant rate limit, TTL sweeper, `GetPoolStatus`") — per-tenant rate limiting on `SpawnSandbox`, after `RESOURCE_EXHAUSTED` (#1545), the TTL sweeper (#1547), and `GetPoolStatus` (#1548). Once this merges, Phase 4 is fully done.

- New `internal/sandbox/ratelimit` package: a per-subject token-bucket limiter over `golang.org/x/time/rate` (promoted from indirect to direct in `go.mod`; nothing else in the repo used it yet). `Disabled()`, `Poisoned(err)`, `New(rate, burst)`, and `NewFromEnv(ratePerMinute, burst)` all return a ready-to-use, non-nil `*Limiter` — no caller-side nil checks needed.
- `SandboxServer` gets an always-non-nil `rateLimiter` field (`ratelimit.Disabled()` by default) and a `SetRateLimiter` setter, mirroring `ClusterServer.SetCaps`'s optional-config-after-construction shape rather than growing `NewSandboxServer`'s parameter list again.
- `SpawnSandbox` checks the limiter immediately after authenticating the subject, before any template resolution or pool/cold work — applies to both POOL and COLD paths, since a caller hammering the RPC pressures shared pool capacity either way.
- Off by default. Opt in via `CONTAINARIUM_SANDBOX_SPAWN_RATE_PER_MINUTE` (+ optional `CONTAINARIUM_SANDBOX_SPAWN_BURST`, defaults to the per-minute rate). A malformed value fails closed — every spawn refused with `Internal`, not silently unlimited — matching this codebase's existing `clusterCaps.configErr` posture. A legitimate rate-limit rejection is `ResourceExhausted`, deliberately distinct from the misconfiguration case so an operator/caller can tell them apart.

## Test plan

- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./internal/server/... ./internal/sandbox/... -race`
- [x] `golangci-lint run` — 0 issues
- [x] `gosec` — 0 new findings (44 pre-existing, unrelated findings match `main` exactly, before and after)
- [x] Mutation-tested by hand: the `SpawnSandbox` enforcement check itself, and the token-bucket's per-subject `Allow` logic in `ratelimit` — each reliably fails its corresponding test(s) before the fix is restored.
- [x] `go test ./...` — only failure is the pre-existing `test/integration` storage tests that need a live server + certs (unrelated, not part of CI's scoped invocations).

No live Incus host in this environment — same constraint as the rest of #1488.
