### PR TITLE
feat(k8s): separate memory/cpu request from limit (#1557)

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -12099,6 +12099,14 @@
         "storageClass": {
           "type": "string",
           "description": "storage_class is the K8s StorageClass for the box's data PVC (K8s\nruntime only). Empty means use the backend's cluster-wide default\n(CONTAINARIUM_K8S_STORAGE_CLASS). Ignored by the LXC backend.\nExample: \"fast-nvme\", \"standard\", \"ceph-block\"."
+        },
+        "memoryRequest": {
+          "type": "string",
+          "description": "memory_request is the K8s memory *request* (what the scheduler reserves\nagainst node capacity), separate from the `memory` field above, which is\nalways applied as the *limit* (K8s runtime only; ignored by the LXC\nbackend, which has no separate request concept for `limits.memory`).\nEmpty (the default) preserves today's behavior: `memory`'s value is used\nfor both request and limit (Guaranteed QoS). Set this to something\nsmaller than `memory` for Burstable QoS — e.g. request 128Mi, limit\n256Mi, matching how most upstream Kubernetes workloads size a pod."
+        },
+        "cpuRequest": {
+          "type": "string",
+          "description": "cpu_request is the K8s CPU *request*, separate from the `cpu` field\nabove (always applied as the limit). Same defaulting and K8s-only scope\nas memory_request."
         }
       },
       "title": "ResourceLimits defines resource constraints for a container"

--- a/internal/client/grpc.go
+++ b/internal/client/grpc.go
@@ -166,17 +166,19 @@ func (c *GRPCClient) ListContainers() ([]incus.ContainerInfo, error) {
 }
 
 // CreateContainer creates a container via gRPC
