### PR TITLE
docs(benchmark): nested-incus-pod (#1565) — mechanism validated, resource limits blocked

### DIFF
--- a/benchmark/agent-sandbox-density/README.md
+++ b/benchmark/agent-sandbox-density/README.md
@@ -370,6 +370,37 @@ Incus-backed), and the default `--image` works as documented (no
 [#1524](https://github.com/FootprintAI/Containarium/issues/1524)-style
 `InvalidImageName` — that bug is k8s-backend-specific too).
 
+## Fourth scenario: nested Incus inside a k8s pod
+
+An exploration of the idea sketched in ["The experiment group's k8s
+footprint"](#the-experiment-groups-k8s-footprint) above, taken further:
+what if, instead of one k8s pod per box, one k8s pod hosted a **nested
+`incusd`**, running the existing, unmodified `containarium daemon
+--runtime=lxc` inside it? Kubernetes would then only ever admit the one
+pod's own declared request/limit, while the nested Incus packs however
+many boxes it can inside — the same declared-vs-actual accounting trick
+that makes the third scenario (929) denser than the k8s scenarios (373),
+attempted *inside* a k8s-scheduled pod instead of on a bare VM. Tracked in
+[#1565](https://github.com/FootprintAI/Containarium/issues/1565); manifests
+and scripts in `manifests/nested-incus-pod/`,
+`scripts/09-provision-nested-incus-pod.sh`,
+`scripts/10-run-density-nested-incus-pod.sh`.
+
+**No density number came out of this.** The mechanism itself works —
+nested Incus starts cleanly inside a real k8s pod, with working storage
+and networking, no fictional kernel wall (the biggest flagged risk,
+Incus's bridge conflicting with Calico's pod networking, turned out to be
+a non-issue). What doesn't work, in this cluster: Incus enforcing a
+per-container cgroup *resource limit* — which is every single
+`containarium create` call, and precisely the mechanism this whole
+benchmark series measures. See [`RESULTS.md`](RESULTS.md)'s 2026-08-26
+entry for the full, precise diagnosis (a cgroup-namespace/delegation gap,
+not a hard architectural block) and
+`manifests/nested-incus-pod/README.md` for what a follow-up attempt would
+need to try next. Like the third scenario, this is a benchmark-only
+exploration — it does not touch `charts/containarium-k8s/` and is not a
+proposed production architecture.
+
 ## Results so far: 373 / 373 / 929
 
 Three scenarios have actually been run end-to-end on the same host (full
@@ -381,6 +412,7 @@ numbers, host specs, and every fix's before/after data are in
 | Control — k8s + gVisor + agent-sandbox | **373** | pods request `128Mi`; k8s admission-bound |
 | Experiment — k8s + gVisor + Containarium (`pod → gVisor → containarium`) | **373** | request=`128Mi`/limit=`256Mi` via [#1557](https://github.com/FootprintAI/Containarium/issues/1557)'s `--memory-request` — exact match once the request-size asymmetry was fixed (was **186** before the fix; see RESULTS.md's 2026-08-26 entry) |
 | Third scenario — Containarium native LXC/Incus, no k8s, no gVisor | **929** | `limits.memory` is a cgroup ceiling, not a k8s reservation — different deployment mode, not a gVisor comparison |
+| Fourth scenario — nested Incus inside one k8s pod | *(none)* | Mechanism validated, but per-container cgroup resource limits don't enforce in this cluster — see [Fourth scenario](#fourth-scenario-nested-incus-inside-a-k8s-pod) above |
 
 A write-up of what those three numbers actually mean (the 186-vs-373 gap,
 the CLI fix, and the 373-vs-373 re-run) lives in the marketing blog, not
@@ -444,7 +476,8 @@ benchmark/agent-sandbox-density/
 ├── RESULTS.md                   — reviewed summary of actual runs, one dated entry per run
 ├── manifests/
 │   ├── sandbox-template.yaml     — Sandbox CR (agents.x-k8s.io/v1beta1) with the resource profile above
-│   └── sentinel-statefulset/     — benchmark-only Service/Deployment(sentinel)/StatefulSet(daemon) manifests, see its own README.md
+│   ├── sentinel-statefulset/     — benchmark-only Service/Deployment(sentinel)/StatefulSet(daemon) manifests, see its own README.md
+│   └── nested-incus-pod/         — benchmark-only nested-Incus-in-a-pod manifests, see its own README.md
 └── scripts/
     ├── lib.sh                       — shared logging / resource-snapshot / stop-on-N-failures helpers (density loop supports resuming via --start-index)
     ├── k8s-common.sh                — shared kubeadm+CNI+agent-sandbox-controller base, used by both 01 and 03
@@ -457,5 +490,7 @@ benchmark/agent-sandbox-density/
     ├── 06-run-density-containarium-lxc.sh — `containarium create` on the LXC backend until the stopping rule triggers (--start-index to resume a stopped run)
     ├── 07-provision-containarium-sentinel.sh — benchmark-only: same base as 03, daemon.replicaCount=0 + jq-reshaped into manifests/sentinel-statefulset/
     ├── 08-run-density-containarium-sentinel.sh — `containarium create` through the sentinel hop until the stopping rule triggers
+    ├── 09-provision-nested-incus-pod.sh — benchmark-only: shared k8s base (no gVisor) + a privileged pod running nested incusd + containarium daemon
+    ├── 10-run-density-nested-incus-pod.sh — `containarium create` inside the nested-Incus pod until the stopping rule triggers (blocked — see RESULTS.md)
     └── 99-teardown-vm.sh            — stop + delete the VM
 ```

--- a/benchmark/agent-sandbox-density/RESULTS.md
+++ b/benchmark/agent-sandbox-density/RESULTS.md
@@ -572,6 +572,122 @@ sentinel replica were never going to bottleneck 373 sequential creates;
 whether either component becomes a real bottleneck under concurrent load
 or many daemon replicas is a different, unasked question.
 
+### 2026-08-26 — nested-incus-pod (#1565): mechanism validated, resource-limit enforcement blocked
+
+Fourth scenario, tracked from #1565: put a nested `incusd` inside one k8s
+pod, run the existing `containarium daemon --runtime=lxc` alongside it
+pointed at that nested Incus, and see whether every `containarium create`
+becoming a real LXC container — cgroup-ceilinged by the nested Incus,
+invisible to Kubernetes' own admission accounting beyond the one pod's
+declared request/limit — could reach scenario 3's (929) density from
+*inside* a k8s-scheduled pod. **Result: the mechanism itself works, but
+the specific thing this whole benchmark series measures — a per-container
+resource *limit* actually being enforced — does not, in this environment.
+No density number came out of this run.**
+
+Host cap: 20 vCPU / 48GiB RAM / 200GB disk (Incus KVM VM), same as every
+other k8s scenario. Base cluster: `provision_base_k8s` (kubeadm + Calico)
+with `install_gvisor` deliberately *not* called — this pod must run under
+plain `runc` (gVisor blocks the mount/cgroup/namespace syscalls Incus
+itself needs; see manifests/nested-incus-pod/README.md). Pod: single
+`ubuntu:24.04` container, `privileged: true`, no `runtimeClassName`,
+`resources.requests == limits` = 16 CPU / 40Gi (the one declared number
+the whole experiment is about), `emptyDir` at `/var/lib/incus` (`dir`
+storage backend — no block device inside a pod). Daemon built from
+`main` (same snag as the #1558 and sentinel-statefulset entries above:
+the released tag, v0.66.0, predates `--disable-{security,pentest,zap}-
+scanner`) and served to the pod over a throwaway HTTP endpoint on the VM
+itself, since the pod can reach the VM's own IP directly.
+
+**Milestone 0 (spike) passed cleanly, no caveats.** A bare `incus admin
+init --auto --storage-backend=dir` plus `incus launch images:ubuntu/24.04
+test1` — Incus's own default profile, no explicit resource limits —
+worked exactly like on bare metal: `incusd` started as a plain background
+process (no systemd inside the container; the real binary is
+`/opt/incus/lib/systemd/incusd`, not on `$PATH`), the container reached
+`RUNNING`, `incus exec test1 -- echo ok` succeeded, and Incus's own
+`incusbr0` bridge came up nested *inside* the pod's own Calico-managed
+network namespace with a real DHCP-assigned IP (`10.224.76.16`) — the
+single biggest risk this scenario's design doc flagged (Incus's bridge
+creation conflicting with Calico's veth/netns setup) turned out to be a
+complete non-issue.
+
+**Milestone 1 (the real pod) also came up clean** — daemon healthy, core
+services attempted (see below), base image baked (#1037) — but revealed
+the real wall the moment box creation was actually tried.
+
+**What actually blocks the density run:** every `containarium create`
+call — with the benchmark's own 200m/256MiB profile, and even with zero
+explicit `--cpu`/`--memory` flags (containarium's own defaults, 4
+cores/4GB) — fails identically:
+
+```
+Error: failed to create container via HTTP API: failed to create
+container: ... failed to start container (operation failed): Failed to
+run: /opt/incus/bin/incusd forklxc <name>-container ...: exit status 1
+```
+
+The container-specific LXC log names it precisely:
+
+```
+cgfsng - Device or resource busy - Could not enable "+cpuset +cpu +io
++memory +hugetlb +pids +rdma +misc" controllers in the unified cgroup 11
+cgfsng - No such file or directory - Failed to set "memory.max" to
+"268435456"
+start - Failed to setup cgroup limits for container "<name>-container"
+```
+
+An *unconstrained* create (Incus's bare default profile — the spike's
+`test1`, and confirmed again live via a direct `incus launch` with no
+`-c limits.*`) starts fine in this same pod. Only a create that asks
+Incus to enforce a per-container cgroup ceiling fails — which is every
+single `containarium create` call, since the CLI always sets
+`limits.cpu`/`limits.memory` to something (explicit values, or its own
+4-core/4GB default). That is precisely the mechanism this entire
+benchmark series exists to measure (declared-vs-actual cgroup
+accounting), so this scenario cannot produce a comparable density number
+without it.
+
+**Root cause, as far as this run diagnosed it (not fixed, not chased
+further — see below):** `/proc/self/cgroup` inside the pod reads
+`0::/kubepods.slice/kubepods-pod<uid>.slice/cri-containerd-<id>.scope` —
+a full, host-rooted path, not `/`. That means this cluster's containerd/
+runc is *not* giving even a `privileged: true` pod its own cgroup
+namespace; nested Incus is creating its LXC containers' cgroups as real
+siblings of the pod's own live-managed cgroup subtree, contending with
+whatever kubelet/containerd are simultaneously doing there. `cgroup.
+subtree_control` already listed every controller as available and
+enabled at the point Incus tried to delegate further — the failure isn't
+missing controllers, it's contention/depth at that specific host-rooted
+path. The zabbly Incus package's own (unused here) systemd unit sets
+`Delegate=yes` on `incus.service` — systemd's mechanism for exactly this
+kind of controlled sub-delegation — which this pod never gets, since
+there's no systemd (no init at all) running as PID 1 inside a bare
+`ubuntu:24.04` container.
+
+**Two plausible fixes, neither attempted in this run** (real engineering
+effort, judged out of scope for a benchmark-only exploration — see
+manifests/nested-incus-pod/README.md): (1) run systemd as the pod's PID 1
+(the standard "systemd-in-a-container" pattern — needs a systemd-capable
+image/boot sequence, not just `apt-get install systemd` inside a running
+bare container) so the shipped `incus.service`'s `Delegate=yes` actually
+takes effect; (2) a node-level containerd/CRI config change so privileged
+pods get a private cgroup namespace (`cgroupns_mode`), which is outside
+what a Pod manifest alone can request and would need touching this
+cluster's base provisioning, not just this scenario's own files.
+
+**What this settles and what it doesn't.** It settles that the shared-
+process-hosting mechanism itself is sound — a nested Incus genuinely runs
+inside a k8s pod, with working storage, networking, and exec, no fictional
+kernel wall. It does *not* produce a density number, because the one
+thing that mechanism needs to actually work (per-box resource ceilings)
+doesn't, in this specific cluster's cgroup delegation setup. This is a
+narrower, more specific finding than "nested Incus in a pod doesn't
+work" — it's "nested Incus in a pod doesn't work *for resource-limited
+containers*, in a cluster where privileged pods don't get their own
+cgroup namespace" — which is exactly the kind of precise, actionable
+negative result worth keeping rather than silently abandoning.
+
 ## Template
 
 ```

--- a/benchmark/agent-sandbox-density/manifests/nested-incus-pod/README.md
+++ b/benchmark/agent-sandbox-density/manifests/nested-incus-pod/README.md
@@ -1,0 +1,64 @@
+# nested-incus-pod manifests
+
+Raw k8s manifests (not Helm-templated) for the fourth benchmark scenario
+tracked in [#1565](https://github.com/FootprintAI/Containarium/issues/1565):
+one privileged pod running a nested `incusd` plus the existing,
+unmodified `containarium daemon --runtime=lxc` inside it, pointed at that
+nested Incus over its own Unix socket. Every `containarium create` then
+becomes a real LXC container, cgroup-ceilinged by the nested Incus — but
+Kubernetes only ever admits the *one* declared request/limit on the pod
+below, regardless of how many boxes the nested Incus packs inside it.
+See `../../RESULTS.md`'s 2026-08-26 entry for what actually happened.
+
+**This is a benchmark-only exploration, not a proposed production
+architecture.** `charts/containarium-k8s/` is untouched by this scenario.
+
+## What's here
+
+- `spike-pod.yaml` — a throwaway Milestone-0 pod (no ConfigMap, no
+  containarium at all) used to answer one question before building
+  anything real: can a nested `incusd` even start and run a container
+  inside a k8s pod at all? It passed cleanly — see RESULTS.md.
+- `pod-configmap.yaml` — the real pod's startup script (installs Incus,
+  starts `incusd` as a plain background process — there's no systemd/init
+  inside a bare `ubuntu:24.04` container, so the zabbly package's own
+  `incus.service` unit is never actually used — installs and starts the
+  containarium daemon, bakes the base image).
+- `pod.yaml` — the real pod: `privileged: true`, no `runtimeClassName`
+  (must be plain `runc` — gVisor blocks the mount/cgroup/namespace
+  syscalls Incus itself needs to manage its own child containers), one
+  `emptyDir` for `/var/lib/incus` (the `dir` storage backend — no block
+  device inside a pod), `resources.requests == limits` — the single
+  declared number the whole experiment is about.
+
+## Why the daemon isn't started via the real Incus systemd unit
+
+The zabbly Incus package installs a real `incus.service` systemd unit
+(`Delegate=yes`, pointing at `/opt/incus/lib/systemd/incusd`) — but there
+is no systemd, no init of any kind, running as PID 1 inside a bare
+`ubuntu:24.04` container. `pod-configmap.yaml`'s start script backgrounds
+`incusd` directly (`nohup ... &`) instead. This turned out to matter: see
+RESULTS.md — the *reason* resource-limited containers fail to start here
+is plausibly exactly this gap (`Delegate=yes` never takes effect without
+systemd actually managing the cgroup), not something a Pod manifest alone
+can fix. A genuine systemd-as-PID-1 setup was judged out of scope for
+this benchmark-only pass; it's the most promising next step if anyone
+picks this back up.
+
+## Why `containarium create` never succeeded here
+
+Short version — full diagnosis in `RESULTS.md`: nested Incus itself
+works fine (the spike proved a real, unconstrained container starting,
+networking, and being exec'd into). What doesn't work is Incus enforcing
+a per-container cgroup *limit* — `containarium create` always sets
+`limits.cpu`/`limits.memory` to something (explicit flags, or its own
+4-core/4GB default), and every single one of those creates fails with
+`cgfsng: Device or resource busy` trying to delegate cgroup controllers
+further, and `Failed to set "memory.max"`. `/proc/self/cgroup` inside the
+pod shows a full host-rooted path rather than `/`, meaning this cluster's
+containerd/runc isn't giving even a `privileged: true` pod its own cgroup
+namespace — nested Incus's child-container cgroups are real siblings of
+the pod's own live-managed cgroup subtree, not a private, delegated
+subtree it fully owns. That's precisely the mechanism this whole
+benchmark series is about (declared-vs-actual cgroup accounting), so this
+scenario could not produce a comparable density number.

--- a/benchmark/agent-sandbox-density/manifests/nested-incus-pod/pod-configmap.yaml
+++ b/benchmark/agent-sandbox-density/manifests/nested-incus-pod/pod-configmap.yaml
@@ -1,0 +1,122 @@
+# Startup script for the nested-Incus-in-a-k8s-pod benchmark scenario
+# (issue #1565). Runs `incusd` and `containarium daemon --runtime=lxc`
+# INSIDE this one pod — every `containarium create` becomes a real LXC
+# container, cgroup-ceilinged by this nested Incus, invisible to
+# Kubernetes' own admission accounting (which only ever sees this one
+# pod's declared request/limit). See README.md in this directory.
+#
+# No systemd in a bare ubuntu:24.04 container image — incusd and the
+# containarium daemon are started directly (nohup'd background
+# processes), not via systemctl. The zabbly Incus package's postinst
+# scripts still try to touch systemd unit files (harmless — no init is
+# actually running them); the real daemon binary lives at
+# /opt/incus/lib/systemd/incusd, not on $PATH as `incusd`.
+#
+# Every `incus`/`containarium` invocation that spawns a nested process
+# (launch, exec, image-bake) is redirected from /dev/null — found live
+# (matches this repo's own documented gotcha) that piping a multi-line
+# script into a shell over `kubectl exec -i` can let a subprocess like
+# `incus launch` steal bytes meant for the *outer* script's remaining
+# lines if its stdin isn't explicitly detached.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nested-incus-pod-start
+  namespace: __NAMESPACE__
+  labels:
+    benchmark: agent-sandbox-density
+    scenario: nested-incus-pod
+data:
+  start.sh: |
+    set -euo pipefail
+    export DEBIAN_FRONTEND=noninteractive
+    LOG=/var/log/nested-incus-pod-start.log
+    # Tee, not a plain redirect — `kubectl logs` only ever sees this
+    # container's own stdout/stderr, and once the container exits
+    # `kubectl exec` stops working entirely (found live: a plain redirect
+    # here left both `kubectl logs` empty AND the log file unreachable
+    # after a failure, with no way to see what happened).
+    exec > >(tee "$LOG") 2>&1
+
+    echo "[start.sh] installing curl + Incus"
+    apt-get update -qq
+    apt-get install -y -qq curl jq
+    curl -fsSL https://pkgs.zabbly.com/get/incus-stable | sh
+
+    echo "[start.sh] starting incusd (no systemd here — direct background start)"
+    mkdir -p /var/log/incus
+    nohup /opt/incus/lib/systemd/incusd --group incus-admin --logfile /var/log/incus/incusd.log >/var/log/incus/incusd.stdout.log 2>&1 &
+    disown
+    i=0
+    while ! incus list </dev/null >/dev/null 2>&1; do
+      i=$((i + 1))
+      [ "$i" -lt 30 ] || { echo "[start.sh] incusd never became ready"; exit 1; }
+      sleep 2
+    done
+    echo "[start.sh] incusd ready after ${i} checks"
+
+    echo "[start.sh] incus admin init (dir storage backend — no block device inside a pod)"
+    incus admin init --auto --storage-backend=dir </dev/null
+
+    echo "[start.sh] installing containarium ${CONTAINARIUM_VERSION}"
+    if [ -n "${CONTAINARIUM_BINARY_URL:-}" ]; then
+      # Override for when the released tag predates a flag this scenario's
+      # daemon invocation needs (same class of snag #1558's entry hit:
+      # --disable-{security,pentest,zap}-scanner postdates v0.66.0). Points
+      # at a binary built from `main` and served over plain HTTP from
+      # somewhere the pod can reach (e.g. the VM's own host network) —
+      # checksum-verified against a SHA256SUMS file served alongside it,
+      # same as the release-download path below.
+      echo "[start.sh] using override binary URL: ${CONTAINARIUM_BINARY_URL}"
+      curl -fsSL -o /tmp/containarium "${CONTAINARIUM_BINARY_URL}"
+      curl -fsSL -o /tmp/containarium.sha256 "${CONTAINARIUM_BINARY_URL}.sha256"
+      EXPECTED=$(awk '{print $1}' /tmp/containarium.sha256)
+    else
+      TAG="${CONTAINARIUM_VERSION}"
+      if [ "$TAG" = "latest" ]; then
+        TAG=$(curl -fsSL https://api.github.com/repos/FootprintAI/Containarium/releases/latest | jq -r .tag_name)
+      fi
+      echo "[start.sh] resolved tag: ${TAG}"
+      BASE_URL="https://github.com/FootprintAI/Containarium/releases/download/${TAG}"
+      curl -fsSL -o /tmp/containarium "${BASE_URL}/containarium-linux-amd64"
+      curl -fsSL -o /tmp/SHA256SUMS.txt "${BASE_URL}/SHA256SUMS.txt"
+      EXPECTED=$(grep 'containarium-linux-amd64$' /tmp/SHA256SUMS.txt | awk '{print $1}')
+    fi
+    ACTUAL=$(sha256sum /tmp/containarium | awk '{print $1}')
+    [ "$EXPECTED" = "$ACTUAL" ] || { echo "[start.sh] SHA256 mismatch: expected $EXPECTED, got $ACTUAL"; exit 1; }
+    install -m 0755 /tmp/containarium /usr/local/bin/containarium
+    containarium version
+
+    echo "[start.sh] starting the containarium daemon (LXC backend, pointed at the nested incusd)"
+    # Default (non-standalone) mode, same as scenario 3's 05-provision-
+    # containarium-lxc.sh — the daemon spins up its own core services
+    # (Postgres, Caddy, otel collector) as nested LXC containers via this
+    # same nested incusd, so the fixed overhead this scenario pays matches
+    # what scenario 3 already pays, keeping the comparison fair rather
+    # than quietly giving this scenario a lighter footprint.
+    mkdir -p /etc/containarium
+    openssl rand -hex 32 >/etc/containarium/jwt.secret
+    chmod 0400 /etc/containarium/jwt.secret
+    nohup containarium daemon --address 0.0.0.0 --rest --http-port 8080 \
+      --jwt-secret-file /etc/containarium/jwt.secret \
+      --disable-security-scanner --disable-pentest-scanner --disable-zap-scanner \
+      >/var/log/containarium-daemon.log 2>&1 &
+    disown
+    i=0
+    while ! curl -fsS http://127.0.0.1:8080/health >/dev/null 2>&1; do
+      i=$((i + 1))
+      if [ "$i" -ge 90 ]; then
+        echo "[start.sh] containarium daemon never became healthy — dumping its log:"
+        cat /var/log/containarium-daemon.log
+        exit 1
+      fi
+      sleep 3
+    done
+    echo "[start.sh] containarium daemon healthy after ${i} checks"
+
+    echo "[start.sh] baking the base image (#1037) so creates clone instead of re-installing packages every time"
+    containarium image-bake --image images:ubuntu/24.04 --podman=false </dev/null
+
+    echo "[start.sh] ready"
+    touch /tmp/ready
+    sleep infinity

--- a/benchmark/agent-sandbox-density/manifests/nested-incus-pod/pod.yaml
+++ b/benchmark/agent-sandbox-density/manifests/nested-incus-pod/pod.yaml
@@ -1,0 +1,59 @@
+# The real nested-Incus-in-a-k8s-pod benchmark pod (issue #1565). Runs a
+# nested `incusd` plus `containarium daemon --runtime=lxc` (bootstrapped
+# via the ConfigMap-mounted start.sh) inside ONE pod. Every
+# `containarium create` becomes a real LXC container, cgroup-ceilinged
+# by the nested Incus — but Kubernetes only ever admits the ONE declared
+# request/limit below for the whole pod, regardless of how many boxes
+# the nested Incus packs inside it. That's the entire experiment.
+#
+# No runtimeClassName (defaults to plain runc) — gVisor cannot host
+# this: Incus performs mount/cgroup/namespace-creation syscalls against
+# its own child containers, exactly what gVisor intercepts and blocks.
+# securityContext.privileged: true is a benchmark-only simplification —
+# capability scoping is explicitly out of scope here (see README.md).
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nested-incus-pod
+  namespace: __NAMESPACE__
+  labels:
+    benchmark: agent-sandbox-density
+    scenario: nested-incus-pod
+spec:
+  restartPolicy: Never
+  containers:
+    - name: nested-incus
+      image: ubuntu:24.04
+      command: ["/bin/bash", "/scripts/start.sh"]
+      env:
+        - name: CONTAINARIUM_VERSION
+          value: __CONTAINARIUM_VERSION__
+        - name: CONTAINARIUM_BINARY_URL
+          value: __CONTAINARIUM_BINARY_URL__
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: __POD_CPU__
+          memory: __POD_MEM__
+        limits:
+          cpu: __POD_CPU__
+          memory: __POD_MEM__
+      volumeMounts:
+        - name: incus-data
+          mountPath: /var/lib/incus
+        - name: start-script
+          mountPath: /scripts
+      readinessProbe:
+        exec:
+          command: ["cat", "/tmp/ready"]
+        periodSeconds: 5
+        failureThreshold: 200 # apt+incus-init+image-bake all run at startup
+  volumes:
+    - name: incus-data
+      emptyDir:
+        sizeLimit: 150Gi
+    - name: start-script
+      configMap:
+        name: nested-incus-pod-start
+        defaultMode: 0755

--- a/benchmark/agent-sandbox-density/manifests/nested-incus-pod/spike-pod.yaml
+++ b/benchmark/agent-sandbox-density/manifests/nested-incus-pod/spike-pod.yaml
@@ -1,0 +1,43 @@
+# Throwaway spike pod for the nested-Incus-in-a-k8s-pod benchmark scenario
+# (issue #1565). NOT the real benchmark manifest — this is Milestone 0's
+# go/no-go check: can a nested `incusd` even start and create one LXC
+# container inside a real k8s pod at all? That has never been tried in
+# this repo. See manifests/nested-incus-pod/README.md once Milestone 0
+# resolves either way.
+#
+# No runtimeClassName (defaults to plain runc) — gVisor cannot host this:
+# Incus performs mount/cgroup/namespace-creation syscalls against its own
+# child containers, exactly what gVisor intercepts and blocks.
+#
+# privileged: true is a fast-POC choice for the spike only; capability
+# scoping is explicitly out of scope for this benchmark-only exploration.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nested-incus-spike
+  namespace: __NAMESPACE__
+  labels:
+    benchmark: agent-sandbox-density
+    scenario: nested-incus-pod
+spec:
+  restartPolicy: Never
+  containers:
+    - name: nested-incus
+      image: ubuntu:24.04
+      command: ["sleep", "infinity"]
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: "4"
+          memory: "8Gi"
+        limits:
+          cpu: "4"
+          memory: "8Gi"
+      volumeMounts:
+        - name: incus-data
+          mountPath: /var/lib/incus
+  volumes:
+    - name: incus-data
+      emptyDir:
+        sizeLimit: 150Gi

--- a/benchmark/agent-sandbox-density/scripts/09-provision-nested-incus-pod.sh
+++ b/benchmark/agent-sandbox-density/scripts/09-provision-nested-incus-pod.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+#
+# Provision the fourth benchmark scenario (#1565): a k8s cluster hosting
+# ONE privileged pod that runs a nested `incusd` plus the existing,
+# unmodified `containarium daemon --runtime=lxc` inside it. See
+# manifests/nested-incus-pod/README.md for what this is and RESULTS.md's
+# 2026-08-26 entry for what actually happened when it was run — the
+# mechanism works, but per-container cgroup resource limits don't enforce
+# in every cluster (a cgroup-namespace/delegation gap, diagnosed but not
+# fixed here).
+#
+# gVisor is NOT installed on this VM's base cluster — the privileged pod
+# must run under plain `runc` (unset RuntimeClassName), since Incus
+# itself performs mount/cgroup/namespace-creation syscalls against its
+# own child containers, exactly what gVisor intercepts and blocks.
+#
+# CONTAINARIUM_BINARY_URL (optional, config.env): if the resolved
+# CONTAINARIUM_VERSION release predates a flag this scenario's daemon
+# invocation needs (--disable-{security,pentest,zap}-scanner — the same
+# snag the #1558 and sentinel-statefulset entries in RESULTS.md hit),
+# build a `containarium` binary from `main` (CGO_ENABLED=0 GOOS=linux
+# GOARCH=amd64 go build -buildvcs=false ./cmd/containarium), serve it and
+# a `<url>.sha256` file over plain HTTP from somewhere this VM's pod can
+# reach (its own host IP works — pods can reach the node they're
+# scheduled on), and set this to that URL. Leave unset to use the
+# resolved release tag's binary as normal.
+#
+# Usage:
+#   scripts/09-provision-nested-incus-pod.sh --name <vm-name>
+#
+# Assumes the guest is Ubuntu Server 24.04 with passwordless sudo for
+# REMOTE_SSH_USER, same as the other provisioning scripts.
+
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+# shellcheck source=lib.sh
+source ./lib.sh
+# shellcheck source=k8s-common.sh
+source ./k8s-common.sh
+
+VM_NAME=""
+POD_CPU="16"
+POD_MEM="40Gi"
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--name)
+		VM_NAME="$2"
+		shift 2
+		;;
+	--pod-cpu)
+		POD_CPU="$2"
+		shift 2
+		;;
+	--pod-mem)
+		POD_MEM="$2"
+		shift 2
+		;;
+	-h | --help)
+		grep '^#' "$0" | sed 's/^# \{0,1\}//'
+		exit 0
+		;;
+	*)
+		die "unknown argument: $1"
+		;;
+	esac
+done
+[[ -n "$VM_NAME" ]] || die "usage: $0 --name <vm-name> [--pod-cpu N] [--pod-mem NGi]"
+
+load_config
+require_vars K8S_MAX_PODS CONTAINARIUM_VERSION REMOTE_SSH_USER BENCH_SSH_KEY_FILE
+resolve_remote "$VM_NAME"
+
+log "provisioning nested-incus-pod scenario on '${VM_NAME}' (pod budget: ${POD_CPU} CPU / ${POD_MEM})"
+provision_base_k8s
+# install_gvisor deliberately NOT called — see header comment.
+
+RELEASE_NS="default"
+BINARY_URL="${CONTAINARIUM_BINARY_URL:-}"
+
+log "rendering and applying the ConfigMap"
+sed "s/__NAMESPACE__/${RELEASE_NS}/g" "${BENCH_ROOT}/manifests/nested-incus-pod/pod-configmap.yaml" |
+	ssh_or_local "kubectl apply -f -"
+
+log "rendering and applying the pod"
+sed \
+	-e "s/__NAMESPACE__/${RELEASE_NS}/g" \
+	-e "s/__CONTAINARIUM_VERSION__/${CONTAINARIUM_VERSION}/g" \
+	-e "s/__POD_CPU__/${POD_CPU}/g" \
+	-e "s/__POD_MEM__/${POD_MEM}/g" \
+	-e "s#__CONTAINARIUM_BINARY_URL__#${BINARY_URL}#g" \
+	"${BENCH_ROOT}/manifests/nested-incus-pod/pod.yaml" |
+	ssh_or_local "kubectl apply -f -"
+
+log "waiting for the pod to be Ready (apt-get + incus-init + image-bake all run at startup — this takes several minutes)"
+ssh_or_local "kubectl wait --for=condition=ready pod/nested-incus-pod --timeout=15m" ||
+	die "pod never became ready — check: ssh (see config.env) 'kubectl logs nested-incus-pod'"
+
+log "provisioning complete. Verify: ssh (see config.env) 'kubectl exec nested-incus-pod -- incus list'"

--- a/benchmark/agent-sandbox-density/scripts/10-run-density-nested-incus-pod.sh
+++ b/benchmark/agent-sandbox-density/scripts/10-run-density-nested-incus-pod.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+#
+# Density loop for the fourth scenario: create Containarium boxes one at a
+# time on a nested Incus running INSIDE a k8s pod (issue #1565) until the
+# shared stopping rule in lib.sh's run_density_loop triggers. See
+# manifests/nested-incus-pod/README.md for what this scenario is and isn't
+# testing.
+#
+# Near-identical to 06-run-density-containarium-lxc.sh — same create/ready/
+# cleanup logic, same CPU/memory profile (this is the same LXC backend,
+# just nested inside a pod instead of running on a bare VM). The only real
+# difference is the transport: every command that would go straight to the
+# VM over SSH instead goes one hop further, through `kubectl exec` into
+# the pod — see pod_exec() below.
+#
+# Usage:
+#   scripts/10-run-density-nested-incus-pod.sh --name <vm-name> [--pod <pod-name>] [--start-index N]
+
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+# shellcheck source=lib.sh
+source ./lib.sh
+
+VM_NAME=""
+POD_NAME="nested-incus-pod"
+START_INDEX=1
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--name)
+		VM_NAME="$2"
+		shift 2
+		;;
+	--pod)
+		POD_NAME="$2"
+		shift 2
+		;;
+	--start-index)
+		START_INDEX="$2"
+		shift 2
+		;;
+	-h | --help)
+		grep '^#' "$0" | sed 's/^# \{0,1\}//'
+		exit 0
+		;;
+	*)
+		die "unknown argument: $1"
+		;;
+	esac
+done
+[[ -n "$VM_NAME" ]] || die "usage: $0 --name <vm-name> [--pod <pod-name>] [--start-index N]"
+
+load_config
+require_vars SANDBOX_MEM_LIMIT FAILURE_STREAK_TO_STOP CREATE_TIMEOUT_SECONDS BENCH_SSH_KEY_FILE
+
+# Same rationale as 06's LXC_SANDBOX_CPU_LIMIT/LXC_CREATE_TIMEOUT_SECONDS —
+# this is the same LXC backend, a real LXC box still has to fully boot an
+# OS before it's usable, and create_box below is synchronous just like 06.
+LXC_CPU_LIMIT="${LXC_SANDBOX_CPU_LIMIT:-${SANDBOX_CPU_LIMIT:-200m}}"
+CREATE_TIMEOUT_SECONDS="${LXC_CREATE_TIMEOUT_SECONDS:-$CREATE_TIMEOUT_SECONDS}"
+
+resolve_remote "$VM_NAME"
+
+# pod_exec runs a command inside the nested-Incus pod itself — one hop
+# further than ssh_or_local, which only gets us to the VM. containarium's
+# CLI and the daemon it's talking to (127.0.0.1:8080) both live inside the
+# pod, not on the VM directly.
+pod_exec() {
+	ssh_or_local "kubectl exec ${POD_NAME} -- $*"
+}
+
+INCUS_MEM_LIMIT="${SANDBOX_MEM_LIMIT/Mi/MiB}"
+INCUS_MEM_LIMIT="${INCUS_MEM_LIMIT/Gi/GiB}"
+log "sandbox profile on the nested-Incus-pod side: cpu=${LXC_CPU_LIMIT} memory=${INCUS_MEM_LIMIT} (Incus limits.cpu/limits.memory, single ceiling, same as scenario 3)"
+
+RESULTS_DIR="${BENCH_ROOT}/results"
+mkdir -p "$RESULTS_DIR"
+RESULTS_FILE="${RESULTS_DIR}/nested-incus-pod-$(date -u +%Y%m%dT%H%M%SZ).md"
+
+CTN_SERVER="http://127.0.0.1:8080"
+
+log "minting an admin token"
+CTN_TOKEN=$(pod_exec "containarium token generate --username bench-admin --roles admin --expiry 6h --secret-file /etc/containarium/jwt.secret --raw")
+[[ -n "$CTN_TOKEN" ]] || die "failed to mint a token — check the daemon is running inside the pod"
+
+create_box() {
+	local name="$1"
+	pod_exec "containarium create ${name} --no-ssh-key --podman=false --cpu ${LXC_CPU_LIMIT} --memory ${INCUS_MEM_LIMIT} --server ${CTN_SERVER} --http --token ${CTN_TOKEN}" >/dev/null 2>&1
+}
+
+box_ready() {
+	local name="$1"
+	local state
+	state=$(pod_exec "containarium get ${name} --format json --server ${CTN_SERVER} --http --token ${CTN_TOKEN} 2>/dev/null" |
+		jq -r --arg n "$name" '.containers[] | select(.Username==$n) | .State' 2>/dev/null || true)
+	[[ "$state" == "CONTAINER_STATE_RUNNING" ]]
+}
+
+cleanup_box() {
+	local name="$1"
+	pod_exec "containarium delete ${name} --force --server ${CTN_SERVER} --http --token ${CTN_TOKEN}" >/dev/null 2>&1 || true
+}
+
+resource_snapshot "before" "$RESULTS_FILE"
+{
+	echo "profile: cpu ${LXC_CPU_LIMIT}, mem ${INCUS_MEM_LIMIT} (Incus native, single ceiling, same profile as scenario 3)"
+	echo "backend: nested Incus inside one k8s pod (issue #1565) — Kubernetes only ever admits the pod's own declared request/limit"
+	echo
+} >>"$RESULTS_FILE"
+
+run_density_loop "sbdnip" create_box box_ready cleanup_box "$RESULTS_FILE" "$START_INDEX"
+
+resource_snapshot "after (${DENSITY_RESULT_COUNT} ready)" "$RESULTS_FILE"
+{
+	echo "containarium list totals (inside the pod):"
+	echo '```'
+	pod_exec "containarium list --server ${CTN_SERVER} --http --token ${CTN_TOKEN} 2>&1 | tail -5" || true
+	echo '```'
+	echo "pod's own declared request/limit (the one number k8s admitted for everything inside it):"
+	echo '```'
+	ssh_or_local "kubectl get pod ${POD_NAME} -o jsonpath='{.spec.containers[0].resources}'" || true
+	echo '```'
+} >>"$RESULTS_FILE"
+
+log "nested-Incus-pod fourth-scenario result: ${DENSITY_RESULT_COUNT} boxes reached RUNNING"
+log "full log: ${RESULTS_FILE}"


