### PR TITLE
docs(benchmark): build and benchmark the real sentinel-statefulset topology

### DIFF
--- a/benchmark/agent-sandbox-density/README.md
+++ b/benchmark/agent-sandbox-density/README.md
@@ -103,17 +103,32 @@ path simply never carries — it doesn't scale with sandbox count, but it
 isn't free either, and it's worth naming rather than folding silently
 into "one extra pod."
 
-**This is the general, conceptually intended shape of the architecture —
-not the literal chart this benchmark deploys.** `charts/containarium-k8s/`
-(what `03-provision-containarium.sh` actually installs) runs the daemon
-as a single `Deployment` with `sshpiper` as its gateway component — no
-separate `containarium-sentinel` and no `StatefulSet`. The sentinel/
-StatefulSet split above is how Containarium's k8s deployment mode is
-intended to work architecturally; this benchmark's numbers measure
-density and wall-clock, not this fixed k8s scheduling/networking cost,
-and don't currently distinguish between the two shapes. If that
-distinction turns out to matter for the fixed-overhead comparison, that's
-a follow-up benchmark note, not something to assume from this doc alone.
+**Not the literal chart this benchmark's primary run deploys —
+`charts/containarium-k8s/`** (what `03-provision-containarium.sh` installs)
+runs the daemon as a single `Deployment` with `sshpiper` as its gateway
+component, no separate `containarium-sentinel` and no `StatefulSet`. But
+this topology has since actually been built and benchmarked, not just
+described — see `scripts/07-provision-containarium-sentinel.sh` /
+`08-run-density-containarium-sentinel.sh` and RESULTS.md's 2026-08-26
+"sentinel-statefulset" entry: **373 sandboxes, an exact match to the
+plain-Deployment baseline, with wall-clock landing within noise of
+gVisor's own cost.** The extra Service → Deployment(sentinel) →
+StatefulSet(daemon) hop is measurably invisible to both density and
+speed at this scale — the bottleneck stays k8s memory-request admission
+for sandbox pods either way.
+
+That settles the fixed-overhead question this section originally raised,
+but it's still a benchmark-only exploration, not a production
+recommendation: the daemon is stateless (no PVCs, all durable state in
+the k8s API/etcd via CRDs) so the StatefulSet buys nothing
+architecturally, and the "sentinel" in that run is a stock nginx reverse
+proxy standing in for a `containarium-sentinel` component that doesn't
+exist yet (the real `internal/sentinel` binary does something unrelated
+— see `manifests/sentinel-statefulset/README.md`). One StatefulSet pod
+and one sentinel replica also were never going to bottleneck 373
+sequential creates — whether either becomes a real bottleneck under
+concurrent load or many daemon replicas is a different, unmeasured
+question.
 
 ## Why this matters
 
@@ -428,7 +443,8 @@ benchmark/agent-sandbox-density/
 ├── config.env.example           — copy to config.env, fill in your host's numbers
 ├── RESULTS.md                   — reviewed summary of actual runs, one dated entry per run
 ├── manifests/
-│   └── sandbox-template.yaml    — Sandbox CR (agents.x-k8s.io/v1beta1) with the resource profile above
+│   ├── sandbox-template.yaml     — Sandbox CR (agents.x-k8s.io/v1beta1) with the resource profile above
+│   └── sentinel-statefulset/     — benchmark-only Service/Deployment(sentinel)/StatefulSet(daemon) manifests, see its own README.md
 └── scripts/
     ├── lib.sh                       — shared logging / resource-snapshot / stop-on-N-failures helpers (density loop supports resuming via --start-index)
     ├── k8s-common.sh                — shared kubeadm+CNI+agent-sandbox-controller base, used by both 01 and 03
@@ -439,5 +455,7 @@ benchmark/agent-sandbox-density/
     ├── 04-run-density-containarium.sh — `containarium create` (pod -> gVisor -> containarium) until the stopping rule triggers
     ├── 05-provision-containarium-lxc.sh — third scenario: Incus + Containarium daemon, native LXC backend, no k8s/gVisor (explicit zfs storage backend, image-bake, scanners disabled)
     ├── 06-run-density-containarium-lxc.sh — `containarium create` on the LXC backend until the stopping rule triggers (--start-index to resume a stopped run)
