### PR TITLE
feat(metrics): export CPU-throttling series so throttling is alertable, not just readable (#1575)

### DIFF
--- a/internal/metrics/cloudexport/collector.go
+++ b/internal/metrics/cloudexport/collector.go
@@ -56,6 +56,27 @@ const (
 	MetricContainerNetworkRxBytes   = "containarium.container.network.rx_bytes"
 	MetricContainerNetworkTxBytes   = "containarium.container.network.tx_bytes"
 
+	// MetricContainerCPUCFSPeriods / ThrottledPeriods / ThrottledUsec are
+	// the container group's CFS-throttling series (#1575), the alertable
+	// half of #1573. cpu.usage_seconds above cannot distinguish a box
+	// pinned at its CFS quota from an idle one — both read as a low
+	// number — so it is the one CPU series exported and it has exactly
+	// the blind spot the counters exist to close.
+	//
+	// Both the numerator and the denominator are exported because the
+	// alert worth writing is a *ratio* ("throttled >30% of its periods
+	// for 15 minutes"), which cannot be reconstructed from the throttled
+	// count alone. All three are cumulative counters, matching the
+	// container's own cgroup accounting and the usage/network series
+	// beside them.
+	//
+	// A box whose runtime reports no signal (K8s boxes, a cgroup with no
+	// bandwidth limit, a stopped container) has NO point observed rather
+	// than a zero — see registerContainerInstruments.
+	MetricContainerCPUCFSPeriods       = "containarium.container.cpu.cfs_periods"
+	MetricContainerCPUThrottledPeriods = "containarium.container.cpu.throttled_periods"
+	MetricContainerCPUThrottledUsec    = "containarium.container.cpu.throttled_usec"
+
 	// MetricHeartbeat is the liveness/up series (#1072): a constant 1
 	// emitted every export interval while the daemon runs. It is the
 	// out-of-band dead-man signal — a metric-absence alert policy in the
@@ -664,10 +685,12 @@ func registerHostInstruments(mp *sdkmetric.MeterProvider, sources Sources, label
 	return err
 }
 
-// registerContainerInstruments creates the container group's five
-// per-container series (#1071) and wires one callback that pulls a
-// single AllContainerMetrics snapshot per tick and observes all five for
-// every container currently reported. CPU/network are counters
+// registerContainerInstruments creates the container group's per-container
+// series — the original five (#1071) plus the three CFS-throttling counters
+// (#1575) — and wires one callback that pulls a single AllContainerMetrics
+// snapshot per tick and observes them for every container currently reported.
+// The five are observed unconditionally; the throttling three only when the
+// runtime reported a signal. CPU/network are counters
 // (cumulative, matching incus's own CPU-seconds and byte counters);
 // memory/disk are gauges (point-in-time). A container absent from the
 // snapshot — because AllContainerMetrics enumerates live containers
@@ -703,6 +726,21 @@ func registerContainerInstruments(mp *sdkmetric.MeterProvider, sources Sources, 
 	if err != nil {
 		return err
 	}
+	cfsPeriods, err := meter.Int64ObservableCounter(MetricContainerCPUCFSPeriods,
+		metric.WithUnit("{period}"), metric.WithDescription("Cumulative CFS bandwidth periods elapsed for the container. The denominator for a throttled-share alert."))
+	if err != nil {
+		return err
+	}
+	throttledPeriods, err := meter.Int64ObservableCounter(MetricContainerCPUThrottledPeriods,
+		metric.WithUnit("{period}"), metric.WithDescription("Cumulative CFS periods in which the container was throttled against its CPU ceiling."))
+	if err != nil {
+		return err
+	}
+	throttledUsec, err := meter.Int64ObservableCounter(MetricContainerCPUThrottledUsec,
+		metric.WithUnit("us"), metric.WithDescription("Cumulative time the container spent throttled, in microseconds."))
+	if err != nil {
+		return err
+	}
 
 	_, err = meter.RegisterCallback(
 		func(ctx context.Context, o metric.Observer) error {
@@ -724,10 +762,25 @@ func registerContainerInstruments(mp *sdkmetric.MeterProvider, sources Sources, 
 				o.ObserveInt64(disk, m.DiskUsageBytes, observeOpt)
 				o.ObserveInt64(rx, m.NetworkRxBytes, observeOpt)
 				o.ObserveInt64(tx, m.NetworkTxBytes, observeOpt)
+
+				// Throttling counters are observed only when the runtime
+				// actually reported them (#1575). A zero period count means
+				// "no signal available" — a K8s box, a cgroup with no CPU
+				// bandwidth limit, a container that just stopped — and
+				// emitting a flat zero for those would read as a confident
+				// "never throttled", silencing a throttling alert for exactly
+				// the boxes it cannot see. Absence is the honest answer, and
+				// it is already this collector's idiom for "nothing to
+				// report" (see the deleted-container behavior above).
+				if m.CpuNrPeriods > 0 {
+					o.ObserveInt64(cfsPeriods, m.CpuNrPeriods, observeOpt)
+					o.ObserveInt64(throttledPeriods, m.CpuNrThrottled, observeOpt)
+					o.ObserveInt64(throttledUsec, m.CpuThrottledUsec, observeOpt)
+				}
 			}
 			return nil
 		},
-		cpu, mem, disk, rx, tx,
+		cpu, mem, disk, rx, tx, cfsPeriods, throttledPeriods, throttledUsec,
 	)
 	return err
 }

--- a/internal/metrics/cloudexport/collector_test.go
+++ b/internal/metrics/cloudexport/collector_test.go
@@ -1126,6 +1126,13 @@ func sampleContainerMetrics() map[string]*pb.ContainerMetrics {
 			DiskUsageBytes:   2 << 30,
 			NetworkRxBytes:   1000,
 			NetworkTxBytes:   500,
+			// alice reports a throttling signal and bob does not, so tests
+			// built on this fixture cover both #1575 paths. The conditional
+			// series are filtered out of the golden count below, which
+			// counts only the unconditional five.
+			CpuNrPeriods:     40031,
+			CpuNrThrottled:   12847,
+			CpuThrottledUsec: 98765432,
 		},
 		"bob-container": {
 			Name:             "bob-container",
@@ -1147,6 +1154,17 @@ var containerMetricNames = map[string]bool{
 	MetricContainerDiskUsageBytes:   true,
 	MetricContainerNetworkRxBytes:   true,
 	MetricContainerNetworkTxBytes:   true,
+}
+
+// containerThrottlingMetricNames is the #1575 subset: part of the same
+// container group, but emitted CONDITIONALLY — only for containers whose
+// runtime reported a throttling signal. They are deliberately kept out of
+// containerMetricNames above, which means "must be present for every live
+// container"; asserting that of a conditional series would be wrong.
+var containerThrottlingMetricNames = map[string]bool{
+	MetricContainerCPUCFSPeriods:       true,
+	MetricContainerCPUThrottledPeriods: true,
+	MetricContainerCPUThrottledUsec:    true,
 }
 
 // pointsByNameAndContainer indexes flattened points by (series name,
@@ -1270,7 +1288,7 @@ func TestNoTenantLabels_ContainerSeries(t *testing.T) {
 
 	var pts []point
 	for _, p := range all {
-		if containerMetricNames[p.name] {
+		if containerMetricNames[p.name] || containerThrottlingMetricNames[p.name] {
 			pts = append(pts, p)
 		}
 	}
@@ -1333,4 +1351,87 @@ func TestContainerGroup_SourcesErrorSkipsTickWithoutPanic(t *testing.T) {
 		}
 	}
 	heartbeatOf(t, pts) // heartbeat still present; fails if absent.
+}
+
+// sampleThrottledContainerMetrics pairs a container whose runtime reported CFS
+// throttling with one that reported none — the two cases #1575 must render
+// differently.
+func sampleThrottledContainerMetrics() map[string]*pb.ContainerMetrics {
+	return map[string]*pb.ContainerMetrics{
+		"throttled-container": {
+			Name:             "throttled-container",
+			CpuUsageSeconds:  120,
+			CpuNrPeriods:     40031,
+			CpuNrThrottled:   12847,
+			CpuThrottledUsec: 98765432,
+		},
+		"unreported-container": {
+			Name:            "unreported-container",
+			CpuUsageSeconds: 30,
+			// No throttling signal — a K8s box, or a cgroup with no CPU
+			// bandwidth limit.
+		},
+	}
+}
+
+// TestExportedSeries_ContainerThrottlingGolden is #1575's acceptance criterion:
+// a container whose runtime reports CFS throttling emits all three counters
+// with the exact values AllContainerMetrics reports.
+func TestExportedSeries_ContainerThrottlingGolden(t *testing.T) {
+	containerGroup := pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_CONTAINER
+	rm := collectGroupsOnce(t, []pb.CloudMetricsGroup{containerGroup},
+		&fakeSources{containers: sampleThrottledContainerMetrics()}, nil, sampleLabels())
+	byNameContainer := pointsByNameAndContainer(flattenPoints(t, rm))
+
+	checks := []struct {
+		metric string
+		want   int64
+	}{
+		{MetricContainerCPUCFSPeriods, 40031},
+		{MetricContainerCPUThrottledPeriods, 12847},
+		{MetricContainerCPUThrottledUsec, 98765432},
+	}
+	for _, c := range checks {
+		p, ok := byNameContainer[c.metric]["throttled-container"]
+		if !ok {
+			t.Errorf("missing %s{container_name=%q}", c.metric, "throttled-container")
+			continue
+		}
+		if p.ival != c.want {
+			t.Errorf("%s{container_name=%q} = %d, want %d", c.metric, "throttled-container", p.ival, c.want)
+		}
+	}
+}
+
+// TestUnreportedThrottlingEmitsNoSeries is the other half of #1575's contract,
+// and the reason the observation is conditional rather than unconditional: a
+// container whose runtime reports no throttling signal must emit NO point, not
+// a zero.
+//
+// A zero-valued cumulative counter is indistinguishable from a box that has
+// genuinely never been throttled, so exporting one would make a throttling
+// alert read "all clear" for precisely the boxes it cannot see — a false
+// negative that is worse than having no series at all.
+func TestUnreportedThrottlingEmitsNoSeries(t *testing.T) {
+	containerGroup := pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_CONTAINER
+	rm := collectGroupsOnce(t, []pb.CloudMetricsGroup{containerGroup},
+		&fakeSources{containers: sampleThrottledContainerMetrics()}, nil, sampleLabels())
+	byNameContainer := pointsByNameAndContainer(flattenPoints(t, rm))
+
+	for _, name := range []string{
+		MetricContainerCPUCFSPeriods,
+		MetricContainerCPUThrottledPeriods,
+		MetricContainerCPUThrottledUsec,
+	} {
+		if p, ok := byNameContainer[name]["unreported-container"]; ok {
+			t.Errorf("%s{container_name=%q} was emitted with value %d — a container with no throttling signal must emit no point, not a zero",
+				name, "unreported-container", p.ival)
+		}
+	}
+
+	// The unconditional series are unaffected: the container is still exported,
+	// it just carries no throttling data.
+	if _, ok := byNameContainer[MetricContainerCPUUsageSeconds]["unreported-container"]; !ok {
+		t.Error("unreported-container lost its cpu.usage_seconds series — only the throttling series should be withheld")
+	}
 }


### PR DESCRIPTION
## Summary

Fixes #1575. **Stacked on #1574 — base branch is `feat/1573-cpu-throttle-metrics`, not `main`.** Retarget to `main` once #1574 merges; the diff shown here is this PR's own work only.

#1573/#1574 made CPU throttling *readable* through the API. The cloud metrics
export still published only five per-container series, of which the one CPU
series — `cpu.usage_seconds` — is precisely the signal that cannot tell a
throttled box from an idle one. The alerting surface kept the blind spot the
API had just shed.

Adds three counters to the container group (#1071):

```
containarium.container.cpu.cfs_periods         {period}
containarium.container.cpu.throttled_periods   {period}
containarium.container.cpu.throttled_usec      us
```

Both numerator and denominator, because the alert worth writing is a **ratio**
— "throttled >30% of its CFS periods for 15 minutes" — which cannot be
reconstructed from the throttled count alone.

## The design decision worth reviewing

**A container with no throttling signal emits no point, not a zero.**

A zero-valued cumulative counter is indistinguishable from a box that has
genuinely never been throttled. Exporting one for K8s boxes, cgroups with no
bandwidth limit, or containers that just stopped would make a throttling alert
read *all-clear* for exactly the boxes it cannot see — a false negative that is
worse than having no series at all. Absence is already this collector's idiom
for "nothing to report": it is how a deleted container's series stop.

This is the one behavior most worth a second opinion, so it has a dedicated
test (`TestUnreportedThrottlingEmitsNoSeries`), and I confirmed that test fails
when the condition is removed rather than passing vacuously.

## No source change needed

`AllContainerMetrics` builds its snapshot through `toProtoMetrics`, so #1574
already populates these fields — the collector simply wasn't observing them.

## Test plan

- [x] `TestExportedSeries_ContainerThrottlingGolden` — a reporting container
      emits all three counters with the exact values the source reports.
- [x] `TestUnreportedThrottlingEmitsNoSeries` — a non-reporting container emits
      none of the three, while keeping its unconditional series. **Verified this
      test fails when the guard is removed.**
- [x] Existing container-series tests still green, including the deletion and
      label-cardinality criteria.
- [x] `go build ./...`, `go vet`, `gofmt` clean.

## A note on the test allowlist

`containerMetricNames` in the test file means *"must be present for every live
container"*. Adding the conditional series to it broke `TestDeletedContainerSeriesStop`
— correctly, since asserting the presence of a conditional series is wrong. The
throttling names therefore live in a separate `containerThrottlingMetricNames`
set. The label-cardinality test covers **both** sets, and the shared fixture now
has one container reporting throttling and one not, so both paths are exercised
rather than the new series quietly escaping the label assertions.

## Cardinality

+3 series per container per tick, for reporting containers only. A 25-box LXC
host goes from 125 to 200 container series; K8s boxes add none.

## Out of scope

The older host-local OTel pipeline (`internal/metrics/otel.go`) exports its own
gauge-shaped container series and has the same gap. Different pipeline,
different shape — not folded in here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added container CPU throttling metrics for elapsed periods, throttled periods, and throttled microseconds.
  * Metrics are reported when throttling data is available, with accurate per-container values.

* **Bug Fixes**
  * Prevented unsupported runtimes from emitting misleading zero-valued throttling metrics.
  * Existing container CPU, memory, disk, and network metrics remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->