-func (c *GRPCClient) CreateContainer(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack string, gpus []string, osType pb.OSType, monitoring bool, pool, backendID string, git GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64, storageClass string, enc EncryptionOpts) (*incus.ContainerInfo, error) {
+func (c *GRPCClient) CreateContainer(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack string, gpus []string, osType pb.OSType, monitoring bool, pool, backendID string, git GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64, storageClass string, enc EncryptionOpts, memoryRequest, cpuRequest string) (*incus.ContainerInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute) // Container creation can take time (includes ultra-aggressive retry logic for google_guest_agent)
 	defer cancel()
 
 	req := &pb.CreateContainerRequest{
 		Username: username,
 		Resources: &pb.ResourceLimits{
-			Cpu:          cpu,
-			Memory:       memory,
-			Disk:         disk,
-			StorageClass: storageClass,
+			Cpu:           cpu,
+			Memory:        memory,
+			Disk:          disk,
+			StorageClass:  storageClass,
+			MemoryRequest: memoryRequest,
+			CpuRequest:    cpuRequest,
 		},
 		SshKeys:                   sshKeys,
 		Image:                     image,

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -306,17 +306,19 @@ type GitSourceOpts struct {
 	WorkspacePath string // empty defaults to /workspace
 }
 
-func (c *HTTPClient) CreateContainer(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack string, gpus []string, osType pb.OSType, monitoring bool, pool, backendID string, git GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64, storageClass string, enc EncryptionOpts) (*incus.ContainerInfo, error) {
+func (c *HTTPClient) CreateContainer(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack string, gpus []string, osType pb.OSType, monitoring bool, pool, backendID string, git GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64, storageClass string, enc EncryptionOpts, memoryRequest, cpuRequest string) (*incus.ContainerInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
 	defer cancel()
 
 	req := createContainerRequest{
 		Username: username,
 		Resources: containerResources{
-			CPU:          cpu,
-			Memory:       memory,
-			Disk:         disk,
-			StorageClass: storageClass,
+			CPU:           cpu,
+			Memory:        memory,
+			Disk:          disk,
+			StorageClass:  storageClass,
+			MemoryRequest: memoryRequest,
+			CPURequest:    cpuRequest,
 		},
 		SSHKeys:      sshKeys,
 		Image:        image,

--- a/internal/client/http_requests.go
+++ b/internal/client/http_requests.go
@@ -33,6 +33,9 @@ type containerResources struct {
 	Disk   string `json:"disk"`
 	// Only sent when a storage class was requested.
 	StorageClass string `json:"storageClass,omitempty"`
+	// Only sent when a request override was given (#1557).
+	MemoryRequest string `json:"memoryRequest,omitempty"`
+	CPURequest    string `json:"cpuRequest,omitempty"`
 }
 
 // createContainerRequest is POST /v1/containers.

--- a/internal/cmd/create.go
+++ b/internal/cmd/create.go
@@ -45,6 +45,8 @@ var (
 	createIdleStop           string
 	createDeleteAfterStopped string
 	createStorageClass       string
+	createMemoryRequest      string
+	createCPURequest         string
 	createWait               bool
 	createWaitTimeout        time.Duration
 )
@@ -164,6 +166,8 @@ func init() {
 	createCmd.Flags().StringVar(&createIdleStop, "idle-stop", "", "Birth idle-stop — auto-STOP the box (free CPU/RAM, keep disk; wakes on access) after this long with no activity (Go duration: '20m', '1h'). Enables auto-sleep atomically at create, so a crashed/cancelled job still releases compute — no separate 'toggle_auto_sleep' needed (#524). An active SSH/exec session counts as activity, so a box being debugged is never stopped mid-session. Empty = no auto-sleep.")
 	createCmd.Flags().StringVar(&createDeleteAfterStopped, "delete-after-stopped", "", "Birth stopped→delete — auto-DELETE the box (reclaim disk) once it has been STOPPED this long (Go duration: '6h', '24h'). The second timer of the two-phase lifecycle: pair with --idle-stop to free CPU/RAM fast, then disk after a debug window (#525). The clock resets when the box is woken, so a box you keep investigating is never reaped. Separate opt-in from --idle-stop. Empty = never delete on stop.")
 	createCmd.Flags().StringVar(&createStorageClass, "storage-class", "", "K8s StorageClass for the box's data PVC (K8s backend only). Empty = use the cluster's default StorageClass. Example: 'fast-nvme', 'standard', 'ceph-block'. Ignored on the LXC backend.")
+	createCmd.Flags().StringVar(&createMemoryRequest, "memory-request", "", "K8s memory *request* (K8s backend only), separate from --memory which is always applied as the limit (e.g. '128Mi'). Empty = request equals --memory (today's default, Guaranteed QoS). Set this lower than --memory for Burstable QoS. Ignored on the LXC backend.")
+	createCmd.Flags().StringVar(&createCPURequest, "cpu-request", "", "K8s CPU *request* (K8s backend only), separate from --cpu which is always applied as the limit. Same defaulting and K8s-only scope as --memory-request.")
 	createCmd.Flags().BoolVar(&createWait, "wait", false, "Block until the box finishes provisioning (remote mode). A remote create is async: the daemon returns CREATING immediately and provisions for minutes — SSH only works once the state reaches RUNNING. --wait polls the daemon until then (or --wait-timeout), exiting non-zero if provisioning fails. Local mode provisions synchronously; --wait is a no-op there.")
 	createCmd.Flags().DurationVar(&createWaitTimeout, "wait-timeout", 5*time.Minute, "How long --wait polls before giving up (Go duration).")
 }
@@ -429,13 +433,13 @@ func runCreate(cmd *cobra.Command, args []string) error {
 
 	if httpMode && serverAddr != "" {
 		// Remote mode via HTTP
-		info, err = createRemoteHTTP(username, containerImage, cpuLimit, memoryLimit, diskLimit, sshKeys, enablePodman, stackID, gpuDevices, osType, monitoring, createPool, createBackendID, gitOpts, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds, createStorageClass, client.EncryptionOpts{Encrypted: createEncrypted, TenantID: createTenantID})
+		info, err = createRemoteHTTP(username, containerImage, cpuLimit, memoryLimit, diskLimit, sshKeys, enablePodman, stackID, gpuDevices, osType, monitoring, createPool, createBackendID, gitOpts, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds, createStorageClass, client.EncryptionOpts{Encrypted: createEncrypted, TenantID: createTenantID}, createMemoryRequest, createCPURequest)
 		if err != nil {
 			return fmt.Errorf("failed to create container via HTTP API: %w", err)
 		}
 	} else if serverAddr != "" {
 		// Remote mode via gRPC
-		info, err = createRemote(username, containerImage, cpuLimit, memoryLimit, diskLimit, sshKeys, enablePodman, stackID, gpuDevices, osType, monitoring, createPool, createBackendID, gitOpts, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds, createStorageClass, client.EncryptionOpts{Encrypted: createEncrypted, TenantID: createTenantID})
+		info, err = createRemote(username, containerImage, cpuLimit, memoryLimit, diskLimit, sshKeys, enablePodman, stackID, gpuDevices, osType, monitoring, createPool, createBackendID, gitOpts, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds, createStorageClass, client.EncryptionOpts{Encrypted: createEncrypted, TenantID: createTenantID}, createMemoryRequest, createCPURequest)
 		if err != nil {
 			return fmt.Errorf("failed to create container via remote server: %w", err)
 		}
@@ -763,23 +767,23 @@ func parseLabels(labelSlice []string) map[string]string {
 }
 
 // createRemote creates a container using remote gRPC server
-func createRemote(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack string, gpus []string, osType pb.OSType, monitoring bool, pool, backendID string, git client.GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64, storageClass string, enc client.EncryptionOpts) (*incus.ContainerInfo, error) {
+func createRemote(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack string, gpus []string, osType pb.OSType, monitoring bool, pool, backendID string, git client.GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64, storageClass string, enc client.EncryptionOpts, memoryRequest, cpuRequest string) (*incus.ContainerInfo, error) {
 	grpcClient, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = grpcClient.Close() }()
 
-	return grpcClient.CreateContainer(username, image, cpu, memory, disk, sshKeys, enablePodman, stack, gpus, osType, monitoring, pool, backendID, git, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds, storageClass, enc)
+	return grpcClient.CreateContainer(username, image, cpu, memory, disk, sshKeys, enablePodman, stack, gpus, osType, monitoring, pool, backendID, git, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds, storageClass, enc, memoryRequest, cpuRequest)
 }
 
 // createRemoteHTTP creates a container using remote HTTP API
-func createRemoteHTTP(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack string, gpus []string, osType pb.OSType, monitoring bool, pool, backendID string, git client.GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64, storageClass string, enc client.EncryptionOpts) (*incus.ContainerInfo, error) {
+func createRemoteHTTP(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack string, gpus []string, osType pb.OSType, monitoring bool, pool, backendID string, git client.GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64, storageClass string, enc client.EncryptionOpts, memoryRequest, cpuRequest string) (*incus.ContainerInfo, error) {
 	httpClient, err := client.NewHTTPClient(serverAddr, authToken)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = httpClient.Close() }()
 
-	return httpClient.CreateContainer(username, image, cpu, memory, disk, sshKeys, enablePodman, stack, gpus, osType, monitoring, pool, backendID, git, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds, storageClass, enc)
+	return httpClient.CreateContainer(username, image, cpu, memory, disk, sshKeys, enablePodman, stack, gpus, osType, monitoring, pool, backendID, git, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds, storageClass, enc, memoryRequest, cpuRequest)
 }

--- a/internal/cmd/runner.go
+++ b/internal/cmd/runner.go
@@ -395,6 +395,8 @@ func buildDaemonAPI() (runner.DaemonAPI, runner.DaemonCreator, error) {
 				0,                       // delete-after-stopped: not applicable to runner boxes
 				"",                      // storage-class: runner boxes use cluster default
 				client.EncryptionOpts{}, // encryption: runner boxes carry no tenant data (#1198)
+				"",                      // memory-request: runner boxes use request==limit (#1557)
+				"",                      // cpu-request: ditto
 			)
 			if err != nil {
 				return "", "", err
@@ -434,6 +436,8 @@ func buildDaemonAPI() (runner.DaemonAPI, runner.DaemonCreator, error) {
 			0,                       // delete-after-stopped: not applicable to runner boxes
 			"",                      // storage-class: runner boxes use cluster default
 			client.EncryptionOpts{}, // encryption: runner boxes carry no tenant data (#1198)
+			"",                      // memory-request: runner boxes use request==limit (#1557)
+			"",                      // cpu-request: ditto
 		)
 		if err != nil {
 			return "", "", err

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -552,6 +552,8 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 		spec.Resources.Memory = req.Resources.Memory
 		spec.Resources.Disk = req.Resources.Disk
 		spec.Resources.StorageClass = req.Resources.StorageClass
+		spec.Resources.MemoryRequest = req.Resources.MemoryRequest
+		spec.Resources.CPURequest = req.Resources.CpuRequest
 	}
 
 	// Use defaults if not specified (os_type takes precedence in manager.go)
@@ -622,10 +624,12 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 				Username: req.Username,
 				State:    pb.ContainerState_CONTAINER_STATE_CREATING,
 				Resources: &pb.ResourceLimits{
-					Cpu:          spec.Resources.CPU,
-					Memory:       spec.Resources.Memory,
-					Disk:         spec.Resources.Disk,
-					StorageClass: spec.Resources.StorageClass,
+					Cpu:           spec.Resources.CPU,
+					Memory:        spec.Resources.Memory,
+					Disk:          spec.Resources.Disk,
+					StorageClass:  spec.Resources.StorageClass,
+					MemoryRequest: spec.Resources.MemoryRequest,
+					CpuRequest:    spec.Resources.CPURequest,
 				},
 			},
 			Message: fmt.Sprintf("Box CR created for user %s; the operator is reconciling it. Poll GET /v1/containers/%s to check status.", req.Username, req.Username),
@@ -788,10 +792,12 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 				Username: req.Username,
 				State:    pb.ContainerState_CONTAINER_STATE_CREATING,
 				Resources: &pb.ResourceLimits{
-					Cpu:          spec.Resources.CPU,
-					Memory:       spec.Resources.Memory,
-					Disk:         spec.Resources.Disk,
-					StorageClass: spec.Resources.StorageClass,
+					Cpu:           spec.Resources.CPU,
+					Memory:        spec.Resources.Memory,
+					Disk:          spec.Resources.Disk,
+					StorageClass:  spec.Resources.StorageClass,
+					MemoryRequest: spec.Resources.MemoryRequest,
+					CpuRequest:    spec.Resources.CPURequest,
 				},
 			},
 			Message: fmt.Sprintf("Container creation started for user %s. Poll GET /v1/containers/%s to check status.", req.Username, req.Username),
@@ -3592,10 +3598,12 @@ func toProtoContainer(st *box.BoxStatus) *pb.Container {
 		Username: st.Ref.Tenant,
 		State:    st.State,
 		Resources: &pb.ResourceLimits{
-			Cpu:          st.Resources.CPU,
-			Memory:       st.Resources.Memory,
-			Disk:         st.Resources.Disk,
-			StorageClass: st.Resources.StorageClass,
+			Cpu:           st.Resources.CPU,
+			Memory:        st.Resources.Memory,
+			Disk:          st.Resources.Disk,
+			StorageClass:  st.Resources.StorageClass,
+			MemoryRequest: st.Resources.MemoryRequest,
+			CpuRequest:    st.Resources.CPURequest,
 		},
 		Network: &pb.NetworkInfo{
 			IpAddress: st.IPAddress,

--- a/pkg/core/box/box.go
+++ b/pkg/core/box/box.go
@@ -50,6 +50,15 @@ type ResourceLimits struct {
 	// Empty = use the backend's default (Config.StorageClass).
 	// Only meaningful on the K8s backend; ignored by LXC.
 	StorageClass string
+	// MemoryRequest is the K8s memory *request*, separate from Memory
+	// (always applied as the limit). Empty = request equals Memory
+	// (today's Guaranteed-QoS behavior). Only meaningful on the K8s
+	// backend; ignored by LXC, which has no separate request concept.
+	MemoryRequest string
+	// CPURequest is the K8s CPU *request*, separate from CPU (always
+	// applied as the limit). Same defaulting and K8s-only scope as
+	// MemoryRequest.
+	CPURequest string
 }
 
 // BoxSpec is the declarative input to Create. The backend makes a box matching

--- a/pkg/core/box/k8s/k8s_test.go
+++ b/pkg/core/box/k8s/k8s_test.go
@@ -314,6 +314,58 @@ func TestExplicitMemoryOverridesDefault(t *testing.T) {
 	}
 }
 
+// TestMemoryRequestOverride verifies MemoryRequest (#1557) sets a request
+// below the limit — Burstable QoS — instead of the default request==limit
+// (Guaranteed) behavior.
+func TestMemoryRequestOverride(t *testing.T) {
+	r := resourceRequirements(box.ResourceLimits{Memory: "256Mi", MemoryRequest: "128Mi"}, 0, builtinMemDefaults())
+	lim := r.Limits["memory"]
+	req := r.Requests["memory"]
+	if lim.String() != "256Mi" {
+		t.Errorf("memory limit = %q, want 256Mi (MemoryRequest must not change the limit)", lim.String())
+	}
+	if req.String() != "128Mi" {
+		t.Errorf("memory request = %q, want 128Mi", req.String())
+	}
+}
+
+// TestCPURequestOverride is the CPU analog of TestMemoryRequestOverride.
+func TestCPURequestOverride(t *testing.T) {
+	r := resourceRequirements(box.ResourceLimits{CPU: "200m", CPURequest: "100m"}, 0, builtinMemDefaults())
+	lim := r.Limits["cpu"]
+	req := r.Requests["cpu"]
+	if lim.String() != "200m" {
+		t.Errorf("cpu limit = %q, want 200m", lim.String())
+	}
+	if req.String() != "100m" {
+		t.Errorf("cpu request = %q, want 100m", req.String())
+	}
+}
+
+// TestMemoryRequestOverrideExceedingLimitIsIgnored verifies a request larger
+// than the limit is ignored (falls back to request==limit) rather than
+// producing an invalid pod spec (request must not exceed limit).
+func TestMemoryRequestOverrideExceedingLimitIsIgnored(t *testing.T) {
+	r := resourceRequirements(box.ResourceLimits{Memory: "128Mi", MemoryRequest: "256Mi"}, 0, builtinMemDefaults())
+	lim := r.Limits["memory"]
+	req := r.Requests["memory"]
+	if req.String() != lim.String() {
+		t.Errorf("request/limit = %q/%q, want equal (oversized request override ignored)", req.String(), lim.String())
+	}
+}
+
+// TestMemoryRequestOverrideInvalidQuantityIsIgnored verifies a request that
+// isn't a valid K8s quantity is ignored (falls back to request==limit)
+// rather than failing admission.
+func TestMemoryRequestOverrideInvalidQuantityIsIgnored(t *testing.T) {
+	r := resourceRequirements(box.ResourceLimits{Memory: "256Mi", MemoryRequest: "not-a-quantity"}, 0, builtinMemDefaults())
+	lim := r.Limits["memory"]
+	req := r.Requests["memory"]
+	if req.String() != lim.String() {
+		t.Errorf("request/limit = %q/%q, want equal (invalid request override ignored)", req.String(), lim.String())
+	}
+}
+
 // TestSpecInvalidMemoryFallsBackToDefault verifies an incus-native quantity in
 // the spec that isn't a valid K8s quantity ("4GB") is skipped and the default
 // floor applies, rather than leaving the box unconstrained.

--- a/pkg/core/box/k8s/objects.go
+++ b/pkg/core/box/k8s/objects.go
@@ -321,7 +321,11 @@ type memDefaults struct {
 // resourceRequirements maps the runtime-neutral limits onto K8s requests/limits.
 // CPU and Memory strings that aren't valid K8s quantities (e.g. incus-native
 // "4GB") are silently skipped so the pod doesn't fail admission. Explicit CPU
-// and Memory pin request==limit (Guaranteed for that resource).
+// and Memory pin request==limit (Guaranteed for that resource) unless the
+// caller also set CPURequest/MemoryRequest (#1557), in which case that value
+// is used for the request instead — an invalid or larger-than-limit request
+// string is ignored (falls back to request==limit) rather than failing
+// admission or silently exceeding the limit.
 //
 // When the spec sets no valid memory limit, the resolved default memory floor
 // (def.request < def.limit) is applied so the scheduler can bin-pack the box
@@ -343,12 +347,22 @@ func resourceRequirements(r box.ResourceLimits, gpuCount int, def memDefaults) *
 		if q, err := resource.ParseQuantity(r.CPU); err == nil {
 			requests[corev1.ResourceCPU] = q
 			limits[corev1.ResourceCPU] = q
+			if r.CPURequest != "" {
+				if reqQ, err := resource.ParseQuantity(r.CPURequest); err == nil && reqQ.Cmp(q) <= 0 {
+					requests[corev1.ResourceCPU] = reqQ
+				}
+			}
 		}
 	}
 	if r.Memory != "" {
 		if q, err := resource.ParseQuantity(r.Memory); err == nil {
 			requests[corev1.ResourceMemory] = q
 			limits[corev1.ResourceMemory] = q
+			if r.MemoryRequest != "" {
+				if reqQ, err := resource.ParseQuantity(r.MemoryRequest); err == nil && reqQ.Cmp(q) <= 0 {
+					requests[corev1.ResourceMemory] = reqQ
+				}
+			}
 		}
 	}
 	// Apply the default memory floor when the spec set no valid memory limit.

--- a/pkg/pb/containarium/v1/container.pb.go
+++ b/pkg/pb/containarium/v1/container.pb.go
@@ -486,7 +486,20 @@ type ResourceLimits struct {
 	// runtime only). Empty means use the backend's cluster-wide default
 	// (CONTAINARIUM_K8S_STORAGE_CLASS). Ignored by the LXC backend.
 	// Example: "fast-nvme", "standard", "ceph-block".
-	StorageClass  string `protobuf:"bytes,6,opt,name=storage_class,json=storageClass,proto3" json:"storage_class,omitempty"`
+	StorageClass string `protobuf:"bytes,6,opt,name=storage_class,json=storageClass,proto3" json:"storage_class,omitempty"`
+	// memory_request is the K8s memory *request* (what the scheduler reserves
+	// against node capacity), separate from the `memory` field above, which is
+	// always applied as the *limit* (K8s runtime only; ignored by the LXC
+	// backend, which has no separate request concept for `limits.memory`).
+	// Empty (the default) preserves today's behavior: `memory`'s value is used
+	// for both request and limit (Guaranteed QoS). Set this to something
+	// smaller than `memory` for Burstable QoS — e.g. request 128Mi, limit
+	// 256Mi, matching how most upstream Kubernetes workloads size a pod.
+	MemoryRequest string `protobuf:"bytes,7,opt,name=memory_request,json=memoryRequest,proto3" json:"memory_request,omitempty"`
+	// cpu_request is the K8s CPU *request*, separate from the `cpu` field
+	// above (always applied as the limit). Same defaulting and K8s-only scope
+	// as memory_request.
+	CpuRequest    string `protobuf:"bytes,8,opt,name=cpu_request,json=cpuRequest,proto3" json:"cpu_request,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -559,6 +572,20 @@ func (x *ResourceLimits) GetGpus() []string {
 func (x *ResourceLimits) GetStorageClass() string {
 	if x != nil {
 		return x.StorageClass
+	}
+	return ""
+}
+
+func (x *ResourceLimits) GetMemoryRequest() string {
+	if x != nil {
+		return x.MemoryRequest
+	}
+	return ""
+}
+
+func (x *ResourceLimits) GetCpuRequest() string {
+	if x != nil {
+		return x.CpuRequest
 	}
 	return ""
 }
@@ -5924,14 +5951,17 @@ var File_containarium_v1_container_proto protoreflect.FileDescriptor
 
 const file_containarium_v1_container_proto_rawDesc = "" +
 	"\n" +
-	"\x1fcontainarium/v1/container.proto\x12\x0fcontainarium.v1\x1a google/protobuf/descriptor.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\x99\x01\n" +
+	"\x1fcontainarium/v1/container.proto\x12\x0fcontainarium.v1\x1a google/protobuf/descriptor.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xe1\x01\n" +
 	"\x0eResourceLimits\x12\x10\n" +
 	"\x03cpu\x18\x01 \x01(\tR\x03cpu\x12\x16\n" +
 	"\x06memory\x18\x02 \x01(\tR\x06memory\x12\x12\n" +
 	"\x04disk\x18\x03 \x01(\tR\x04disk\x12\x10\n" +
 	"\x03gpu\x18\x04 \x01(\tR\x03gpu\x12\x12\n" +
 	"\x04gpus\x18\x05 \x03(\tR\x04gpus\x12#\n" +
-	"\rstorage_class\x18\x06 \x01(\tR\fstorageClass\"\x83\x01\n" +
+	"\rstorage_class\x18\x06 \x01(\tR\fstorageClass\x12%\n" +
+	"\x0ememory_request\x18\a \x01(\tR\rmemoryRequest\x12\x1f\n" +
+	"\vcpu_request\x18\b \x01(\tR\n" +
+	"cpuRequest\"\x83\x01\n" +
 	"\vNetworkInfo\x12\x1d\n" +
 	"\n" +
 	"ip_address\x18\x01 \x01(\tR\tipAddress\x12\x1f\n" +

--- a/proto/containarium/v1/container.proto
+++ b/proto/containarium/v1/container.proto
@@ -108,6 +108,21 @@ message ResourceLimits {
   // (CONTAINARIUM_K8S_STORAGE_CLASS). Ignored by the LXC backend.
   // Example: "fast-nvme", "standard", "ceph-block".
   string storage_class = 6;
+
+  // memory_request is the K8s memory *request* (what the scheduler reserves
+  // against node capacity), separate from the `memory` field above, which is
+  // always applied as the *limit* (K8s runtime only; ignored by the LXC
+  // backend, which has no separate request concept for `limits.memory`).
+  // Empty (the default) preserves today's behavior: `memory`'s value is used
+  // for both request and limit (Guaranteed QoS). Set this to something
+  // smaller than `memory` for Burstable QoS — e.g. request 128Mi, limit
+  // 256Mi, matching how most upstream Kubernetes workloads size a pod.
+  string memory_request = 7;
+
+  // cpu_request is the K8s CPU *request*, separate from the `cpu` field
+  // above (always applied as the limit). Same defaulting and K8s-only scope
+  // as memory_request.
+  string cpu_request = 8;
 }
 
 // NetworkInfo contains network configuration for a container

--- a/test/integration/storage_test.go
+++ b/test/integration/storage_test.go
@@ -108,6 +108,8 @@ func testCreateContainerWithQuota(t *testing.T, ctx context.Context, grpcClient 
 		0,                            // No stopped→delete
 		"",                           // No storage-class override
 		client.EncryptionOpts{},      // No per-tenant dataset encryption (#1198)
+		"",                           // No memory-request override (#1557)
+		"",                           // No cpu-request override (#1557)
 	)
 	require.NoError(t, err, "Failed to create container")
 	require.NotNil(t, container)
@@ -161,6 +163,8 @@ func testQuotaEnforcement(t *testing.T, ctx context.Context, grpcClient *client.
 		0,                       // No stopped→delete
 		"",                      // No storage-class override
 		client.EncryptionOpts{}, // No per-tenant dataset encryption (#1198)
+		"",                      // No memory-request override (#1557)
+		"",                      // No cpu-request override (#1557)
 	)
 	require.NoError(t, err)
 	require.NotNil(t, container)
@@ -197,11 +201,11 @@ func testMultiContainerIsolation(t *testing.T, ctx context.Context, grpcClient *
 	t.Log("Creating multiple containers to test quota isolation...")
 
 	// Create two containers with different quotas
-	_, err := grpcClient.CreateContainer(user1, "images:ubuntu/24.04", "1", "1GB", "10GB", []string{}, false, "", nil, 0, false, "", "", client.GitSourceOpts{}, 0, 0, 0, "", client.EncryptionOpts{})
+	_, err := grpcClient.CreateContainer(user1, "images:ubuntu/24.04", "1", "1GB", "10GB", []string{}, false, "", nil, 0, false, "", "", client.GitSourceOpts{}, 0, 0, 0, "", client.EncryptionOpts{}, "", "")
 	require.NoError(t, err)
 	defer func() { _ = grpcClient.DeleteContainer(user1, true) }()
 
-	_, err = grpcClient.CreateContainer(user2, "images:ubuntu/24.04", "1", "1GB", "15GB", []string{}, false, "", nil, 0, false, "", "", client.GitSourceOpts{}, 0, 0, 0, "", client.EncryptionOpts{})
+	_, err = grpcClient.CreateContainer(user2, "images:ubuntu/24.04", "1", "1GB", "15GB", []string{}, false, "", nil, 0, false, "", "", client.GitSourceOpts{}, 0, 0, 0, "", client.EncryptionOpts{}, "", "")
 	require.NoError(t, err)
 	defer func() { _ = grpcClient.DeleteContainer(user2, true) }()
 
@@ -227,7 +231,7 @@ func testCompression(t *testing.T, ctx context.Context, grpcClient *client.GRPCC
 
 	t.Log("Creating container to test compression...")
 
-	_, err := grpcClient.CreateContainer(username, "images:ubuntu/24.04", "1", "1GB", "10GB", []string{}, false, "", nil, 0, false, "", "", client.GitSourceOpts{}, 0, 0, 0, "", client.EncryptionOpts{})
+	_, err := grpcClient.CreateContainer(username, "images:ubuntu/24.04", "1", "1GB", "10GB", []string{}, false, "", nil, 0, false, "", "", client.GitSourceOpts{}, 0, 0, 0, "", client.EncryptionOpts{}, "", "")
 	require.NoError(t, err)
 	defer func() { _ = grpcClient.DeleteContainer(username, true) }()
 
@@ -250,7 +254,7 @@ func testPrepareRebootData(t *testing.T, ctx context.Context, grpcClient *client
 	t.Logf("Creating container for persistence test: %s", username)
 
 	// Create container
-	container, err := grpcClient.CreateContainer(username, "images:ubuntu/24.04", "2", "2GB", "20GB", []string{}, false, "", nil, 0, false, "", "", client.GitSourceOpts{}, 0, 0, 0, "", client.EncryptionOpts{})
+	container, err := grpcClient.CreateContainer(username, "images:ubuntu/24.04", "2", "2GB", "20GB", []string{}, false, "", nil, 0, false, "", "", client.GitSourceOpts{}, 0, 0, 0, "", client.EncryptionOpts{}, "", "")
 	require.NoError(t, err)
 	require.NotNil(t, container)
 


### PR DESCRIPTION
## Summary
- Closes #1557. `ResourceLimits.memory`/`cpu` are always applied as both request and limit on the k8s backend (`pkg/core/box/k8s/objects.go`) — every box is pinned to Guaranteed QoS with no way to request less than its ceiling, unlike most upstream K8s workloads (including agent-sandbox's own pods, request 128Mi / limit 256Mi).
- This is a real, measured cost: `benchmark/agent-sandbox-density/RESULTS.md`'s 186-vs-373 result on an identical host is explained almost entirely by this 2x request asymmetry (Containarium's boxes request 256Mi, agent-sandbox's pods request 128Mi).
- Adds `memory_request`/`cpu_request` to the `ResourceLimits` proto (fields 7/8, K8s-only; empty preserves today's behavior), threads it through `resourceRequirements()`, both clients, and `containarium create --memory-request`/`--cpu-request`.
- An oversized or invalid request override is silently ignored (falls back to request==limit) rather than producing an invalid pod spec — same defensive pattern already used for the memory-floor clamp.

## Not in scope
The declarative Box-CRD path (`BoxResources` in `apis/containarium/v1alpha1`) doesn't carry these fields yet. The imperative `containarium create` path this PR unblocks (used by the benchmark scripts and by `containarium-k8s`'s direct-create mode) doesn't go through the CRD/GitOps path, so it wasn't needed here — flagged as a follow-up if that path needs the same knob later.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/core/box/... ./internal/client/... ./internal/cmd/...` — new unit tests for the override, its CPU analog, and the two ignore-and-fallback cases (oversized request, invalid quantity)
- [x] `make proto` — clean diff, no `.pb.gw.go` churn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional CPU and memory request overrides for Kubernetes container deployments.
  * Added `--cpu-request` and `--memory-request` command-line options.
  * Valid requests can enable Burstable QoS while preserving configured resource limits.
  * Added support for listing, creating, and deleting TCP/UDP passthrough routes.
* **Bug Fixes**
  * Invalid or oversized requests safely fall back to matching the corresponding resource limits.
  * LXC deployments remain unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->