+    ├── 07-provision-containarium-sentinel.sh — benchmark-only: same base as 03, daemon.replicaCount=0 + jq-reshaped into manifests/sentinel-statefulset/
+    ├── 08-run-density-containarium-sentinel.sh — `containarium create` through the sentinel hop until the stopping rule triggers
     └── 99-teardown-vm.sh            — stop + delete the VM
 ```

--- a/benchmark/agent-sandbox-density/RESULTS.md
+++ b/benchmark/agent-sandbox-density/RESULTS.md
@@ -470,6 +470,108 @@ number was a real, honestly-reported result of a real CLI gap, not a
 measurement error; #1557 closes that gap. `BLOG-DRAFT.md` needs a
 follow-up pass to fold this in before it's treated as final.
 
+### 2026-08-26 — sentinel-statefulset: the real topology, benchmarked
+
+README.md's "The experiment group's k8s footprint" describes Containarium's
+k8s deployment mode as conceptually `Service → Deployment
+(containarium-sentinel, traffic forwarding) → StatefulSet
+(containarium-daemon, provisions boxes)` — three k8s-native layers in front
+of box provisioning, versus the third scenario's single bare process. That
+was prose with no number behind it. This run builds it for real and
+measures what it actually costs.
+
+**This is a benchmark-only exploration, not a production chart change** —
+`charts/containarium-k8s/` is untouched. The daemon is stateless (no PVCs,
+all durable state in the k8s API/etcd via CRDs), so a StatefulSet buys it
+nothing architecturally; there is no real `containarium-sentinel` binary
+that forwards HTTP/gRPC to the daemon's own API (`internal/sentinel` does
+something unrelated — iptables DNAT to spot VMs — see
+`manifests/sentinel-statefulset/README.md`). The sentinel here is a stock
+`nginx:1.27-alpine` reverse proxy standing in for one. New files only:
+`manifests/sentinel-statefulset/`, `scripts/07-provision-containarium-sentinel.sh`,
+`scripts/08-run-density-containarium-sentinel.sh`.
+
+How the daemon's container spec got into the StatefulSet without
+hand-duplicating Helm's env-var logic: `helm install` the real chart with
+`daemon.replicaCount=0` (so its own Deployment never runs a pod), read
+back the resulting (0-replica but fully-specced) Deployment with `kubectl
+get -o json`, and reshape `spec.template.spec` into a StatefulSet with
+`jq` — the container spec is copied exactly, not re-typed.
+
+Same host cap as every other k8s scenario (20 vCPU / 48GiB RAM / 200GB
+disk Incus KVM VM), same profile as the 373 baseline (cpu 25m/50m, mem
+request `128Mi` / limit `256Mi` via #1557's `--memory-request`/
+`--cpu-request`).
+
+**Daemon version snag, found live, same shape as the #1558 entry above:**
+the CLI and daemon image this VM resolves via `CONTAINARIUM_VERSION=latest`
+are the last *released* tag (v0.66.0) — #1557 is on `main`, unreleased.
+`containarium create --cpu-request ...` failed outright with `unknown
+flag`. Built a `containarium` CLI binary from the current `main` checkout
+(`go build cmd/containarium/main.go` — needed `docker run --network=host`
+for the build container too; same TLS-over-bridge-network issue the
+#1558 daemon image build hit) and reused the `containarium-daemon:bench-1558`
+image already built for that earlier run (same #1557 source, still
+functionally current). Swapping the image surfaced a second, unrelated
+issue: the newer daemon binary enforces #1496's upstream-gateway-key
+startup check more strictly than v0.66.0's build did, and the
+`CONTAINARIUM_K8S_GATEWAY_UPSTREAM_KEY_SECRET`/`_PUBLIC_KEY` env vars
+were absent from the reshaped StatefulSet even though the same `helm
+install --set gateway.upstreamKeySecret=...` flags 03's proven pattern
+uses were passed — recovered the public key from the already-created
+Secret (`ssh-keygen -y`) and patched both env vars onto the StatefulSet
+directly. Not yet root-caused *why* the values didn't land in the first
+place (a Helm `--set` edge case with the specific value shape, or a
+timing issue in this script's install step) — flagged, not chased
+further, since the workaround is clean and the resulting container spec
+is byte-identical to what 03's own pattern produces.
+
+**Third issue, also found live: nginx's static DNS resolution.** The
+sentinel's `proxy_pass` targets the daemon StatefulSet pod's own DNS name
+(`containarium-bench-daemon-0.containarium-bench-daemon-headless`) —
+nginx resolves that hostname *once*, at container startup, and caches the
+IP for its lifetime. Restarting the daemon pod (twice, chasing the two
+issues above) gave it a new IP each time, silently stranding the
+sentinel's cached resolution — `upstream timed out` on every request
+until the sentinel itself was restarted. Fixed by restarting
+`containarium-bench-sentinel` once daemon was finally stable, immediately
+before the density loop. A production sentinel would need dynamic
+resolution (nginx's `resolver` directive + a variable in `proxy_pass`) to
+survive pod restarts; not needed for a one-shot measurement where nothing
+restarts mid-run.
+
+| | plain Deployment (baseline) | sentinel-statefulset |
+|---|---|---|
+| Sandboxes reached RUNNING | **373** | **373** |
+| Attempted (incl. failures) | 376 | 376 |
+| Node memory requests at stop | 47984Mi/48GiB (99%) | 47984Mi/48GiB (99%) |
+| Node CPU requests at stop | 10425m/20000m (52%) | 10425m/20000m (52%) |
+| Wall-clock for the density loop | ~15 min (original run) / ~77 min (#1558's runsc leg, same profile) | ~77 min |
+| Pods by RuntimeClass (sanity check) | `runsc` on all 373 | `runsc` on all 373 |
+
+**Exact match — 373 vs. 373, identical node memory snapshot down to the
+Mi.** The extra Service → Deployment(sentinel) → StatefulSet(daemon) hop
+is invisible to density: the bottleneck is still k8s memory-request
+admission for sandbox pods, which this topology change doesn't touch at
+all. Wall-clock also landed within noise of the #1558 runsc leg's ~77
+minutes (same profile, same gVisor cost, no sentinel) — an extra
+in-cluster HTTP hop through nginx per `create` call didn't move the
+needle against gVisor's own per-sandbox startup cost, which already
+dominates that number.
+
+**What this settles and what it doesn't.** It settles the question the
+prose in README.md couldn't: this specific topology shape, built for
+real, costs nothing measurable in density or wall-clock at 373 sandboxes
+on a 48GiB host. It does *not* validate the topology as a production
+design — the daemon is still stateless, the "sentinel" here is a generic
+proxy standing in for a component that doesn't exist yet, and a real
+implementation would carry real engineering cost (build, operate, secure
+an actual forwarding layer) that this benchmark can't measure. Nor does
+it rule out cost at a different scale — one StatefulSet pod and one
+sentinel replica were never going to bottleneck 373 sequential creates;
+whether either component becomes a real bottleneck under concurrent load
+or many daemon replicas is a different, unasked question.
+
 ## Template
 
 ```

