### PR TITLE
fix(k8s): resize must merge into a box's resources, not replace them (#1582, #1572)

### DIFF
--- a/pkg/core/box/k8s/k8s.go
+++ b/pkg/core/box/k8s/k8s.go
@@ -526,16 +526,20 @@ func (b *Backend) boxAuthorizedKeys(agentKeys []string) []string {
 // Get→mutate→Update rather than a patch: CRDs don't support strategic merge,
 // and a plain merge patch would replace the whole containers list.
 //
+// The mutation MERGES into the container's existing requirements rather than
+// replacing them (#1582). Replacing meant every axis the caller did not name
+// was dropped — `resize --cpu 4` deleted the box's memory limit outright,
+// leaving an already-running box memory-unbounded on a shared kernel, which is
+// exactly the guarantee the create-time memory floor exists to provide. The
+// contract this function's comment always claimed, "empty = unchanged", is now
+// what it does.
+//
 // Behavioral note vs the old StatefulSet path: the agent-sandbox controller
 // does not recreate a live pod on template drift, so a resize takes effect at
 // the NEXT pod creation (the next Stop→Start cycle), not immediately. The
 // server-side dispatch layer decides whether to bounce the box.
 func (b *Backend) Resize(ctx context.Context, ref box.BoxRef, r box.ResourceLimits) error {
-	// Resize does not change GPU count, and passes no memory default: the floor
-	// is a create-time concern, so an explicit resize honors "empty = unchanged"
-	// rather than re-stamping the default.
-	res := resourceRequirements(r, 0, memDefaults{})
-	if res == nil {
+	if r.CPU == "" && r.Memory == "" && r.CPURequest == "" && r.MemoryRequest == "" {
 		return nil
 	}
 	ns := b.namespaceFor(ref.Tenant)
@@ -543,13 +547,71 @@ func (b *Backend) Resize(ctx context.Context, ref box.BoxRef, r box.ResourceLimi
 	if err != nil {
 		return err
 	}
+	found := false
 	for i := range sb.Spec.PodTemplate.Spec.Containers {
 		if sb.Spec.PodTemplate.Spec.Containers[i].Name == "agent-box" {
-			sb.Spec.PodTemplate.Spec.Containers[i].Resources = *res
+			mergeResizeInto(&sb.Spec.PodTemplate.Spec.Containers[i].Resources, r)
+			found = true
 		}
+	}
+	if !found {
+		return nil
 	}
 	_, err = b.sandboxes.AgentsV1beta1().Sandboxes(ns).Update(ctx, sb, metav1.UpdateOptions{})
 	return err
+}
+
+// mergeResizeInto applies a resize onto a container's existing resource
+// requirements in place, leaving untouched everything the caller did not name.
+//
+// Per axis:
+//   - A new limit replaces the old limit. An unparseable quantity (an
+//     incus-native "4GB" reaching the K8s path) is skipped, matching
+//     resourceRequirements, so a bad string can't fail pod admission.
+//   - An explicit request replaces the old request.
+//   - With no explicit request, the existing request is KEPT — a limit-only
+//     resize must not move the box's scheduler reservation, which is what
+//     silently flipped a deliberately Burstable box to Guaranteed (#1572).
+//   - A box with no request at all gets request == limit, matching what
+//     create would have produced for it.
+//   - A request may never exceed its limit (K8s rejects the pod), so a request
+//     carried over from a larger previous limit is clamped down to the new one.
+func mergeResizeInto(cur *corev1.ResourceRequirements, r box.ResourceLimits) {
+	if cur.Limits == nil {
+		cur.Limits = corev1.ResourceList{}
+	}
+	if cur.Requests == nil {
+		cur.Requests = corev1.ResourceList{}
+	}
+
+	apply := func(name corev1.ResourceName, limit, request string) {
+		if limit != "" {
+			if q, err := resource.ParseQuantity(limit); err == nil {
+				cur.Limits[name] = q
+			}
+		}
+		if request != "" {
+			if q, err := resource.ParseQuantity(request); err == nil {
+				cur.Requests[name] = q
+			}
+		} else if _, ok := cur.Requests[name]; !ok {
+			// No existing reservation to preserve — mirror create's
+			// request == limit default.
+			if lim, ok := cur.Limits[name]; ok {
+				cur.Requests[name] = lim
+			}
+		}
+		// A request above its limit fails admission; clamp rather than write a
+		// spec the API server will reject.
+		lim, hasLim := cur.Limits[name]
+		req, hasReq := cur.Requests[name]
+		if hasLim && hasReq && req.Cmp(lim) > 0 {
+			cur.Requests[name] = lim
+		}
+	}
+
+	apply(corev1.ResourceCPU, r.CPU, r.CPURequest)
+	apply(corev1.ResourceMemory, r.Memory, r.MemoryRequest)
 }
 
 // SetMeta writes the runtime-neutral metadata as prefixed Sandbox annotations.

--- a/pkg/core/box/k8s/resize_test.go
+++ b/pkg/core/box/k8s/resize_test.go
@@ -1,0 +1,276 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fake "k8s.io/client-go/kubernetes/fake"
+
+	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
+	sandboxfake "sigs.k8s.io/agent-sandbox/clients/k8s/clientset/versioned/fake"
+
+	"github.com/footprintai/containarium/pkg/core/box"
+)
+
+// resizeBackend wires a Backend over a fake Sandbox already carrying the given
+// resource requirements on its agent-box container, so a Resize can be observed
+// against a known starting state.
+func resizeBackend(t *testing.T, tenant string, start corev1.ResourceRequirements) (*Backend, *sandboxfake.Clientset) {
+	t.Helper()
+	sc := sandboxfake.NewSimpleClientset()
+	if _, err := sc.AgentsV1beta1().Sandboxes("containarium-"+tenant).Create(context.Background(), &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: sandboxName, Namespace: "containarium-" + tenant},
+		Spec: sandboxv1beta1.SandboxSpec{
+			SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate: sandboxv1beta1.PodTemplate{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "agent-box", Resources: start}},
+					},
+				},
+			},
+		},
+	}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed sandbox: %v", err)
+	}
+	b := NewWithClients(fake.NewSimpleClientset(), sc, nil, Config{TenantNamespacePrefix: "containarium-"})
+	return b, sc
+}
+
+func resizedResources(t *testing.T, sc *sandboxfake.Clientset, tenant string) corev1.ResourceRequirements {
+	t.Helper()
+	sb, err := sc.AgentsV1beta1().Sandboxes("containarium-"+tenant).
+		Get(context.Background(), sandboxName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get sandbox: %v", err)
+	}
+	for _, c := range sb.Spec.PodTemplate.Spec.Containers {
+		if c.Name == "agent-box" {
+			return c.Resources
+		}
+	}
+	t.Fatal("agent-box container not found")
+	return corev1.ResourceRequirements{}
+}
+
+func qty(t *testing.T, s string) resource.Quantity {
+	t.Helper()
+	q, err := resource.ParseQuantity(s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return q
+}
+
+// A resize that names only CPU must leave the box's memory alone. Resize's own
+// contract is "empty = unchanged" — the doc comment says so explicitly about
+// the memory default — so an unmentioned axis must survive.
+func TestResizeCPUOnlyPreservesMemory(t *testing.T) {
+	start := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    qty(t, "2"),
+			corev1.ResourceMemory: qty(t, "4Gi"),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    qty(t, "2"),
+			corev1.ResourceMemory: qty(t, "4Gi"),
+		},
+	}
+	b, sc := resizeBackend(t, "alice", start)
+
+	if err := b.Resize(context.Background(), box.BoxRef{Tenant: "alice"}, box.ResourceLimits{CPU: "4"}); err != nil {
+		t.Fatalf("Resize: %v", err)
+	}
+
+	got := resizedResources(t, sc, "alice")
+
+	if c := got.Limits[corev1.ResourceCPU]; c.String() != "4" {
+		t.Errorf("cpu limit = %q, want 4", c.String())
+	}
+	memLimit, ok := got.Limits[corev1.ResourceMemory]
+	if !ok {
+		t.Fatal("memory limit was DROPPED by a CPU-only resize — an unmentioned axis must survive")
+	}
+	if memLimit.String() != "4Gi" {
+		t.Errorf("memory limit = %q, want 4Gi", memLimit.String())
+	}
+	memReq, ok := got.Requests[corev1.ResourceMemory]
+	if !ok {
+		t.Fatal("memory request was DROPPED by a CPU-only resize")
+	}
+	if memReq.String() != "4Gi" {
+		t.Errorf("memory request = %q, want 4Gi", memReq.String())
+	}
+}
+
+// The mirror case: a memory-only resize must not wipe the CPU ceiling.
+func TestResizeMemoryOnlyPreservesCPU(t *testing.T) {
+	start := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    qty(t, "2"),
+			corev1.ResourceMemory: qty(t, "4Gi"),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    qty(t, "2"),
+			corev1.ResourceMemory: qty(t, "4Gi"),
+		},
+	}
+	b, sc := resizeBackend(t, "bob", start)
+
+	if err := b.Resize(context.Background(), box.BoxRef{Tenant: "bob"}, box.ResourceLimits{Memory: "8Gi"}); err != nil {
+		t.Fatalf("Resize: %v", err)
+	}
+
+	got := resizedResources(t, sc, "bob")
+
+	if m := got.Limits[corev1.ResourceMemory]; m.String() != "8Gi" {
+		t.Errorf("memory limit = %q, want 8Gi", m.String())
+	}
+	cpuLimit, ok := got.Limits[corev1.ResourceCPU]
+	if !ok {
+		t.Fatal("cpu limit was DROPPED by a memory-only resize — an unmentioned axis must survive")
+	}
+	if cpuLimit.String() != "2" {
+		t.Errorf("cpu limit = %q, want 2", cpuLimit.String())
+	}
+}
+
+// A resize that changes only the CPU *limit* must not silently move the box's
+// scheduler reservation. A Burstable box (request < limit) must stay Burstable
+// rather than being re-pinned to Guaranteed. This is #1572.
+func TestResizeCPUPreservesBurstableRequest(t *testing.T) {
+	start := corev1.ResourceRequirements{
+		Limits:   corev1.ResourceList{corev1.ResourceCPU: qty(t, "2")},
+		Requests: corev1.ResourceList{corev1.ResourceCPU: qty(t, "500m")},
+	}
+	b, sc := resizeBackend(t, "carol", start)
+
+	if err := b.Resize(context.Background(), box.BoxRef{Tenant: "carol"}, box.ResourceLimits{CPU: "4"}); err != nil {
+		t.Fatalf("Resize: %v", err)
+	}
+
+	got := resizedResources(t, sc, "carol")
+
+	if c := got.Limits[corev1.ResourceCPU]; c.String() != "4" {
+		t.Errorf("cpu limit = %q, want 4", c.String())
+	}
+	if r := got.Requests[corev1.ResourceCPU]; r.String() != "500m" {
+		t.Errorf("cpu request = %q, want 500m — a limit-only resize must not move the reservation", r.String())
+	}
+}
+
+// A resize may set the request explicitly, which is what makes a box's
+// reservation adjustable after create at all (#1572 — create had
+// --cpu-request/--memory-request; resize had no counterpart).
+func TestResizeSetsExplicitRequest(t *testing.T) {
+	start := corev1.ResourceRequirements{
+		Limits:   corev1.ResourceList{corev1.ResourceCPU: qty(t, "2")},
+		Requests: corev1.ResourceList{corev1.ResourceCPU: qty(t, "2")},
+	}
+	b, sc := resizeBackend(t, "dave", start)
+
+	if err := b.Resize(context.Background(), box.BoxRef{Tenant: "dave"},
+		box.ResourceLimits{CPU: "4", CPURequest: "500m"}); err != nil {
+		t.Fatalf("Resize: %v", err)
+	}
+
+	got := resizedResources(t, sc, "dave")
+	if c := got.Limits[corev1.ResourceCPU]; c.String() != "4" {
+		t.Errorf("cpu limit = %q, want 4", c.String())
+	}
+	if r := got.Requests[corev1.ResourceCPU]; r.String() != "500m" {
+		t.Errorf("cpu request = %q, want 500m", r.String())
+	}
+}
+
+// A request carried over from a larger previous limit must be clamped down:
+// K8s rejects a pod whose request exceeds its limit, so shrinking a box would
+// otherwise write a spec the API server refuses.
+func TestResizeClampsPreservedRequestToNewLimit(t *testing.T) {
+	start := corev1.ResourceRequirements{
+		Limits:   corev1.ResourceList{corev1.ResourceMemory: qty(t, "8Gi")},
+		Requests: corev1.ResourceList{corev1.ResourceMemory: qty(t, "6Gi")},
+	}
+	b, sc := resizeBackend(t, "erin", start)
+
+	// Shrink the limit below the preserved request.
+	if err := b.Resize(context.Background(), box.BoxRef{Tenant: "erin"},
+		box.ResourceLimits{Memory: "2Gi"}); err != nil {
+		t.Fatalf("Resize: %v", err)
+	}
+
+	got := resizedResources(t, sc, "erin")
+	if m := got.Limits[corev1.ResourceMemory]; m.String() != "2Gi" {
+		t.Errorf("memory limit = %q, want 2Gi", m.String())
+	}
+	if r := got.Requests[corev1.ResourceMemory]; r.String() != "2Gi" {
+		t.Errorf("memory request = %q, want 2Gi (clamped to the new limit)", r.String())
+	}
+}
+
+// A box that carried no request at all gets request == limit, matching what
+// create would have produced for it.
+func TestResizeDefaultsMissingRequestToLimit(t *testing.T) {
+	start := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{corev1.ResourceCPU: qty(t, "1")},
+	}
+	b, sc := resizeBackend(t, "frank", start)
+
+	if err := b.Resize(context.Background(), box.BoxRef{Tenant: "frank"},
+		box.ResourceLimits{CPU: "3"}); err != nil {
+		t.Fatalf("Resize: %v", err)
+	}
+
+	got := resizedResources(t, sc, "frank")
+	if r := got.Requests[corev1.ResourceCPU]; r.String() != "3" {
+		t.Errorf("cpu request = %q, want 3", r.String())
+	}
+}
+
+// An incus-native quantity reaching the K8s path is skipped rather than
+// written, so a bad string cannot fail pod admission — and, with the merge
+// semantics, must not damage the existing value either.
+func TestResizeSkipsUnparseableQuantity(t *testing.T) {
+	start := corev1.ResourceRequirements{
+		Limits:   corev1.ResourceList{corev1.ResourceMemory: qty(t, "4Gi")},
+		Requests: corev1.ResourceList{corev1.ResourceMemory: qty(t, "4Gi")},
+	}
+	b, sc := resizeBackend(t, "grace", start)
+
+	if err := b.Resize(context.Background(), box.BoxRef{Tenant: "grace"},
+		box.ResourceLimits{Memory: "8GB"}); err != nil { // incus-native, not a K8s quantity
+		t.Fatalf("Resize: %v", err)
+	}
+
+	got := resizedResources(t, sc, "grace")
+	if m := got.Limits[corev1.ResourceMemory]; m.String() != "4Gi" {
+		t.Errorf("memory limit = %q, want the original 4Gi to survive an unparseable input", m.String())
+	}
+}
+
+// A resize naming nothing changes nothing.
+func TestResizeNoOpLeavesResourcesUntouched(t *testing.T) {
+	start := corev1.ResourceRequirements{
+		Limits:   corev1.ResourceList{corev1.ResourceCPU: qty(t, "2"), corev1.ResourceMemory: qty(t, "4Gi")},
+		Requests: corev1.ResourceList{corev1.ResourceCPU: qty(t, "1"), corev1.ResourceMemory: qty(t, "2Gi")},
+	}
+	b, sc := resizeBackend(t, "heidi", start)
+
+	if err := b.Resize(context.Background(), box.BoxRef{Tenant: "heidi"}, box.ResourceLimits{}); err != nil {
+		t.Fatalf("Resize: %v", err)
+	}
+
+	got := resizedResources(t, sc, "heidi")
+	for name, want := range map[corev1.ResourceName]string{corev1.ResourceCPU: "2", corev1.ResourceMemory: "4Gi"} {
+		if q := got.Limits[name]; q.String() != want {
+			t.Errorf("%s limit = %q, want %q", name, q.String(), want)
+		}
+	}
+	for name, want := range map[corev1.ResourceName]string{corev1.ResourceCPU: "1", corev1.ResourceMemory: "2Gi"} {
+		if q := got.Requests[name]; q.String() != want {
+			t.Errorf("%s request = %q, want %q", name, q.String(), want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #1582. Closes the dangerous half of #1572. **Independent of the metrics
stack (#1574/#1576) — branches off `main`, touches different files.**

`Resize` assigned a freshly built `ResourceRequirements` over the agent-box
container's existing one, so every axis the caller did not name was dropped:

```go
res := resourceRequirements(r, 0, memDefaults{})   // only the axes r mentions
sb.Spec.PodTemplate.Spec.Containers[i].Resources = *res   // replaces everything
```

**`containarium resize <box> --cpu 4` deleted the box's memory limit.** An
already-running box became memory-unbounded on a shared kernel — free to
balloon and pressure every neighbour on the node, which is exactly the
guarantee the create-time memory floor exists to provide. The mirror case
(`--memory` wiping the CPU limit) was equally true, and the memory *request*
went with the limit, so the box stopped reserving anything either.

The function's doc comment already claimed the right contract — *"an explicit
resize honors 'empty = unchanged'"*. Now the code does too.

## What merging does, per axis

| Situation | Result |
| --- | --- |
| Limit named | Replaces the old limit |
| Limit unparseable (incus-native `8GB`) | Skipped — and can no longer damage the existing value |
| Request named | Replaces the old request |
| Request **not** named | Existing request **kept** — a limit-only resize no longer moves the reservation (#1572) |
| No request at all | `request == limit`, matching create |
| Preserved request > new limit | Clamped down — K8s rejects a pod whose request exceeds its limit |

## Test plan

The package had **no `Resize` test at all**. There are now nine.

- [x] The three describing the reported symptoms were confirmed **failing
      before the fix** — CPU-only resize dropping memory (limit and request),
      memory-only resize dropping CPU, and a Burstable box being re-pinned from
      `500m` to `4`.
- [x] Explicit request set through resize.
- [x] Preserved request clamped when the new limit is smaller.
- [x] Missing request defaults to the limit.
- [x] Unparseable quantity leaves the existing value intact.
- [x] A resize naming nothing changes nothing.
- [x] `go build ./...`, `go vet`, `gofmt`, full `pkg/core/box/...` green.
- [x] gosec clean on the package (the one hit is a pre-existing G101 in
      `sentinelkey.go`, untouched here).

## Scope

Closes #1582 entirely, and the half of #1572 where a resize mutates a
reservation nobody asked it to touch.

**#1572 stays open** for its other half: being able to *set* a request through
resize, mirroring create's `--cpu-request` / `--memory-request`. That needs
`cpu_request` / `memory_request` on `ResizeContainerRequest` plus CLI and
client plumbing — an API surface addition rather than a correctness fix, so
it's better reviewed on its own.

## Not live-verified

Reproduced and fixed against the fake Sandbox clientset. The assertion is on
the Sandbox spec the backend writes, which is the backend's whole contribution;
what a controller does with a template missing a memory limit is standard K8s
behavior. A live confirmation on a K8s-backed box would still be worth one
check before release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Kubernetes resource resizing to preserve unspecified CPU and memory settings.
  - Preserved existing resource requests when only limits change.
  - Defaulted missing requests to their corresponding limits and prevented requests from exceeding limits.
  - Ignored invalid resource quantities and safely handled empty resize requests or missing containers.

- **Tests**
  - Added coverage for resource preservation, request updates, clamping, defaults, invalid values, and no-op behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->