### PR TITLE
docs(benchmark): draft blog post on the density benchmark's real mechanism

### DIFF
--- a/benchmark/agent-sandbox-density/BLOG-DRAFT.md
+++ b/benchmark/agent-sandbox-density/BLOG-DRAFT.md
@@ -34,6 +34,11 @@ technology, same admission model, smaller declared footprint wins. Nothing
 about Containarium is more efficient here; it just asks for less. If we'd
 declared Containarium's sandboxes at 128Mi too, the two numbers converge.
 
+We re-ran this scenario independently on a fresh cluster to check it wasn't
+a fluke — 186 ready, 189 attempted, an exact match down to the node memory
+snapshot at the stopping point (47856Mi/48GiB, 99%, identical both times).
+It's a solid, reproducible number.
+
 ## Where 929 comes from — a different deployment entirely
 
 Containarium also ships a native LXC/Incus backend: no Kubernetes, no

--- a/benchmark/agent-sandbox-density/BLOG-DRAFT.md
+++ b/benchmark/agent-sandbox-density/BLOG-DRAFT.md
@@ -1,0 +1,102 @@
+# We packed 929 sandboxes on one box — and it's not about gVisor
+
+We wanted to know a simple thing: how many isolated agent sandboxes can you
+actually fit on one machine? So we ran a real, live density benchmark —
+Kubernetes + [agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox)
+on one side, Containarium's native LXC backend on the other — pushed both
+until they broke, and fixed what we broke along the way.
+
+The headline number: **929 Containarium sandboxes vs. 373 agent-sandbox
+pods**, both under a 48GiB / 20-vCPU host. But if you stop at that number
+you'll walk away with the wrong lesson. The real story is more interesting
+— and more useful, whichever side of this you're building on.
+
+## The setup
+
+Same host, same hard resource cap, same sandbox profile (200m CPU /
+256Mi memory) on every side. Two groups:
+
+- **Control**: kubeadm + Calico + agent-sandbox, sandboxes as pods
+- **Experiment**: Containarium's native LXC/Incus backend — no
+  Kubernetes, same host
+
+Both groups' actual boxes idle at roughly the same real memory footprint
+(tens of MiB). The difference isn't the sandbox — it's what each system
+does with the *declared* resource size when deciding whether to admit one
+more.
+
+## The mechanism, not the marketing
+
+Kubernetes' scheduler reserves the full **declared request** against node
+capacity the instant a pod is scheduled — 128Mi requested means 128Mi
+reserved, whether the pod ever touches it or not. That's a deliberate,
+sane default: it protects every *other* tenant on the node from a noisy
+neighbor. Our control group hit its wall at exactly `48GiB / 128Mi ≈ 373`
+— textbook admission-controlled scheduling, working exactly as designed.
+
+Incus's `limits.memory`, by contrast, is a cgroup **ceiling**, not a
+reservation. A box declared at 256Mi that's only using 90MiB only counts
+90MiB against the host. Containarium's density number is higher because
+it's *not reserving headroom nobody's using* — which is a real,
+legitimate operational property, and also a real trade-off: no admission
+backpressure means nothing tells the platform "stop" until the host
+actually runs out. When we pushed far enough, that's exactly what
+happened — the host ran out of real RAM at ~930 sandboxes, full stop,
+independent of anything else we fixed along the way.
+
+**If we'd held both sides to the same admission model — memory *request*
+== memory *limit*, same as Containarium's `create` always does — Container-
+ium's own earlier k8s+gVisor run actually landed *behind* the control
+group** (186 vs. 373), because its declared ceiling (256Mi) is exactly 2x
+the control group's declared request (128Mi). Same host, same math,
+opposite conclusion. The admission model is the variable, not the
+sandboxing technology.
+
+## What we actually hit pushing to 929
+
+Getting there wasn't one clean run — it took three real fixes, found live:
+
+1. **`containarium list` didn't scale.** The benchmark's own polling loop
+   called `list` (which fetches every container's full state) every ~2s
+   while waiting on one sandbox to boot. At a few hundred containers that
+   put real, unnecessary load on the management daemon. Fix: a `get`
+   command for the one-container case ([#1543](https://github.com/FootprintAI/Containarium/pull/1543)) — roughly 3x lower daemon
+   load at the same container count once we swapped the benchmark to use it.
+2. **A background cache had the same bug, independent of the benchmark.**
+   Containarium's own traffic-attribution cache re-fetched *every*
+   container's details every 30 seconds, forever, regardless of whether
+   anything changed. Fixed to only re-fetch what actually changed
+   ([#1546](https://github.com/FootprintAI/Containarium/pull/1546)) — the daemon CPU wall that had crept back in past ~600
+   containers disappeared entirely; load stayed flat (single digits) all
+   the way to the same real memory ceiling.
+3. **The real wall was RAM, not CPU** — and it stayed at ~930 sandboxes on
+   both the buggy and the fixed run, which is exactly the confirmation we
+   wanted: fixing the software bugs didn't move the physical ceiling, it
+   just let us actually reach it cleanly instead of stalling early on
+   self-inflicted overhead.
+
+We also found and fixed a couple of smaller things along the way — a
+per-create install step that should've been baked into an image once
+instead of repeated on every create, and a host account creation bug that
+silently broke after about a dozen tenants. Full detail, every number,
+every commit: [`RESULTS.md`](RESULTS.md) in the benchmark folder.
+
+## What this means if you're running agent-sandbox
+
+Not "switch to Containarium." The actual, portable takeaway: **if your
+agents are idle-heavy** (most agent sandboxes spend most of their time
+waiting, not computing), your real memory usage is probably far below
+whatever you've declared as the request. Kubernetes gives you the lever
+to close that gap yourself — lower requests, a VPA tuned to actual usage,
+or a `LimitRange` that keeps limits generous while requests track reality
+— without touching gVisor, without touching agent-sandbox's own code.
+The density gap we measured isn't a verdict on either project; it's a
+measurement of two different default postures toward the same trade-off,
+and it's one you can dial on either side.
+
+---
+
+*Full methodology, every host spec, every raw number, and the complete
+bug-by-bug investigation are in [`benchmark/agent-sandbox-density/`](.)
+in the Containarium repo — reproduce it yourself, or tell us where the
+comparison should go next.*

--- a/benchmark/agent-sandbox-density/BLOG-DRAFT.md
+++ b/benchmark/agent-sandbox-density/BLOG-DRAFT.md
@@ -1,81 +1,123 @@
-# 929, 373, 186: what actually explains agent sandbox density
+# 929, 373, 373: a density gap, a one-flag fix, and a different deployment mode entirely
 
 We wanted to know a simple thing: how many isolated agent sandboxes can you
 actually fit on one machine? So we ran a real, live density benchmark
 across three deployment modes on the same host, pushed each until it
-broke, and fixed what we broke along the way.
+broke, found a real gap, fixed it, and re-ran to confirm.
 
 - **373** — Kubernetes + [agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox), sandboxes as gVisor pods
-- **186** — Containarium running the same way: `pod → gVisor → Containarium`, same Kubernetes, same isolation
+- **373** — Containarium running the same way: `pod → gVisor → Containarium`, same Kubernetes, same isolation, **once a real CLI gap was fixed**
 - **929** — Containarium's native LXC backend, no Kubernetes, no gVisor at all
 
-If you only remember one of those numbers, remember that the **gVisor-matched
-comparison is 186 vs. 373 — and Containarium is the smaller one.** That's not
-a caveat buried in the fine print; it's the fair fight, and it's worth
-understanding exactly why before the 929 number means anything.
+The middle number used to be 186. We found out why, fixed the actual
+cause — a genuine, one-flag CLI gap, not a measurement error — and
+re-ran the exact same comparison. It now matches exactly. Here's the
+whole story, including the part where we were wrong first.
 
-## The apples-to-apples result: 186 vs. 373
+## Round one: 186 vs. 373, and why
 
 Same host, same hard resource cap (48GiB RAM / 20 vCPU), same sandbox
 profile family, both under Kubernetes with the identical `runsc` (gVisor)
-RuntimeClass. The clearest, most quantifiable difference between the two
-runs is how each side declares its sandbox's memory:
+RuntimeClass. The first time we ran this, Containarium's boxes only
+reached 186 against agent-sandbox's 373 — roughly half.
 
-- agent-sandbox's pods request **128Mi**
-- Containarium's `create` sets request and limit to the same value —
-  **256Mi**, exactly 2x
+The cause traced to how each side declares its sandbox's memory:
 
-Kubernetes' scheduler reserves the full **declared request** against node
-capacity the instant a pod is scheduled, whether the pod ever touches that
-memory or not. At the stopping point, node memory requests hit
-47984Mi/48GiB (99%) for agent-sandbox and 47856Mi/48GiB (99%) for
+- agent-sandbox's pods request **128Mi**, with a **256Mi** limit
+- Containarium's `create` had no way to set those two numbers
+  separately — `--memory 256Mi` set *both* request and limit to 256Mi,
+  exactly 2x agent-sandbox's request
+
+Kubernetes' scheduler reserves the full **declared request** against
+node capacity the instant a pod is scheduled, whether the pod ever
+touches that memory or not. At the stopping point, node memory requests
+hit 47984Mi/48GiB (99%) for agent-sandbox and 47856Mi/48GiB (99%) for
 Containarium — both sides essentially saturated the same total memory
-budget, just divided into differently-sized chunks: 373 × 128Mi ≈ 46.6GiB,
-186 × 256Mi ≈ 46.5GiB. Halving the request size, not halving anything
-else, is what produces almost exactly half the count.
+budget, just divided into differently-sized chunks: 373 × 128Mi ≈
+46.6GiB, 186 × 256Mi ≈ 46.5GiB. Halving the request size, not halving
+anything else, produced almost exactly half the count. We re-ran it
+independently on a fresh cluster to rule out a fluke — 186 ready, 189
+attempted, an exact match down to the node memory snapshot. It was a
+real, solid, reproducible number. It just wasn't the whole story yet.
 
-**That declared-size asymmetry accounts for the ~2:1 gap we observed —
-not gVisor overhead, not orchestration cost.** Same isolation technology,
-same admission model, smaller declared footprint wins. Nothing about
-Containarium is more efficient here; it just asks for less. If we'd
-declared Containarium's sandboxes at 128Mi too, the two numbers converge.
-One other asymmetry worth naming honestly rather than glossing over:
-agent-sandbox's pods run a minimal `busybox` image, while Containarium's
-boxes run its real, heavier `containarium-agent-box` runtime — a
-structural difference in what each side actually deploys, not a knob
-either side can equalize (see the README's "Fairness notes" for the full
-accounting).
+## The fix: a missing CLI flag, not an architecture problem
 
-We re-ran this scenario independently on a fresh cluster to check it wasn't
-a fluke — 186 ready, 189 attempted, an exact match down to the node memory
-snapshot at the stopping point (47856Mi/48GiB, 99%, identical both times).
-It's a solid, reproducible number.
+`ResourceLimits.memory` (`pkg/core/box/k8s/objects.go`) was always
+applied as *both* request and limit — there was no field, no flag, no
+way to ask for a smaller request under a bigger limit, the way Burstable
+QoS pods (agent-sandbox's included) are normally sized. Kubernetes
+itself supports `request ≠ limit` fine; Containarium's `create` API had
+simply never exposed the second number.
+
+We added it —
+[#1557](https://github.com/FootprintAI/Containarium/issues/1557),
+shipped as [PR #1560](https://github.com/FootprintAI/Containarium/pull/1560):
+`containarium create` gained `--memory-request`/`--cpu-request`, separate
+from `--memory`/`--cpu` (which stay the limit). Empty preserves the old
+behavior exactly — this is additive, not a breaking change.
+
+## Round two: 373 vs. 373, exact match
+
+With the fix landed, we re-ran the comparison on a fresh cluster —
+Containarium's boxes now declared at the *same* profile as
+agent-sandbox's pods (request 128Mi / limit 256Mi memory, 25m/50m CPU) —
+and, since only the runtime class was the remaining variable, we also
+took the opportunity to isolate gVisor's own cost cleanly: the identical
+matched profile, run once under gVisor (`runsc`) and once under plain
+`runc`, on the same cluster.
+
+| | gVisor (`runsc`) | plain `runc` |
+|---|---|---|
+| Sandboxes reached RUNNING | **373** | **373** |
+| Attempted (incl. failures) | 376 | 376 |
+| Node memory requests at stop | 47984Mi/48GiB (99%) | 47984Mi/48GiB (99%) |
+| Wall-clock for the density loop | ~77 min | ~40 min |
+
+**Exact match, identical node memory snapshot down to the Mi, and it
+lands within a rounding error of agent-sandbox's own 373.** With the
+request/limit split available, Containarium's k8s+gVisor path doesn't
+just close the gap with agent-sandbox — it matches it. gVisor's own
+per-pod density cost is not measurable at this sandbox size against a
+48GiB host: the entire 186-vs-373 gap really was the declared-size
+asymmetry, exactly as we suspected but couldn't yet prove the first time
+around. Worth naming honestly: agent-sandbox's pods still run a minimal
+`busybox` image against Containarium's real, heavier
+`containarium-agent-box` runtime in this run too — that asymmetry never
+went away, and the counts matched exactly anyway, because density here
+is governed by the declared memory *request*, not image size or pull
+time.
+
+The one real, measurable difference between the two legs wasn't density
+— it was time. ~77 minutes under gVisor vs. ~40 minutes under plain
+`runc` to reach the same 373, roughly 2x. gVisor's per-sandbox startup
+overhead is real; it shows up in *how fast* you get to a given density,
+not in *how dense* you can get. Worth knowing, not worth losing sleep
+over for most workloads — but it's the honest, separate cost gVisor
+actually has here.
 
 ## Where 929 comes from — a different deployment entirely
 
 Containarium also ships a native LXC/Incus backend: no Kubernetes, no
 gVisor, sandboxes run directly on the host. Run the same benchmark there
 and you get **929** — but this isn't a gVisor-vs-gVisor result, because
-there's no gVisor and no Kubernetes admission control in this path at all.
-It's a different question: raw LXC density vs. k8s+gVisor density, with a
-different isolation model underneath.
+there's no gVisor and no Kubernetes admission control in this path at
+all. It's a different question: raw LXC density vs. k8s+gVisor density,
+with a different isolation model underneath.
 
 <!-- diagram: declared vs. actual used, three columns — see blog-preview.html -->
 
-The mechanism is the same *kind* of gap, just triggered differently.
-Kubernetes reserves what's *declared*, always, both for agent-sandbox's
-pods and for Containarium's own pods above — that's why 186 tracks 373 so
-cleanly. Incus's `limits.memory`, when there's no Kubernetes scheduler in
-front of it, is a cgroup **ceiling**, not a reservation: through most of
-this run, boxes declared at 256Mi were only actually using something like
-90-100MiB (measured at checkpoints along the way, not a number we
-confirmed still held at the final count) — and only that much counted
-against the host. That's
-a real, legitimate operational property of running LXC directly — and a
-real trade-off. No admission backpressure means nothing tells the platform
-"stop" until the host actually runs out. When we pushed far enough, that's
-exactly what happened: the host ran out of real RAM at ~930 sandboxes,
-full stop, independent of anything else we fixed along the way.
+Kubernetes reserves what's *declared*, always — that's the mechanism
+behind both 373s above. Incus's `limits.memory`, when there's no
+Kubernetes scheduler in front of it, is a cgroup **ceiling**, not a
+reservation: through most of this run, boxes declared at 256Mi were only
+actually using something like 90-100MiB (measured at checkpoints along
+the way, not a number we confirmed still held at the final count) — and
+only that much counted against the host. That's a real, legitimate
+operational property of running LXC directly — and a real trade-off. No
+admission backpressure means nothing tells the platform "stop" until the
+host actually runs out. When we pushed far enough, that's exactly what
+happened: the host ran out of real RAM at ~930 sandboxes, full stop,
+independent of anything else we fixed along the way.
 
 ## What we actually hit pushing the LXC path to 929
 
@@ -119,24 +161,27 @@ every commit: [`RESULTS.md`](RESULTS.md) in the benchmark folder.
 
 ## What this actually means
 
-Two separate, honest takeaways, not one flattering headline:
-
 **If you need gVisor-grade isolation under Kubernetes**, Containarium's
-sandboxes don't magically pack denser than agent-sandbox's — on this
-benchmark they packed for fewer, purely because of a declared-size choice
-that's easy to change. If your agents are idle-heavy (most agent sandboxes
-spend most of their time waiting, not computing), the real lever for
-*either* system is the same: your actual memory usage is probably far
-below whatever you've declared as the request. Lower it, or tune a VPA to
-track reality — without touching gVisor, without touching either
-project's code.
+sandboxes now pack exactly as densely as agent-sandbox's — 373 vs. 373,
+confirmed twice. That wasn't true when we started this investigation: it
+took finding a real gap and shipping a real fix
+([#1557](https://github.com/FootprintAI/Containarium/issues/1557)) to
+get here, and we're telling that whole story rather than only the
+flattering ending. The one remaining cost is time-to-density under
+gVisor (~2x slower to fill the same host), not density itself. If your
+agents are idle-heavy (most agent sandboxes spend most of their time
+waiting, not computing), the lever that matters for *either* system is
+the same regardless: your actual memory usage is probably far below
+whatever you've declared as the request — lower it, or tune a VPA to
+track reality.
 
 **If you're willing to leave Kubernetes and gVisor's isolation model
 behind**, Containarium's native LXC backend can pack meaningfully more —
-because it isn't reserving headroom nobody's using. That's a real,
-different trade-off (weaker isolation boundary, no admission
+929 vs. 373 — because it isn't reserving headroom nobody's using. That's
+a real, different trade-off (weaker isolation boundary, no admission
 backpressure, a hard wall when you finally exhaust real memory), not a
-strictly-better number.
+strictly-better number, and not the same comparison as the gVisor-matched
+result above.
 
 ---
 

--- a/benchmark/agent-sandbox-density/BLOG-DRAFT.md
+++ b/benchmark/agent-sandbox-density/BLOG-DRAFT.md
@@ -18,8 +18,8 @@ understanding exactly why before the 929 number means anything.
 
 Same host, same hard resource cap (48GiB RAM / 20 vCPU), same sandbox
 profile family, both under Kubernetes with the identical `runsc` (gVisor)
-RuntimeClass. The only real difference is how each side declares its
-sandbox's memory:
+RuntimeClass. The clearest, most quantifiable difference between the two
+runs is how each side declares its sandbox's memory:
 
 - agent-sandbox's pods request **128Mi**
 - Containarium's `create` sets request and limit to the same value —
@@ -27,12 +27,24 @@ sandbox's memory:
 
 Kubernetes' scheduler reserves the full **declared request** against node
 capacity the instant a pod is scheduled, whether the pod ever touches that
-memory or not. `48GiB ÷ 128Mi ≈ 373`. `48GiB ÷ 256Mi ≈ 186`. Halve 373 and
-you land almost exactly on 186. **The entire gap is the declared-size
-asymmetry — not gVisor overhead, not orchestration cost.** Same isolation
-technology, same admission model, smaller declared footprint wins. Nothing
-about Containarium is more efficient here; it just asks for less. If we'd
+memory or not. At the stopping point, node memory requests hit
+47984Mi/48GiB (99%) for agent-sandbox and 47856Mi/48GiB (99%) for
+Containarium — both sides essentially saturated the same total memory
+budget, just divided into differently-sized chunks: 373 × 128Mi ≈ 46.6GiB,
+186 × 256Mi ≈ 46.5GiB. Halving the request size, not halving anything
+else, is what produces almost exactly half the count.
+
+**That declared-size asymmetry accounts for the ~2:1 gap we observed —
+not gVisor overhead, not orchestration cost.** Same isolation technology,
+same admission model, smaller declared footprint wins. Nothing about
+Containarium is more efficient here; it just asks for less. If we'd
 declared Containarium's sandboxes at 128Mi too, the two numbers converge.
+One other asymmetry worth naming honestly rather than glossing over:
+agent-sandbox's pods run a minimal `busybox` image, while Containarium's
+boxes run its real, heavier `containarium-agent-box` runtime — a
+structural difference in what each side actually deploys, not a knob
+either side can equalize (see the README's "Fairness notes" for the full
+accounting).
 
 We re-ran this scenario independently on a fresh cluster to check it wasn't
 a fluke — 186 ready, 189 attempted, an exact match down to the node memory
@@ -54,8 +66,11 @@ The mechanism is the same *kind* of gap, just triggered differently.
 Kubernetes reserves what's *declared*, always, both for agent-sandbox's
 pods and for Containarium's own pods above — that's why 186 tracks 373 so
 cleanly. Incus's `limits.memory`, when there's no Kubernetes scheduler in
-front of it, is a cgroup **ceiling**, not a reservation: a box declared at
-256Mi that's only using ~90MiB only counts ~90MiB against the host. That's
+front of it, is a cgroup **ceiling**, not a reservation: through most of
+this run, boxes declared at 256Mi were only actually using something like
+90-100MiB (measured at checkpoints along the way, not a number we
+confirmed still held at the final count) — and only that much counted
+against the host. That's
 a real, legitimate operational property of running LXC directly — and a
 real trade-off. No admission backpressure means nothing tells the platform
 "stop" until the host actually runs out. When we pushed far enough, that's
@@ -64,8 +79,8 @@ full stop, independent of anything else we fixed along the way.
 
 ## What we actually hit pushing the LXC path to 929
 
-Getting there wasn't one clean run — it took three real fixes, found live,
-in order:
+Getting there wasn't one clean run — two real fixes, found live, then a
+wall that held:
 
 1. **`containarium list` didn't scale.** The benchmark's own polling loop
    called `list` (which fetches every container's full state) every ~2s
@@ -80,20 +95,21 @@ in order:
    ([#1546](https://github.com/FootprintAI/Containarium/pull/1546)) — the daemon CPU wall that had crept back in past ~600
    containers disappeared entirely; load stayed flat (single digits) all
    the way to the same real memory ceiling.
-3. **The real wall was RAM, not CPU** — and it landed at ~930 sandboxes on
-   both the buggy and the fixed run, which is exactly the confirmation we
-   wanted: fixing the software bugs didn't move the physical ceiling, it
-   just let us actually reach it cleanly instead of stalling early on
-   self-inflicted overhead.
+
+**Then the real wall: RAM, not CPU.** It landed at ~930 sandboxes on both
+the fixed run and the earlier, buggy one — not because fixing the software
+bugs moved the physical ceiling, but because the fixes let us actually
+*reach* it cleanly instead of stalling early on self-inflicted daemon CPU
+overhead.
 
 Each fix, measured live at the same checkpoint container counts:
 
 | containers | before either fix | `get` fix only | both fixes |
 |---|---|---|---|
-| ~400 | `incusd` at 914% CPU | load ~19 | load 4-8 |
-| ~570 | load ~117 | load 32-40 | load 15-21 |
-| ~760 | — (had already stopped) | load 125-182 | load 38-40 |
-| ~930 | 569 (stopped: bug) | 931 (stopped: RAM) | 929 (stopped: RAM) |
+| ~400 | n/a — the unfixed run never got a clean reading this early | load ~19, `incusd` at 914% CPU | load 4-8, `incusd` at 48% CPU |
+| ~570 | `incusd` at 1025% CPU, load ~117 — **this is where it stopped** | load 32-40 | load 15-21 |
+| ~760 | — | load 125-182 | load 38-40 |
+| final count | **569** (stopped: `incusd` CPU wall) | **931** (stopped: RAM, `incusd` OOM-killed) | **929** (stopped: RAM, `context deadline exceeded`) |
 
 We also found and fixed a couple of smaller things along the way — a
 per-create install step that should've been baked into an image once

--- a/benchmark/agent-sandbox-density/BLOG-DRAFT.md
+++ b/benchmark/agent-sandbox-density/BLOG-DRAFT.md
@@ -1,60 +1,66 @@
-# We packed 929 sandboxes on one box — and it's not about gVisor
+# 929, 373, 186: what actually explains agent sandbox density
 
 We wanted to know a simple thing: how many isolated agent sandboxes can you
-actually fit on one machine? So we ran a real, live density benchmark —
-Kubernetes + [agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox)
-on one side, Containarium's native LXC backend on the other — pushed both
-until they broke, and fixed what we broke along the way.
+actually fit on one machine? So we ran a real, live density benchmark
+across three deployment modes on the same host, pushed each until it
+broke, and fixed what we broke along the way.
 
-The headline number: **929 Containarium sandboxes vs. 373 agent-sandbox
-pods**, both under a 48GiB / 20-vCPU host. But if you stop at that number
-you'll walk away with the wrong lesson. The real story is more interesting
-— and more useful, whichever side of this you're building on.
+- **373** — Kubernetes + [agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox), sandboxes as gVisor pods
+- **186** — Containarium running the same way: `pod → gVisor → Containarium`, same Kubernetes, same isolation
+- **929** — Containarium's native LXC backend, no Kubernetes, no gVisor at all
 
-## The setup
+If you only remember one of those numbers, remember that the **gVisor-matched
+comparison is 186 vs. 373 — and Containarium is the smaller one.** That's not
+a caveat buried in the fine print; it's the fair fight, and it's worth
+understanding exactly why before the 929 number means anything.
 
-Same host, same hard resource cap, same sandbox profile (200m CPU /
-256Mi memory) on every side. Two groups:
+## The apples-to-apples result: 186 vs. 373
 
-- **Control**: kubeadm + Calico + agent-sandbox, sandboxes as pods
-- **Experiment**: Containarium's native LXC/Incus backend — no
-  Kubernetes, same host
+Same host, same hard resource cap (48GiB RAM / 20 vCPU), same sandbox
+profile family, both under Kubernetes with the identical `runsc` (gVisor)
+RuntimeClass. The only real difference is how each side declares its
+sandbox's memory:
 
-Both groups' actual boxes idle at roughly the same real memory footprint
-(tens of MiB). The difference isn't the sandbox — it's what each system
-does with the *declared* resource size when deciding whether to admit one
-more.
-
-## The mechanism, not the marketing
+- agent-sandbox's pods request **128Mi**
+- Containarium's `create` sets request and limit to the same value —
+  **256Mi**, exactly 2x
 
 Kubernetes' scheduler reserves the full **declared request** against node
-capacity the instant a pod is scheduled — 128Mi requested means 128Mi
-reserved, whether the pod ever touches it or not. That's a deliberate,
-sane default: it protects every *other* tenant on the node from a noisy
-neighbor. Our control group hit its wall at exactly `48GiB / 128Mi ≈ 373`
-— textbook admission-controlled scheduling, working exactly as designed.
+capacity the instant a pod is scheduled, whether the pod ever touches that
+memory or not. `48GiB ÷ 128Mi ≈ 373`. `48GiB ÷ 256Mi ≈ 186`. Halve 373 and
+you land almost exactly on 186. **The entire gap is the declared-size
+asymmetry — not gVisor overhead, not orchestration cost.** Same isolation
+technology, same admission model, smaller declared footprint wins. Nothing
+about Containarium is more efficient here; it just asks for less. If we'd
+declared Containarium's sandboxes at 128Mi too, the two numbers converge.
 
-Incus's `limits.memory`, by contrast, is a cgroup **ceiling**, not a
-reservation. A box declared at 256Mi that's only using 90MiB only counts
-90MiB against the host. Containarium's density number is higher because
-it's *not reserving headroom nobody's using* — which is a real,
-legitimate operational property, and also a real trade-off: no admission
-backpressure means nothing tells the platform "stop" until the host
-actually runs out. When we pushed far enough, that's exactly what
-happened — the host ran out of real RAM at ~930 sandboxes, full stop,
-independent of anything else we fixed along the way.
+## Where 929 comes from — a different deployment entirely
 
-**If we'd held both sides to the same admission model — memory *request*
-== memory *limit*, same as Containarium's `create` always does — Container-
-ium's own earlier k8s+gVisor run actually landed *behind* the control
-group** (186 vs. 373), because its declared ceiling (256Mi) is exactly 2x
-the control group's declared request (128Mi). Same host, same math,
-opposite conclusion. The admission model is the variable, not the
-sandboxing technology.
+Containarium also ships a native LXC/Incus backend: no Kubernetes, no
+gVisor, sandboxes run directly on the host. Run the same benchmark there
+and you get **929** — but this isn't a gVisor-vs-gVisor result, because
+there's no gVisor and no Kubernetes admission control in this path at all.
+It's a different question: raw LXC density vs. k8s+gVisor density, with a
+different isolation model underneath.
 
-## What we actually hit pushing to 929
+<!-- diagram: declared vs. actual used, three columns — see blog-preview.html -->
 
-Getting there wasn't one clean run — it took three real fixes, found live:
+The mechanism is the same *kind* of gap, just triggered differently.
+Kubernetes reserves what's *declared*, always, both for agent-sandbox's
+pods and for Containarium's own pods above — that's why 186 tracks 373 so
+cleanly. Incus's `limits.memory`, when there's no Kubernetes scheduler in
+front of it, is a cgroup **ceiling**, not a reservation: a box declared at
+256Mi that's only using ~90MiB only counts ~90MiB against the host. That's
+a real, legitimate operational property of running LXC directly — and a
+real trade-off. No admission backpressure means nothing tells the platform
+"stop" until the host actually runs out. When we pushed far enough, that's
+exactly what happened: the host ran out of real RAM at ~930 sandboxes,
+full stop, independent of anything else we fixed along the way.
+
+## What we actually hit pushing the LXC path to 929
+
+Getting there wasn't one clean run — it took three real fixes, found live,
+in order:
 
 1. **`containarium list` didn't scale.** The benchmark's own polling loop
    called `list` (which fetches every container's full state) every ~2s
@@ -69,11 +75,20 @@ Getting there wasn't one clean run — it took three real fixes, found live:
    ([#1546](https://github.com/FootprintAI/Containarium/pull/1546)) — the daemon CPU wall that had crept back in past ~600
    containers disappeared entirely; load stayed flat (single digits) all
    the way to the same real memory ceiling.
-3. **The real wall was RAM, not CPU** — and it stayed at ~930 sandboxes on
+3. **The real wall was RAM, not CPU** — and it landed at ~930 sandboxes on
    both the buggy and the fixed run, which is exactly the confirmation we
    wanted: fixing the software bugs didn't move the physical ceiling, it
    just let us actually reach it cleanly instead of stalling early on
    self-inflicted overhead.
+
+Each fix, measured live at the same checkpoint container counts:
+
+| containers | before either fix | `get` fix only | both fixes |
+|---|---|---|---|
+| ~400 | `incusd` at 914% CPU | load ~19 | load 4-8 |
+| ~570 | load ~117 | load 32-40 | load 15-21 |
+| ~760 | — (had already stopped) | load 125-182 | load 38-40 |
+| ~930 | 569 (stopped: bug) | 931 (stopped: RAM) | 929 (stopped: RAM) |
 
 We also found and fixed a couple of smaller things along the way — a
 per-create install step that should've been baked into an image once
@@ -81,18 +96,26 @@ instead of repeated on every create, and a host account creation bug that
 silently broke after about a dozen tenants. Full detail, every number,
 every commit: [`RESULTS.md`](RESULTS.md) in the benchmark folder.
 
-## What this means if you're running agent-sandbox
+## What this actually means
 
-Not "switch to Containarium." The actual, portable takeaway: **if your
-agents are idle-heavy** (most agent sandboxes spend most of their time
-waiting, not computing), your real memory usage is probably far below
-whatever you've declared as the request. Kubernetes gives you the lever
-to close that gap yourself — lower requests, a VPA tuned to actual usage,
-or a `LimitRange` that keeps limits generous while requests track reality
-— without touching gVisor, without touching agent-sandbox's own code.
-The density gap we measured isn't a verdict on either project; it's a
-measurement of two different default postures toward the same trade-off,
-and it's one you can dial on either side.
+Two separate, honest takeaways, not one flattering headline:
+
+**If you need gVisor-grade isolation under Kubernetes**, Containarium's
+sandboxes don't magically pack denser than agent-sandbox's — on this
+benchmark they packed for fewer, purely because of a declared-size choice
+that's easy to change. If your agents are idle-heavy (most agent sandboxes
+spend most of their time waiting, not computing), the real lever for
+*either* system is the same: your actual memory usage is probably far
+below whatever you've declared as the request. Lower it, or tune a VPA to
+track reality — without touching gVisor, without touching either
+project's code.
+
+**If you're willing to leave Kubernetes and gVisor's isolation model
+behind**, Containarium's native LXC backend can pack meaningfully more —
+because it isn't reserving headroom nobody's using. That's a real,
+different trade-off (weaker isolation boundary, no admission
+backpressure, a hard wall when you finally exhaust real memory), not a
+strictly-better number.
 
 ---
 

--- a/benchmark/agent-sandbox-density/blog-preview.html
+++ b/benchmark/agent-sandbox-density/blog-preview.html
@@ -1,4 +1,4 @@
-<title>929 Sandboxes</title>
+<title>929, 373, 186</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,400&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap">
 
 <style>
@@ -59,7 +59,7 @@
   }
 
   main {
-    max-width: 680px;
+    max-width: 700px;
     margin: 0 auto;
   }
 
@@ -86,8 +86,8 @@
   h1 {
     font-family: 'Newsreader', Georgia, serif;
     font-weight: 500;
-    font-size: clamp(2rem, 5vw, 2.65rem);
-    line-height: 1.15;
+    font-size: clamp(1.9rem, 5vw, 2.5rem);
+    line-height: 1.18;
     letter-spacing: -0.01em;
     margin: 18px 0 8px;
     text-wrap: balance;
@@ -99,14 +99,14 @@
     font-size: 1.2rem;
     color: var(--ink-soft);
     line-height: 1.5;
-    margin: 0 0 40px;
+    margin: 0 0 36px;
     text-wrap: balance;
   }
 
   h2 {
     font-family: 'Newsreader', Georgia, serif;
     font-weight: 500;
-    font-size: 1.55rem;
+    font-size: 1.5rem;
     margin: 3em 0 0.6em;
     letter-spacing: -0.005em;
   }
@@ -127,37 +127,43 @@
   }
 
   .headline-figure {
-    display: flex;
-    gap: 28px;
-    margin: 36px 0 8px;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 16px;
+    margin: 32px 0 8px;
+  }
+
+  @media (max-width: 560px) {
+    .headline-figure { grid-template-columns: 1fr; }
   }
 
   .headline-stat {
-    flex: 1;
-    min-width: 200px;
     background: var(--paper-raised);
     border: 1px solid var(--rule);
     border-radius: 12px;
-    padding: 22px 24px;
+    padding: 18px 20px;
   }
+
+  .headline-stat.win { border-color: var(--accent); box-shadow: 0 0 0 1px var(--accent) inset; }
 
   .headline-stat .n {
     font-family: 'JetBrains Mono', monospace;
     font-weight: 600;
-    font-size: 2.3rem;
+    font-size: 2rem;
     color: var(--ink);
     line-height: 1;
   }
 
-  .headline-stat.hi .n { color: var(--accent); }
+  .headline-stat.win .n { color: var(--accent); }
 
   .headline-stat .l {
-    font-size: 0.85rem;
+    font-size: 0.82rem;
     color: var(--muted);
     margin-top: 8px;
     line-height: 1.4;
   }
+
+  .headline-stat .l strong { color: var(--ink-soft); font-weight: 600; }
 
   .callout {
     background: var(--accent-soft);
@@ -229,80 +235,91 @@
 
 <main>
   <p class="kicker">Containarium engineering</p>
-  <h1>We packed 929 sandboxes on one box — and it's not about gVisor</h1>
-  <p class="dek">A live density benchmark, three real bugs found and fixed along the way, and the honest mechanism behind the headline number.</p>
+  <h1>929, 373, 186: what actually explains agent sandbox density</h1>
+  <p class="dek">Three deployment modes, one host, and the resource-accounting mechanism behind every number &mdash; including the one where Containarium loses.</p>
 
-  <p>We wanted to know a simple thing: how many isolated agent sandboxes can you actually fit on one machine? So we ran a real, live density benchmark &mdash; Kubernetes + <a href="https://github.com/kubernetes-sigs/agent-sandbox">agent-sandbox</a> on one side, Containarium's native LXC backend on the other &mdash; pushed both until they broke, and fixed what we broke along the way.</p>
+  <p>We wanted to know a simple thing: how many isolated agent sandboxes can you actually fit on one machine? So we ran a real, live density benchmark across three deployment modes on the same host, pushed each until it broke, and fixed what we broke along the way.</p>
 
   <div class="headline-figure">
-    <div class="headline-stat hi">
-      <div class="n">929</div>
-      <div class="l">Containarium sandboxes<br>native LXC backend</div>
-    </div>
     <div class="headline-stat">
       <div class="n">373</div>
-      <div class="l">agent-sandbox pods<br>Kubernetes + Calico</div>
+      <div class="l"><strong>k8s + agent-sandbox</strong><br>gVisor pods</div>
+    </div>
+    <div class="headline-stat">
+      <div class="n">186</div>
+      <div class="l"><strong>k8s + gVisor + Containarium</strong><br>same isolation, same host</div>
+    </div>
+    <div class="headline-stat win">
+      <div class="n">929</div>
+      <div class="l"><strong>Containarium native LXC</strong><br>no k8s, no gVisor</div>
     </div>
   </div>
 
-  <p>If you stop at that comparison you'll walk away with the wrong lesson. The real story is more interesting &mdash; and more useful, whichever side of this you're building on.</p>
+  <p>If you only remember one of those numbers, remember that the <strong>gVisor-matched comparison is 186 vs. 373 &mdash; and Containarium is the smaller one.</strong> That's not a caveat buried in the fine print; it's the fair fight, and it's worth understanding exactly why before the 929 number means anything.</p>
 
-  <h2>The setup</h2>
-  <p>Same host, same hard resource cap (48GiB RAM / 20 vCPU), same sandbox profile (200m CPU / 256Mi memory) on every side. Two groups:</p>
+  <h2>The apples-to-apples result: 186 vs. 373</h2>
+  <p>Same host, same hard resource cap (48GiB RAM / 20 vCPU), same sandbox profile family, both under Kubernetes with the identical <code>runsc</code> (gVisor) RuntimeClass. The only real difference is how each side declares its sandbox's memory:</p>
   <ul>
-    <li><strong>Control</strong> &mdash; kubeadm + Calico + agent-sandbox, sandboxes as pods</li>
-    <li><strong>Experiment</strong> &mdash; Containarium's native LXC/Incus backend, no Kubernetes, same host</li>
+    <li>agent-sandbox's pods request <strong>128Mi</strong></li>
+    <li>Containarium's <code>create</code> sets request and limit to the same value &mdash; <strong>256Mi</strong>, exactly 2&times;</li>
   </ul>
-  <p>Both groups' actual boxes idle at roughly the same real memory footprint &mdash; tens of MiB. The difference isn't the sandbox. It's what each system does with the <em>declared</em> resource size when deciding whether to admit one more.</p>
-
-  <h2>The mechanism, not the marketing</h2>
-  <p>Kubernetes' scheduler reserves the full <strong>declared request</strong> against node capacity the instant a pod is scheduled &mdash; 128Mi requested means 128Mi reserved, whether the pod ever touches it or not. That's a deliberate, sane default: it protects every other tenant on the node from a noisy neighbor. Our control group hit its wall at exactly 48GiB &divide; 128Mi &asymp; 373 &mdash; textbook admission-controlled scheduling, working exactly as designed.</p>
-  <p>Incus's <code>limits.memory</code>, by contrast, is a cgroup <strong>ceiling</strong>, not a reservation. A box declared at 256Mi that's only using 90MiB only counts 90MiB against the host.</p>
-
-  <figure>
-    <svg viewBox="0 0 640 260" role="img" aria-label="Bar chart comparing declared memory reservation versus actual memory used, for Kubernetes agent-sandbox and for Containarium. Kubernetes' declared and actual bars are equal at 128 mebibytes. Containarium's declared bar is 256 mebibytes but its actual bar is only about 90 mebibytes, showing the gap that explains the density difference.">
-      <g font-size="12.5" fill="currentColor">
-        <!-- axis -->
-        <line x1="70" y1="210" x2="620" y2="210" stroke="currentColor" stroke-opacity="0.25"/>
-
-        <!-- k8s group -->
-        <text x="150" y="234" text-anchor="middle" font-size="13" font-weight="600">k8s + agent-sandbox</text>
-        <!-- declared -->
-        <rect x="95" y="82" width="42" height="128" fill="currentColor" fill-opacity="0.35"/>
-        <text x="116" y="72" text-anchor="middle">128Mi</text>
-        <text x="116" y="228" text-anchor="middle" font-size="11" fill-opacity="0.6">declared</text>
-        <!-- actual -->
-        <rect x="163" y="82" width="42" height="128" fill="#4c5fd5"/>
-        <text x="184" y="72" text-anchor="middle">128Mi</text>
-        <text x="184" y="228" text-anchor="middle" font-size="11" fill-opacity="0.6">actual used</text>
-
-        <!-- containarium group -->
-        <text x="470" y="234" text-anchor="middle" font-size="13" font-weight="600">Containarium (LXC)</text>
-        <!-- declared -->
-        <rect x="415" y="10" width="42" height="200" fill="currentColor" fill-opacity="0.35"/>
-        <text x="436" y="0" text-anchor="middle" dy="8">256Mi</text>
-        <text x="436" y="228" text-anchor="middle" font-size="11" fill-opacity="0.6">declared</text>
-        <!-- actual -->
-        <rect x="483" y="140" width="42" height="70" fill="#4c5fd5"/>
-        <text x="504" y="130" text-anchor="middle">~90Mi</text>
-        <text x="504" y="228" text-anchor="middle" font-size="11" fill-opacity="0.6">actual used</text>
-
-        <!-- gap annotation -->
-        <line x1="483" y1="10" x2="483" y2="140" stroke="#4c5fd5" stroke-dasharray="3,3" stroke-opacity="0.6"/>
-        <text x="560" y="75" font-size="11" fill="#4c5fd5" font-weight="600">unreserved</text>
-        <text x="560" y="90" font-size="11" fill="#4c5fd5" font-weight="600">headroom</text>
-      </g>
-    </svg>
-    <figcaption>Kubernetes reserves what's declared, whether it's used or not. Incus only ever counts what's actually used against the host &mdash; that gap is the entire density difference.</figcaption>
-  </figure>
+  <p>Kubernetes' scheduler reserves the full <strong>declared request</strong> against node capacity the instant a pod is scheduled, whether the pod ever touches that memory or not. 48GiB &divide; 128Mi &asymp; 373. 48GiB &divide; 256Mi &asymp; 186. Halve 373 and you land almost exactly on 186.</p>
 
   <div class="callout">
-    <p>Containarium's density number is higher because it's <strong>not reserving headroom nobody's using</strong> &mdash; a real, legitimate operational property, and also a real trade-off: no admission backpressure means nothing tells the platform "stop" until the host actually runs out. When we pushed far enough, that's exactly what happened.</p>
+    <p><strong>The entire gap is the declared-size asymmetry &mdash; not gVisor overhead, not orchestration cost.</strong> Same isolation technology, same admission model, smaller declared footprint wins. Nothing about Containarium is more efficient here; it just asks for less. Declare Containarium's sandboxes at 128Mi too, and the two numbers converge.</p>
   </div>
 
-  <p><strong>If we'd held both sides to the same admission model</strong> &mdash; memory request == memory limit, same as Containarium's <code>create</code> always does &mdash; Containarium's own earlier k8s+gVisor run actually landed <em>behind</em> the control group (186 vs. 373), because its declared ceiling (256Mi) is exactly 2&times; the control group's declared request (128Mi). Same host, same math, opposite conclusion. The admission model is the variable, not the sandboxing technology.</p>
+  <h2>Where 929 comes from &mdash; a different deployment entirely</h2>
+  <p>Containarium also ships a native LXC/Incus backend: no Kubernetes, no gVisor, sandboxes run directly on the host. Run the same benchmark there and you get <strong>929</strong> &mdash; but this isn't a gVisor-vs-gVisor result, because there's no gVisor and no Kubernetes admission control in this path at all. It's a different question: raw LXC density vs. k8s+gVisor density, with a different isolation model underneath.</p>
 
-  <h2>What we actually hit pushing to 929</h2>
+  <figure>
+    <svg viewBox="0 0 660 280" role="img" aria-label="Bar chart comparing declared memory reservation versus actual memory used across three deployment modes. Kubernetes agent-sandbox: declared and actual both 128 mebibytes. Kubernetes plus gVisor plus Containarium: declared and actual both 256 mebibytes, because Kubernetes reserves the full declared amount regardless of the runtime underneath. Containarium native LXC, no Kubernetes: declared 256 mebibytes but actual used only about 90 mebibytes, the gap that explains its higher density.">
+      <g font-size="11.5" fill="currentColor">
+        <line x1="30" y1="230" x2="630" y2="230" stroke="currentColor" stroke-opacity="0.25"/>
+
+        <!-- group 1: agent-sandbox -->
+        <text x="105" y="252" text-anchor="middle" font-size="12" font-weight="600">agent-sandbox</text>
+        <text x="105" y="266" text-anchor="middle" font-size="10" fill-opacity="0.55">(k8s)</text>
+        <rect x="65" y="105" width="34" height="125" fill="currentColor" fill-opacity="0.35"/>
+        <text x="82" y="96" text-anchor="middle">128Mi</text>
+        <rect x="120" y="105" width="34" height="125" fill="#4c5fd5"/>
+        <text x="137" y="96" text-anchor="middle">128Mi</text>
+
+        <!-- group 2: containarium k8s+gvisor -->
+        <text x="335" y="252" text-anchor="middle" font-size="12" font-weight="600">gVisor + Containarium</text>
+        <text x="335" y="266" text-anchor="middle" font-size="10" fill-opacity="0.55">(k8s)</text>
+        <rect x="295" y="20" width="34" height="210" fill="currentColor" fill-opacity="0.35"/>
+        <text x="312" y="11" text-anchor="middle">256Mi</text>
+        <rect x="350" y="20" width="34" height="210" fill="#4c5fd5"/>
+        <text x="367" y="11" text-anchor="middle">256Mi</text>
+        <text x="335" y="-4" text-anchor="middle" font-size="10" fill-opacity="0.6" dy="14">reserved = used, same as agent-sandbox</text>
+
+        <!-- group 3: native LXC -->
+        <text x="565" y="252" text-anchor="middle" font-size="12" font-weight="600">Containarium native</text>
+        <text x="565" y="266" text-anchor="middle" font-size="10" fill-opacity="0.55">(LXC, no k8s)</text>
+        <rect x="525" y="20" width="34" height="210" fill="currentColor" fill-opacity="0.35"/>
+        <text x="542" y="11" text-anchor="middle">256Mi</text>
+        <rect x="580" y="160" width="34" height="70" fill="#4c5fd5"/>
+        <text x="597" y="151" text-anchor="middle">~90Mi</text>
+        <line x1="580" y1="20" x2="580" y2="160" stroke="#4c5fd5" stroke-dasharray="3,3" stroke-opacity="0.6"/>
+
+        <!-- legend -->
+        <rect x="30" y="8" width="10" height="10" fill="currentColor" fill-opacity="0.35"/>
+        <text x="44" y="17" font-size="10.5" fill-opacity="0.7">declared</text>
+        <rect x="110" y="8" width="10" height="10" fill="#4c5fd5"/>
+        <text x="124" y="17" font-size="10.5" fill-opacity="0.7">actually used</text>
+      </g>
+    </svg>
+    <figcaption>Kubernetes reserves the full declared amount either way &mdash; that's why the middle bars match. Only the native LXC path (right) ever counts less than what's declared, and that gap is the entire density difference.</figcaption>
+  </figure>
+
+  <p>The mechanism is the same <em>kind</em> of gap, just triggered differently. Kubernetes reserves what's <em>declared</em>, always, both for agent-sandbox's pods and for Containarium's own pods above &mdash; that's why 186 tracks 373 so cleanly. Incus's <code>limits.memory</code>, when there's no Kubernetes scheduler in front of it, is a cgroup <strong>ceiling</strong>, not a reservation: a box declared at 256Mi that's only using ~90MiB only counts ~90MiB against the host.</p>
+
+  <div class="callout">
+    <p>That's a real, legitimate operational property of running LXC directly &mdash; and a real trade-off. No admission backpressure means nothing tells the platform "stop" until the host actually runs out. When we pushed far enough, that's exactly what happened: the host ran out of real RAM at ~930 sandboxes, full stop, independent of anything else we fixed along the way.</p>
+  </div>
+
+  <h2>What we actually hit pushing the LXC path to 929</h2>
   <p>Getting there wasn't one clean run &mdash; it took three real fixes, found live, in order:</p>
 
   <ol>
@@ -327,11 +344,14 @@
     </table>
   </div>
 
-  <p>We also found and fixed a couple of smaller things along the way &mdash; a per-create install step that should've been baked into an image once instead of repeated on every create, and a host account creation bug that silently broke after about a dozen tenants.</p>
+  <p>We also found and fixed a couple of smaller things along the way &mdash; a per-create install step that should've been baked into an image once instead of repeated on every create, and a host account creation bug that silently broke after about a dozen tenants. Full detail, every number, every commit: <code>RESULTS.md</code> in the benchmark folder.</p>
 
-  <h2>What this means if you're running agent-sandbox</h2>
-  <p>Not "switch to Containarium." The actual, portable takeaway: <strong>if your agents are idle-heavy</strong> &mdash; and most agent sandboxes spend most of their time waiting, not computing &mdash; your real memory usage is probably far below whatever you've declared as the request. Kubernetes gives you the lever to close that gap yourself: lower requests, a VPA tuned to actual usage, or a <code>LimitRange</code> that keeps limits generous while requests track reality &mdash; without touching gVisor, without touching agent-sandbox's own code.</p>
-  <p>The density gap we measured isn't a verdict on either project. It's a measurement of two different default postures toward the same trade-off, and it's one you can dial on either side.</p>
+  <h2>What this actually means</h2>
+  <p>Two separate, honest takeaways, not one flattering headline:</p>
+
+  <p><strong>If you need gVisor-grade isolation under Kubernetes</strong>, Containarium's sandboxes don't magically pack denser than agent-sandbox's &mdash; on this benchmark they packed for fewer, purely because of a declared-size choice that's easy to change. If your agents are idle-heavy (most agent sandboxes spend most of their time waiting, not computing), the real lever for <em>either</em> system is the same: your actual memory usage is probably far below whatever you've declared as the request. Lower it, or tune a VPA to track reality &mdash; without touching gVisor, without touching either project's code.</p>
+
+  <p><strong>If you're willing to leave Kubernetes and gVisor's isolation model behind</strong>, Containarium's native LXC backend can pack meaningfully more &mdash; because it isn't reserving headroom nobody's using. That's a real, different trade-off (weaker isolation boundary, no admission backpressure, a hard wall when you finally exhaust real memory), not a strictly-better number.</p>
 
   <hr class="end">
   <p class="byline">Full methodology, every host spec, every raw number, and the complete bug-by-bug investigation live in <code>benchmark/agent-sandbox-density/</code> in the Containarium repo &mdash; reproduce it yourself, or tell us where the comparison should go next.</p>

--- a/benchmark/agent-sandbox-density/blog-preview.html
+++ b/benchmark/agent-sandbox-density/blog-preview.html
@@ -1,0 +1,338 @@
+<title>929 Sandboxes</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,400&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap">
+
+<style>
+  :root {
+    --ink: #1a1d29;
+    --ink-soft: #3a3e4d;
+    --paper: #f4f5f8;
+    --paper-raised: #ffffff;
+    --accent: #4c5fd5;
+    --accent-ink: #333f99;
+    --accent-soft: #eef0fc;
+    --muted: #6b7280;
+    --rule: #d8dbe6;
+    --good: #1f7a52;
+    --bad: #b8452f;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      --ink: #e8e9f0;
+      --ink-soft: #c7cad9;
+      --paper: #14161f;
+      --paper-raised: #1c1f2c;
+      --accent: #8b9aff;
+      --accent-ink: #b7c0ff;
+      --accent-soft: #21254a;
+      --muted: #9498a8;
+      --rule: #2a2e3d;
+      --good: #4fbf8f;
+      --bad: #e2795f;
+    }
+  }
+
+  :root[data-theme="dark"] {
+    --ink: #e8e9f0;
+    --ink-soft: #c7cad9;
+    --paper: #14161f;
+    --paper-raised: #1c1f2c;
+    --accent: #8b9aff;
+    --accent-ink: #b7c0ff;
+    --accent-soft: #21254a;
+    --muted: #9498a8;
+    --rule: #2a2e3d;
+    --good: #4fbf8f;
+    --bad: #e2795f;
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    background: var(--paper);
+    color: var(--ink);
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+    font-size: 17px;
+    line-height: 1.65;
+    margin: 0;
+    padding: 0 24px 96px;
+  }
+
+  main {
+    max-width: 680px;
+    margin: 0 auto;
+  }
+
+  .kicker {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 12.5px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--muted);
+    margin-top: 64px;
+    display: flex;
+    gap: 10px;
+    align-items: center;
+  }
+
+  .kicker::before {
+    content: "";
+    width: 22px;
+    height: 1px;
+    background: var(--accent);
+    display: inline-block;
+  }
+
+  h1 {
+    font-family: 'Newsreader', Georgia, serif;
+    font-weight: 500;
+    font-size: clamp(2rem, 5vw, 2.65rem);
+    line-height: 1.15;
+    letter-spacing: -0.01em;
+    margin: 18px 0 8px;
+    text-wrap: balance;
+  }
+
+  .dek {
+    font-family: 'Newsreader', Georgia, serif;
+    font-style: italic;
+    font-size: 1.2rem;
+    color: var(--ink-soft);
+    line-height: 1.5;
+    margin: 0 0 40px;
+    text-wrap: balance;
+  }
+
+  h2 {
+    font-family: 'Newsreader', Georgia, serif;
+    font-weight: 500;
+    font-size: 1.55rem;
+    margin: 3em 0 0.6em;
+    letter-spacing: -0.005em;
+  }
+
+  p { margin: 1.1em 0; color: var(--ink-soft); }
+  p strong { color: var(--ink); font-weight: 600; }
+
+  a { color: var(--accent-ink); text-decoration-color: var(--rule); text-underline-offset: 3px; }
+  a:hover { text-decoration-color: var(--accent-ink); }
+
+  code {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.87em;
+    background: var(--accent-soft);
+    color: var(--accent-ink);
+    padding: 0.15em 0.4em;
+    border-radius: 4px;
+  }
+
+  .headline-figure {
+    display: flex;
+    gap: 28px;
+    margin: 36px 0 8px;
+    flex-wrap: wrap;
+  }
+
+  .headline-stat {
+    flex: 1;
+    min-width: 200px;
+    background: var(--paper-raised);
+    border: 1px solid var(--rule);
+    border-radius: 12px;
+    padding: 22px 24px;
+  }
+
+  .headline-stat .n {
+    font-family: 'JetBrains Mono', monospace;
+    font-weight: 600;
+    font-size: 2.3rem;
+    color: var(--ink);
+    line-height: 1;
+  }
+
+  .headline-stat.hi .n { color: var(--accent); }
+
+  .headline-stat .l {
+    font-size: 0.85rem;
+    color: var(--muted);
+    margin-top: 8px;
+    line-height: 1.4;
+  }
+
+  .callout {
+    background: var(--accent-soft);
+    border-left: 3px solid var(--accent);
+    border-radius: 0 10px 10px 0;
+    padding: 20px 24px;
+    margin: 32px 0;
+  }
+
+  .callout p {
+    color: var(--ink);
+    margin: 0.6em 0;
+    font-size: 0.98rem;
+  }
+
+  .callout p:first-child { margin-top: 0; }
+  .callout p:last-child { margin-bottom: 0; }
+
+  figure { margin: 40px 0; }
+  figcaption {
+    font-size: 0.85rem;
+    color: var(--muted);
+    text-align: center;
+    margin-top: 14px;
+    line-height: 1.5;
+  }
+
+  svg text { font-family: 'JetBrains Mono', monospace; }
+
+  ol, ul { color: var(--ink-soft); padding-left: 1.3em; }
+  li { margin: 0.6em 0; }
+  li strong { color: var(--ink); }
+
+  .tablewrap { overflow-x: auto; margin: 28px 0; border: 1px solid var(--rule); border-radius: 10px; }
+  table { width: 100%; border-collapse: collapse; font-size: 0.88rem; min-width: 480px; }
+  th, td {
+    text-align: left;
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--rule);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.83rem;
+    white-space: nowrap;
+  }
+  th {
+    font-family: 'Inter', sans-serif;
+    font-weight: 600;
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--muted);
+    background: var(--paper);
+  }
+  tr:last-child td { border-bottom: none; }
+  td.bad { color: var(--bad); }
+  td.good { color: var(--good); }
+
+  hr.end {
+    border: none;
+    border-top: 1px solid var(--rule);
+    margin: 56px 0 28px;
+  }
+
+  .byline {
+    font-size: 0.9rem;
+    color: var(--muted);
+    line-height: 1.6;
+  }
+</style>
+
+<main>
+  <p class="kicker">Containarium engineering</p>
+  <h1>We packed 929 sandboxes on one box — and it's not about gVisor</h1>
+  <p class="dek">A live density benchmark, three real bugs found and fixed along the way, and the honest mechanism behind the headline number.</p>
+
+  <p>We wanted to know a simple thing: how many isolated agent sandboxes can you actually fit on one machine? So we ran a real, live density benchmark &mdash; Kubernetes + <a href="https://github.com/kubernetes-sigs/agent-sandbox">agent-sandbox</a> on one side, Containarium's native LXC backend on the other &mdash; pushed both until they broke, and fixed what we broke along the way.</p>
+
+  <div class="headline-figure">
+    <div class="headline-stat hi">
+      <div class="n">929</div>
+      <div class="l">Containarium sandboxes<br>native LXC backend</div>
+    </div>
+    <div class="headline-stat">
+      <div class="n">373</div>
+      <div class="l">agent-sandbox pods<br>Kubernetes + Calico</div>
+    </div>
+  </div>
+
+  <p>If you stop at that comparison you'll walk away with the wrong lesson. The real story is more interesting &mdash; and more useful, whichever side of this you're building on.</p>
+
+  <h2>The setup</h2>
+  <p>Same host, same hard resource cap (48GiB RAM / 20 vCPU), same sandbox profile (200m CPU / 256Mi memory) on every side. Two groups:</p>
+  <ul>
+    <li><strong>Control</strong> &mdash; kubeadm + Calico + agent-sandbox, sandboxes as pods</li>
+    <li><strong>Experiment</strong> &mdash; Containarium's native LXC/Incus backend, no Kubernetes, same host</li>
+  </ul>
+  <p>Both groups' actual boxes idle at roughly the same real memory footprint &mdash; tens of MiB. The difference isn't the sandbox. It's what each system does with the <em>declared</em> resource size when deciding whether to admit one more.</p>
+
+  <h2>The mechanism, not the marketing</h2>
+  <p>Kubernetes' scheduler reserves the full <strong>declared request</strong> against node capacity the instant a pod is scheduled &mdash; 128Mi requested means 128Mi reserved, whether the pod ever touches it or not. That's a deliberate, sane default: it protects every other tenant on the node from a noisy neighbor. Our control group hit its wall at exactly 48GiB &divide; 128Mi &asymp; 373 &mdash; textbook admission-controlled scheduling, working exactly as designed.</p>
+  <p>Incus's <code>limits.memory</code>, by contrast, is a cgroup <strong>ceiling</strong>, not a reservation. A box declared at 256Mi that's only using 90MiB only counts 90MiB against the host.</p>
+
+  <figure>
+    <svg viewBox="0 0 640 260" role="img" aria-label="Bar chart comparing declared memory reservation versus actual memory used, for Kubernetes agent-sandbox and for Containarium. Kubernetes' declared and actual bars are equal at 128 mebibytes. Containarium's declared bar is 256 mebibytes but its actual bar is only about 90 mebibytes, showing the gap that explains the density difference.">
+      <g font-size="12.5" fill="currentColor">
+        <!-- axis -->
+        <line x1="70" y1="210" x2="620" y2="210" stroke="currentColor" stroke-opacity="0.25"/>
+
+        <!-- k8s group -->
+        <text x="150" y="234" text-anchor="middle" font-size="13" font-weight="600">k8s + agent-sandbox</text>
+        <!-- declared -->
+        <rect x="95" y="82" width="42" height="128" fill="currentColor" fill-opacity="0.35"/>
+        <text x="116" y="72" text-anchor="middle">128Mi</text>
+        <text x="116" y="228" text-anchor="middle" font-size="11" fill-opacity="0.6">declared</text>
+        <!-- actual -->
+        <rect x="163" y="82" width="42" height="128" fill="#4c5fd5"/>
+        <text x="184" y="72" text-anchor="middle">128Mi</text>
+        <text x="184" y="228" text-anchor="middle" font-size="11" fill-opacity="0.6">actual used</text>
+
+        <!-- containarium group -->
+        <text x="470" y="234" text-anchor="middle" font-size="13" font-weight="600">Containarium (LXC)</text>
+        <!-- declared -->
+        <rect x="415" y="10" width="42" height="200" fill="currentColor" fill-opacity="0.35"/>
+        <text x="436" y="0" text-anchor="middle" dy="8">256Mi</text>
+        <text x="436" y="228" text-anchor="middle" font-size="11" fill-opacity="0.6">declared</text>
+        <!-- actual -->
+        <rect x="483" y="140" width="42" height="70" fill="#4c5fd5"/>
+        <text x="504" y="130" text-anchor="middle">~90Mi</text>
+        <text x="504" y="228" text-anchor="middle" font-size="11" fill-opacity="0.6">actual used</text>
+
+        <!-- gap annotation -->
+        <line x1="483" y1="10" x2="483" y2="140" stroke="#4c5fd5" stroke-dasharray="3,3" stroke-opacity="0.6"/>
+        <text x="560" y="75" font-size="11" fill="#4c5fd5" font-weight="600">unreserved</text>
+        <text x="560" y="90" font-size="11" fill="#4c5fd5" font-weight="600">headroom</text>
+      </g>
+    </svg>
+    <figcaption>Kubernetes reserves what's declared, whether it's used or not. Incus only ever counts what's actually used against the host &mdash; that gap is the entire density difference.</figcaption>
+  </figure>
+
+  <div class="callout">
+    <p>Containarium's density number is higher because it's <strong>not reserving headroom nobody's using</strong> &mdash; a real, legitimate operational property, and also a real trade-off: no admission backpressure means nothing tells the platform "stop" until the host actually runs out. When we pushed far enough, that's exactly what happened.</p>
+  </div>
+
+  <p><strong>If we'd held both sides to the same admission model</strong> &mdash; memory request == memory limit, same as Containarium's <code>create</code> always does &mdash; Containarium's own earlier k8s+gVisor run actually landed <em>behind</em> the control group (186 vs. 373), because its declared ceiling (256Mi) is exactly 2&times; the control group's declared request (128Mi). Same host, same math, opposite conclusion. The admission model is the variable, not the sandboxing technology.</p>
+
+  <h2>What we actually hit pushing to 929</h2>
+  <p>Getting there wasn't one clean run &mdash; it took three real fixes, found live, in order:</p>
+
+  <ol>
+    <li><strong><code>containarium list</code> didn't scale.</strong> The benchmark's own polling loop called <code>list</code> &mdash; which fetches every container's full state &mdash; every ~2 seconds while waiting on one sandbox to boot. At a few hundred containers that put real, unnecessary load on the management daemon. Fix: a <code>get</code> command for the one-container case.</li>
+    <li><strong>A background cache had the same bug, independent of the benchmark.</strong> Containarium's own traffic-attribution cache re-fetched every container's details every 30 seconds, forever, regardless of whether anything changed. Fixed to only re-fetch what actually changed.</li>
+    <li><strong>The real wall was RAM, not CPU</strong> &mdash; and it landed at ~930 sandboxes on both the buggy and the fixed run. That's the confirmation we wanted: fixing the software bugs didn't move the physical ceiling, it just let us actually reach it cleanly instead of stalling early on self-inflicted overhead.</li>
+  </ol>
+
+  <p>Each fix, measured live at the same checkpoint container counts:</p>
+
+  <div class="tablewrap">
+    <table>
+      <thead>
+        <tr><th>containers</th><th>before either fix</th><th>get fix only</th><th>both fixes</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>~400</td><td class="bad">incusd 914% cpu</td><td>load ~19</td><td class="good">load 4&ndash;8</td></tr>
+        <tr><td>~570</td><td class="bad">load ~117</td><td>load 32&ndash;40</td><td class="good">load 15&ndash;21</td></tr>
+        <tr><td>~760</td><td>&mdash; (had already stopped)</td><td class="bad">load 125&ndash;182</td><td class="good">load 38&ndash;40</td></tr>
+        <tr><td>~930</td><td>569 (stopped: bug)</td><td>931 (stopped: RAM)</td><td class="good">929 (stopped: RAM)</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <p>We also found and fixed a couple of smaller things along the way &mdash; a per-create install step that should've been baked into an image once instead of repeated on every create, and a host account creation bug that silently broke after about a dozen tenants.</p>
+
+  <h2>What this means if you're running agent-sandbox</h2>
+  <p>Not "switch to Containarium." The actual, portable takeaway: <strong>if your agents are idle-heavy</strong> &mdash; and most agent sandboxes spend most of their time waiting, not computing &mdash; your real memory usage is probably far below whatever you've declared as the request. Kubernetes gives you the lever to close that gap yourself: lower requests, a VPA tuned to actual usage, or a <code>LimitRange</code> that keeps limits generous while requests track reality &mdash; without touching gVisor, without touching agent-sandbox's own code.</p>
+  <p>The density gap we measured isn't a verdict on either project. It's a measurement of two different default postures toward the same trade-off, and it's one you can dial on either side.</p>
+
+  <hr class="end">
+  <p class="byline">Full methodology, every host spec, every raw number, and the complete bug-by-bug investigation live in <code>benchmark/agent-sandbox-density/</code> in the Containarium repo &mdash; reproduce it yourself, or tell us where the comparison should go next.</p>
+</main>

--- a/benchmark/agent-sandbox-density/blog-preview.html
+++ b/benchmark/agent-sandbox-density/blog-preview.html
@@ -144,8 +144,6 @@
     padding: 18px 20px;
   }
 
-  .headline-stat.win { border-color: var(--accent); box-shadow: 0 0 0 1px var(--accent) inset; }
-
   .headline-stat .n {
     font-family: 'JetBrains Mono', monospace;
     font-weight: 600;
@@ -153,8 +151,6 @@
     color: var(--ink);
     line-height: 1;
   }
-
-  .headline-stat.win .n { color: var(--accent); }
 
   .headline-stat .l {
     font-size: 0.82rem;
@@ -192,6 +188,7 @@
   }
 
   svg text { font-family: 'JetBrains Mono', monospace; }
+  figure svg { width: 100%; height: auto; display: block; }
 
   ol, ul { color: var(--ink-soft); padding-left: 1.3em; }
   li { margin: 0.6em 0; }
@@ -249,7 +246,7 @@
       <div class="n">186</div>
       <div class="l"><strong>k8s + gVisor + Containarium</strong><br>same isolation, same host</div>
     </div>
-    <div class="headline-stat win">
+    <div class="headline-stat">
       <div class="n">929</div>
       <div class="l"><strong>Containarium native LXC</strong><br>no k8s, no gVisor</div>
     </div>
@@ -258,15 +255,15 @@
   <p>If you only remember one of those numbers, remember that the <strong>gVisor-matched comparison is 186 vs. 373 &mdash; and Containarium is the smaller one.</strong> That's not a caveat buried in the fine print; it's the fair fight, and it's worth understanding exactly why before the 929 number means anything.</p>
 
   <h2>The apples-to-apples result: 186 vs. 373</h2>
-  <p>Same host, same hard resource cap (48GiB RAM / 20 vCPU), same sandbox profile family, both under Kubernetes with the identical <code>runsc</code> (gVisor) RuntimeClass. The only real difference is how each side declares its sandbox's memory:</p>
+  <p>Same host, same hard resource cap (48GiB RAM / 20 vCPU), same sandbox profile family, both under Kubernetes with the identical <code>runsc</code> (gVisor) RuntimeClass. The clearest, most quantifiable difference between the two runs is how each side declares its sandbox's memory:</p>
   <ul>
     <li>agent-sandbox's pods request <strong>128Mi</strong></li>
     <li>Containarium's <code>create</code> sets request and limit to the same value &mdash; <strong>256Mi</strong>, exactly 2&times;</li>
   </ul>
-  <p>Kubernetes' scheduler reserves the full <strong>declared request</strong> against node capacity the instant a pod is scheduled, whether the pod ever touches that memory or not. 48GiB &divide; 128Mi &asymp; 373. 48GiB &divide; 256Mi &asymp; 186. Halve 373 and you land almost exactly on 186.</p>
+  <p>Kubernetes' scheduler reserves the full <strong>declared request</strong> against node capacity the instant a pod is scheduled, whether the pod ever touches that memory or not. At the stopping point, node memory requests hit 47984Mi/48GiB (99%) for agent-sandbox and 47856Mi/48GiB (99%) for Containarium &mdash; both sides essentially saturated the same total memory budget, just divided into differently-sized chunks: 373 &times; 128Mi &asymp; 46.6GiB, 186 &times; 256Mi &asymp; 46.5GiB. Halving the request size, not halving anything else, is what produces almost exactly half the count.</p>
 
   <div class="callout">
-    <p><strong>The entire gap is the declared-size asymmetry &mdash; not gVisor overhead, not orchestration cost.</strong> Same isolation technology, same admission model, smaller declared footprint wins. Nothing about Containarium is more efficient here; it just asks for less. Declare Containarium's sandboxes at 128Mi too, and the two numbers converge.</p>
+    <p><strong>That declared-size asymmetry accounts for the ~2:1 gap we observed &mdash; not gVisor overhead, not orchestration cost.</strong> Same isolation technology, same admission model, smaller declared footprint wins. Nothing about Containarium is more efficient here; it just asks for less. Declare Containarium's sandboxes at 128Mi too, and the two numbers converge. One other asymmetry worth naming honestly rather than glossing over: agent-sandbox's pods run a minimal <code>busybox</code> image, while Containarium's boxes run its real, heavier <code>containarium-agent-box</code> runtime &mdash; a structural difference neither side can equalize with a flag (see the README's "Fairness notes" for the full accounting).</p>
   </div>
 
   <p>We re-ran this scenario independently on a fresh cluster to check it wasn't a fluke &mdash; <strong>186 ready, 189 attempted, an exact match</strong> down to the node memory snapshot at the stopping point (47856Mi/48GiB, 99%, identical both times). It's a solid, reproducible number.</p>
@@ -294,7 +291,6 @@
         <text x="312" y="11" text-anchor="middle">256Mi</text>
         <rect x="350" y="20" width="34" height="210" fill="#4c5fd5"/>
         <text x="367" y="11" text-anchor="middle">256Mi</text>
-        <text x="335" y="-4" text-anchor="middle" font-size="10" fill-opacity="0.6" dy="14">reserved = used, same as agent-sandbox</text>
 
         <!-- group 3: native LXC -->
         <text x="565" y="252" text-anchor="middle" font-size="12" font-weight="600">Containarium native</text>
@@ -315,20 +311,21 @@
     <figcaption>Kubernetes reserves the full declared amount either way &mdash; that's why the middle bars match. Only the native LXC path (right) ever counts less than what's declared, and that gap is the entire density difference.</figcaption>
   </figure>
 
-  <p>The mechanism is the same <em>kind</em> of gap, just triggered differently. Kubernetes reserves what's <em>declared</em>, always, both for agent-sandbox's pods and for Containarium's own pods above &mdash; that's why 186 tracks 373 so cleanly. Incus's <code>limits.memory</code>, when there's no Kubernetes scheduler in front of it, is a cgroup <strong>ceiling</strong>, not a reservation: a box declared at 256Mi that's only using ~90MiB only counts ~90MiB against the host.</p>
+  <p>The mechanism is the same <em>kind</em> of gap, just triggered differently. Kubernetes reserves what's <em>declared</em>, always, both for agent-sandbox's pods and for Containarium's own pods above &mdash; that's why 186 tracks 373 so cleanly. Incus's <code>limits.memory</code>, when there's no Kubernetes scheduler in front of it, is a cgroup <strong>ceiling</strong>, not a reservation: through most of this run, boxes declared at 256Mi were only actually using something like 90&ndash;100MiB (measured at checkpoints along the way, not a number we confirmed still held at the final count) &mdash; and only that much counted against the host.</p>
 
   <div class="callout">
     <p>That's a real, legitimate operational property of running LXC directly &mdash; and a real trade-off. No admission backpressure means nothing tells the platform "stop" until the host actually runs out. When we pushed far enough, that's exactly what happened: the host ran out of real RAM at ~930 sandboxes, full stop, independent of anything else we fixed along the way.</p>
   </div>
 
   <h2>What we actually hit pushing the LXC path to 929</h2>
-  <p>Getting there wasn't one clean run &mdash; it took three real fixes, found live, in order:</p>
+  <p>Getting there wasn't one clean run &mdash; two real fixes, found live, then a wall that held:</p>
 
   <ol>
     <li><strong><code>containarium list</code> didn't scale.</strong> The benchmark's own polling loop called <code>list</code> &mdash; which fetches every container's full state &mdash; every ~2 seconds while waiting on one sandbox to boot. At a few hundred containers that put real, unnecessary load on the management daemon. Fix: a <code>get</code> command for the one-container case.</li>
     <li><strong>A background cache had the same bug, independent of the benchmark.</strong> Containarium's own traffic-attribution cache re-fetched every container's details every 30 seconds, forever, regardless of whether anything changed. Fixed to only re-fetch what actually changed.</li>
-    <li><strong>The real wall was RAM, not CPU</strong> &mdash; and it landed at ~930 sandboxes on both the buggy and the fixed run. That's the confirmation we wanted: fixing the software bugs didn't move the physical ceiling, it just let us actually reach it cleanly instead of stalling early on self-inflicted overhead.</li>
   </ol>
+
+  <p><strong>Then the real wall: RAM, not CPU.</strong> It landed at ~930 sandboxes on both the fixed run and the earlier, buggy one &mdash; not because fixing the software bugs moved the physical ceiling, but because the fixes let us actually <em>reach</em> it cleanly instead of stalling early on self-inflicted daemon CPU overhead.</p>
 
   <p>Each fix, measured live at the same checkpoint container counts:</p>
 
@@ -338,10 +335,10 @@
         <tr><th>containers</th><th>before either fix</th><th>get fix only</th><th>both fixes</th></tr>
       </thead>
       <tbody>
-        <tr><td>~400</td><td class="bad">incusd 914% cpu</td><td>load ~19</td><td class="good">load 4&ndash;8</td></tr>
-        <tr><td>~570</td><td class="bad">load ~117</td><td>load 32&ndash;40</td><td class="good">load 15&ndash;21</td></tr>
-        <tr><td>~760</td><td>&mdash; (had already stopped)</td><td class="bad">load 125&ndash;182</td><td class="good">load 38&ndash;40</td></tr>
-        <tr><td>~930</td><td>569 (stopped: bug)</td><td>931 (stopped: RAM)</td><td class="good">929 (stopped: RAM)</td></tr>
+        <tr><td>~400</td><td>n/a &mdash; unfixed run never got a clean reading this early</td><td>load ~19, incusd 914% cpu</td><td class="good">load 4&ndash;8, incusd 48% cpu</td></tr>
+        <tr><td>~570</td><td class="bad">incusd 1025% cpu, load ~117 &mdash; stopped here</td><td>load 32&ndash;40</td><td class="good">load 15&ndash;21</td></tr>
+        <tr><td>~760</td><td>&mdash;</td><td class="bad">load 125&ndash;182</td><td class="good">load 38&ndash;40</td></tr>
+        <tr><td>final count</td><td class="bad">569 (stopped: incusd CPU wall)</td><td>931 (stopped: RAM, incusd OOM-killed)</td><td class="good">929 (stopped: RAM)</td></tr>
       </tbody>
     </table>
   </div>

--- a/benchmark/agent-sandbox-density/blog-preview.html
+++ b/benchmark/agent-sandbox-density/blog-preview.html
@@ -269,6 +269,8 @@
     <p><strong>The entire gap is the declared-size asymmetry &mdash; not gVisor overhead, not orchestration cost.</strong> Same isolation technology, same admission model, smaller declared footprint wins. Nothing about Containarium is more efficient here; it just asks for less. Declare Containarium's sandboxes at 128Mi too, and the two numbers converge.</p>
   </div>
 
+  <p>We re-ran this scenario independently on a fresh cluster to check it wasn't a fluke &mdash; <strong>186 ready, 189 attempted, an exact match</strong> down to the node memory snapshot at the stopping point (47856Mi/48GiB, 99%, identical both times). It's a solid, reproducible number.</p>
+
   <h2>Where 929 comes from &mdash; a different deployment entirely</h2>
   <p>Containarium also ships a native LXC/Incus backend: no Kubernetes, no gVisor, sandboxes run directly on the host. Run the same benchmark there and you get <strong>929</strong> &mdash; but this isn't a gVisor-vs-gVisor result, because there's no gVisor and no Kubernetes admission control in this path at all. It's a different question: raw LXC density vs. k8s+gVisor density, with a different isolation model underneath.</p>
 

--- a/benchmark/agent-sandbox-density/blog-preview.html
+++ b/benchmark/agent-sandbox-density/blog-preview.html
@@ -1,4 +1,4 @@
-<title>929, 373, 186</title>
+<title>929, 373, 373</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,400&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap">
 
 <style>
@@ -161,6 +161,13 @@
 
   .headline-stat .l strong { color: var(--ink-soft); font-weight: 600; }
 
+  .headline-stat .was {
+    font-size: 0.78rem;
+    color: var(--muted);
+    margin-top: 6px;
+  }
+  .headline-stat .was s { color: var(--bad); text-decoration-color: var(--bad); }
+
   .callout {
     background: var(--accent-soft);
     border-left: 3px solid var(--accent);
@@ -232,10 +239,10 @@
 
 <main>
   <p class="kicker">Containarium engineering</p>
-  <h1>929, 373, 186: what actually explains agent sandbox density</h1>
-  <p class="dek">Three deployment modes, one host, and the resource-accounting mechanism behind every number &mdash; including the one where Containarium loses.</p>
+  <h1>929, 373, 373: a density gap, a one-flag fix, and a different deployment mode entirely</h1>
+  <p class="dek">We found a real gap, a real cause, and a real fix &mdash; and we're telling the whole story, not just the ending.</p>
 
-  <p>We wanted to know a simple thing: how many isolated agent sandboxes can you actually fit on one machine? So we ran a real, live density benchmark across three deployment modes on the same host, pushed each until it broke, and fixed what we broke along the way.</p>
+  <p>We wanted to know a simple thing: how many isolated agent sandboxes can you actually fit on one machine? So we ran a real, live density benchmark across three deployment modes on the same host, pushed each until it broke, found a real gap, fixed it, and re-ran to confirm.</p>
 
   <div class="headline-figure">
     <div class="headline-stat">
@@ -243,8 +250,9 @@
       <div class="l"><strong>k8s + agent-sandbox</strong><br>gVisor pods</div>
     </div>
     <div class="headline-stat">
-      <div class="n">186</div>
+      <div class="n">373</div>
       <div class="l"><strong>k8s + gVisor + Containarium</strong><br>same isolation, same host</div>
+      <div class="was">was <s>186</s> &mdash; fixed by #1557</div>
     </div>
     <div class="headline-stat">
       <div class="n">929</div>
@@ -252,27 +260,49 @@
     </div>
   </div>
 
-  <p>If you only remember one of those numbers, remember that the <strong>gVisor-matched comparison is 186 vs. 373 &mdash; and Containarium is the smaller one.</strong> That's not a caveat buried in the fine print; it's the fair fight, and it's worth understanding exactly why before the 929 number means anything.</p>
+  <p>The middle number used to be 186. We found out why, fixed the actual cause &mdash; a genuine, one-flag CLI gap, not a measurement error &mdash; and re-ran the exact same comparison. It now matches exactly. Here's the whole story, including the part where we were wrong first.</p>
 
-  <h2>The apples-to-apples result: 186 vs. 373</h2>
-  <p>Same host, same hard resource cap (48GiB RAM / 20 vCPU), same sandbox profile family, both under Kubernetes with the identical <code>runsc</code> (gVisor) RuntimeClass. The clearest, most quantifiable difference between the two runs is how each side declares its sandbox's memory:</p>
+  <h2>Round one: 186 vs. 373, and why</h2>
+  <p>Same host, same hard resource cap (48GiB RAM / 20 vCPU), same sandbox profile family, both under Kubernetes with the identical <code>runsc</code> (gVisor) RuntimeClass. The first time we ran this, Containarium's boxes only reached 186 against agent-sandbox's 373 &mdash; roughly half.</p>
+  <p>The cause traced to how each side declares its sandbox's memory:</p>
   <ul>
-    <li>agent-sandbox's pods request <strong>128Mi</strong></li>
-    <li>Containarium's <code>create</code> sets request and limit to the same value &mdash; <strong>256Mi</strong>, exactly 2&times;</li>
+    <li>agent-sandbox's pods request <strong>128Mi</strong>, with a <strong>256Mi</strong> limit</li>
+    <li>Containarium's <code>create</code> had no way to set those two numbers separately &mdash; <code>--memory 256Mi</code> set <em>both</em> request and limit to 256Mi, exactly 2&times; agent-sandbox's request</li>
   </ul>
-  <p>Kubernetes' scheduler reserves the full <strong>declared request</strong> against node capacity the instant a pod is scheduled, whether the pod ever touches that memory or not. At the stopping point, node memory requests hit 47984Mi/48GiB (99%) for agent-sandbox and 47856Mi/48GiB (99%) for Containarium &mdash; both sides essentially saturated the same total memory budget, just divided into differently-sized chunks: 373 &times; 128Mi &asymp; 46.6GiB, 186 &times; 256Mi &asymp; 46.5GiB. Halving the request size, not halving anything else, is what produces almost exactly half the count.</p>
+  <p>Kubernetes' scheduler reserves the full <strong>declared request</strong> against node capacity the instant a pod is scheduled, whether the pod ever touches that memory or not. At the stopping point, node memory requests hit 47984Mi/48GiB (99%) for agent-sandbox and 47856Mi/48GiB (99%) for Containarium &mdash; both sides essentially saturated the same total memory budget, just divided into differently-sized chunks: 373 &times; 128Mi &asymp; 46.6GiB, 186 &times; 256Mi &asymp; 46.5GiB. Halving the request size, not halving anything else, produced almost exactly half the count. We re-ran it independently on a fresh cluster to rule out a fluke &mdash; 186 ready, 189 attempted, an exact match down to the node memory snapshot. It was a real, solid, reproducible number. It just wasn't the whole story yet.</p>
 
-  <div class="callout">
-    <p><strong>That declared-size asymmetry accounts for the ~2:1 gap we observed &mdash; not gVisor overhead, not orchestration cost.</strong> Same isolation technology, same admission model, smaller declared footprint wins. Nothing about Containarium is more efficient here; it just asks for less. Declare Containarium's sandboxes at 128Mi too, and the two numbers converge. One other asymmetry worth naming honestly rather than glossing over: agent-sandbox's pods run a minimal <code>busybox</code> image, while Containarium's boxes run its real, heavier <code>containarium-agent-box</code> runtime &mdash; a structural difference neither side can equalize with a flag (see the README's "Fairness notes" for the full accounting).</p>
+  <h2>The fix: a missing CLI flag, not an architecture problem</h2>
+  <p><code>ResourceLimits.memory</code> was always applied as <em>both</em> request and limit &mdash; there was no field, no flag, no way to ask for a smaller request under a bigger limit, the way Burstable QoS pods (agent-sandbox's included) are normally sized. Kubernetes itself supports <code>request &ne; limit</code> fine; Containarium's <code>create</code> API had simply never exposed the second number.</p>
+  <p>We added it &mdash; <a href="https://github.com/FootprintAI/Containarium/issues/1557">#1557</a>, shipped as <a href="https://github.com/FootprintAI/Containarium/pull/1560">PR #1560</a>: <code>containarium create</code> gained <code>--memory-request</code>/<code>--cpu-request</code>, separate from <code>--memory</code>/<code>--cpu</code> (which stay the limit). Empty preserves the old behavior exactly &mdash; additive, not a breaking change.</p>
+
+  <h2>Round two: 373 vs. 373, exact match</h2>
+  <p>With the fix landed, we re-ran the comparison on a fresh cluster &mdash; Containarium's boxes now declared at the <em>same</em> profile as agent-sandbox's pods (request 128Mi / limit 256Mi memory, 25m/50m CPU) &mdash; and, since only the runtime class was the remaining variable, we also took the opportunity to isolate gVisor's own cost cleanly: the identical matched profile, run once under gVisor (<code>runsc</code>) and once under plain <code>runc</code>, on the same cluster.</p>
+
+  <div class="tablewrap">
+    <table>
+      <thead>
+        <tr><th></th><th>gVisor (runsc)</th><th>plain runc</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>Sandboxes reached RUNNING</td><td class="good">373</td><td class="good">373</td></tr>
+        <tr><td>Attempted (incl. failures)</td><td>376</td><td>376</td></tr>
+        <tr><td>Node memory requests at stop</td><td>47984Mi/48GiB (99%)</td><td>47984Mi/48GiB (99%)</td></tr>
+        <tr><td>Wall-clock for the density loop</td><td class="bad">~77 min</td><td class="good">~40 min</td></tr>
+      </tbody>
+    </table>
   </div>
 
-  <p>We re-ran this scenario independently on a fresh cluster to check it wasn't a fluke &mdash; <strong>186 ready, 189 attempted, an exact match</strong> down to the node memory snapshot at the stopping point (47856Mi/48GiB, 99%, identical both times). It's a solid, reproducible number.</p>
+  <div class="callout">
+    <p><strong>Exact match, identical node memory snapshot down to the Mi, and it lands within a rounding error of agent-sandbox's own 373.</strong> With the request/limit split available, Containarium's k8s+gVisor path doesn't just close the gap with agent-sandbox &mdash; it matches it. gVisor's own per-pod density cost is not measurable at this sandbox size against a 48GiB host: the entire 186-vs-373 gap really was the declared-size asymmetry, exactly as we suspected but couldn't yet prove the first time around. Worth naming honestly: agent-sandbox's pods still run a minimal <code>busybox</code> image against Containarium's real, heavier <code>containarium-agent-box</code> runtime in this run too &mdash; that asymmetry never went away, and the counts matched exactly anyway, because density here is governed by the declared memory <em>request</em>, not image size or pull time.</p>
+  </div>
+
+  <p>The one real, measurable difference between the two legs wasn't density &mdash; it was time. ~77 minutes under gVisor vs. ~40 minutes under plain <code>runc</code> to reach the same 373, roughly 2&times;. gVisor's per-sandbox startup overhead is real; it shows up in <em>how fast</em> you get to a given density, not in <em>how dense</em> you can get. Worth knowing, not worth losing sleep over for most workloads &mdash; but it's the honest, separate cost gVisor actually has here.</p>
 
   <h2>Where 929 comes from &mdash; a different deployment entirely</h2>
   <p>Containarium also ships a native LXC/Incus backend: no Kubernetes, no gVisor, sandboxes run directly on the host. Run the same benchmark there and you get <strong>929</strong> &mdash; but this isn't a gVisor-vs-gVisor result, because there's no gVisor and no Kubernetes admission control in this path at all. It's a different question: raw LXC density vs. k8s+gVisor density, with a different isolation model underneath.</p>
 
   <figure>
-    <svg viewBox="0 0 660 280" role="img" aria-label="Bar chart comparing declared memory reservation versus actual memory used across three deployment modes. Kubernetes agent-sandbox: declared and actual both 128 mebibytes. Kubernetes plus gVisor plus Containarium: declared and actual both 256 mebibytes, because Kubernetes reserves the full declared amount regardless of the runtime underneath. Containarium native LXC, no Kubernetes: declared 256 mebibytes but actual used only about 90 mebibytes, the gap that explains its higher density.">
+    <svg viewBox="0 0 660 280" role="img" aria-label="Bar chart comparing declared memory reservation versus actual memory counted across three deployment modes. Kubernetes agent-sandbox: declared and counted both 128 mebibytes. Kubernetes plus gVisor plus Containarium, with the fixed request/limit split: declared and counted both 128 mebibytes too, matching agent-sandbox exactly. Containarium native LXC, no Kubernetes: declared 256 mebibytes but actual used only about 90 mebibytes, the gap that explains its higher density.">
       <g font-size="11.5" fill="currentColor">
         <line x1="30" y1="230" x2="630" y2="230" stroke="currentColor" stroke-opacity="0.25"/>
 
@@ -284,13 +314,13 @@
         <rect x="120" y="105" width="34" height="125" fill="#4c5fd5"/>
         <text x="137" y="96" text-anchor="middle">128Mi</text>
 
-        <!-- group 2: containarium k8s+gvisor -->
+        <!-- group 2: containarium k8s+gvisor, fixed to match group 1 -->
         <text x="335" y="252" text-anchor="middle" font-size="12" font-weight="600">gVisor + Containarium</text>
-        <text x="335" y="266" text-anchor="middle" font-size="10" fill-opacity="0.55">(k8s)</text>
-        <rect x="295" y="20" width="34" height="210" fill="currentColor" fill-opacity="0.35"/>
-        <text x="312" y="11" text-anchor="middle">256Mi</text>
-        <rect x="350" y="20" width="34" height="210" fill="#4c5fd5"/>
-        <text x="367" y="11" text-anchor="middle">256Mi</text>
+        <text x="335" y="266" text-anchor="middle" font-size="10" fill-opacity="0.55">(k8s, fixed)</text>
+        <rect x="295" y="105" width="34" height="125" fill="currentColor" fill-opacity="0.35"/>
+        <text x="312" y="96" text-anchor="middle">128Mi</text>
+        <rect x="350" y="105" width="34" height="125" fill="#4c5fd5"/>
+        <text x="367" y="96" text-anchor="middle">128Mi</text>
 
         <!-- group 3: native LXC -->
         <text x="565" y="252" text-anchor="middle" font-size="12" font-weight="600">Containarium native</text>
@@ -305,13 +335,13 @@
         <rect x="30" y="8" width="10" height="10" fill="currentColor" fill-opacity="0.35"/>
         <text x="44" y="17" font-size="10.5" fill-opacity="0.7">declared</text>
         <rect x="110" y="8" width="10" height="10" fill="#4c5fd5"/>
-        <text x="124" y="17" font-size="10.5" fill-opacity="0.7">actually used</text>
+        <text x="124" y="17" font-size="10.5" fill-opacity="0.7">counted against the host</text>
       </g>
     </svg>
-    <figcaption>Kubernetes reserves the full declared amount either way &mdash; that's why the middle bars match. Only the native LXC path (right) ever counts less than what's declared, and that gap is the entire density difference.</figcaption>
+    <figcaption>Left and middle bars are now the same height &mdash; once Containarium declares the same request as agent-sandbox, Kubernetes counts the same amount either way. Only the native LXC path (right) ever counts less than what's declared, and that gap is what explains its higher density.</figcaption>
   </figure>
 
-  <p>The mechanism is the same <em>kind</em> of gap, just triggered differently. Kubernetes reserves what's <em>declared</em>, always, both for agent-sandbox's pods and for Containarium's own pods above &mdash; that's why 186 tracks 373 so cleanly. Incus's <code>limits.memory</code>, when there's no Kubernetes scheduler in front of it, is a cgroup <strong>ceiling</strong>, not a reservation: through most of this run, boxes declared at 256Mi were only actually using something like 90&ndash;100MiB (measured at checkpoints along the way, not a number we confirmed still held at the final count) &mdash; and only that much counted against the host.</p>
+  <p>The mechanism is the same <em>kind</em> of gap, just triggered differently. Kubernetes reserves what's <em>declared</em>, always &mdash; that's the mechanism behind both 373s above. Incus's <code>limits.memory</code>, when there's no Kubernetes scheduler in front of it, is a cgroup <strong>ceiling</strong>, not a reservation: through most of this run, boxes declared at 256Mi were only actually using something like 90&ndash;100MiB (measured at checkpoints along the way, not a number we confirmed still held at the final count) &mdash; and only that much counted against the host.</p>
 
   <div class="callout">
     <p>That's a real, legitimate operational property of running LXC directly &mdash; and a real trade-off. No admission backpressure means nothing tells the platform "stop" until the host actually runs out. When we pushed far enough, that's exactly what happened: the host ran out of real RAM at ~930 sandboxes, full stop, independent of anything else we fixed along the way.</p>
@@ -346,11 +376,10 @@
   <p>We also found and fixed a couple of smaller things along the way &mdash; a per-create install step that should've been baked into an image once instead of repeated on every create, and a host account creation bug that silently broke after about a dozen tenants. Full detail, every number, every commit: <code>RESULTS.md</code> in the benchmark folder.</p>
 
   <h2>What this actually means</h2>
-  <p>Two separate, honest takeaways, not one flattering headline:</p>
 
-  <p><strong>If you need gVisor-grade isolation under Kubernetes</strong>, Containarium's sandboxes don't magically pack denser than agent-sandbox's &mdash; on this benchmark they packed for fewer, purely because of a declared-size choice that's easy to change. If your agents are idle-heavy (most agent sandboxes spend most of their time waiting, not computing), the real lever for <em>either</em> system is the same: your actual memory usage is probably far below whatever you've declared as the request. Lower it, or tune a VPA to track reality &mdash; without touching gVisor, without touching either project's code.</p>
+  <p><strong>If you need gVisor-grade isolation under Kubernetes</strong>, Containarium's sandboxes now pack exactly as densely as agent-sandbox's &mdash; 373 vs. 373, confirmed twice. That wasn't true when we started this investigation: it took finding a real gap and shipping a real fix (<a href="https://github.com/FootprintAI/Containarium/issues/1557">#1557</a>) to get here, and we're telling that whole story rather than only the flattering ending. The one remaining cost is time-to-density under gVisor (~2&times; slower to fill the same host), not density itself. If your agents are idle-heavy (most agent sandboxes spend most of their time waiting, not computing), the lever that matters for <em>either</em> system is the same regardless: your actual memory usage is probably far below whatever you've declared as the request &mdash; lower it, or tune a VPA to track reality.</p>
 
-  <p><strong>If you're willing to leave Kubernetes and gVisor's isolation model behind</strong>, Containarium's native LXC backend can pack meaningfully more &mdash; because it isn't reserving headroom nobody's using. That's a real, different trade-off (weaker isolation boundary, no admission backpressure, a hard wall when you finally exhaust real memory), not a strictly-better number.</p>
+  <p><strong>If you're willing to leave Kubernetes and gVisor's isolation model behind</strong>, Containarium's native LXC backend can pack meaningfully more &mdash; 929 vs. 373 &mdash; because it isn't reserving headroom nobody's using. That's a real, different trade-off (weaker isolation boundary, no admission backpressure, a hard wall when you finally exhaust real memory), not a strictly-better number, and not the same comparison as the gVisor-matched result above.</p>
 
   <hr class="end">
   <p class="byline">Full methodology, every host spec, every raw number, and the complete bug-by-bug investigation live in <code>benchmark/agent-sandbox-density/</code> in the Containarium repo &mdash; reproduce it yourself, or tell us where the comparison should go next.</p>


### PR DESCRIPTION
## Summary
Short narrative blog draft for containarium.dev, distilled from `RESULTS.md`'s full investigation across all three scenarios and the #1541 fix-verification runs.

- Leads with the resource-accounting mechanism (declared-reservation vs. actual-usage admission), not the headline count
- Includes the counter-example that keeps this honest: holding both sides to the same admission model reverses the outcome (186 vs 373)
- Summarizes the fix-by-fix load-average data as evidence, not marketing
- `blog-preview.html` is a rendered preview for review before this content goes into the actual site's publishing pipeline (separate repo)

Not auto-merging — this is a content draft for review/editing, not a code change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the benchmark article comparing density across native LXC and Kubernetes-based deployments.
  - Corrected the reported results on a 48 GiB, 20-vCPU host to 929 native LXC sandboxes, 373 agent-sandbox pods, and 373 Containarium sandboxes.
  - Added matched gVisor and `runc` timing comparisons, clarified memory and CPU request behavior, and revised deployment trade-offs.
  - Updated the responsive HTML preview, charts, captions, comparison tables, and operational guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->