--- a/benchmark/agent-sandbox-density/manifests/sentinel-statefulset/README.md
+++ b/benchmark/agent-sandbox-density/manifests/sentinel-statefulset/README.md
@@ -1,0 +1,34 @@
+# sentinel-statefulset manifests
+
+Raw k8s manifests (not Helm-templated) for the benchmark-only topology
+documented in `../../README.md`'s "The experiment group's k8s footprint":
+`Service → Deployment (containarium-bench-sentinel) → StatefulSet
+(containarium-bench-daemon)`, in front of the same daemon container spec
+`charts/containarium-k8s/` produces.
+
+**This does not replace `charts/containarium-k8s/` and is not a proposed
+production architecture.** The real chart's daemon is stateless (no PVCs,
+all durable state lives in the k8s API/etcd via CRDs) — a StatefulSet buys
+it nothing. This exists purely to measure, live, what this specific
+topology shape actually costs, since "conceptually intended architecture"
+in prose isn't a number. See `scripts/07-provision-containarium-sentinel.sh`
+for how these get applied, and `RESULTS.md` for what the measurement found.
+
+## Why these files have no `__PLACEHOLDER__` values
+
+Every other manifest in this benchmark (`../sandbox-template.yaml`) is a
+static template with `sed`-substituted placeholders. These can't be: the
+daemon's actual container spec (image tag, JWT secret name, gateway env
+vars) is entirely Helm-computed and would have to be re-derived by hand
+here, which drifts the moment the chart changes. Instead,
+`07-provision-containarium-sentinel.sh` `helm install`s the real chart
+with `daemon.replicaCount=0` (so nothing double-runs), reads back the
+resulting (0-replica but fully-specced) Deployment object with `kubectl
+get -o json`, and uses `jq` to reshape that exact `spec.template.spec`
+into a StatefulSet — the container spec is guaranteed identical to what
+the chart would have run, because it's not re-typed, it's extracted.
+
+Only the sentinel (a stock `nginx:1.27-alpine` reverse proxy — there is no
+Containarium-specific "sentinel" component that fronts the daemon's own
+API today, see `README.md`) and the headless Service are static files
+here, since neither depends on chart-computed values.

--- a/benchmark/agent-sandbox-density/manifests/sentinel-statefulset/daemon-headless-service.yaml
+++ b/benchmark/agent-sandbox-density/manifests/sentinel-statefulset/daemon-headless-service.yaml
@@ -1,0 +1,25 @@
+# Headless Service pairing for the benchmark-only daemon StatefulSet
+# (see README.md in this directory). clusterIP: None gives each pod a
+# stable DNS name (containarium-bench-daemon-0.containarium-bench-daemon-headless),
+# which the sentinel's nginx.conf proxies to directly — with a single
+# replica there's no load-balancing to do, so a headless Service is used
+# for its pod-identity DNS, not for balancing.
+apiVersion: v1
+kind: Service
+metadata:
+  name: containarium-bench-daemon-headless
+  namespace: __NAMESPACE__
+  labels:
+    app.kubernetes.io/name: containarium-bench-daemon
+    app.kubernetes.io/instance: containarium-bench
+    benchmark: agent-sandbox-density
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: containarium-bench-daemon
+    app.kubernetes.io/instance: containarium-bench
+  ports:
+    - name: api
+      port: 8080
+      targetPort: api
+      protocol: TCP

