### PR TITLE
feat(metrics): expose CFS throttling counters so a throttled box is distinguishable from an idle one (#1573)

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -8334,6 +8334,21 @@
           "type": "integer",
           "format": "int32",
           "title": "Number of running processes in container"
+        },
+        "cpuNrPeriods": {
+          "type": "string",
+          "format": "int64",
+          "title": "CFS periods elapsed"
+        },
+        "cpuNrThrottled": {
+          "type": "string",
+          "format": "int64",
+          "title": "CFS periods in which the container was throttled"
+        },
+        "cpuThrottledUsec": {
+          "type": "string",
+          "format": "int64",
+          "title": "Total time the container spent throttled, in microseconds"
         }
       },
       "title": "ContainerMetrics contains runtime metrics for a container"

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -1950,6 +1950,11 @@ type ContainerMetrics struct {
 	NetworkRxBytes   int64 `json:"networkRxBytes,string"`
 	NetworkTxBytes   int64 `json:"networkTxBytes,string"`
 	ProcessCount     int32 `json:"processCount"`
+	// CFS throttling counters (#1573) — cumulative, like CPUUsageSeconds.
+	// All zero means the runtime reported no signal, not "never throttled".
+	CPUNrPeriods     int64 `json:"cpuNrPeriods,string"`
+	CPUNrThrottled   int64 `json:"cpuNrThrottled,string"`
+	CPUThrottledUsec int64 `json:"cpuThrottledUsec,string"`
 }
 
 type SystemInfo struct {

--- a/internal/mcp/cpu_throttling_format_test.go
+++ b/internal/mcp/cpu_throttling_format_test.go
@@ -1,0 +1,71 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatCPUThrottling(t *testing.T) {
+	tests := []struct {
+		name    string
+		metrics ContainerMetrics
+		want    string
+	}{
+		{
+			// The case the whole feature exists for: usage looks low, and this
+			// line is what says the box is hitting its ceiling rather than idling.
+			name: "heavily throttled box",
+			metrics: ContainerMetrics{
+				CPUNrPeriods: 40031, CPUNrThrottled: 12847, CPUThrottledUsec: 98765432,
+			},
+			want: "   CPU Throttling: 12847/40031 periods (32.1%), 98.8s throttled\n",
+		},
+		{
+			// Signal present, value zero — a real "not throttled" finding, which
+			// must read differently from "nothing was measured".
+			name: "unthrottled box with a live signal",
+			metrics: ContainerMetrics{
+				CPUNrPeriods: 8123, CPUNrThrottled: 0, CPUThrottledUsec: 0,
+			},
+			want: "   CPU Throttling: 0/8123 periods (0.0%), 0.0s throttled\n",
+		},
+		{
+			name:    "no signal available",
+			metrics: ContainerMetrics{},
+			want:    "   CPU Throttling: not reported\n",
+		},
+		{
+			name: "no periods but stale counters — still no signal, no divide by zero",
+			metrics: ContainerMetrics{
+				CPUNrPeriods: 0, CPUNrThrottled: 5, CPUThrottledUsec: 100,
+			},
+			want: "   CPU Throttling: not reported\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatCPUThrottling(tt.metrics); got != tt.want {
+				t.Errorf("formatCPUThrottling()\n got = %q\nwant = %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// A throttled box and an idle box must not render identically — that
+// indistinguishability is the defect #1573 records.
+func TestFormatCPUThrottlingDistinguishesThrottledFromIdle(t *testing.T) {
+	throttled := formatCPUThrottling(ContainerMetrics{
+		CPUNrPeriods: 1000, CPUNrThrottled: 900, CPUThrottledUsec: 5_000_000,
+	})
+	idle := formatCPUThrottling(ContainerMetrics{
+		CPUNrPeriods: 1000, CPUNrThrottled: 0, CPUThrottledUsec: 0,
+	})
+
+	if throttled == idle {
+		t.Fatal("throttled and idle boxes render identically — the whole point of #1573 is that they must not")
+	}
+	if !strings.Contains(throttled, "90.0%") {
+		t.Errorf("throttled box should surface its throttled share, got %q", throttled)
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2021,10 +2021,33 @@ func handleGetMetrics(client API, args map[string]interface{}) (string, error) {
 		result += fmt.Sprintf("   Network: ↓%d MB ↑%d MB\n",
 			m.NetworkRxBytes/1024/1024, m.NetworkTxBytes/1024/1024)
 		result += fmt.Sprintf("   Processes: %d\n", m.ProcessCount)
+		result += formatCPUThrottling(m)
 		result += "\n"
 	}
 
 	return result, nil
+}
+
+// formatCPUThrottling renders the CFS throttling counters as a one-line
+// diagnostic (#1573).
+//
+// This is the line that separates a *throttled* box from an *idle* one. CPU
+// usage alone reads as the same low number in both cases, which is what made
+// "give the box more CPU" look like a plausible remedy for a slow box — a
+// remedy that cannot work, because Containarium's CPU numbers are ceilings
+// rather than reservations (#1571).
+//
+// A zero period count means the runtime reported no signal at all (K8s boxes,
+// a cgroup with no bandwidth limit, a stopped container) — say so explicitly
+// rather than printing "0% throttled", which would read as a positive finding
+// of "not throttled" when nothing was actually measured.
+func formatCPUThrottling(m ContainerMetrics) string {
+	if m.CPUNrPeriods == 0 {
+		return "   CPU Throttling: not reported\n"
+	}
+	pct := float64(m.CPUNrThrottled) / float64(m.CPUNrPeriods) * 100
+	return fmt.Sprintf("   CPU Throttling: %d/%d periods (%.1f%%), %.1fs throttled\n",
+		m.CPUNrThrottled, m.CPUNrPeriods, pct, float64(m.CPUThrottledUsec)/1e6)
 }
 
 func handleGetSystemInfo(client API, args map[string]interface{}) (string, error) {

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -3572,6 +3572,9 @@ func toProtoMetrics(m *incus.ContainerMetrics) *pb.ContainerMetrics {
 		NetworkRxBytes:   m.NetworkRxBytes,
 		NetworkTxBytes:   m.NetworkTxBytes,
 		ProcessCount:     m.ProcessCount,
+		CpuNrPeriods:     m.CPUNrPeriods,
+		CpuNrThrottled:   m.CPUNrThrottled,
+		CpuThrottledUsec: m.CPUThrottledUsec,
 	}
 }
 

--- a/internal/server/metrics_proto_test.go
+++ b/internal/server/metrics_proto_test.go
@@ -1,0 +1,68 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/footprintai/containarium/pkg/core/incus"
+)
+
+// toProtoMetrics is the last hop before the wire. A field dropped here reaches
+// every consumer — REST, gRPC, the MCP get_metrics tool, and peer-forwarded
+// responses — as a zero, which for the throttling counters reads as
+// "not reported" and silently restores the #1573 blind spot.
+func TestToProtoMetricsCarriesEveryField(t *testing.T) {
+	in := &incus.ContainerMetrics{
+		Name:             "alice-container",
+		CPUUsageSeconds:  1234,
+		MemoryUsageBytes: 2048,
+		MemoryLimitBytes: 4096,
+		DiskUsageBytes:   8192,
+		NetworkRxBytes:   16,
+		NetworkTxBytes:   32,
+		ProcessCount:     7,
+		CPUNrPeriods:     40031,
+		CPUNrThrottled:   12847,
+		CPUThrottledUsec: 98765432,
+	}
+
+	got := toProtoMetrics(in)
+
+	checks := []struct {
+		field string
+		got   int64
+		want  int64
+	}{
+		{"CpuUsageSeconds", got.CpuUsageSeconds, 1234},
+		{"MemoryUsageBytes", got.MemoryUsageBytes, 2048},
+		{"MemoryPeakBytes", got.MemoryPeakBytes, 4096},
+		{"DiskUsageBytes", got.DiskUsageBytes, 8192},
+		{"NetworkRxBytes", got.NetworkRxBytes, 16},
+		{"NetworkTxBytes", got.NetworkTxBytes, 32},
+		{"CpuNrPeriods", got.CpuNrPeriods, 40031},
+		{"CpuNrThrottled", got.CpuNrThrottled, 12847},
+		{"CpuThrottledUsec", got.CpuThrottledUsec, 98765432},
+	}
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("%s = %d, want %d", c.field, c.got, c.want)
+		}
+	}
+	if got.Name != "alice-container" {
+		t.Errorf("Name = %q, want %q", got.Name, "alice-container")
+	}
+	if got.ProcessCount != 7 {
+		t.Errorf("ProcessCount = %d, want 7", got.ProcessCount)
+	}
+}
+
+// A box whose runtime reports no throttling signal must come back as zeros
+// rather than inventing a value — the MCP layer renders that as
+// "not reported", which is a different claim from "not throttled".
+func TestToProtoMetricsLeavesUnreportedThrottlingAtZero(t *testing.T) {
+	got := toProtoMetrics(&incus.ContainerMetrics{Name: "bob-container", CPUUsageSeconds: 5})
+
+	if got.CpuNrPeriods != 0 || got.CpuNrThrottled != 0 || got.CpuThrottledUsec != 0 {
+		t.Errorf("unreported throttling should stay zero, got periods %d, throttled %d, usec %d",
+			got.CpuNrPeriods, got.CpuNrThrottled, got.CpuThrottledUsec)
+	}
+}

--- a/pkg/core/box/box.go
+++ b/pkg/core/box/box.go
@@ -195,6 +195,14 @@ type BoxMetrics struct {
 	NetworkRxBytes   int64
 	NetworkTxBytes   int64
 	ProcessCount     int32
+
+	// CFS bandwidth-throttling counters, cumulative like CPUUsageSeconds.
+	// They distinguish a throttled box from an idle one (#1573); all zero
+	// means "no signal available", not "never throttled". Populated by the
+	// LXC backend only — K8s exposes no equivalent read today.
+	CPUNrPeriods     int64
+	CPUNrThrottled   int64
+	CPUThrottledUsec int64
 }
 
 // BoxBackend is the runtime-neutral seam. LXC/incus and Kubernetes both

--- a/pkg/core/box/lxc/lxc.go
+++ b/pkg/core/box/lxc/lxc.go
@@ -158,6 +158,9 @@ func (b *Backend) Metrics(_ context.Context, ref box.BoxRef) (*box.BoxMetrics, e
 		NetworkRxBytes:   m.NetworkRxBytes,
 		NetworkTxBytes:   m.NetworkTxBytes,
 		ProcessCount:     m.ProcessCount,
+		CPUNrPeriods:     m.CPUNrPeriods,
+		CPUNrThrottled:   m.CPUNrThrottled,
+		CPUThrottledUsec: m.CPUThrottledUsec,
 	}, nil
 }
 

--- a/pkg/core/box/lxc/lxc_test.go
+++ b/pkg/core/box/lxc/lxc_test.go
@@ -238,7 +238,10 @@ func TestMetaDelegation(t *testing.T) {
 func TestMetricsDelegation(t *testing.T) {
 	mock := incustest.NewMockBackend()
 	mock.GetContainerMetricsFunc = func(name string) (*incus.ContainerMetrics, error) {
-		return &incus.ContainerMetrics{Name: name, CPUUsageSeconds: 42, MemoryUsageBytes: 1024, ProcessCount: 7}, nil
+		return &incus.ContainerMetrics{
+			Name: name, CPUUsageSeconds: 42, MemoryUsageBytes: 1024, ProcessCount: 7,
+			CPUNrPeriods: 900, CPUNrThrottled: 120, CPUThrottledUsec: 3400,
+		}, nil
 	}
 	b := newTestBackend(mock)
 	m, err := b.Metrics(context.Background(), box.BoxRef{Tenant: "alice"})
@@ -247,6 +250,12 @@ func TestMetricsDelegation(t *testing.T) {
 	}
 	if m.CPUUsageSeconds != 42 || m.MemoryUsageBytes != 1024 || m.ProcessCount != 7 {
 		t.Errorf("Metrics mapping = %+v", m)
+	}
+	// Throttling counters must survive the mapping — dropping one here would
+	// silently return "not reported" for every box (#1573).
+	if m.CPUNrPeriods != 900 || m.CPUNrThrottled != 120 || m.CPUThrottledUsec != 3400 {
+		t.Errorf("throttling mapping = periods %d, throttled %d, usec %d; want 900/120/3400",
+			m.CPUNrPeriods, m.CPUNrThrottled, m.CPUThrottledUsec)
 	}
 }
 

--- a/pkg/core/incus/client.go
+++ b/pkg/core/incus/client.go
@@ -663,6 +663,13 @@ type ContainerMetrics struct {
 	NetworkRxBytes   int64 // Network bytes received
 	NetworkTxBytes   int64 // Network bytes transmitted
 	ProcessCount     int32 // Number of running processes
+
+	// CFS bandwidth-throttling counters from the container's cgroup cpu.stat,
+	// cumulative like CPUUsageSeconds. All zero means "no signal available"
+	// (see cpuThrottle in cpu_stat.go), not "never throttled".
+	CPUNrPeriods     int64 // CFS periods elapsed
+	CPUNrThrottled   int64 // CFS periods in which the container was throttled
+	CPUThrottledUsec int64 // Total time spent throttled, in microseconds
 }
 
 // ServerInfo holds information about the Incus server
@@ -2053,6 +2060,19 @@ func (c *Client) GetContainerMetrics(name string) (*ContainerMetrics, error) {
 			metrics.NetworkRxBytes += network.Counters.BytesReceived
 			metrics.NetworkTxBytes += network.Counters.BytesSent
 		}
+	}
+
+	// CFS throttling counters (#1573). Incus's own InstanceState reports CPU
+	// *usage* but no throttling, so this reads the container's cgroup directly
+	// on the host, resolved through the container's init PID. A container that
+	// isn't running, a host that mounts cgroups differently, or a cgroup with
+	// no bandwidth limit all leave the fields at zero rather than failing the
+	// whole metrics read — throttling is a diagnostic signal, not a reason to
+	// lose usage/memory/disk numbers.
+	if t, ok := containerCPUThrottle(state.Pid); ok {
+		metrics.CPUNrPeriods = t.NrPeriods
+		metrics.CPUNrThrottled = t.NrThrottled
+		metrics.CPUThrottledUsec = t.ThrottledUsec
 	}
 
 	return metrics, nil

--- a/pkg/core/incus/cpu_stat.go
+++ b/pkg/core/incus/cpu_stat.go
@@ -1,0 +1,134 @@
+package incus
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// cgroupV2Root is where the unified cgroup v2 hierarchy is mounted on the host
+// the daemon runs on.
+const cgroupV2Root = "/sys/fs/cgroup"
+
+// cpuThrottle holds the CFS bandwidth-throttling counters a cgroup reports in
+// cpu.stat.
+//
+// These are what separate a *throttled* box from an *idle* one. Cumulative
+// CPU-seconds alone reads as the same low number in both cases, which is why a
+// starved tenant has no observable signal saying so today (#1573). A box whose
+// nr_throttled climbs is hitting its own CFS quota — the
+// limits.cpu.allowance ceiling written by cpu_limits.go. A box with flat
+// nr_throttled and low usage is either genuinely idle or losing the host CPU
+// race to its neighbours; the box's own cgroup cannot tell those apart, so that
+// distinction needs the host's committed:physical ratio as well (#1571).
+//
+// All three are cumulative over the container's lifetime, matching how
+// CPUUsageSeconds already behaves — callers take deltas between two reads.
+type cpuThrottle struct {
+	NrPeriods     int64 // CFS periods elapsed
+	NrThrottled   int64 // periods in which the container was throttled
+	ThrottledUsec int64 // total time spent throttled, in microseconds
+}
+
+// parseCPUStat parses the contents of a cgroup cpu.stat file.
+//
+// The bool reports whether any throttling counter was found — not whether the
+// container was throttled. A cgroup with no CPU bandwidth limit omits the
+// throttling keys entirely on some kernels and reports usage only; that is a
+// legitimate "no signal available" answer rather than a parse error, and the
+// caller leaves the fields unset instead of publishing a misleading zero.
+//
+// Unparseable values are skipped individually so one malformed line cannot
+// discard the counters around it.
+func parseCPUStat(content string) (cpuThrottle, bool) {
+	var t cpuThrottle
+	found := false
+
+	for _, line := range strings.Split(content, "\n") {
+		key, value, ok := strings.Cut(strings.TrimSpace(line), " ")
+		if !ok {
+			continue
+		}
+		n, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64)
+		if err != nil {
+			continue
+		}
+		switch key {
+		case "nr_periods":
+			t.NrPeriods, found = n, true
+		case "nr_throttled":
+			t.NrThrottled, found = n, true
+		case "throttled_usec":
+			t.ThrottledUsec, found = n, true
+		case "throttled_time":
+			// cgroup v1 spells the same counter in nanoseconds. Normalize so
+			// callers see one unit regardless of the host's hierarchy.
+			t.ThrottledUsec, found = n/1000, true
+		}
+	}
+
+	return t, found
+}
+
+// cgroupV2PathFromProc extracts the unified-hierarchy cgroup path from the
+// contents of a /proc/<pid>/cgroup file, relative to the cgroup root.
+//
+// Only the "0::" line is usable: on a hybrid host the v1 controllers are listed
+// first with their own paths, and cpu.stat lives under the v2 mount. A process
+// in the root cgroup ("0::/") yields "" — there is no per-container subtree to
+// read.
+//
+// Deriving the path from the container's init PID rather than assembling a
+// conventional name ("lxc.payload.<name>") keeps this working across Incus's
+// scope-naming variations and systemd-managed nesting.
+func cgroupV2PathFromProc(content string) string {
+	for _, line := range strings.Split(content, "\n") {
+		rest, ok := strings.CutPrefix(strings.TrimSpace(line), "0::")
+		if !ok {
+			continue
+		}
+		return strings.Trim(rest, "/")
+	}
+	return ""
+}
+
+// readCPUThrottle resolves a process's cgroup and reads its throttling counters
+// from cgroupRoot.
+//
+// Every failure is a silent "no signal": metrics collection must not fail — or
+// log per container per scrape — just because a host mounts its cgroups
+// differently or the container exited between the state read and this one.
+func readCPUThrottle(procCgroupPath, cgroupRoot string) (cpuThrottle, bool) {
+	raw, err := os.ReadFile(procCgroupPath)
+	if err != nil {
+		return cpuThrottle{}, false
+	}
+
+	rel := cgroupV2PathFromProc(string(raw))
+	if rel == "" {
+		return cpuThrottle{}, false
+	}
+	// The path comes from /proc, but it is still untrusted input being joined
+	// onto a host path — refuse anything that could climb out of the hierarchy.
+	if rel != filepath.Clean(rel) || strings.HasPrefix(rel, "..") {
+		return cpuThrottle{}, false
+	}
+
+	stat, err := os.ReadFile(filepath.Join(cgroupRoot, rel, "cpu.stat"))
+	if err != nil {
+		return cpuThrottle{}, false
+	}
+	return parseCPUStat(string(stat))
+}
+
+// containerCPUThrottle reads the CFS throttling counters for the container
+// whose init process is pid. A non-positive pid (a stopped container) has no
+// cgroup to read.
+func containerCPUThrottle(pid int64) (cpuThrottle, bool) {
+	if pid <= 0 {
+		return cpuThrottle{}, false
+	}
+	return readCPUThrottle(fmt.Sprintf("/proc/%d/cgroup", pid), cgroupV2Root)
+}

--- a/pkg/core/incus/cpu_stat.go
+++ b/pkg/core/incus/cpu_stat.go
@@ -2,6 +2,7 @@ package incus
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -101,6 +102,9 @@ func cgroupV2PathFromProc(content string) string {
 // log per container per scrape — just because a host mounts its cgroups
 // differently or the container exited between the state read and this one.
 func readCPUThrottle(procCgroupPath, cgroupRoot string) (cpuThrottle, bool) {
+	// #nosec G304 -- callers build this as /proc/<pid>/cgroup from an int64
+	// PID that Incus reported; it is a parameter only so the resolve-and-read
+	// path is testable against a fixture tree.
 	raw, err := os.ReadFile(procCgroupPath)
 	if err != nil {
 		return cpuThrottle{}, false
@@ -110,13 +114,25 @@ func readCPUThrottle(procCgroupPath, cgroupRoot string) (cpuThrottle, bool) {
 	if rel == "" {
 		return cpuThrottle{}, false
 	}
-	// The path comes from /proc, but it is still untrusted input being joined
-	// onto a host path — refuse anything that could climb out of the hierarchy.
-	if rel != filepath.Clean(rel) || strings.HasPrefix(rel, "..") {
+
+	// The cgroup path is read out of /proc, so it is host-derived rather than
+	// tenant-supplied — but it is still a variable path being resolved against
+	// a host directory, so contain it at the OS level instead of by inspection.
+	// os.Root refuses any traversal out of cgroupRoot, symlinks included, which
+	// a filepath.Clean check cannot promise.
+	root, err := os.OpenRoot(cgroupRoot)
+	if err != nil {
 		return cpuThrottle{}, false
 	}
+	defer func() { _ = root.Close() }()
 
-	stat, err := os.ReadFile(filepath.Join(cgroupRoot, rel, "cpu.stat"))
+	f, err := root.Open(filepath.Join(rel, "cpu.stat"))
+	if err != nil {
+		return cpuThrottle{}, false
+	}
+	defer func() { _ = f.Close() }()
+
+	stat, err := io.ReadAll(f)
 	if err != nil {
 		return cpuThrottle{}, false
 	}

--- a/pkg/core/incus/cpu_stat_test.go
+++ b/pkg/core/incus/cpu_stat_test.go
@@ -1,0 +1,194 @@
+package incus
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseCPUStat(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    cpuThrottle
+		wantOK  bool
+	}{
+		{
+			name: "cgroup v2 cpu.stat with a throttled container",
+			content: `usage_usec 12345678
+user_usec 9000000
+system_usec 3345678
+nr_periods 40031
+nr_throttled 12847
+throttled_usec 98765432
+`,
+			want:   cpuThrottle{NrPeriods: 40031, NrThrottled: 12847, ThrottledUsec: 98765432},
+			wantOK: true,
+		},
+		{
+			name: "unthrottled container still reports periods",
+			content: `usage_usec 500
+nr_periods 8123
+nr_throttled 0
+throttled_usec 0
+`,
+			want:   cpuThrottle{NrPeriods: 8123},
+			wantOK: true,
+		},
+		{
+			// A cgroup with no CPU bandwidth limit set omits the burst/throttle
+			// keys entirely on some kernels — usage-only is not a parse failure,
+			// but it carries no throttling signal.
+			name:    "usage-only cpu.stat has no throttling keys",
+			content: "usage_usec 500\nuser_usec 100\nsystem_usec 400\n",
+			want:    cpuThrottle{},
+			wantOK:  false,
+		},
+		{
+			name:    "empty file",
+			content: "",
+			want:    cpuThrottle{},
+			wantOK:  false,
+		},
+		{
+			// Defensive: a malformed value must not poison the other counters.
+			name:    "malformed value is skipped, siblings survive",
+			content: "nr_periods 100\nnr_throttled notanumber\nthrottled_usec 42\n",
+			want:    cpuThrottle{NrPeriods: 100, ThrottledUsec: 42},
+			wantOK:  true,
+		},
+		{
+			// cgroup v1 spells the time counter in nanoseconds under a different
+			// key; we normalize it to microseconds so callers see one unit.
+			name:    "cgroup v1 throttled_time (ns) normalizes to usec",
+			content: "nr_periods 10\nnr_throttled 3\nthrottled_time 5000000\n",
+			want:    cpuThrottle{NrPeriods: 10, NrThrottled: 3, ThrottledUsec: 5000},
+			wantOK:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseCPUStat(tt.content)
+			if ok != tt.wantOK {
+				t.Fatalf("parseCPUStat() ok = %v, want %v", ok, tt.wantOK)
+			}
+			if got != tt.want {
+				t.Errorf("parseCPUStat() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCgroupV2PathFromProc(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "incus container under lxc.payload scope",
+			content: "0::/lxc.payload.alice-container\n",
+			want:    "lxc.payload.alice-container",
+		},
+		{
+			name:    "systemd-managed nested path",
+			content: "0::/lxc.payload.bob-container/system.slice/sshd.service\n",
+			want:    "lxc.payload.bob-container/system.slice/sshd.service",
+		},
+		{
+			// A hybrid host lists v1 controllers first; only the unified 0:: line
+			// is usable for a cgroup v2 cpu.stat read.
+			name:    "hybrid hierarchy picks the unified line",
+			content: "12:memory:/lxc.payload.carol\n11:cpu,cpuacct:/lxc.payload.carol\n0::/lxc.payload.carol\n",
+			want:    "lxc.payload.carol",
+		},
+		{
+			name:    "root cgroup yields no relative path",
+			content: "0::/\n",
+			want:    "",
+		},
+		{
+			name:    "cgroup v1 only — no unified line",
+			content: "11:cpu,cpuacct:/lxc.payload.dave\n",
+			want:    "",
+		},
+		{
+			name:    "empty",
+			content: "",
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cgroupV2PathFromProc(tt.content); got != tt.want {
+				t.Errorf("cgroupV2PathFromProc() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReadCPUThrottle(t *testing.T) {
+	// Build a fake cgroup hierarchy plus a fake /proc/<pid>/cgroup pointing into
+	// it, so the whole resolve-then-read path is exercised without a live host.
+	newTree := func(t *testing.T, procLine, cgroupRel, statBody string) (string, string) {
+		t.Helper()
+		dir := t.TempDir()
+		procPath := filepath.Join(dir, "proc-cgroup")
+		if err := os.WriteFile(procPath, []byte(procLine), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		root := filepath.Join(dir, "cgroup")
+		if cgroupRel != "" {
+			leaf := filepath.Join(root, cgroupRel)
+			if err := os.MkdirAll(leaf, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(leaf, "cpu.stat"), []byte(statBody), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return procPath, root
+	}
+
+	t.Run("reads the container's counters", func(t *testing.T) {
+		proc, root := newTree(t, "0::/lxc.payload.alice-container\n", "lxc.payload.alice-container",
+			"usage_usec 10\nnr_periods 900\nnr_throttled 120\nthrottled_usec 3400\n")
+		got, ok := readCPUThrottle(proc, root)
+		if !ok {
+			t.Fatal("readCPUThrottle() ok = false, want true")
+		}
+		want := cpuThrottle{NrPeriods: 900, NrThrottled: 120, ThrottledUsec: 3400}
+		if got != want {
+			t.Errorf("readCPUThrottle() = %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("missing proc file is a silent no-signal", func(t *testing.T) {
+		_, root := newTree(t, "", "", "")
+		if _, ok := readCPUThrottle(filepath.Join(t.TempDir(), "absent"), root); ok {
+			t.Error("readCPUThrottle() ok = true, want false")
+		}
+	})
+
+	t.Run("missing cpu.stat is a silent no-signal", func(t *testing.T) {
+		proc, root := newTree(t, "0::/lxc.payload.bob-container\n", "", "")
+		if _, ok := readCPUThrottle(proc, root); ok {
+			t.Error("readCPUThrottle() ok = true, want false")
+		}
+	})
+
+	t.Run("path traversal in the cgroup line is refused", func(t *testing.T) {
+		proc, root := newTree(t, "0::/../../etc\n", "", "")
+		if _, ok := readCPUThrottle(proc, root); ok {
+			t.Error("readCPUThrottle() ok = true, want false — traversal must be refused")
+		}
+	})
+
+	t.Run("stopped container has no pid to resolve", func(t *testing.T) {
+		if _, ok := containerCPUThrottle(0); ok {
+			t.Error("containerCPUThrottle(0) ok = true, want false")
+		}
+	})
+}

--- a/pkg/pb/containarium/v1/container.pb.go
+++ b/pkg/pb/containarium/v1/container.pb.go
@@ -1023,9 +1023,15 @@ type ContainerMetrics struct {
 	// Network bytes transmitted (all interfaces except loopback)
 	NetworkTxBytes int64 `protobuf:"varint,7,opt,name=network_tx_bytes,json=networkTxBytes,proto3" json:"network_tx_bytes,omitempty"`
 	// Number of running processes in container
-	ProcessCount  int32 `protobuf:"varint,8,opt,name=process_count,json=processCount,proto3" json:"process_count,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	ProcessCount int32 `protobuf:"varint,8,opt,name=process_count,json=processCount,proto3" json:"process_count,omitempty"`
+	// CFS periods elapsed
+	CpuNrPeriods int64 `protobuf:"varint,9,opt,name=cpu_nr_periods,json=cpuNrPeriods,proto3" json:"cpu_nr_periods,omitempty"`
+	// CFS periods in which the container was throttled
+	CpuNrThrottled int64 `protobuf:"varint,10,opt,name=cpu_nr_throttled,json=cpuNrThrottled,proto3" json:"cpu_nr_throttled,omitempty"`
+	// Total time the container spent throttled, in microseconds
+	CpuThrottledUsec int64 `protobuf:"varint,11,opt,name=cpu_throttled_usec,json=cpuThrottledUsec,proto3" json:"cpu_throttled_usec,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *ContainerMetrics) Reset() {
@@ -1110,6 +1116,27 @@ func (x *ContainerMetrics) GetNetworkTxBytes() int64 {
 func (x *ContainerMetrics) GetProcessCount() int32 {
 	if x != nil {
 		return x.ProcessCount
+	}
+	return 0
+}
+
+func (x *ContainerMetrics) GetCpuNrPeriods() int64 {
+	if x != nil {
+		return x.CpuNrPeriods
+	}
+	return 0
+}
+
+func (x *ContainerMetrics) GetCpuNrThrottled() int64 {
+	if x != nil {
+		return x.CpuNrThrottled
+	}
+	return 0
+}
+
+func (x *ContainerMetrics) GetCpuThrottledUsec() int64 {
+	if x != nil {
+		return x.CpuThrottledUsec
 	}
 	return 0
 }
@@ -6010,7 +6037,7 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\x10encryption_state\x18\x1c \x01(\x0e2 .containarium.v1.EncryptionStateR\x0fencryptionState\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xcf\x02\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xcd\x03\n" +
 	"\x10ContainerMetrics\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12*\n" +
 	"\x11cpu_usage_seconds\x18\x02 \x01(\x03R\x0fcpuUsageSeconds\x12,\n" +
@@ -6019,7 +6046,11 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\x10disk_usage_bytes\x18\x05 \x01(\x03R\x0ediskUsageBytes\x12(\n" +
 	"\x10network_rx_bytes\x18\x06 \x01(\x03R\x0enetworkRxBytes\x12(\n" +
 	"\x10network_tx_bytes\x18\a \x01(\x03R\x0enetworkTxBytes\x12#\n" +
-	"\rprocess_count\x18\b \x01(\x05R\fprocessCount\"\xc1\b\n" +
+	"\rprocess_count\x18\b \x01(\x05R\fprocessCount\x12$\n" +
+	"\x0ecpu_nr_periods\x18\t \x01(\x03R\fcpuNrPeriods\x12(\n" +
+	"\x10cpu_nr_throttled\x18\n" +
+	" \x01(\x03R\x0ecpuNrThrottled\x12,\n" +
+	"\x12cpu_throttled_usec\x18\v \x01(\x03R\x10cpuThrottledUsec\"\xc1\b\n" +
 	"\x16CreateContainerRequest\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\x12=\n" +
 	"\tresources\x18\x02 \x01(\v2\x1f.containarium.v1.ResourceLimitsR\tresources\x12\x19\n" +

--- a/proto/containarium/v1/container.proto
+++ b/proto/containarium/v1/container.proto
@@ -335,6 +335,30 @@ message ContainerMetrics {
 
   // Number of running processes in container
   int32 process_count = 8;
+
+  // CFS bandwidth-throttling counters, cumulative over the container's
+  // lifetime — like cpu_usage_seconds, callers take deltas between two reads.
+  //
+  // These are what separate a *throttled* box from an *idle* one: cumulative
+  // CPU time alone reads as the same low number in both cases, which left a
+  // starved tenant with no observable signal at all (#1573). A climbing
+  // cpu_nr_throttled means the box is hitting its own CFS quota (the
+  // limits.cpu.allowance ceiling); flat counters with low usage mean the box
+  // is idle or losing the host CPU race to neighbours — a distinction its own
+  // cgroup cannot make (#1571).
+  //
+  // All three zero means "no signal available" — the runtime doesn't expose
+  // cpu.stat, or the cgroup carries no CPU bandwidth limit — NOT "never
+  // throttled". Only the LXC/Incus backend populates these today.
+
+  // CFS periods elapsed
+  int64 cpu_nr_periods = 9;
+
+  // CFS periods in which the container was throttled
+  int64 cpu_nr_throttled = 10;
+
+  // Total time the container spent throttled, in microseconds
+  int64 cpu_throttled_usec = 11;
 }
 
 // CreateContainerRequest is the request to create a new container


### PR DESCRIPTION
## Summary

Fixes #1573. `ContainerMetrics` carried cumulative CPU-seconds and nothing
else, so a box pinned at its CFS quota and a box doing nothing returned the
same low number. That blind spot is what makes "give the box more CPU" look
like a plausible remedy for a slow box — a remedy that cannot work, because
Containarium's CPU values are ceilings rather than reservations (#1571).

Adds `cpu_nr_periods` / `cpu_nr_throttled` / `cpu_throttled_usec` to the proto
contract, cumulative like `cpu_usage_seconds` so callers take deltas between
two reads.

## How it reads

`get_metrics` gains one line per box:

```
   CPU Throttling: 12847/40031 periods (32.1%), 98.8s throttled   ← hitting its ceiling
   CPU Throttling: 0/8123 periods (0.0%), 0.0s throttled          ← measured, not throttled
   CPU Throttling: not reported                                    ← nothing measured
```

The third case is deliberately not rendered as "0% throttled": all-zero
counters mean *no signal was available* (a K8s box, a cgroup with no bandwidth
limit, a stopped container), which is a different claim from "not throttled".

## Implementation notes

- **Where the numbers come from.** Incus's `InstanceState` reports CPU *usage*
  but no throttling, so the LXC backend reads the container's cgroup
  `cpu.stat` on the host. The path is resolved through the container's init
  PID (`/proc/<pid>/cgroup`) rather than assembling a conventional
  `lxc.payload.<name>` — that survives Incus's scope-naming variations and
  systemd-managed nesting. The cgroup line is untrusted input joined onto a
  host path, so traversal is refused.
- **cgroup v1** spells the time counter as `throttled_time` in nanoseconds;
  it is normalized to microseconds so callers see one unit.
- **Failures are silent no-signal.** A host that mounts cgroups differently, or
  a container that exited between the state read and the cgroup read, leaves
  the fields at zero rather than failing the whole metrics call — throttling is
  a diagnostic, never a reason to lose the usage/memory/disk numbers with it.
- **Peers need no change.** Both peer-forwarding paths in `GetMetrics`
  `protojson.Unmarshal` into `pb.GetMetricsResponse`, so the new fields flow
  through automatically. Verified by reading both branches, not assumed.
- **K8s backend** populates nothing — it has no equivalent read today, so its
  boxes report "not reported" honestly.

## Test plan

- [x] `parseCPUStat` — v2, v1-with-`throttled_time`, usage-only (no signal),
      empty, and a malformed value that must not discard its siblings.
- [x] `cgroupV2PathFromProc` — `lxc.payload` scope, systemd nesting, hybrid
      hierarchy (must pick the `0::` line), root cgroup, v1-only, empty.
- [x] `readCPUThrottle` against a fake cgroup tree — happy path, missing proc
      file, missing `cpu.stat`, path traversal refused, stopped container.
- [x] `formatCPUThrottling` — including an explicit test that a throttled box
      and an idle box do **not** render identically, which is the defect.
- [x] Mapping tests at both silent-drop points: `lxc.Backend.Metrics` and
      `toProtoMetrics` (the latter had no test at all before).
- [x] `go build ./...`, `go vet`, `gofmt` clean; affected packages green.

## Not included

The OTel / Cloud Monitoring export publishes no throttling series, so this is
diagnosable on demand but **not alertable**. That needs new metric names in the
`cloudexport` registry and its own review of series cardinality — filed as a
follow-up rather than smuggled in here.

## Needs live verification

The parsing and mapping are unit-tested, but the host read
(`/proc/<pid>/cgroup` → `cpu.stat`) has not been exercised against a real Incus
host — I have no local Incus. Worth one live check on a backend that the
counters are non-zero for a box under load before this is relied on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CPU throttling metrics to container monitoring, including throttled periods, throttling percentage, and throttled CPU time.
  * Metrics are available through container APIs and diagnostic output when supported by the runtime.
  * Clearly indicates when throttling data is unavailable.

* **Bug Fixes**
  * Preserved CPU throttling metrics across container monitoring and backend responses.
  * Prevented unavailable runtime data from causing metrics requests to fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->