### PR TITLE
feat(routes): add CLI/MCP surface for TCP/UDP passthrough routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,9 +539,15 @@ containarium route add api.example.com --target 10.0.3.42:3000
 containarium route list
 containarium route delete api.example.com
 
-# Raw TCP/UDP passthrough (no TLS termination)
+# Raw TCP/UDP passthrough via local iptables (host running the CLI only)
 containarium passthrough add --port 50051 \
   --target-ip 10.0.3.150 --target-port 50051
+
+# Raw TCP/UDP passthrough via the daemon API (works against a remote box)
+containarium passthrough-route add --port 9443 \
+  --target-ip 10.0.3.150 --target-port 50051 --server <host:port>
+containarium passthrough-route list --server <host:port>
+containarium passthrough-route remove --port 9443 --server <host:port>
 ```
 
 ### SSH config

--- a/README.md
+++ b/README.md
@@ -182,16 +182,17 @@ Same surface as the platform MCP, plus deeper administration. Top-level
 verbs:
 
 ```
-containarium create        Create a new container
-containarium list          List all containers
-containarium delete        Delete a container
-containarium expose-port   Expose container:port on a public hostname
-containarium ssh-config    Generate self-contained ssh_config
-containarium route         Manage proxy routes (low-level)
-containarium passthrough   Manage TCP/UDP passthrough rules
-containarium token         Issue JWT tokens for the API
-containarium info          System info
-containarium version       Print version
+containarium create             Create a new container
+containarium list               List all containers
+containarium delete             Delete a container
+containarium expose-port        Expose container:port on a public hostname
+containarium ssh-config         Generate self-contained ssh_config
+containarium route              Manage proxy routes (low-level)
+containarium passthrough        Manage TCP/UDP passthrough rules (local iptables)
+containarium passthrough-route  Manage TCP/UDP passthrough routes (daemon API)
+containarium token              Issue JWT tokens for the API
+containarium info               System info
+containarium version            Print version
 ```
 
 Run `containarium <verb> --help` for full options.

--- a/internal/client/grpc.go
+++ b/internal/client/grpc.go
@@ -1210,6 +1210,59 @@ func (c *GRPCClient) DeleteRoute(domain string) error {
 	return nil
 }
 
+// ListPassthroughRoutes lists all TCP/UDP passthrough routes via gRPC
+func (c *GRPCClient) ListPassthroughRoutes() ([]*pb.PassthroughRoute, int32, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resp, err := c.networkClient.ListPassthroughRoutes(ctx, &pb.ListPassthroughRoutesRequest{})
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to list passthrough routes: %w", err)
+	}
+
+	return resp.Routes, resp.TotalCount, nil
+}
+
+// AddPassthroughRoute adds a new TCP/UDP passthrough route via gRPC
+func (c *GRPCClient) AddPassthroughRoute(externalPort, targetPort int32, targetIP string, protocol pb.RouteProtocol, containerName, description string) (*pb.PassthroughRoute, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	req := &pb.AddPassthroughRouteRequest{
+		ExternalPort:  externalPort,
+		TargetIp:      targetIP,
+		TargetPort:    targetPort,
+		Protocol:      protocol,
+		ContainerName: containerName,
+		Description:   description,
+	}
+
+	resp, err := c.networkClient.AddPassthroughRoute(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to add passthrough route: %w", err)
+	}
+
+	return resp.Route, nil
+}
+
+// DeletePassthroughRoute deletes a TCP/UDP passthrough route via gRPC
+func (c *GRPCClient) DeletePassthroughRoute(externalPort int32, protocol pb.RouteProtocol) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	req := &pb.DeletePassthroughRouteRequest{
+		ExternalPort: externalPort,
+		Protocol:     protocol,
+	}
+
+	_, err := c.networkClient.DeletePassthroughRoute(ctx, req)
+	if err != nil {
+		return fmt.Errorf("failed to delete passthrough route: %w", err)
+	}
+
+	return nil
+}
+
 // StartEgressProxy asks the daemon to bridge a host-loopback SOCKS (exposed by
 // the caller via `ssh -R`) into a box's netns (#808 egress-via-client). Returns
 // the in-box SOCKS address to point the box's apps at.

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -2017,6 +2017,96 @@ func (c *HTTPClient) DeleteRoute(domain string) error {
 	return nil
 }
 
+// --- Passthrough routes (#1550) --------------------------------------------
+//
+// TCP/UDP passthrough routes (raw L4, no TLS termination) mirror the proxy
+// route methods above but talk to /v1/network/passthrough[...]. These RPCs
+// existed server-side with no external caller until this issue; see
+// AddPassthroughRoute/ListPassthroughRoutes/DeletePassthroughRoute in
+// internal/server/network_server.go.
+
+// ListPassthroughRoutes returns the TCP/UDP passthrough routes (GET
+// /v1/network/passthrough). Mirrors GRPCClient.ListPassthroughRoutes.
+func (c *HTTPClient) ListPassthroughRoutes() ([]*pb.PassthroughRoute, int32, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	resp, err := c.doRequest(ctx, http.MethodGet, "/v1/network/passthrough", nil)
+	if err != nil {
+		return nil, 0, fmt.Errorf("list passthrough routes: %w", err)
+	}
+	defer drainClose(resp)
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return nil, 0, httpErr("list passthrough routes", resp.StatusCode, bodyBytes)
+	}
+	out := &pb.ListPassthroughRoutesResponse{}
+	if err := protojson.Unmarshal(bodyBytes, out); err != nil {
+		return nil, 0, fmt.Errorf("decode list-passthrough-routes response: %w", err)
+	}
+	return out.GetRoutes(), out.GetTotalCount(), nil
+}
+
+// AddPassthroughRoute registers a TCP/UDP port-forwarding rule (POST
+// /v1/network/passthrough). Mirrors GRPCClient.AddPassthroughRoute.
+func (c *HTTPClient) AddPassthroughRoute(externalPort, targetPort int32, targetIP string, protocol pb.RouteProtocol, containerName, description string) (*pb.PassthroughRoute, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	body, err := json.Marshal(addPassthroughRouteRequest{
+		ExternalPort:  externalPort,
+		TargetIP:      targetIP,
+		TargetPort:    targetPort,
+		Protocol:      protocol,
+		ContainerName: containerName,
+		Description:   description,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+	resp, err := c.doRequest(ctx, http.MethodPost, "/v1/network/passthrough", body)
+	if err != nil {
+		return nil, fmt.Errorf("add passthrough route: %w", err)
+	}
+	defer drainClose(resp)
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return nil, httpErr("add passthrough route", resp.StatusCode, bodyBytes)
+	}
+	out := &pb.AddPassthroughRouteResponse{}
+	if err := protojson.Unmarshal(bodyBytes, out); err != nil {
+		return nil, fmt.Errorf("decode add-passthrough-route response: %w", err)
+	}
+	return out.GetRoute(), nil
+}
+
+// DeletePassthroughRoute removes a TCP/UDP passthrough route (DELETE
+// /v1/network/passthrough/{external_port}?protocol=...). Protocol travels as
+// a query param (grpc-gateway accepts either the enum name or its numeric
+// value; we send the name for readability). Mirrors
+// GRPCClient.DeletePassthroughRoute.
+func (c *HTTPClient) DeletePassthroughRoute(externalPort int32, protocol pb.RouteProtocol) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	q := url.Values{}
+	q.Set("protocol", protocol.String())
+	path := fmt.Sprintf("/v1/network/passthrough/%d?%s", externalPort, q.Encode())
+	resp, err := c.doRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return fmt.Errorf("delete passthrough route: %w", err)
+	}
+	defer drainClose(resp)
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return httpErr("delete passthrough route", resp.StatusCode, bodyBytes)
+	}
+	return nil
+}
+
 // httpErr builds an error from a >=400 REST response, preferring the daemon's
 // {"error": ...} body over a bare status code.
 func httpErr(op string, status int, body []byte) error {

--- a/internal/client/http_passthrough_test.go
+++ b/internal/client/http_passthrough_test.go
@@ -1,0 +1,183 @@
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// Tests for the TCP/UDP passthrough route methods added for #1550: until
+// now AddPassthroughRoute/ListPassthroughRoutes/DeletePassthroughRoute had
+// no client-layer caller at all, even though the RPCs and their REST
+// mapping (grpc-gateway on /v1/network/passthrough[...]) already existed
+// server-side.
+
+func TestHTTPAddPassthroughRoute_Success(t *testing.T) {
+	var gotPath, gotMethod string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"route": {
+				"externalPort": 9443,
+				"targetIp": "10.0.3.150",
+				"targetPort": 50051,
+				"protocol": "ROUTE_PROTOCOL_TCP",
+				"active": true,
+				"containerName": "alice-container"
+			},
+			"message": "Passthrough route added: tcp:9443 -> 10.0.3.150:50051 (will sync to iptables)"
+		}`))
+	}))
+	defer srv.Close()
+
+	c, err := NewHTTPClient(srv.URL, "tok")
+	if err != nil {
+		t.Fatalf("NewHTTPClient: %v", err)
+	}
+
+	route, err := c.AddPassthroughRoute(9443, 50051, "10.0.3.150", pb.RouteProtocol_ROUTE_PROTOCOL_TCP, "alice-container", "grpc mTLS")
+	if err != nil {
+		t.Fatalf("AddPassthroughRoute: %v", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q; want POST", gotMethod)
+	}
+	if gotPath != "/v1/network/passthrough" {
+		t.Errorf("path = %q; want /v1/network/passthrough", gotPath)
+	}
+	// JSON numbers decode as float64.
+	if gotBody["external_port"] != float64(9443) {
+		t.Errorf("external_port = %v; want 9443", gotBody["external_port"])
+	}
+	if gotBody["target_ip"] != "10.0.3.150" {
+		t.Errorf("target_ip = %v; want 10.0.3.150", gotBody["target_ip"])
+	}
+	if gotBody["protocol"] != float64(pb.RouteProtocol_ROUTE_PROTOCOL_TCP) {
+		t.Errorf("protocol = %v; want %v", gotBody["protocol"], pb.RouteProtocol_ROUTE_PROTOCOL_TCP)
+	}
+
+	if route.GetExternalPort() != 9443 {
+		t.Errorf("route.ExternalPort = %d; want 9443", route.GetExternalPort())
+	}
+	if route.GetTargetIp() != "10.0.3.150" {
+		t.Errorf("route.TargetIp = %q; want 10.0.3.150", route.GetTargetIp())
+	}
+	if route.GetProtocol() != pb.RouteProtocol_ROUTE_PROTOCOL_TCP {
+		t.Errorf("route.Protocol = %v; want TCP", route.GetProtocol())
+	}
+}
+
+func TestHTTPAddPassthroughRoute_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"error":"port already in use"}`))
+	}))
+	defer srv.Close()
+
+	c, err := NewHTTPClient(srv.URL, "tok")
+	if err != nil {
+		t.Fatalf("NewHTTPClient: %v", err)
+	}
+	_, err = c.AddPassthroughRoute(9443, 50051, "10.0.3.150", pb.RouteProtocol_ROUTE_PROTOCOL_TCP, "", "")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestHTTPListPassthroughRoutes(t *testing.T) {
+	var gotPath, gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"routes": [
+				{
+					"externalPort": 9443,
+					"targetIp": "10.0.3.150",
+					"targetPort": 50051,
+					"protocol": "ROUTE_PROTOCOL_TCP",
+					"active": true,
+					"containerName": "alice-container"
+				}
+			],
+			"totalCount": 1
+		}`))
+	}))
+	defer srv.Close()
+
+	c, err := NewHTTPClient(srv.URL, "tok")
+	if err != nil {
+		t.Fatalf("NewHTTPClient: %v", err)
+	}
+	routes, total, err := c.ListPassthroughRoutes()
+	if err != nil {
+		t.Fatalf("ListPassthroughRoutes: %v", err)
+	}
+	if gotMethod != http.MethodGet {
+		t.Errorf("method = %q; want GET", gotMethod)
+	}
+	if gotPath != "/v1/network/passthrough" {
+		t.Errorf("path = %q; want /v1/network/passthrough", gotPath)
+	}
+	if total != 1 {
+		t.Errorf("total = %d; want 1", total)
+	}
+	if len(routes) != 1 || routes[0].GetExternalPort() != 9443 {
+		t.Fatalf("routes = %+v; want one route with externalPort 9443", routes)
+	}
+}
+
+func TestHTTPDeletePassthroughRoute(t *testing.T) {
+	var gotPath, gotMethod, gotProtocol string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		gotProtocol = r.URL.Query().Get("protocol")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"message":"Passthrough route removed: tcp:9443 (will sync to iptables)"}`))
+	}))
+	defer srv.Close()
+
+	c, err := NewHTTPClient(srv.URL, "tok")
+	if err != nil {
+		t.Fatalf("NewHTTPClient: %v", err)
+	}
+	if err := c.DeletePassthroughRoute(9443, pb.RouteProtocol_ROUTE_PROTOCOL_TCP); err != nil {
+		t.Fatalf("DeletePassthroughRoute: %v", err)
+	}
+	if gotMethod != http.MethodDelete {
+		t.Errorf("method = %q; want DELETE", gotMethod)
+	}
+	if gotPath != "/v1/network/passthrough/9443" {
+		t.Errorf("path = %q; want /v1/network/passthrough/9443", gotPath)
+	}
+	if gotProtocol != "ROUTE_PROTOCOL_TCP" {
+		t.Errorf("protocol query = %q; want ROUTE_PROTOCOL_TCP", gotProtocol)
+	}
+}
+
+func TestHTTPDeletePassthroughRoute_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"not found"}`))
+	}))
+	defer srv.Close()
+
+	c, err := NewHTTPClient(srv.URL, "tok")
+	if err != nil {
+		t.Fatalf("NewHTTPClient: %v", err)
+	}
+	err = c.DeletePassthroughRoute(9443, pb.RouteProtocol_ROUTE_PROTOCOL_TCP)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}

