### PR TITLE
docs(benchmark): confirm #1541's ContainerCache fix live — 929, load fully flat

### DIFF
--- a/benchmark/agent-sandbox-density/RESULTS.md
+++ b/benchmark/agent-sandbox-density/RESULTS.md
@@ -323,6 +323,42 @@ the full comment history: what got fixed, what's still open, and why the
 daemon-CPU framing in the issue's original title turned out to be only
 part of the picture).
 
+### 2026-08-25 — #1541's second fix verified: `ContainerCache` incremental refresh
+
+Same host and profile as the two runs above. #1546 made `internal/traffic.
+ContainerCache`'s background refresh incremental (O(Δ) instead of O(N) per
+~30s cycle — only genuinely new/changed container names are re-fetched from
+Incus, not the whole fleet every tick) — this run confirms its effect live,
+on a fresh VM, against the exact same checkpoint counts as the prior run.
+
+| container count | get-fix-only run (previous) | both fixes (this run) |
+|---|---|---|
+| ~365-400 | load ~19, `incusd` 914% CPU | load 4-8, `incusd` 48% CPU |
+| ~430 | load ~26 | load ~11 |
+| ~548-570 | load 32-40 | load 15-21 |
+| ~760-762 | load 125-182 (exceeded the *original* unfixed run's peak) | load 38-40 — the wall that reappeared here before is gone |
+
+**Result: 929 sandboxes reached RUNNING** (933 attempted) — essentially
+identical to the previous run's 931, confirming the memory ceiling is a
+real, reproducible physical limit independent of the CPU fix, not
+something either fix should (or does) move. The stop was cleaner this
+time: journalctl showed Postgres and internal daemon operations timing
+out (`context deadline exceeded`) under severe memory pressure, but
+`dmesg` recorded no kernel OOM-kill of `incusd` this run (vs. the
+previous run, where it did) — plausibly because `incusd` itself now runs
+with a smaller memory footprint under load, so it wasn't the OOM
+killer's top-scored target this time. Same underlying cause (the host
+ran out of real RAM at ~930 tenants), different specific casualty.
+
+**Both #1541 fixes compound as designed**: the `get`-based polling
+fix (#1543) cut load roughly 3x at mid-scale; the `ContainerCache`
+incremental-refresh fix (#1546) removed the remaining climb that
+previously reappeared past ~600 containers, holding load flat (single
+digits to ~40) all the way to the same real memory ceiling both runs
+independently found. #1541 is now fully closed out — every identified
+contributor has a landed, live-verified fix; the memory ceiling itself is
+a genuine hardware limit, not a bug.
+
 ## Template
 
 ```


### PR DESCRIPTION
## Summary
Re-ran the density benchmark with both #1541 fixes live (#1543 get-based polling + #1546 ContainerCache incremental refresh) on a fresh VM, at the same checkpoint counts as the earlier get-only-fix run, for a direct comparison.

## Result
- **929 sandboxes reached RUNNING** (933 attempted) — essentially identical to the previous run's 931
- The CPU climb that previously reappeared past ~600 containers is gone: at ~760 (where the prior run hit load 125-182), this run stayed at 38-40
- Confirms the memory ceiling (~930 on this 46GiB host) is a real, reproducible physical limit independent of the CPU fixes — exactly what should happen once the CPU-side bottleneck is actually fixed

#1541 is fully closed out: every identified contributor (benchmark polling, ContainerCache background refresh) has a landed, live-verified fix; the remaining ceiling is genuine hardware, not a bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added results from a second verification run for incremental container refreshes.
  * Confirmed reduced daemon CPU and load across container counts.
  * Documented a reproducible capacity ceiling of 929 running sandboxes under available host memory.
  * Verified that severe memory pressure caused timeout errors without a kernel-level daemon termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->