--- a/benchmark/agent-sandbox-density/manifests/sentinel-statefulset/sentinel-configmap.yaml
+++ b/benchmark/agent-sandbox-density/manifests/sentinel-statefulset/sentinel-configmap.yaml
@@ -1,0 +1,33 @@
+# Stock nginx reverse proxy standing in for a "containarium-sentinel"
+# component fronting the daemon's own control-plane API — see README.md in
+# this directory for why this is a generic proxy, not the real
+# `internal/sentinel` binary (which does something else entirely: iptables
+# DNAT to spot VMs, not HTTP forwarding to a k8s StatefulSet).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: containarium-bench-sentinel-nginx
+  namespace: __NAMESPACE__
+  labels:
+    app.kubernetes.io/name: containarium-bench-sentinel
+    app.kubernetes.io/instance: containarium-bench
+    benchmark: agent-sandbox-density
+data:
+  nginx.conf: |
+    events {}
+    http {
+      server {
+        listen 8080;
+        location / {
+          # Fully-qualified, not the short in-namespace form: nginx-alpine's
+          # musl libc resolver does not expand k8s search-domain suffixes
+          # the way glibc does, so the short name NXDOMAINs here even
+          # though it resolves fine everywhere else in the cluster
+          # (confirmed live) — found running this exact scenario.
+          proxy_pass http://containarium-bench-daemon-0.containarium-bench-daemon-headless.__NAMESPACE__.svc.cluster.local:8080;
+          proxy_http_version 1.1;
+          proxy_set_header Host $host;
+          proxy_set_header Connection "";
+        }
+      }
+    }

--- a/benchmark/agent-sandbox-density/manifests/sentinel-statefulset/sentinel-deployment.yaml
+++ b/benchmark/agent-sandbox-density/manifests/sentinel-statefulset/sentinel-deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: containarium-bench-sentinel
+  namespace: __NAMESPACE__
+  labels:
+    app.kubernetes.io/name: containarium-bench-sentinel
+    app.kubernetes.io/instance: containarium-bench
+    benchmark: agent-sandbox-density
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: containarium-bench-sentinel
+      app.kubernetes.io/instance: containarium-bench
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: containarium-bench-sentinel
+        app.kubernetes.io/instance: containarium-bench
+    spec:
+      containers:
+        - name: sentinel
+          image: nginx:1.27-alpine
+          ports:
+            - name: api
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: nginx-conf
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+              readOnly: true
+          readinessProbe:
+            tcpSocket:
+              port: api
+            initialDelaySeconds: 2
+            periodSeconds: 5
+      volumes:
+        - name: nginx-conf
+          configMap:
+            name: containarium-bench-sentinel-nginx

--- a/benchmark/agent-sandbox-density/manifests/sentinel-statefulset/sentinel-service.yaml
+++ b/benchmark/agent-sandbox-density/manifests/sentinel-statefulset/sentinel-service.yaml
@@ -1,0 +1,24 @@
+# Stable in-cluster address for the sentinel — this is what
+# 08-run-density-containarium-sentinel.sh points CTN_SERVER at, so every
+# `containarium create` call actually traverses the sentinel hop instead
+# of hitting the daemon Service directly (see README.md in this
+# directory).
+apiVersion: v1
+kind: Service
+metadata:
+  name: containarium-bench-sentinel
+  namespace: __NAMESPACE__
+  labels:
+    app.kubernetes.io/name: containarium-bench-sentinel
+    app.kubernetes.io/instance: containarium-bench
+    benchmark: agent-sandbox-density
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: containarium-bench-sentinel
+    app.kubernetes.io/instance: containarium-bench
+  ports:
+    - name: api
+      port: 8080
+      targetPort: api
+      protocol: TCP