--- a/internal/client/http_requests.go
+++ b/internal/client/http_requests.go
@@ -244,3 +244,13 @@ type addRouteRequest struct {
 	ContainerName string `json:"container_name"`
 	Description   string `json:"description"`
 }
+
+// addPassthroughRouteRequest is POST /v1/network/passthrough.
+type addPassthroughRouteRequest struct {
+	ExternalPort  int32            `json:"external_port"`
+	TargetIP      string           `json:"target_ip"`
+	TargetPort    int32            `json:"target_port"`
+	Protocol      pb.RouteProtocol `json:"protocol"`
+	ContainerName string           `json:"container_name"`
+	Description   string           `json:"description"`
+}

--- a/internal/client/http_requests_test.go
+++ b/internal/client/http_requests_test.go
@@ -61,6 +61,9 @@ func TestRequestPayloadWireFormat(t *testing.T) {
 		{"addRouteRequest", addRouteRequest{}, []string{
 			"container_name", "description", "domain", "target_ip", "target_port",
 		}},
+		{"addPassthroughRouteRequest", addPassthroughRouteRequest{}, []string{
+			"container_name", "description", "external_port", "protocol", "target_ip", "target_port",
+		}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			got := marshalKeys(t, tc.payload)

--- a/internal/cmd/passthrough_route.go
+++ b/internal/cmd/passthrough_route.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"github.com/spf13/cobra"
+)
+
+// passthroughRouteCmd represents the passthrough-route command group.
+//
+// Named distinctly from the existing `passthrough` command (local iptables
+// DNAT on the host running the CLI, pkg/core/network — see passthrough.go):
+// this one talks to the daemon's AddPassthroughRoute / ListPassthroughRoutes
+// / DeletePassthroughRoute RPCs, so it works against a remote box the CLI
+// has no shell access to, the same way `route` does for HTTPS proxy routes.
+// See #1550.
+var passthroughRouteCmd = &cobra.Command{
+	Use:   "passthrough-route",
+	Short: "Manage daemon-level TCP/UDP passthrough routes",
+	Long: `Manage TCP/UDP passthrough routes on the Containarium daemon.
+
+Passthrough routes forward traffic directly to a container without TLS
+termination (raw L4), unlike 'route' which is an HTTPS reverse-proxy
+mapping. These routes are created via the daemon's API — use this command
+(rather than 'passthrough', which edits iptables on the local host) to
+manage passthrough routes on a remote box.
+
+Examples:
+  # Add a passthrough route
+  containarium passthrough-route add --port 9443 --target-ip 10.0.3.150 --target-port 50051 --server <host:port>
+
+  # List all passthrough routes
+  containarium passthrough-route list --server <host:port>
+
+  # Remove a passthrough route
+  containarium passthrough-route remove --port 9443 --server <host:port>`,
+}
+
+func init() {
+	rootCmd.AddCommand(passthroughRouteCmd)
+}
+
+// parsePassthroughRouteProtocol maps the CLI's --protocol flag to the
+// proto enum. Empty defaults to TCP, matching the daemon's own default
+// (internal/server/network_server.go's AddPassthroughRoute).
+func parsePassthroughRouteProtocol(s string) (pb.RouteProtocol, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "tcp":
+		return pb.RouteProtocol_ROUTE_PROTOCOL_TCP, nil
+	case "udp":
+		return pb.RouteProtocol_ROUTE_PROTOCOL_UDP, nil
+	default:
+		return pb.RouteProtocol_ROUTE_PROTOCOL_UNSPECIFIED, fmt.Errorf("protocol must be 'tcp' or 'udp', got %q", s)
+	}
+}

