### PR TITLE
fix(benchmark): address CodeRabbit review on #1567

### DIFF
--- a/benchmark/agent-sandbox-density/RESULTS.md
+++ b/benchmark/agent-sandbox-density/RESULTS.md
@@ -621,7 +621,7 @@ call — with the benchmark's own 200m/256MiB profile, and even with zero
 explicit `--cpu`/`--memory` flags (containarium's own defaults, 4
 cores/4GB) — fails identically:
 
-```
+```text
 Error: failed to create container via HTTP API: failed to create
 container: ... failed to start container (operation failed): Failed to
 run: /opt/incus/bin/incusd forklxc <name>-container ...: exit status 1
@@ -629,7 +629,7 @@ run: /opt/incus/bin/incusd forklxc <name>-container ...: exit status 1
 
 The container-specific LXC log names it precisely:
 
-```
+```text
 cgfsng - Device or resource busy - Could not enable "+cpuset +cpu +io
 +memory +hugetlb +pids +rdma +misc" controllers in the unified cgroup 11
 cgfsng - No such file or directory - Failed to set "memory.max" to

--- a/benchmark/agent-sandbox-density/manifests/nested-incus-pod/pod-configmap.yaml
+++ b/benchmark/agent-sandbox-density/manifests/nested-incus-pod/pod-configmap.yaml
@@ -97,7 +97,7 @@ data:
     mkdir -p /etc/containarium
     openssl rand -hex 32 >/etc/containarium/jwt.secret
     chmod 0400 /etc/containarium/jwt.secret
-    nohup containarium daemon --address 0.0.0.0 --rest --http-port 8080 \
+    nohup containarium daemon --runtime=lxc --address 0.0.0.0 --rest --http-port 8080 \
       --jwt-secret-file /etc/containarium/jwt.secret \
       --disable-security-scanner --disable-pentest-scanner --disable-zap-scanner \
       >/var/log/containarium-daemon.log 2>&1 &


### PR DESCRIPTION
## Summary
Small follow-up to #1567 (merged), addressing CodeRabbit's two review comments there:
- `pod-configmap.yaml`: pass `--runtime=lxc` explicitly rather than relying on the CLI's empty-string-falls-through-to-lxc default (`internal/server/boxbackend_factory.go:49`). Verified this was never a functional bug — the run's own spike/milestone-1 already proved the default resolved correctly — but explicit is clearer than relying on a fallthrough case.
- `RESULTS.md`: language-tag the two error-log fences (markdownlint MD040).

## Test plan
- [x] Docs/manifest-only change, no behavior to test beyond the markdown lint and the explicit flag matching the daemon's documented default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The containarium daemon now explicitly starts with the LXC runtime.

* **Documentation**
  * Improved syntax highlighting for error output examples in the nested-Incus benchmark results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->