--- a/benchmark/agent-sandbox-density/scripts/07-provision-containarium-sentinel.sh
+++ b/benchmark/agent-sandbox-density/scripts/07-provision-containarium-sentinel.sh
@@ -1,0 +1,187 @@
+#!/bin/bash
+#
+# Provision the "sentinel-statefulset" benchmark scenario: the same shared
+# base cluster + gVisor as 03-provision-containarium.sh, but with
+# Containarium's daemon fronted by the topology documented in README.md's
+# "The experiment group's k8s footprint" — a Service, a Deployment running
+# a stand-in "sentinel" that forwards traffic, and a StatefulSet running
+# the daemon itself — instead of the chart's own single Deployment.
+#
+# This is a BENCHMARK-ONLY exploration, not a proposed production chart
+# change. See manifests/sentinel-statefulset/README.md for why: the real
+# daemon is stateless (no PVCs, all durable state in the k8s API/etcd via
+# CRDs), so a StatefulSet buys it nothing architecturally — this exists to
+# put a real number on what the topology costs, not to recommend building
+# it. `charts/containarium-k8s/` is untouched by this script.
+#
+# How the daemon's container spec gets here without hand-duplicating Helm's
+# logic: this still `helm install`s the real chart (same as 03), but with
+# `daemon.replicaCount=0` so its own Deployment never actually runs a pod.
+# The resulting (0-replica but fully-specced) Deployment object is read
+# back with `kubectl get -o json` and reshaped into a StatefulSet with
+# `jq` — the container spec (image, env, probes, ports) is copied exactly
+# from what Helm computed, not re-typed by hand, so it can't drift from
+# what the chart actually produces.
+#
+# Usage:
+#   scripts/07-provision-containarium-sentinel.sh --name <vm-name>
+#
+# Assumes the guest is Ubuntu Server 24.04 with passwordless sudo for
+# REMOTE_SSH_USER, same as 03-provision-containarium.sh.
+
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+# shellcheck source=lib.sh
+source ./lib.sh
+# shellcheck source=k8s-common.sh
+source ./k8s-common.sh
+
+VM_NAME=""
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--name)
+		VM_NAME="$2"
+		shift 2
+		;;
+	-h | --help)
+		grep '^#' "$0" | sed 's/^# \{0,1\}//'
+		exit 0
+		;;
+	*)
+		die "unknown argument: $1"
+		;;
+	esac
+done
+[[ -n "$VM_NAME" ]] || die "usage: $0 --name <vm-name>"
+
+load_config
+require_vars K8S_MAX_PODS AGENT_SANDBOX_VERSION CONTAINARIUM_VERSION GVISOR_RUNTIME_CLASS REMOTE_SSH_USER BENCH_SSH_KEY_FILE
+resolve_remote "$VM_NAME"
+
+log "provisioning Containarium sentinel-statefulset scenario on '${VM_NAME}'"
+provision_base_k8s
+install_gvisor
+
+log "installing Helm and jq (jq drives the Deployment->StatefulSet reshape below)"
+ssh_or_local "curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | sudo bash"
+ssh_or_local "sudo apt-get install -y -qq jq git >/dev/null"
+
+log "resolving Containarium ${CONTAINARIUM_VERSION} and fetching the chart + CLI"
+ssh_or_local "sudo bash -s" <<REMOTE
+set -euo pipefail
+TAG="${CONTAINARIUM_VERSION}"
+if [[ "\$TAG" == "latest" ]]; then
+	TAG=\$(curl -fsSL https://api.github.com/repos/FootprintAI/Containarium/releases/latest | jq -r .tag_name)
+fi
+echo "resolved tag: \$TAG"
+echo "\$TAG" >/tmp/containarium-resolved-tag
+
+BASE_URL="https://github.com/FootprintAI/Containarium/releases/download/\${TAG}"
+curl -fsSL -o /tmp/containarium "\${BASE_URL}/containarium-linux-amd64"
+curl -fsSL -o /tmp/SHA256SUMS.txt "\${BASE_URL}/SHA256SUMS.txt"
+EXPECTED=\$(grep 'containarium-linux-amd64\$' /tmp/SHA256SUMS.txt | awk '{print \$1}')
+ACTUAL=\$(sha256sum /tmp/containarium | awk '{print \$1}')
+[[ "\$EXPECTED" == "\$ACTUAL" ]] || { echo "SHA256 mismatch: expected \$EXPECTED, got \$ACTUAL" >&2; exit 1; }
+install -m 0755 /tmp/containarium /usr/local/bin/containarium
+containarium version
+
+rm -rf /opt/containarium-src
+git clone --depth 1 --branch "\$TAG" https://github.com/FootprintAI/Containarium.git /opt/containarium-src
+REMOTE
+
+log "helm installing the chart with daemon.replicaCount=0 (same throwaway gateway keypair workaround as 03-provision-containarium.sh — see its header comment)"
+ssh_or_local "sudo bash -s" <<REMOTE
+set -euo pipefail
+ssh-keygen -t ed25519 -N "" -f /tmp/sshpiper_upstream -C sshpiper-upstream <<<y >/dev/null 2>&1 || true
+PUBKEY=\$(cat /tmp/sshpiper_upstream.pub)
+
+helm install containarium /opt/containarium-src/charts/containarium-k8s \
+	--set daemon.jwtSecret="\$(openssl rand -hex 32)" \
+	--set daemon.replicaCount=0 \
+	--set runtimeClass=${GVISOR_RUNTIME_CLASS} \
+	--set gateway.enabled=false \
+	--set gateway.upstreamKeySecret=sshpiper-upstream-key \
+	--set gateway.upstreamPublicKey="\$PUBKEY" \
+	--wait --timeout 5m
+
+kubectl -n agent-gateway create secret generic sshpiper-upstream-key \
+	--from-file=ssh-privatekey=/tmp/sshpiper_upstream \
+	--dry-run=client -o yaml | kubectl apply -f -
+REMOTE
+
+log "reshaping the chart's (0-replica) daemon Deployment into a StatefulSet with jq (remote: needs a live kubectl against the cluster)"
+ssh_or_local "sudo bash -s" <<'REMOTE'
+set -euo pipefail
+kubectl get deployment containarium-containarium-k8s-daemon -o jsonpath='{.metadata.namespace}' >/tmp/release-ns.txt
+
+kubectl get deployment containarium-containarium-k8s-daemon -o json | jq \
+'{
+  apiVersion: "apps/v1",
+  kind: "StatefulSet",
+  metadata: {
+    name: "containarium-bench-daemon",
+    namespace: .metadata.namespace,
+    labels: {
+      "app.kubernetes.io/name": "containarium-bench-daemon",
+      "app.kubernetes.io/instance": "containarium-bench",
+      "benchmark": "agent-sandbox-density"
+    }
+  },
+  spec: {
+    serviceName: "containarium-bench-daemon-headless",
+    replicas: 1,
+    selector: {
+      matchLabels: {
+        "app.kubernetes.io/name": "containarium-bench-daemon",
+        "app.kubernetes.io/instance": "containarium-bench"
+      }
+    },
+    template: {
+      metadata: {
+        labels: {
+          "app.kubernetes.io/name": "containarium-bench-daemon",
+          "app.kubernetes.io/instance": "containarium-bench"
+        }
+      },
+      spec: .spec.template.spec
+    }
+  }
+}' >/tmp/daemon-statefulset.json
+
+echo "--- reshaped StatefulSet (verify the container spec below matches what the chart would have run) ---"
+jq '.spec.template.spec.containers[0] | {image, args, env: (.env | map(.name))}' /tmp/daemon-statefulset.json
+
+kubectl apply -f /tmp/daemon-statefulset.json
+REMOTE
+
+# The remaining manifests (headless Service, sentinel ConfigMap/Deployment/
+# Service) are static — no cluster state to read — so they're templated
+# LOCALLY (same __NAMESPACE__-substitution pattern 02-run-density-k8s.sh
+# uses for sandbox-template.yaml) and piped through ssh, rather than
+# expected to exist inside the VM's own tag-pinned git clone (which only
+# ever contains a released tag — these benchmark-only files aren't part of
+# any release).
+RELEASE_NS=$(ssh_or_local "cat /tmp/release-ns.txt")
+[[ -n "$RELEASE_NS" ]] || die "couldn't read back the release namespace from the VM"
+log "release namespace: ${RELEASE_NS}"
+
+log "waiting for the daemon StatefulSet's pod to be Ready"
+ssh_or_local "kubectl wait --for=condition=ready pod/containarium-bench-daemon-0 --timeout=180s"
+
+for manifest in daemon-headless-service sentinel-configmap sentinel-deployment sentinel-service; do
+	sed "s/__NAMESPACE__/${RELEASE_NS}/g" "${BENCH_ROOT}/manifests/sentinel-statefulset/${manifest}.yaml" |
+		ssh_or_local "kubectl apply -f -"
+done
+
+log "waiting for the sentinel Deployment to be available"
+ssh_or_local "kubectl wait --for=condition=available deployment/containarium-bench-sentinel --timeout=180s"
+
+log "topology summary:"
+ssh_or_local "kubectl get deployment,statefulset,svc -l 'app.kubernetes.io/instance in (containarium,containarium-bench)'"
+
+log "sanity check: a request through the sentinel actually reaches the daemon"
+ssh_or_local "kubectl run -it --rm sentinel-smoke-test --image=curlimages/curl:latest --restart=Never --command -- curl -sf http://containarium-bench-sentinel:8080/health" \
+	&& log "sentinel -> daemon hop confirmed reachable" \
+	|| die "sentinel smoke test failed — the density loop would fail the same way; check nginx.conf / StatefulSet pod logs before proceeding"
+
+log "provisioning complete. Verify: ssh (see config.env) 'kubectl get pods -A; kubectl get statefulset,deployment,svc -A | grep bench'"