--- a/internal/cmd/passthrough_route_add.go
+++ b/internal/cmd/passthrough_route_add.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	passthroughRouteAddPort        int
+	passthroughRouteAddTargetIP    string
+	passthroughRouteAddTargetPort  int
+	passthroughRouteAddProtocol    string
+	passthroughRouteAddContainer   string
+	passthroughRouteAddDescription string
+)
+
+var passthroughRouteAddCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Add a daemon-level TCP/UDP passthrough route",
+	Long: `Add a new TCP/UDP passthrough route on the Containarium daemon.
+
+Forwards an external port on the daemon's host directly to a container's
+IP:port without TLS termination.
+
+Examples:
+  # Forward port 50051 to a container
+  containarium passthrough-route add --port 50051 --target-ip 10.0.3.150 --target-port 50051 --server <host:port>
+
+  # Forward external port 9443 to container port 50051, with metadata
+  containarium passthrough-route add --port 9443 --target-ip 10.0.3.150 --target-port 50051 \
+    --container myapp-container --description "mTLS gRPC" --server <host:port>
+
+  # Add a UDP passthrough
+  containarium passthrough-route add --port 53 --target-ip 10.0.3.150 --target-port 53 --protocol udp --server <host:port>`,
+	RunE: runPassthroughRouteAdd,
+}
+
+func init() {
+	passthroughRouteCmd.AddCommand(passthroughRouteAddCmd)
+
+	passthroughRouteAddCmd.Flags().IntVar(&passthroughRouteAddPort, "port", 0, "External port to expose (required)")
+	passthroughRouteAddCmd.Flags().StringVar(&passthroughRouteAddTargetIP, "target-ip", "", "Target container IP address (required)")
+	passthroughRouteAddCmd.Flags().IntVar(&passthroughRouteAddTargetPort, "target-port", 0, "Target port on the container (required)")
+	passthroughRouteAddCmd.Flags().StringVar(&passthroughRouteAddProtocol, "protocol", "tcp", "Protocol: tcp or udp")
+	passthroughRouteAddCmd.Flags().StringVarP(&passthroughRouteAddContainer, "container", "c", "", "Associated container name (optional)")
+	passthroughRouteAddCmd.Flags().StringVarP(&passthroughRouteAddDescription, "description", "d", "", "Route description (optional)")
+
+	_ = passthroughRouteAddCmd.MarkFlagRequired("port")
+	_ = passthroughRouteAddCmd.MarkFlagRequired("target-ip")
+	_ = passthroughRouteAddCmd.MarkFlagRequired("target-port")
+}
+
+func runPassthroughRouteAdd(cmd *cobra.Command, args []string) error {
+	if serverAddr == "" {
+		return fmt.Errorf("--server is required")
+	}
+	if passthroughRouteAddPort <= 0 || passthroughRouteAddPort > 65535 {
+		return fmt.Errorf("port must be between 1 and 65535")
+	}
+	if passthroughRouteAddTargetPort <= 0 || passthroughRouteAddTargetPort > 65535 {
+		return fmt.Errorf("target-port must be between 1 and 65535")
+	}
+	if passthroughRouteAddTargetIP == "" {
+		return fmt.Errorf("target-ip is required")
+	}
+	protocol, err := parsePassthroughRouteProtocol(passthroughRouteAddProtocol)
+	if err != nil {
+		return err
+	}
+
+	apiClient, err := newRouteClient()
+	if err != nil {
+		return fmt.Errorf("failed to connect to server: %w", err)
+	}
+	defer func() { _ = apiClient.Close() }()
+
+	route, err := apiClient.AddPassthroughRoute(
+		int32(passthroughRouteAddPort),
+		int32(passthroughRouteAddTargetPort),
+		passthroughRouteAddTargetIP,
+		protocol,
+		passthroughRouteAddContainer,
+		passthroughRouteAddDescription,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to add passthrough route: %w", err)
+	}
+
+	fmt.Printf("Passthrough route added successfully!\n")
+	fmt.Printf("  Protocol: %s\n", passthroughRouteAddProtocol)
+	fmt.Printf("  External: %d\n", route.GetExternalPort())
+	fmt.Printf("  Target:   %s:%d\n", route.GetTargetIp(), route.GetTargetPort())
+	if passthroughRouteAddContainer != "" {
+		fmt.Printf("  Container: %s\n", passthroughRouteAddContainer)
+	}
+
+	return nil
+}

--- a/internal/cmd/passthrough_route_list.go
+++ b/internal/cmd/passthrough_route_list.go
@@ -52,7 +52,7 @@ func runPassthroughRouteList(cmd *cobra.Command, args []string) error {
 	case "table":
 		printPassthroughRouteTableFormat(routes, totalCount)
 	case "json":
-		return printPassthroughRouteJSONFormat(routes)
+		return printPassthroughRouteJSONFormat(routes, totalCount)
 	default:
 		return fmt.Errorf("unknown format: %s (use: table, json)", passthroughRouteListFormat)
 	}
@@ -93,10 +93,10 @@ func printPassthroughRouteTableFormat(routes []*pb.PassthroughRoute, totalCount 
 	fmt.Printf("Total: %d passthrough routes\n", totalCount)
 }
 
-func printPassthroughRouteJSONFormat(routes []*pb.PassthroughRoute) error {
+func printPassthroughRouteJSONFormat(routes []*pb.PassthroughRoute, totalCount int32) error {
 	output := map[string]interface{}{
 		"routes":      routes,
-		"total_count": len(routes),
+		"total_count": totalCount,
 	}
 
 	data, err := json.MarshalIndent(output, "", "  ")

--- a/internal/cmd/passthrough_route_list.go
+++ b/internal/cmd/passthrough_route_list.go
@@ -1,0 +1,109 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"github.com/spf13/cobra"
+)
+
+var passthroughRouteListFormat string
+
+var passthroughRouteListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List daemon-level TCP/UDP passthrough routes",
+	Long: `List all TCP/UDP passthrough routes configured on the Containarium daemon.
+
+Examples:
+  # List all passthrough routes
+  containarium passthrough-route list --server <host:port>
+
+  # List in JSON format
+  containarium passthrough-route list --format json --server <host:port>`,
+	Aliases: []string{"ls"},
+	RunE:    runPassthroughRouteList,
+}
+
+func init() {
+	passthroughRouteCmd.AddCommand(passthroughRouteListCmd)
+
+	passthroughRouteListCmd.Flags().StringVarP(&passthroughRouteListFormat, "format", "f", "table", "Output format: table, json")
+}
+
+func runPassthroughRouteList(cmd *cobra.Command, args []string) error {
+	if serverAddr == "" {
+		return fmt.Errorf("--server is required")
+	}
+
+	apiClient, err := newRouteClient()
+	if err != nil {
+		return fmt.Errorf("failed to connect to server: %w", err)
+	}
+	defer func() { _ = apiClient.Close() }()
+
+	routes, totalCount, err := apiClient.ListPassthroughRoutes()
+	if err != nil {
+		return fmt.Errorf("failed to list passthrough routes: %w", err)
+	}
+
+	switch passthroughRouteListFormat {
+	case "table":
+		printPassthroughRouteTableFormat(routes, totalCount)
+	case "json":
+		return printPassthroughRouteJSONFormat(routes)
+	default:
+		return fmt.Errorf("unknown format: %s (use: table, json)", passthroughRouteListFormat)
+	}
+
+	return nil
+}
+
+func printPassthroughRouteTableFormat(routes []*pb.PassthroughRoute, totalCount int32) {
+	fmt.Printf("%-8s %-10s %-25s %-8s %-12s\n", "EXT PORT", "PROTOCOL", "TARGET", "STATUS", "CONTAINER")
+	fmt.Printf("%-8s %-10s %-25s %-8s %-12s\n",
+		strings.Repeat("-", 8),
+		strings.Repeat("-", 10),
+		strings.Repeat("-", 25),
+		strings.Repeat("-", 8),
+		strings.Repeat("-", 12))
+
+	if len(routes) == 0 {
+		fmt.Println("No passthrough routes configured.")
+		return
+	}
+
+	for _, route := range routes {
+		status := "active"
+		if !route.GetActive() {
+			status = "inactive"
+		}
+		target := fmt.Sprintf("%s:%d", route.GetTargetIp(), route.GetTargetPort())
+
+		fmt.Printf("%-8d %-10s %-25s %-8s %-12s\n",
+			route.GetExternalPort(),
+			route.GetProtocol().String(),
+			truncateRoute(target, 25),
+			status,
+			route.GetContainerName())
+	}
+
+	fmt.Println()
+	fmt.Printf("Total: %d passthrough routes\n", totalCount)
+}
+
+func printPassthroughRouteJSONFormat(routes []*pb.PassthroughRoute) error {
+	output := map[string]interface{}{
+		"routes":      routes,
+		"total_count": len(routes),
+	}
+
+	data, err := json.MarshalIndent(output, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal JSON: %w", err)
+	}
+
+	fmt.Println(string(data))
+	return nil
+}