### PR DESCRIPTION
## Summary
- Fourth benchmark scenario (#1565): one k8s pod hosting a nested `incusd` plus the existing, unmodified `containarium daemon --runtime=lxc`, so Kubernetes only ever admits the pod's own declared request/limit while the nested Incus packs however many boxes it can inside — the same declared-vs-actual accounting trick that makes the third scenario (929) denser than the k8s scenarios (373), attempted inside a k8s-scheduled pod instead of a bare VM.
- **Milestone 0 (spike) passed cleanly**: nested Incus starts, storage initializes, a container launches, gets a real DHCP IP from Incus's own bridge nested inside the pod's Calico netns, and `incus exec` works. The single biggest flagged risk (Incus's bridge conflicting with Calico) turned out to be a complete non-issue.
- **The actual density run is blocked**: every `containarium create` — with or without explicit `--cpu`/`--memory` — fails identically (`cgfsng: Device or resource busy` delegating cgroup controllers, `Failed to set memory.max`). An *unconstrained* Incus container works fine in the same pod; only per-container cgroup **resource limits** fail, which is exactly the mechanism this whole benchmark series measures. `/proc/self/cgroup` inside the pod shows a full host-rooted path rather than `/`, suggesting this cluster's containerd/runc doesn't grant even a `privileged: true` pod its own cgroup namespace.
- Full diagnosis, the two plausible next steps (systemd-as-PID-1 so the shipped `incus.service`'s `Delegate=yes` actually applies, or a node-level containerd `cgroupns_mode` change), and everything reused/adapted from the existing scripts: `RESULTS.md`'s 2026-08-26 entry and `manifests/nested-incus-pod/README.md`.
- Benchmark-only exploration, same framing as the sentinel-statefulset work (#1564) — `charts/containarium-k8s/` is untouched.

## Test plan
- [x] Live-run through Milestone 0 (spike) and Milestone 1 (real pod) on the lab host — both passed.
- [x] Milestone 2 (density loop) attempted live — root-caused the blocker precisely rather than reporting a vague failure.
- [x] Grepped the diff for concrete lab hostnames/IPs before committing — clean (only ephemeral Incus-bridge/pod-network addresses, consistent with existing RESULTS.md entries).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a benchmark scenario for running Incus inside a Kubernetes pod.
  - Added automated provisioning and density-testing workflows for the nested environment.
  - Added configurable pod resources, Containarium versions, binary sources, and readiness checks.
  - Added collection of container counts, resource snapshots, and benchmark results.

- **Documentation**
  - Documented setup requirements, manifests, startup flow, and observed cgroup limitations.
  - Recorded that unrestricted containers run successfully, while resource-limited containers may fail in the tested configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->