--- a/benchmark/agent-sandbox-density/scripts/08-run-density-containarium-sentinel.sh
+++ b/benchmark/agent-sandbox-density/scripts/08-run-density-containarium-sentinel.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+#
+# Density loop for the sentinel-statefulset scenario — identical to
+# 04-run-density-containarium.sh (same sandbox profile via #1557's
+# --memory-request/--cpu-request, same readiness check, same stopping
+# rule), with exactly one difference: CTN_SERVER points at the sentinel
+# Service instead of the daemon Service directly, so every `containarium
+# create` call actually traverses the Service -> Deployment(sentinel) ->
+# StatefulSet(daemon) hop documented in README.md's "The experiment
+# group's k8s footprint" / manifests/sentinel-statefulset/README.md.
+#
+# Compare this run's result directly against the 373 baseline from
+# 04-run-density-containarium.sh (same host, same profile, no sentinel
+# hop) — see RESULTS.md.
+#
+# Usage:
+#   scripts/08-run-density-containarium-sentinel.sh --name <vm-name>
+
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+# shellcheck source=lib.sh
+source ./lib.sh
+
+VM_NAME=""
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--name)
+		VM_NAME="$2"
+		shift 2
+		;;
+	-h | --help)
+		grep '^#' "$0" | sed 's/^# \{0,1\}//'
+		exit 0
+		;;
+	*)
+		die "unknown argument: $1"
+		;;
+	esac
+done
+[[ -n "$VM_NAME" ]] || die "usage: $0 --name <vm-name>"
+
+load_config
+require_vars SANDBOX_CPU_LIMIT SANDBOX_MEM_LIMIT SANDBOX_CPU_REQUEST SANDBOX_MEM_REQUEST FAILURE_STREAK_TO_STOP CREATE_TIMEOUT_SECONDS BENCH_SSH_KEY_FILE
+resolve_remote "$VM_NAME"
+
+log "sandbox profile: cpu=${SANDBOX_CPU_REQUEST}/${SANDBOX_CPU_LIMIT} memory=${SANDBOX_MEM_REQUEST}/${SANDBOX_MEM_LIMIT} (request/limit) via the sentinel hop"
+
+RESULTS_DIR="${BENCH_ROOT}/results"
+mkdir -p "$RESULTS_DIR"
+RESULTS_FILE="${RESULTS_DIR}/containarium-sentinel-$(date -u +%Y%m%dT%H%M%SZ).md"
+
+RESOLVED_TAG=$(ssh_or_local "cat /tmp/containarium-resolved-tag 2>/dev/null" || true)
+[[ -n "$RESOLVED_TAG" ]] || die "couldn't read /tmp/containarium-resolved-tag — did 07-provision-containarium-sentinel.sh run first?"
+AGENT_BOX_IMAGE="ghcr.io/footprintai/containarium-agent-box:${RESOLVED_TAG}"
+log "using agent-box image ${AGENT_BOX_IMAGE}"
+
+log "resolving the SENTINEL's ClusterIP (not the daemon's — this is the whole point of this scenario) and minting an admin token"
+CTN_CLUSTERIP=$(ssh_or_local "kubectl get svc containarium-bench-sentinel -o jsonpath='{.spec.clusterIP}'")
+[[ -n "$CTN_CLUSTERIP" ]] || die "couldn't resolve the sentinel's ClusterIP — did 07-provision-containarium-sentinel.sh run first? check 'kubectl get svc' on the guest"
+CTN_SERVER="http://${CTN_CLUSTERIP}:8080"
+
+# The JWT secret is unchanged from the plain Deployment scenario — it's the
+# same Helm-created Secret (containarium-containarium-k8s-daemon), read
+# straight from the StatefulSet pod's env by the daemon regardless of which
+# controller (Deployment or StatefulSet) is running it.
+JWT_SECRET=$(ssh_or_local "kubectl get secret containarium-containarium-k8s-daemon -o jsonpath='{.data.jwt-secret}' | base64 -d")
+[[ -n "$JWT_SECRET" ]] || die "failed to read the daemon's jwt-secret — check 07-provision-containarium-sentinel.sh's helm install succeeded"
+CTN_TOKEN=$(ssh_or_local "containarium token generate --username bench-admin --roles admin --expiry 6h --secret '${JWT_SECRET}' --raw")
+[[ -n "$CTN_TOKEN" ]] || die "failed to mint a token"
+
+create_box() {
+	local name="$1"
+	ssh_or_local "containarium create ${name} --no-ssh-key --cpu ${SANDBOX_CPU_LIMIT} --memory ${SANDBOX_MEM_LIMIT} --cpu-request ${SANDBOX_CPU_REQUEST} --memory-request ${SANDBOX_MEM_REQUEST} --image ${AGENT_BOX_IMAGE} --server ${CTN_SERVER} --http --token ${CTN_TOKEN}" >/dev/null 2>&1
+}
+
+box_ready() {
+	local name="$1"
+	local phase ready
+	phase=$(ssh_or_local "kubectl get pod -n tenant-${name} box -o jsonpath='{.status.phase}' 2>/dev/null" || true)
+	ready=$(ssh_or_local "kubectl get pod -n tenant-${name} box -o jsonpath='{.status.containerStatuses[0].ready}' 2>/dev/null" || true)
+	[[ "$phase" == "Running" && "$ready" == "true" ]]
+}
+
+cleanup_box() {
+	local name="$1"
+	ssh_or_local "containarium delete ${name} --force --server ${CTN_SERVER} --http --token ${CTN_TOKEN}" >/dev/null 2>&1 || true
+}
+
+resource_snapshot "before" "$RESULTS_FILE"
+{
+	echo "profile: cpu ${SANDBOX_CPU_REQUEST}/${SANDBOX_CPU_LIMIT}, mem ${SANDBOX_MEM_REQUEST}/${SANDBOX_MEM_LIMIT} (request/limit)"
+	echo "image: ${AGENT_BOX_IMAGE}"
+	echo "topology: containarium create -> Service(containarium-bench-sentinel) -> Deployment(sentinel, nginx) -> StatefulSet(containarium-bench-daemon)"
+	echo "compare against: results/containarium-*.md (04-run-density-containarium.sh, no sentinel hop, same profile)"
+	echo
+} >>"$RESULTS_FILE"
+
+run_density_loop "sbdenssent" create_box box_ready cleanup_box "$RESULTS_FILE"
+
+resource_snapshot "after (${DENSITY_RESULT_COUNT} ready)" "$RESULTS_FILE"
+{
+	echo "kubectl top nodes (if metrics-server installed):"
+	echo '```'
+	ssh_or_local "kubectl top nodes 2>&1" || true
+	echo '```'
+	echo "pods by RuntimeClass (sanity check that boxes really landed on gVisor):"
+	echo '```'
+	ssh_or_local "kubectl get pods -A -o custom-columns=NAME:.metadata.name,RUNTIMECLASS:.spec.runtimeClassName 2>&1" || true
+	echo '```'
+	echo "sentinel + daemon pod status at stop:"
+	echo '```'
+	ssh_or_local "kubectl get pods -l 'app.kubernetes.io/instance=containarium-bench' -o wide 2>&1" || true
+	echo '```'
+} >>"$RESULTS_FILE"
+
+log "Containarium (sentinel-statefulset) scenario result: ${DENSITY_RESULT_COUNT} boxes reached RUNNING"
+log "full log: ${RESULTS_FILE}"