--- a/internal/cmd/passthrough_route_remove.go
+++ b/internal/cmd/passthrough_route_remove.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	passthroughRouteRemovePort     int
+	passthroughRouteRemoveProtocol string
+)
+
+var passthroughRouteRemoveCmd = &cobra.Command{
+	Use:   "remove",
+	Short: "Remove a daemon-level TCP/UDP passthrough route",
+	Long: `Remove a TCP/UDP passthrough route from the Containarium daemon by its
+external port and protocol.
+
+Examples:
+  # Remove a TCP passthrough route
+  containarium passthrough-route remove --port 9443 --server <host:port>
+
+  # Remove a UDP passthrough route
+  containarium passthrough-route remove --port 53 --protocol udp --server <host:port>`,
+	Aliases: []string{"rm", "delete"},
+	RunE:    runPassthroughRouteRemove,
+}
+
+func init() {
+	passthroughRouteCmd.AddCommand(passthroughRouteRemoveCmd)
+
+	passthroughRouteRemoveCmd.Flags().IntVar(&passthroughRouteRemovePort, "port", 0, "External port to remove (required)")
+	passthroughRouteRemoveCmd.Flags().StringVar(&passthroughRouteRemoveProtocol, "protocol", "tcp", "Protocol: tcp or udp")
+
+	_ = passthroughRouteRemoveCmd.MarkFlagRequired("port")
+}
+
+func runPassthroughRouteRemove(cmd *cobra.Command, args []string) error {
+	if serverAddr == "" {
+		return fmt.Errorf("--server is required")
+	}
+	if passthroughRouteRemovePort <= 0 || passthroughRouteRemovePort > 65535 {
+		return fmt.Errorf("port must be between 1 and 65535")
+	}
+	protocol, err := parsePassthroughRouteProtocol(passthroughRouteRemoveProtocol)
+	if err != nil {
+		return err
+	}
+
+	apiClient, err := newRouteClient()
+	if err != nil {
+		return fmt.Errorf("failed to connect to server: %w", err)
+	}
+	defer func() { _ = apiClient.Close() }()
+
+	if err := apiClient.DeletePassthroughRoute(int32(passthroughRouteRemovePort), protocol); err != nil {
+		return fmt.Errorf("failed to remove passthrough route: %w", err)
+	}
+
+	fmt.Printf("Passthrough route removed: %s:%d\n", passthroughRouteRemoveProtocol, passthroughRouteRemovePort)
+
+	return nil
+}