### PR DESCRIPTION
## Summary
- README.md's "The experiment group's k8s footprint" described Containarium's k8s deployment mode as conceptually `Service → Deployment(sentinel) → StatefulSet(daemon)` — prose with no number behind it. This PR builds it for real, benchmark-only, and measures it live.
- **Result: 373 sandboxes reached RUNNING (376 attempted) — an exact match to the plain-Deployment baseline**, node memory/CPU requests at stop identical down to the Mi (47984Mi/48GiB 99%, 10425m/20000m 52%). Wall-clock (~77 min) landed within noise of #1558's runsc leg on the same profile with no sentinel hop — the extra `Service → Deployment → StatefulSet` layer is measurably invisible to both density and speed at this scale.
- **Not a production chart change** — `charts/containarium-k8s/` is untouched. The daemon is stateless (no PVCs, all durable state in the k8s API/etcd via CRDs), so the StatefulSet buys nothing architecturally; the "sentinel" is a stock `nginx:1.27-alpine` reverse proxy standing in for a `containarium-sentinel` component that doesn't exist yet (the real `internal/sentinel` binary does something unrelated — see `manifests/sentinel-statefulset/README.md`).

## New files
- `manifests/sentinel-statefulset/` — raw k8s manifests (Service, sentinel Deployment+ConfigMap, daemon headless Service)
- `scripts/07-provision-containarium-sentinel.sh` — `helm install` with `daemon.replicaCount=0`, then `jq`-reshapes the resulting (fully-specced but 0-replica) Deployment into a StatefulSet, so the container spec can't drift from what Helm actually computes
- `scripts/08-run-density-containarium-sentinel.sh` — identical density loop to `04`, `CTN_SERVER` points at the sentinel instead of the daemon directly

## Three real snags, documented in RESULTS.md
1. The released CLI/daemon (`CONTAINARIUM_VERSION=latest` → v0.66.0) predates #1557 — same shape as the #1558 entry. Built a CLI binary from current `main` and reused the `containarium-daemon:bench-1558` image already built for that earlier run.
2. The reshaped StatefulSet's gateway-upstream-key env vars didn't land from the same `helm --set` flags `03`'s proven pattern uses — patched directly onto the StatefulSet (recovered the pubkey via `ssh-keygen -y` from the already-created Secret), not yet root-caused why the values didn't land.
3. nginx's static `proxy_pass` DNS resolution went stale across daemon pod restarts (resolved once, cached forever) — fixed by restarting the sentinel last, right before the density loop. A real limitation of this benchmark-only setup's stand-in proxy, noted as such rather than papered over.

## Test plan
- [x] Live run on a fresh Incus KVM VM, same host/profile as every other k8s scenario
- [x] `runsc` confirmed on all 373 sandbox pods (`kubectl get pods -A -o custom-columns=...RUNTIMECLASS`)
- [x] `bash -n` on both new scripts
- [x] Grepped the diff for concrete host/instance names — none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added benchmark results comparing the sentinel StatefulSet topology with the baseline Deployment.
  * Documented benchmark limitations, setup details, resource usage, and repository layout.
* **Benchmarking**
  * Added scripts and Kubernetes manifests for provisioning and measuring the sentinel topology.
  * Confirmed comparable performance and resource usage at 373 sandboxes.
* **Infrastructure**
  * Added a benchmark-only nginx proxy, services, configuration, and StatefulSet support for connectivity testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->