--- a/internal/cmd/passthrough_route_test.go
+++ b/internal/cmd/passthrough_route_test.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"testing"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+func TestParsePassthroughRouteProtocol(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    pb.RouteProtocol
+		wantErr bool
+	}{
+		{"empty defaults to tcp", "", pb.RouteProtocol_ROUTE_PROTOCOL_TCP, false},
+		{"tcp", "tcp", pb.RouteProtocol_ROUTE_PROTOCOL_TCP, false},
+		{"udp", "udp", pb.RouteProtocol_ROUTE_PROTOCOL_UDP, false},
+		{"uppercase TCP", "TCP", pb.RouteProtocol_ROUTE_PROTOCOL_TCP, false},
+		{"uppercase UDP", "UDP", pb.RouteProtocol_ROUTE_PROTOCOL_UDP, false},
+		{"padded", "  udp  ", pb.RouteProtocol_ROUTE_PROTOCOL_UDP, false},
+		{"invalid", "http", pb.RouteProtocol_ROUTE_PROTOCOL_UNSPECIFIED, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parsePassthroughRouteProtocol(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (result %v)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("parsePassthroughRouteProtocol(%q) = %v; want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cmd/passthrough_route_test.go
+++ b/internal/cmd/passthrough_route_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
@@ -37,5 +39,32 @@ func TestParsePassthroughRouteProtocol(t *testing.T) {
 				t.Errorf("parsePassthroughRouteProtocol(%q) = %v; want %v", tt.in, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestPrintPassthroughRouteJSONFormat_UsesServerTotalCount is the
+// regression guard for a review finding on #1550: the JSON output
+// recomputed total_count as len(routes) instead of using the server's
+// actual totalCount, so the two would silently diverge the moment the
+// daemon's count and the returned page disagree (e.g. once passthrough
+// listing paginates).
+func TestPrintPassthroughRouteJSONFormat_UsesServerTotalCount(t *testing.T) {
+	routes := []*pb.PassthroughRoute{
+		{ExternalPort: 9443, TargetIp: "10.0.3.150", TargetPort: 50051},
+	}
+	out := captureStdout(t, func() {
+		if err := printPassthroughRouteJSONFormat(routes, 42); err != nil {
+			t.Fatalf("printPassthroughRouteJSONFormat: %v", err)
+		}
+	})
+
+	var decoded struct {
+		TotalCount int `json:"total_count"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &decoded); err != nil {
+		t.Fatalf("unmarshal output: %v\noutput: %s", err, out)
+	}
+	if decoded.TotalCount != 42 {
+		t.Errorf("total_count = %d; want the server-reported 42 (got len(routes)=%d instead)", decoded.TotalCount, len(routes))
 	}
 }

--- a/internal/cmd/route_client.go
+++ b/internal/cmd/route_client.go
@@ -10,15 +10,19 @@ import (
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 )
 
-// routeAPI is the subset of client methods the route / expose-port verbs need.
-// Both *client.GRPCClient and *client.HTTPClient satisfy it, so those verbs can
-// honor --http the same way list / create / connect / … already do — instead
-// of hardcoding gRPC and failing with an opaque name-resolver error against an
-// https:// server. See #909.
+// routeAPI is the subset of client methods the route / expose-port /
+// passthrough-route verbs need. Both *client.GRPCClient and
+// *client.HTTPClient satisfy it, so those verbs can honor --http the same
+// way list / create / connect / … already do — instead of hardcoding gRPC
+// and failing with an opaque name-resolver error against an https://
+// server. See #909.
 type routeAPI interface {
 	AddRoute(domain, targetIP string, targetPort int32, containerName, description string) (*pb.ProxyRoute, error)
 	ListRoutes(username string, activeOnly bool) ([]*pb.ProxyRoute, int32, error)
 	DeleteRoute(domain string) error
+	AddPassthroughRoute(externalPort, targetPort int32, targetIP string, protocol pb.RouteProtocol, containerName, description string) (*pb.PassthroughRoute, error)
+	ListPassthroughRoutes() ([]*pb.PassthroughRoute, int32, error)
+	DeletePassthroughRoute(externalPort int32, protocol pb.RouteProtocol) error
 	ListContainers() ([]incus.ContainerInfo, error)
 	Close() error
 }

--- a/internal/mcp/backend.go
+++ b/internal/mcp/backend.go
@@ -66,6 +66,9 @@ type API interface {
 	AddRoute(req AddRouteRequest) (*AddRouteResponse, error)
 	ListRoutes(username string, activeOnly bool) (*ListRoutesResponse, error)
 	DeleteRoute(domain string) error
+	AddPassthroughRoute(req AddPassthroughRouteRequest) (*AddPassthroughRouteResponse, error)
+	ListPassthroughRoutes() (*ListPassthroughRoutesResponse, error)
+	DeletePassthroughRoute(externalPort int32, protocol string) error
 	ListBackends() (*ListBackendsResponse, error)
 	GetBackend(id string) (*Backend, error)
 	ValidateGPU(backendID, pci string) (*ValidateGPUResult, error)

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -1226,6 +1226,52 @@ func (c *Client) ListRoutes(username string, activeOnly bool) (*ListRoutesRespon
 	return &resp, nil
 }
 
+// AddPassthroughRoute creates a raw TCP/UDP port-forwarding rule (no TLS
+// termination) on the daemon. Used by the add_passthrough_route tool — the
+// passthrough counterpart of AddRoute, for callers who need L4 passthrough
+// (e.g. mTLS gRPC) instead of the HTTPS reverse proxy. See #1550.
+func (c *Client) AddPassthroughRoute(req AddPassthroughRouteRequest) (*AddPassthroughRouteResponse, error) {
+	respBody, err := c.doRequest("POST", "/v1/network/passthrough", req)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp AddPassthroughRouteResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	return &resp, nil
+}
+
+// DeletePassthroughRoute removes a TCP/UDP passthrough route by its
+// external port and protocol — the unexpose counterpart of
+// AddPassthroughRoute. Mirrors DELETE /v1/network/passthrough/{external_port}.
+// Used by the delete_passthrough_route tool.
+func (c *Client) DeletePassthroughRoute(externalPort int32, protocol string) error {
+	path := fmt.Sprintf("/v1/network/passthrough/%d", externalPort)
+	if protocol != "" {
+		path += "?protocol=" + url.QueryEscape(protocol)
+	}
+	_, err := c.doRequest("DELETE", path, nil)
+	return err
+}
+
+// ListPassthroughRoutes returns all TCP/UDP passthrough routes the daemon
+// currently forwards. Mirrors GET /v1/network/passthrough. Used by the
+// list_passthrough_routes tool.
+func (c *Client) ListPassthroughRoutes() (*ListPassthroughRoutesResponse, error) {
+	respBody, err := c.doRequest("GET", "/v1/network/passthrough", nil)
+	if err != nil {
+		return nil, err
+	}
+	var resp ListPassthroughRoutesResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+	return &resp, nil
+}
+
 // ListBackends returns the cluster topology — the local daemon plus any
 // tunnel-connected peers. Used by the list_backends MCP tool so an
 // agent can reason about peer health, container counts, and GPU
@@ -1818,6 +1864,45 @@ type ProxyRoute struct {
 type ListRoutesResponse struct {
 	Routes     []ProxyRoute `json:"routes"`
 	TotalCount int          `json:"totalCount"`
+}
+
+// AddPassthroughRouteRequest mirrors network.proto's
+// AddPassthroughRouteRequest. JSON field names match the grpc-gateway HTTP
+// shape (camelCase). Protocol is the proto enum's name (e.g.
+// "ROUTE_PROTOCOL_TCP") — see passthroughProtocolToProto in tools.go for
+// the friendly-string → proto-name mapping the tool handlers use.
+type AddPassthroughRouteRequest struct {
+	ExternalPort  int32  `json:"externalPort"`
+	TargetIP      string `json:"targetIp"`
+	TargetPort    int32  `json:"targetPort"`
+	Protocol      string `json:"protocol,omitempty"`
+	ContainerName string `json:"containerName,omitempty"`
+	Description   string `json:"description,omitempty"`
+}
+
+type AddPassthroughRouteResponse struct {
+	Route   PassthroughRoute `json:"route"`
+	Message string           `json:"message,omitempty"`
+}
+
+// PassthroughRoute mirrors network.proto's PassthroughRoute — unlike
+// ProxyRoute, its field names match the proto directly (no domain/fullDomain
+// split), so no fallback dance is needed in the handlers.
+type PassthroughRoute struct {
+	ExternalPort  int32  `json:"externalPort"`
+	TargetIP      string `json:"targetIp"`
+	TargetPort    int32  `json:"targetPort"`
+	Protocol      string `json:"protocol,omitempty"`
+	Active        bool   `json:"active,omitempty"`
+	ContainerName string `json:"containerName,omitempty"`
+	Description   string `json:"description,omitempty"`
+}
+
+// ListPassthroughRoutesResponse mirrors the daemon's
+// ListPassthroughRoutesResponse.
+type ListPassthroughRoutesResponse struct {
+	Routes     []PassthroughRoute `json:"routes"`
+	TotalCount int                `json:"totalCount"`
 }
 
 type Container struct {

--- a/internal/mcp/passthrough_route_test.go
+++ b/internal/mcp/passthrough_route_test.go
@@ -115,6 +115,11 @@ func TestAddPassthroughRoute_RejectsMissingArgsAndBadProtocol(t *testing.T) {
 		{"no target_ip", map[string]interface{}{"external_port": float64(80), "target_port": float64(80)}},
 		{"no target_port", map[string]interface{}{"external_port": float64(80), "target_ip": "10.0.3.150"}},
 		{"bad protocol", map[string]interface{}{"external_port": float64(80), "target_ip": "10.0.3.150", "target_port": float64(80), "protocol": "sctp"}},
+		{"external_port out of range", map[string]interface{}{"external_port": float64(70000), "target_ip": "10.0.3.150", "target_port": float64(80)}},
+		{"external_port zero", map[string]interface{}{"external_port": float64(0), "target_ip": "10.0.3.150", "target_port": float64(80)}},
+		{"target_port out of range", map[string]interface{}{"external_port": float64(80), "target_ip": "10.0.3.150", "target_port": float64(-1)}},
+		{"external_port fractional", map[string]interface{}{"external_port": float64(9443.7), "target_ip": "10.0.3.150", "target_port": float64(80)}},
+		{"target_port fractional", map[string]interface{}{"external_port": float64(80), "target_ip": "10.0.3.150", "target_port": float64(50051.5)}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -174,4 +179,46 @@ func TestDeletePassthroughRoute_RejectsMissingPort(t *testing.T) {
 	client := NewClient("http://unused", "token")
 	_, err := handleDeletePassthroughRoute(client, map[string]interface{}{})
 	require.Error(t, err)
+}
+
+func TestDeletePassthroughRoute_RejectsInvalidPort(t *testing.T) {
+	client := NewClient("http://unused", "token")
+	cases := []struct {
+		name string
+		args map[string]interface{}
+	}{
+		{"out of range", map[string]interface{}{"external_port": float64(70000)}},
+		{"zero", map[string]interface{}{"external_port": float64(0)}},
+		{"fractional", map[string]interface{}{"external_port": float64(9443.5)}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := handleDeletePassthroughRoute(client, tc.args)
+			require.Error(t, err)
+		})
+	}
+}
+
+// TestGetPortArg_RejectsFractionalPorts is the regression guard for a
+// review finding on #1550: a fractional JSON number (e.g. an agent-side
+// computation bug producing 9443.7) used to silently truncate to 9443 via
+// getIntArg, with no error — routing traffic to a port the caller never
+// actually specified.
+func TestGetPortArg_RejectsFractionalPorts(t *testing.T) {
+	_, err := getPortArg(map[string]interface{}{"port": float64(9443.7)}, "port")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "whole number")
+}
+
+func TestGetPortArg_AcceptsWholeNumberFloats(t *testing.T) {
+	got, err := getPortArg(map[string]interface{}{"port": float64(9443)}, "port")
+	require.NoError(t, err)
+	assert.EqualValues(t, 9443, got)
+}
+
+func TestGetPortArg_RejectsOutOfRange(t *testing.T) {
+	for _, v := range []float64{0, -1, 65536, 100000} {
+		_, err := getPortArg(map[string]interface{}{"port": v}, "port")
+		require.Error(t, err, "port %v should be rejected", v)
+	}
 }

--- a/internal/mcp/passthrough_route_test.go
+++ b/internal/mcp/passthrough_route_test.go
@@ -1,0 +1,177 @@
+package mcp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Tests for the passthrough-route MCP tools added for #1550: until now
+// AddPassthroughRoute/ListPassthroughRoutes/DeletePassthroughRoute had no
+// MCP surface, even though the RPCs and their grpc-gateway REST mapping
+// already existed server-side (list_routes's own docstring flagged the
+// gap).
+
+func TestPassthroughProtocolToProto(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"", "ROUTE_PROTOCOL_TCP", false},
+		{"tcp", "ROUTE_PROTOCOL_TCP", false},
+		{"TCP", "ROUTE_PROTOCOL_TCP", false},
+		{"udp", "ROUTE_PROTOCOL_UDP", false},
+		{" udp ", "ROUTE_PROTOCOL_UDP", false},
+		{"sctp", "", true},
+	}
+	for _, tc := range cases {
+		got, err := passthroughProtocolToProto(tc.in)
+		if tc.wantErr {
+			assert.Error(t, err, "input %q", tc.in)
+			continue
+		}
+		require.NoError(t, err, "input %q", tc.in)
+		assert.Equal(t, tc.want, got, "input %q", tc.in)
+	}
+}
+
+func TestAddPassthroughRoute_HappyPath(t *testing.T) {
+	var addCalls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "POST" && r.URL.Path == "/v1/network/passthrough":
+			addCalls++
+			var req AddPassthroughRouteRequest
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+			assert.Equal(t, int32(9443), req.ExternalPort)
+			assert.Equal(t, "10.0.3.150", req.TargetIP)
+			assert.Equal(t, int32(50051), req.TargetPort)
+			assert.Equal(t, "ROUTE_PROTOCOL_UDP", req.Protocol)
+			assert.Equal(t, "alice-container", req.ContainerName)
+			_, _ = w.Write([]byte(`{
+				"route": {
+					"externalPort": 9443,
+					"targetIp": "10.0.3.150",
+					"targetPort": 50051,
+					"protocol": "ROUTE_PROTOCOL_UDP",
+					"active": true,
+					"containerName": "alice-container"
+				},
+				"message": "Passthrough route added: udp:9443 -> 10.0.3.150:50051 (will sync to iptables)"
+			}`))
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-token")
+	out, err := handleAddPassthroughRoute(client, map[string]interface{}{
+		"external_port":  float64(9443),
+		"target_ip":      "10.0.3.150",
+		"target_port":    float64(50051),
+		"protocol":       "udp",
+		"container_name": "alice-container",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, addCalls)
+	assert.Contains(t, out, "udp:9443")
+	assert.Contains(t, out, "10.0.3.150:50051")
+	assert.Contains(t, out, "alice-container")
+}
+
+func TestAddPassthroughRoute_DefaultsProtocolToTCP(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		var req AddPassthroughRouteRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		assert.Equal(t, "ROUTE_PROTOCOL_TCP", req.Protocol)
+		_, _ = w.Write([]byte(`{"route":{"externalPort":9443,"targetIp":"10.0.3.150","targetPort":50051},"message":"ok"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-token")
+	_, err := handleAddPassthroughRoute(client, map[string]interface{}{
+		"external_port": float64(9443),
+		"target_ip":     "10.0.3.150",
+		"target_port":   float64(50051),
+	})
+	require.NoError(t, err)
+}
+
+func TestAddPassthroughRoute_RejectsMissingArgsAndBadProtocol(t *testing.T) {
+	client := NewClient("http://unused", "token")
+	cases := []struct {
+		name string
+		args map[string]interface{}
+	}{
+		{"no external_port", map[string]interface{}{"target_ip": "10.0.3.150", "target_port": float64(80)}},
+		{"no target_ip", map[string]interface{}{"external_port": float64(80), "target_port": float64(80)}},
+		{"no target_port", map[string]interface{}{"external_port": float64(80), "target_ip": "10.0.3.150"}},
+		{"bad protocol", map[string]interface{}{"external_port": float64(80), "target_ip": "10.0.3.150", "target_port": float64(80), "protocol": "sctp"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := handleAddPassthroughRoute(client, tc.args)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestListPassthroughRoutes_HappyPath(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "GET", r.Method)
+		require.Equal(t, "/v1/network/passthrough", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"routes": [
+				{
+					"externalPort": 9443,
+					"targetIp": "10.0.3.150",
+					"targetPort": 50051,
+					"protocol": "ROUTE_PROTOCOL_TCP",
+					"active": true
+				}
+			],
+			"totalCount": 1
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-token")
+	out, err := handleListPassthroughRoutes(client, map[string]interface{}{})
+	require.NoError(t, err)
+	assert.Contains(t, out, "9443")
+	assert.Contains(t, out, "10.0.3.150")
+}
+
+func TestDeletePassthroughRoute_HappyPath(t *testing.T) {
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "DELETE", r.Method)
+		gotPath = r.URL.Path + "?" + r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-token")
+	out, err := handleDeletePassthroughRoute(client, map[string]interface{}{
+		"external_port": float64(9443),
+		"protocol":      "udp",
+	})
+	require.NoError(t, err)
+	assert.Contains(t, out, "udp:9443")
+	assert.Equal(t, "/v1/network/passthrough/9443?protocol=ROUTE_PROTOCOL_UDP", gotPath)
+}
+
+func TestDeletePassthroughRoute_RejectsMissingPort(t *testing.T) {
+	client := NewClient("http://unused", "token")
+	_, err := handleDeletePassthroughRoute(client, map[string]interface{}{})
+	require.Error(t, err)
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -22,8 +22,8 @@ func TestServerCreation(t *testing.T) {
 	assert.NotNil(t, server)
 	assert.Equal(t, config, server.config)
 	assert.NotNil(t, server.client)
-	// 30 base (+check_for_updates +upgrade_backend +get_upgrade_status, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes + 3 backups + connect (#453) + 2 agent-skills (#562) + call_agent (#570) + 2 crews (#584) + delete_route + install_zap (#960) + set_metrics_export + get_metrics_export (#1069) + verify_backup (#1159).
-	assert.Len(t, server.tools, 59, "Should have 59 tools registered")
+	// 30 base (+check_for_updates +upgrade_backend +get_upgrade_status, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes + 3 backups + connect (#453) + 2 agent-skills (#562) + call_agent (#570) + 2 crews (#584) + delete_route + install_zap (#960) + set_metrics_export + get_metrics_export (#1069) + verify_backup (#1159) + list_passthrough_routes + add_passthrough_route + delete_passthrough_route (#1550).
+	assert.Len(t, server.tools, 62, "Should have 62 tools registered")
 }
 
 // TestServerTools tests tool registration
@@ -127,8 +127,8 @@ func TestHandleToolsList(t *testing.T) {
 
 	tools, ok := result["tools"].([]map[string]interface{})
 	require.True(t, ok)
-	// 30 base (+check_for_updates +upgrade_backend +get_upgrade_status, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes + 3 backups + connect (#453) + 2 agent-skills (#562) + call_agent (#570) + 2 crews (#584) + delete_route + install_zap (#960) + set_metrics_export + get_metrics_export (#1069) + verify_backup (#1159).
-	assert.Len(t, tools, 59)
+	// 30 base (+check_for_updates +upgrade_backend +get_upgrade_status, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes + 3 backups + connect (#453) + 2 agent-skills (#562) + call_agent (#570) + 2 crews (#584) + delete_route + install_zap (#960) + set_metrics_export + get_metrics_export (#1069) + verify_backup (#1159) + list_passthrough_routes + add_passthrough_route + delete_passthrough_route (#1550).
+	assert.Len(t, tools, 62)
 
 	// Check first tool structure
 	firstTool := tools[0]

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1009,9 +1009,9 @@ func (s *Server) registerTools() {
 				"    public URLs.\n" +
 				"  - Filter by `username` to see only one container's routes, or " +
 				"    `active_only=true` to skip disabled ones.\n\n" +
-				"Read-only — no side effects. For TCP passthrough routes (raw L4, not HTTPS), " +
-				"those live on a different daemon endpoint and aren't included here yet — " +
-				"file a request if you need them surfaced.",
+				"Read-only — no side effects. For TCP/UDP passthrough routes (raw L4, not " +
+				"HTTPS), those live on a different daemon endpoint — use " +
+				"list_passthrough_routes instead.",
 			InputSchema: map[string]interface{}{
 				"type": "object",
 				"properties": map[string]interface{}{
@@ -1086,6 +1086,87 @@ func (s *Server) registerTools() {
 				"required": []string{"username", "container_port", "domain"},
 			},
 			Handler: handleExposePort,
+		},
+		{
+			Name: "list_passthrough_routes",
+			Description: "List the TCP/UDP passthrough routes currently registered on the " +
+				"daemon — raw L4 port-forwarding rules (no TLS termination) created by " +
+				"`add_passthrough_route`. This is the passthrough counterpart of " +
+				"`list_routes`, which only covers HTTPS proxy routes.\n\n" +
+				"Use this to audit what raw ports are currently forwarded before adding a " +
+				"new one, or to find the external port/protocol of a stale passthrough " +
+				"route you need to remove.\n\n" +
+				"Read-only — no side effects.",
+			InputSchema: map[string]interface{}{
+				"type":       "object",
+				"properties": map[string]interface{}{},
+			},
+			Handler: handleListPassthroughRoutes,
+		},
+		{
+			Name: "add_passthrough_route",
+			Description: "Create a TCP/UDP passthrough route: forwards an external port on " +
+				"the daemon's host directly to a container's IP:port, with no TLS " +
+				"termination (raw L4). Use this instead of `expose_port` when the traffic " +
+				"needs end-to-end encryption the sentinel shouldn't terminate (e.g. mTLS " +
+				"gRPC) or isn't HTTP at all.\n\n" +
+				"You'll typically need the container's IP from `get_container` first.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"external_port": map[string]interface{}{
+						"type":        "integer",
+						"description": "Port to open on the daemon's host, e.g. 9443.",
+					},
+					"target_ip": map[string]interface{}{
+						"type":        "string",
+						"description": "Target container's IP address (from get_container).",
+					},
+					"target_port": map[string]interface{}{
+						"type":        "integer",
+						"description": "Port the app listens on inside the container.",
+					},
+					"protocol": map[string]interface{}{
+						"type":        "string",
+						"enum":        []string{"tcp", "udp"},
+						"description": "Protocol to forward. Defaults to 'tcp' if omitted.",
+					},
+					"container_name": map[string]interface{}{
+						"type":        "string",
+						"description": "Optional: associated container name, shown in list_passthrough_routes.",
+					},
+					"description": map[string]interface{}{
+						"type":        "string",
+						"description": "Optional human-readable note for the route.",
+					},
+				},
+				"required": []string{"external_port", "target_ip", "target_port"},
+			},
+			Handler: handleAddPassthroughRoute,
+		},
+		{
+			Name: "delete_passthrough_route",
+			Description: "Remove a TCP/UDP passthrough route by its external port and " +
+				"protocol — the unexpose counterpart of `add_passthrough_route`. After " +
+				"this, the external port no longer forwards to any container.\n\n" +
+				"Idempotent: deleting an already-gone route succeeds (no error). Pass the " +
+				"`externalPort`/`protocol` shown by `list_passthrough_routes`.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"external_port": map[string]interface{}{
+						"type":        "integer",
+						"description": "External port to remove (the `externalPort` from list_passthrough_routes).",
+					},
+					"protocol": map[string]interface{}{
+						"type":        "string",
+						"enum":        []string{"tcp", "udp"},
+						"description": "Protocol of the route to remove. Defaults to 'tcp' if omitted.",
+					},
+				},
+				"required": []string{"external_port"},
+			},
+			Handler: handleDeletePassthroughRoute,
 		},
 		{
 			Name: "list_recipes",
@@ -1337,6 +1418,12 @@ func toolScopeAssignments() map[string]string {
 		"list_routes":  auth.ScopeRoutesRead,
 		"expose_port":  auth.ScopeRoutesWrite,
 		"delete_route": auth.ScopeRoutesWrite,
+		// passthrough routes (raw L4, #1550) — scoped the same as their
+		// HTTPS proxy-route siblings above rather than introducing a new
+		// scope for one feature (see set_metrics_export for the same call).
+		"list_passthrough_routes":  auth.ScopeRoutesRead,
+		"add_passthrough_route":    auth.ScopeRoutesWrite,
+		"delete_passthrough_route": auth.ScopeRoutesWrite,
 		// recipes — declarative GPU/app deploys
 		"list_recipes":  auth.ScopeContainersRead,
 		"deploy_recipe": auth.ScopeContainersWrite,
@@ -2208,6 +2295,108 @@ func handleExposePort(client API, args map[string]interface{}) (string, error) {
 	out += fmt.Sprintf("`curl https://%s/` should reach the app inside %s.",
 		res.Domain, getStringArg(args, "username", ""))
 	return out, nil
+}
+
+// passthroughProtocolToProto maps the tool's friendly "tcp"/"udp" input to
+// the proto enum's wire name, matching how the daemon's grpc-gateway
+// (UseEnumNumbers: false) both emits and accepts RouteProtocol. Empty
+// defaults to TCP — the same default network_server.go's AddPassthroughRoute
+// applies when the protocol is unset.
+func passthroughProtocolToProto(s string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "tcp":
+		return "ROUTE_PROTOCOL_TCP", nil
+	case "udp":
+		return "ROUTE_PROTOCOL_UDP", nil
+	default:
+		return "", fmt.Errorf("protocol must be 'tcp' or 'udp', got %q", s)
+	}
+}
+
+// protoProtocolToFriendly is the inverse of passthroughProtocolToProto, for
+// rendering a route's protocol back to callers as "tcp"/"udp" instead of
+// the proto enum name.
+func protoProtocolToFriendly(s string) string {
+	switch s {
+	case "ROUTE_PROTOCOL_UDP":
+		return "udp"
+	case "ROUTE_PROTOCOL_TCP":
+		return "tcp"
+	default:
+		return s
+	}
+}
+
+func handleListPassthroughRoutes(client API, _ map[string]interface{}) (string, error) {
+	resp, err := client.ListPassthroughRoutes()
+	if err != nil {
+		return "", fmt.Errorf("failed to list passthrough routes: %w", err)
+	}
+
+	out, err := json.MarshalIndent(resp, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal response: %w", err)
+	}
+	return string(out), nil
+}
+
+func handleAddPassthroughRoute(client API, args map[string]interface{}) (string, error) {
+	externalPort, ok := getIntArg(args, "external_port")
+	if !ok {
+		return "", fmt.Errorf("external_port is required")
+	}
+	targetIP := getStringArg(args, "target_ip", "")
+	if targetIP == "" {
+		return "", fmt.Errorf("target_ip is required")
+	}
+	targetPort, ok := getIntArg(args, "target_port")
+	if !ok {
+		return "", fmt.Errorf("target_port is required")
+	}
+	protocol, err := passthroughProtocolToProto(getStringArg(args, "protocol", ""))
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := client.AddPassthroughRoute(AddPassthroughRouteRequest{
+		ExternalPort:  int32(externalPort),
+		TargetIP:      targetIP,
+		TargetPort:    int32(targetPort),
+		Protocol:      protocol,
+		ContainerName: getStringArg(args, "container_name", ""),
+		Description:   getStringArg(args, "description", ""),
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to add passthrough route: %w", err)
+	}
+
+	out := fmt.Sprintf("✅ Passthrough route added: %s:%d → %s:%d\n\n",
+		protoProtocolToFriendly(protocol), externalPort, targetIP, targetPort)
+	out += fmt.Sprintf("External:  %d\n", resp.Route.ExternalPort)
+	out += fmt.Sprintf("Target:    %s:%d\n", resp.Route.TargetIP, resp.Route.TargetPort)
+	if resp.Route.ContainerName != "" {
+		out += fmt.Sprintf("Container: %s\n", resp.Route.ContainerName)
+	}
+	if resp.Message != "" {
+		out += fmt.Sprintf("\n%s", resp.Message)
+	}
+	return out, nil
+}
+
+func handleDeletePassthroughRoute(client API, args map[string]interface{}) (string, error) {
+	externalPort, ok := getIntArg(args, "external_port")
+	if !ok {
+		return "", fmt.Errorf("external_port is required")
+	}
+	protocol, err := passthroughProtocolToProto(getStringArg(args, "protocol", ""))
+	if err != nil {
+		return "", err
+	}
+	if err := client.DeletePassthroughRoute(int32(externalPort), protocol); err != nil {
+		return "", fmt.Errorf("failed to delete passthrough route %d/%s: %w", externalPort, protoProtocolToFriendly(protocol), err)
+	}
+	return fmt.Sprintf("✅ Deleted passthrough route %s:%d — it no longer forwards to any container.",
+		protoProtocolToFriendly(protocol), externalPort), nil
 }
 
 func handleListRecipes(client API, _ map[string]interface{}) (string, error) {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2359,9 +2359,9 @@ func handleAddPassthroughRoute(client API, args map[string]interface{}) (string,
 	}
 
 	resp, err := client.AddPassthroughRoute(AddPassthroughRouteRequest{
-		ExternalPort:  int32(externalPort),
+		ExternalPort:  safecast.I32(externalPort),
 		TargetIP:      targetIP,
-		TargetPort:    int32(targetPort),
+		TargetPort:    safecast.I32(targetPort),
 		Protocol:      protocol,
 		ContainerName: getStringArg(args, "container_name", ""),
 		Description:   getStringArg(args, "description", ""),
@@ -2392,7 +2392,7 @@ func handleDeletePassthroughRoute(client API, args map[string]interface{}) (stri
 	if err != nil {
 		return "", err
 	}
-	if err := client.DeletePassthroughRoute(int32(externalPort), protocol); err != nil {
+	if err := client.DeletePassthroughRoute(safecast.I32(externalPort), protocol); err != nil {
 		return "", fmt.Errorf("failed to delete passthrough route %d/%s: %w", externalPort, protoProtocolToFriendly(protocol), err)
 	}
 	return fmt.Sprintf("✅ Deleted passthrough route %s:%d — it no longer forwards to any container.",

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1116,7 +1117,7 @@ func (s *Server) registerTools() {
 				"properties": map[string]interface{}{
 					"external_port": map[string]interface{}{
 						"type":        "integer",
-						"description": "Port to open on the daemon's host, e.g. 9443.",
+						"description": "Port to open on the daemon's host, e.g. 9443. Must be a whole number in 1..65535.",
 					},
 					"target_ip": map[string]interface{}{
 						"type":        "string",
@@ -1124,7 +1125,7 @@ func (s *Server) registerTools() {
 					},
 					"target_port": map[string]interface{}{
 						"type":        "integer",
-						"description": "Port the app listens on inside the container.",
+						"description": "Port the app listens on inside the container. Must be a whole number in 1..65535.",
 					},
 					"protocol": map[string]interface{}{
 						"type":        "string",
@@ -1156,7 +1157,7 @@ func (s *Server) registerTools() {
 				"properties": map[string]interface{}{
 					"external_port": map[string]interface{}{
 						"type":        "integer",
-						"description": "External port to remove (the `externalPort` from list_passthrough_routes).",
+						"description": "External port to remove (the `externalPort` from list_passthrough_routes). Must be a whole number in 1..65535.",
 					},
 					"protocol": map[string]interface{}{
 						"type":        "string",
@@ -2327,6 +2328,24 @@ func protoProtocolToFriendly(s string) string {
 	}
 }
 
+// getPortArg reads a TCP/UDP port argument as a validated int32: present,
+// a whole number (a JSON float like 9443.7 would otherwise silently
+// truncate to 9443 via getIntArg — routing traffic to a port the caller
+// never actually specified, with no error to say so), and in 1..65535.
+func getPortArg(args map[string]interface{}, key string) (int32, error) {
+	if f, ok := args[key].(float64); ok && f != math.Trunc(f) {
+		return 0, fmt.Errorf("%s must be a whole number, got %v", key, f)
+	}
+	v, ok := getIntArg(args, key)
+	if !ok {
+		return 0, fmt.Errorf("%s is required", key)
+	}
+	if v <= 0 || v > 65535 {
+		return 0, fmt.Errorf("%s must be between 1 and 65535, got %d", key, v)
+	}
+	return safecast.I32(v), nil
+}
+
 func handleListPassthroughRoutes(client API, _ map[string]interface{}) (string, error) {
 	resp, err := client.ListPassthroughRoutes()
 	if err != nil {
@@ -2341,17 +2360,17 @@ func handleListPassthroughRoutes(client API, _ map[string]interface{}) (string, 
 }
 
 func handleAddPassthroughRoute(client API, args map[string]interface{}) (string, error) {
-	externalPort, ok := getIntArg(args, "external_port")
-	if !ok {
-		return "", fmt.Errorf("external_port is required")
+	externalPort, err := getPortArg(args, "external_port")
+	if err != nil {
+		return "", err
 	}
 	targetIP := getStringArg(args, "target_ip", "")
 	if targetIP == "" {
 		return "", fmt.Errorf("target_ip is required")
 	}
-	targetPort, ok := getIntArg(args, "target_port")
-	if !ok {
-		return "", fmt.Errorf("target_port is required")
+	targetPort, err := getPortArg(args, "target_port")
+	if err != nil {
+		return "", err
 	}
 	protocol, err := passthroughProtocolToProto(getStringArg(args, "protocol", ""))
 	if err != nil {
@@ -2359,9 +2378,9 @@ func handleAddPassthroughRoute(client API, args map[string]interface{}) (string,
 	}
 
 	resp, err := client.AddPassthroughRoute(AddPassthroughRouteRequest{
-		ExternalPort:  safecast.I32(externalPort),
+		ExternalPort:  externalPort,
 		TargetIP:      targetIP,
-		TargetPort:    safecast.I32(targetPort),
+		TargetPort:    targetPort,
 		Protocol:      protocol,
 		ContainerName: getStringArg(args, "container_name", ""),
 		Description:   getStringArg(args, "description", ""),
@@ -2384,15 +2403,15 @@ func handleAddPassthroughRoute(client API, args map[string]interface{}) (string,
 }
 
 func handleDeletePassthroughRoute(client API, args map[string]interface{}) (string, error) {
-	externalPort, ok := getIntArg(args, "external_port")
-	if !ok {
-		return "", fmt.Errorf("external_port is required")
+	externalPort, err := getPortArg(args, "external_port")
+	if err != nil {
+		return "", err
 	}
 	protocol, err := passthroughProtocolToProto(getStringArg(args, "protocol", ""))
 	if err != nil {
 		return "", err
 	}
-	if err := client.DeletePassthroughRoute(safecast.I32(externalPort), protocol); err != nil {
+	if err := client.DeletePassthroughRoute(externalPort, protocol); err != nil {
 		return "", fmt.Errorf("failed to delete passthrough route %d/%s: %w", externalPort, protoProtocolToFriendly(protocol), err)
 	}
 	return fmt.Sprintf("✅ Deleted passthrough route %s:%d — it no longer forwards to any container.",


### PR DESCRIPTION
## Summary

- Wires `AddPassthroughRoute` / `ListPassthroughRoutes` / `DeletePassthroughRoute` — which existed server-side (`internal/server/network_server.go`) with **zero** external callers — into `internal/client` (both `GRPCClient` and `HTTPClient`), mirroring the existing proxy-route methods (`AddRoute`/`ListRoutes`/`DeleteRoute`).
- Adds a new `containarium passthrough-route add|list|remove` cobra subcommand, deliberately named apart from the existing `passthrough` command (which edits local iptables on the host running the CLI — a different mechanism, see `pkg/core/network`) since that name was already taken.
- Adds matching MCP tools `add_passthrough_route`, `list_passthrough_routes`, `delete_passthrough_route` as thin wrappers over the same client calls (per this repo's CLI-first convention).
- Updates `list_routes`'s tool description, which previously told callers "file a request if you need [passthrough routes] surfaced" — now points at `list_passthrough_routes`.

## Test evidence

- `internal/client/http_passthrough_test.go` — `TestHTTPAddPassthroughRoute_Success`, `TestHTTPAddPassthroughRoute_ServerError`, `TestHTTPListPassthroughRoutes`, `TestHTTPDeletePassthroughRoute`, `TestHTTPDeletePassthroughRoute_ServerError` cover the HTTPClient wire path (method, path, body/query encoding, response decoding).
- `internal/client/http_requests_test.go` — `TestRequestPayloadWireFormat/addPassthroughRouteRequest` pins the JSON key set of the new request payload.
- `internal/cmd/passthrough_route_test.go` — `TestParsePassthroughRouteProtocol` covers the CLI's `--protocol` flag parsing (tcp/udp/case/whitespace/invalid).
- `internal/mcp/passthrough_route_test.go` — `TestPassthroughProtocolToProto`, `TestAddPassthroughRoute_HappyPath` (+ default-protocol, + missing-arg/bad-protocol rejection), `TestListPassthroughRoutes_HappyPath`, `TestDeletePassthroughRoute_HappyPath` (+ missing-port rejection) cover the full MCP handler → HTTP wire path against an `httptest` server.
- `internal/mcp/server_test.go` — tool-count assertions (`TestServerCreation`, `TestHandleToolsList`) bumped 59→62; the existing `toolScopeAssignments()` completeness test (`internal/mcp/scope_filter_test.go`) enforces every new tool has a scope entry.
- CI run: pending — will link once green (`gh pr checks --watch`).

Local run:
```
go build ./...                                            # PASS
go vet ./internal/mcp/... ./internal/client/... ./internal/cmd/...  # PASS
gofmt -l internal/client internal/cmd internal/mcp        # clean
go test ./internal/...                                     # PASS (all packages)
```

## Notes for reviewers

- No `.proto` changes — the RPCs and their `google.api.http` mappings already existed (added for #1462's future recipe-wiring, per the issue). Only the CLI/client/MCP surface was missing.
- `DeletePassthroughRoute`'s REST route is `DELETE /v1/network/passthrough/{external_port}` with `protocol` as a query param; verified against `grpc-gateway`'s `parseField` (v2.30.0) that it accepts the enum's name string (`ROUTE_PROTOCOL_TCP`), which is what both the CLI and MCP client send.
- Reused `auth.ScopeRoutesRead` / `auth.ScopeRoutesWrite` for the new MCP tools rather than adding new scopes, matching the existing precedent for `set_metrics_export` (comment left in `tools.go`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added remote passthrough-route management for TCP and UDP traffic.
  * Added CLI commands to create, list, and remove daemon-managed routes.
  * Added table and JSON output for route listings.
  * Added MCP tools for listing, creating, and deleting passthrough routes.
  * Protocol input defaults to TCP and accepts TCP/UDP values.

* **Documentation**
  * Clarified local passthrough rules versus daemon-managed routes.

* **Bug Fixes**
  * Improved validation for whole-number ports from 1–65535 and invalid route details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->