### PR TITLE
fix(cpu-admission): route resize through the CPU admission gate

### DIFF
--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -1761,6 +1761,22 @@ func (s *ContainerServer) ResizeContainer(ctx context.Context, req *pb.ResizeCon
 		}, nil
 	}
 
+	// CPU capacity admission (#1579): only when the gate is enabled and the
+	// resize actually names a new CPU value, and only once the container is
+	// confirmed to live on THIS host — checked here, before the local resize
+	// attempt below, rather than unconditionally before the local/peer
+	// dispatch decision, so a resize routed to a peer is never evaluated
+	// against the wrong host's capacity. The peer's own ResizeContainer
+	// handler runs this same check against its own host once the request is
+	// forwarded, so no forwarding-side admission logic is needed here.
+	if s.cpuOvercommitFactor > 0 && req.Cpu != "" {
+		if current, gerr := s.manager.GetInfo(containerName); gerr == nil && current != nil {
+			if aerr := s.admitCPUResize(req.Username, current.CPU, req.Cpu); aerr != nil {
+				return nil, aerr
+			}
+		}
+	}
+
 	// Perform resize — try local first, then peer
 	if err := s.manager.Resize(containerName, req.Cpu, req.Memory, req.Disk, false); err != nil {
 		// Container not found locally — check peers

--- a/internal/server/cpu_admission.go
+++ b/internal/server/cpu_admission.go
@@ -59,6 +59,16 @@ func admitCPURequest(physicalCores, committedCores, requestCores, factor float64
 // and the request would exceed the ceiling; otherwise nil (including every
 // fail-open path). username is the tenant being (re)created — its own existing
 // container, if any, is excluded so a resize-by-recreate doesn't double-count.
+//
+// Known gap (#1588): this is a check-then-act read with no lock or
+// reservation held across the caller's subsequent mutation. Two concurrent
+// callers (create, resize, or the cluster reconciler — every caller of this
+// function) can each admit against a stale snapshot and jointly exceed the
+// ceiling. Pre-existing since #1029 for create; #1579 extends the same
+// window to resize without introducing a new kind of gap. Not fixed here —
+// closing it needs serialization (or a reservation step) shared across
+// every local operation that commits CPU, which is bigger than any one
+// caller's scope.
 func (s *ContainerServer) admitCPUCapacity(username, cpuRequest string) error {
 	if s.cpuOvercommitFactor <= 0 {
 		return nil // gate disabled (the default)

--- a/internal/server/cpu_admission.go
+++ b/internal/server/cpu_admission.go
@@ -94,6 +94,42 @@ func (s *ContainerServer) admitCPUCapacity(username, cpuRequest string) error {
 		"CPU capacity exceeded on this backend: %s. Retry on a less-loaded backend/pool or a larger host, or ask an operator to raise the overcommit factor.", detail)
 }
 
+// admitCPUResize applies the capacity gate to a CPU-increasing resize
+// (#1579 — closes the resize-side hole: a resize could push a host past
+// capacity with no check at all, even though create already goes through
+// admitCPUCapacity).
+//
+// It reuses admitCPUCapacity UNCHANGED rather than adding a delta-aware
+// variant of it — do not change admitCPUCapacity's own signature, since
+// dual_server.go wires that exact function into the cluster reconciler's
+// SetAdmission for VM creation, and a signature change breaks that call site
+// silently.
+//
+// committedCoresExcluding already excludes the tenant's own current
+// container from the committed sum, so passing the resize's full new CPU
+// value performs the same "would this fit if the box were (re)created at
+// this size" check create already does — no delta is needed, and a delta
+// would be wrong: checking committed_excl + (newCores - currentCores) would
+// double-subtract the tenant's current allocation (committed_excl already
+// has it removed once) and could silently admit a resize that should be
+// rejected. Worked example: an 8-core host at factor 1 (ceiling 8), another
+// tenant committing 4, this tenant currently at 4 (host exactly at the
+// ceiling). Resizing to 8 must be rejected — true post-resize total is
+// 4+8=12>8. The delta formula computes 4+(8-4)=8<=8 and wrongly admits it;
+// passing the full new value correctly computes 4+8=12>8 and rejects.
+//
+// A resize that does not increase CPU is never blocked: if the new value
+// parses to no more committed cores than the box's current one, the check
+// is skipped outright rather than relying on the arithmetic to always admit
+// a decrease — a host that is already over its ceiling (a legacy, pre-gate
+// fleet) would otherwise have a decrease wrongly rejected too.
+func (s *ContainerServer) admitCPUResize(username, currentCPU, newCPU string) error {
+	if incus.CommittedCores(newCPU) <= incus.CommittedCores(currentCPU) {
+		return nil
+	}
+	return s.admitCPUCapacity(username, newCPU)
+}
+
 // hostPhysicalCores reports the host's logical CPU count (vCPUs — Incus's
 // TotalCPUs sums hardware threads, so this counts SMT threads, matching the
 // unit limits.cpu itself uses). The hostCoresFn seam lets tests inject a count

--- a/internal/server/cpu_admission_test.go
+++ b/internal/server/cpu_admission_test.go
@@ -1,16 +1,27 @@
 package server
 
 import (
+	"context"
 	"errors"
 	"testing"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/footprintai/containarium/internal/auth"
 	"github.com/footprintai/containarium/pkg/core/container"
 	"github.com/footprintai/containarium/pkg/core/incus"
 	"github.com/footprintai/containarium/pkg/core/incus/incustest"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 )
+
+// resizeCtx builds an authenticated context for a tenant resizing their own
+// box, matching what ResizeContainer's auth.RequireScope/AuthorizeTenant
+// gates require.
+func resizeCtx(username string) context.Context {
+	return auth.ContextWithTestSubjectScopes(context.Background(),
+		username, []string{"user"}, []string{auth.ScopeContainersWrite})
+}
 
 // TestAdmitCPURequest pins the pure policy: fits iff committed+request stays
 // within physical×factor, and unknown capacity (physical<=0) always fits so
@@ -132,5 +143,124 @@ func TestAdmitCPUCapacity_FailOpenOnUnknownCores(t *testing.T) {
 	s.SetCPUOvercommitPolicy(1, true)
 	if err := s.admitCPUCapacity("newbie", "8"); err != nil {
 		t.Fatalf("must fail open when host cores unknown, got %v", err)
+	}
+}
+
+// Known gap, not covered by any test below: committedCoresExcluding (which
+// admitCPUResize calls into via admitCPUCapacity) excludes every container
+// whose Tenant matches the given username, not only the specific container
+// being resized. A tenant that owns more than one container would have all
+// of them excluded from the committed sum during a resize of just one,
+// understating true commitment. This is pre-existing — CreateContainer's
+// admission already has the identical exposure via the same helper — not
+// introduced by routing resize through it, and it is out of scope for
+// #1579 to fix (would mean threading a container identity, not just a
+// tenant string, through the shared helper for every caller). Flagged here
+// so this test suite is not read as proving the check airtight for every
+// tenant shape; see docs/architecture/cpu-reservation-and-overcommit-visibility.md
+// section A for the full discussion.
+
+// TestAdmitCPUResize_DecreaseNeverBlocked: a resize that doesn't increase CPU
+// (lower value, or exactly the current value) must never be blocked, even on
+// a host that is already over its ceiling — a legacy, pre-gate fleet must
+// still be able to shrink a box. #1579.
+func TestAdmitCPUResize_DecreaseNeverBlocked(t *testing.T) {
+	// 8-core host, other tenants already committing 10 (over the 8-core
+	// ceiling before this tenant's own 4 cores are even added) — a
+	// pre-existing overcommit scenario the gate must not retroactively punish.
+	s := seedServer(t, 8, []incus.ContainerInfo{tenant("other", "10")})
+	s.SetCPUOvercommitPolicy(1, true)
+
+	if err := s.admitCPUResize("me", "4", "2"); err != nil {
+		t.Fatalf("a decrease must never be blocked, got %v", err)
+	}
+	if err := s.admitCPUResize("me", "4", "4"); err != nil {
+		t.Fatalf("an unchanged value must never be blocked, got %v", err)
+	}
+}
+
+// TestAdmitCPUResize_IncreaseUsesFullNewValueNotDelta pins the exact bug an
+// earlier draft of #1579 nearly shipped: checking committed_excl + delta
+// double-subtracts the tenant's own current allocation (committed_excl
+// already has it removed once) and wrongly admits a resize that would push
+// the host over its ceiling. The worked counterexample from the issue: an
+// 8-core host at factor 1 (ceiling 8), other tenants committing 4, this
+// tenant currently at 4 (host exactly at the ceiling). Resizing to 8 must be
+// REJECTED — true post-resize total is 4+8=12 > 8. The (wrong) delta formula
+// computes 4+(8-4)=8 <= 8 and would wrongly admit it.
+func TestAdmitCPUResize_IncreaseUsesFullNewValueNotDelta(t *testing.T) {
+	s := seedServer(t, 8, []incus.ContainerInfo{tenant("other", "4"), tenant("me", "4")})
+	s.SetCPUOvercommitPolicy(1, true)
+
+	err := s.admitCPUResize("me", "4", "8")
+	if err == nil {
+		t.Fatal("resize to 8 must be rejected (4 other + 8 new = 12 > 8-core ceiling); the delta formula would wrongly admit this")
+	}
+	if status.Code(err) != codes.ResourceExhausted {
+		t.Fatalf("want ResourceExhausted, got %v (%v)", status.Code(err), err)
+	}
+}
+
+// TestAdmitCPUResize_IncreaseWithinCeilingAdmitted is the fitting mirror of
+// the above: a resize that stays within the ceiling once the tenant's own
+// current allocation is properly accounted for is admitted.
+func TestAdmitCPUResize_IncreaseWithinCeilingAdmitted(t *testing.T) {
+	s := seedServer(t, 8, []incus.ContainerInfo{tenant("other", "4"), tenant("me", "2")})
+	s.SetCPUOvercommitPolicy(1, true)
+
+	// committed_excl("me") = 4 (other only, "me" itself is excluded); 4 + 4 == 8-core ceiling.
+	if err := s.admitCPUResize("me", "2", "4"); err != nil {
+		t.Fatalf("resize to 4 should fit (4 other + 4 new = 8 == ceiling), got %v", err)
+	}
+}
+
+// TestAdmitCPUResize_DisabledGateNeverBlocks: with the gate off (the
+// default), a resize increase is never blocked, matching create's behavior.
+func TestAdmitCPUResize_DisabledGateNeverBlocks(t *testing.T) {
+	s := seedServer(t, 8, []incus.ContainerInfo{tenant("other", "8")})
+	// factor stays 0 (disabled)
+	if err := s.admitCPUResize("me", "2", "16"); err != nil {
+		t.Fatalf("disabled gate must never reject a resize, got %v", err)
+	}
+}
+
+// TestResizeContainer_AdmissionRejectsOverCeiling drives ResizeContainer
+// end to end (not just the pure admitCPUResize helper) for a local box: an
+// enforcing gate must reject a CPU increase that would push the host over
+// its ceiling, and the underlying CPU limit must be left untouched.
+func TestResizeContainer_AdmissionRejectsOverCeiling(t *testing.T) {
+	s := seedServer(t, 8, []incus.ContainerInfo{tenant("other", "4"), tenant("me", "4")})
+	s.SetCPUOvercommitPolicy(1, true) // 8-core ceiling, strict
+
+	_, err := s.ResizeContainer(resizeCtx("me"), &pb.ResizeContainerRequest{Username: "me", Cpu: "8"})
+	if err == nil {
+		t.Fatal("resize to 8 should be rejected (4 other + 8 new = 12 > 8-core ceiling)")
+	}
+	if status.Code(err) != codes.ResourceExhausted {
+		t.Fatalf("want ResourceExhausted, got %v (%v)", status.Code(err), err)
+	}
+}
+
+// TestResizeContainer_AdmissionAllowsWithinCeiling is the fitting mirror,
+// also end to end: a resize that stays within the ceiling succeeds.
+func TestResizeContainer_AdmissionAllowsWithinCeiling(t *testing.T) {
+	s := seedServer(t, 8, []incus.ContainerInfo{tenant("other", "4"), tenant("me", "2")})
+	s.SetCPUOvercommitPolicy(1, true)
+
+	if _, err := s.ResizeContainer(resizeCtx("me"), &pb.ResizeContainerRequest{Username: "me", Cpu: "4"}); err != nil {
+		t.Fatalf("resize to 4 should fit (4 other + 4 new = 8 == ceiling), got %v", err)
+	}
+}
+
+// TestResizeContainer_AdmissionSkippedForDecrease: end to end, a resize that
+// lowers CPU is never blocked by admission, even on an already-overcommitted
+// host (the legacy-fleet scenario admitCPUResize's pure test already covers;
+// this proves the same holds through the full ResizeContainer path).
+func TestResizeContainer_AdmissionSkippedForDecrease(t *testing.T) {
+	s := seedServer(t, 8, []incus.ContainerInfo{tenant("other", "10"), tenant("me", "4")})
+	s.SetCPUOvercommitPolicy(1, true)
+
+	if _, err := s.ResizeContainer(resizeCtx("me"), &pb.ResizeContainerRequest{Username: "me", Cpu: "2"}); err != nil {
+		t.Fatalf("a decrease must never be blocked, got %v", err)
 	}
 }

--- a/internal/server/peer_integration_test.go
+++ b/internal/server/peer_integration_test.go
@@ -11,6 +11,9 @@ import (
 	"sync"
 	"testing"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/footprintai/containarium/internal/auth"
 	"github.com/footprintai/containarium/pkg/core/container"
 	"github.com/footprintai/containarium/pkg/core/incus"
@@ -355,6 +358,63 @@ func TestIntegration_ResizeContainerForwardsRequestFields(t *testing.T) {
 	}
 	if forwarded["memoryRequest"] != "1Gi" {
 		t.Errorf("forwarded memoryRequest = %q, want %q (raw body: %s)", forwarded["memoryRequest"], "1Gi", lastReq.Body)
+	}
+}
+
+// TestIntegration_ResizeAdmissionNotEvaluatedForPeerForwardedContainer proves
+// the #1579 requirement that a peer-forwarded resize is never evaluated
+// against the LOCAL host's capacity. The local gate here is configured to
+// reject absolutely everything (factor effectively 0 capacity headroom) —
+// if the admission check ran unconditionally before the local/peer dispatch
+// decision (rather than only once the container is confirmed local), this
+// resize would be wrongly rejected with ResourceExhausted before ever
+// reaching the peer. It must instead sail through to the peer unblocked.
+func TestIntegration_ResizeAdmissionNotEvaluatedForPeerForwardedContainer(t *testing.T) {
+	gpu := newFakeBackend("tunnel-gpu", []fakeContainer{
+		{Name: "charlie-container", Username: "charlie", State: "CONTAINER_STATE_RUNNING"},
+	}, fakeSystemInfo{})
+	gpuSrv := httptest.NewServer(gpu.handler())
+	defer gpuSrv.Close()
+
+	pool := NewPeerPool("local", "", nil, "")
+	pool.mu.Lock()
+	pool.peers["tunnel-gpu"] = &PeerClient{
+		ID: "tunnel-gpu", Addr: gpuSrv.Listener.Addr().String(),
+		Healthy: true, client: gpuSrv.Client(),
+	}
+	pool.mu.Unlock()
+
+	// charlie's box is not local: GetContainer errors so ResizeContainer
+	// falls through to the peer-forward path.
+	mock := incustest.NewMockBackend()
+	mock.GetContainerFunc = func(name string) (*incus.ContainerInfo, error) {
+		return nil, fmt.Errorf("not found")
+	}
+	s := &ContainerServer{
+		manager:  container.NewWithBackend(mock),
+		peerPool: pool,
+	}
+	// A maximally strict local gate: 0 physical cores of headroom would
+	// reject any nonzero CPU request outright if evaluated against THIS
+	// host. hostCoresFn reports a nonzero host (so the gate doesn't fail
+	// open on "capacity unknown") with zero factor-adjusted ceiling.
+	s.hostCoresFn = func() (float64, error) { return 8, nil }
+	s.SetCPUOvercommitPolicy(0.0001, true) // effectively zero headroom, strictly enforced
+
+	ctx := auth.ContextWithTestSubjectScopes(context.Background(),
+		"charlie", []string{"user"}, []string{auth.ScopeContainersWrite})
+
+	_, err := s.ResizeContainer(ctx, &pb.ResizeContainerRequest{Username: "charlie", Cpu: "8"})
+	if err != nil {
+		t.Fatalf("peer-forwarded resize must not be evaluated against local capacity, got %v", err)
+	}
+	if status.Code(err) == codes.ResourceExhausted {
+		t.Fatalf("resize was rejected by the LOCAL admission gate despite the container living on a peer")
+	}
+
+	lastReq := gpu.lastRequest()
+	if lastReq.Method != "PUT" || lastReq.Path != "/v1/containers/charlie/resize" {
+		t.Fatalf("resize never reached the peer: %s %s", lastReq.Method, lastReq.Path)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `ResizeContainer`'s LXC path never called `admitCPUCapacity`, so a resize
  could push a host arbitrarily further past its committed-cores ceiling
  with zero check — the sharper, resize-side half of #1571's own repro
  (`resize --cpu 16` "succeeds ... delivers no additional CPU"), and the one
  hole left after create-time admission (#1029) already guards against
  exactly this.
- `admitCPUResize` reuses `admitCPUCapacity` **unchanged**, passing the
  resize's full new CPU value rather than a delta. `committedCoresExcluding`
  already excludes the tenant's own current container from the committed
  sum, so no delta arithmetic is needed — and a delta would be wrong: an
  earlier draft of the design (#1578, before an independent review caught
  it) checked `committed_excl + delta`, which double-subtracts the tenant's
  current allocation and silently admits resizes it should reject. Passing
  the full value avoids the bug and keeps `admitCPUCapacity`'s signature
  untouched — `dual_server.go:1287` wires that exact function into the
  cluster reconciler's `SetAdmission` for VM creation.
- A resize that doesn't increase CPU (lower value, unchanged, or CPU not
  mentioned) skips the check entirely — a legacy, already-overcommitted host
  must still be able to shrink a box.
- The check runs only once the container is confirmed local
  (`manager.GetInfo`, before the existing local-then-peer-forward dispatch),
  so a peer-forwarded resize is never evaluated against the wrong host's
  capacity — the peer's own `ResizeContainer` handler runs its own gate once
  the request reaches it.
- Same off-by-default / advisory-then-enforce rollout posture as create —
  this closes a hole in an existing opt-in gate, not a new default.

## Test evidence

All test-first (confirmed red before the fix, see below), in
`internal/server/cpu_admission_test.go` and `peer_integration_test.go`:

- `TestAdmitCPUResize_DecreaseNeverBlocked` / `_DisabledGateNeverBlocks` —
  a decrease, an unchanged value, or a disabled gate never blocks.
- `TestAdmitCPUResize_IncreaseUsesFullNewValueNotDelta` — pins the exact
  delta-formula bug the design doc's review caught: an 8-core host at
  factor 1, another tenant committing 4, this tenant at 4 (host exactly at
  ceiling); resizing to 8 must reject (true total 4+8=12>8), which the
  (wrong) delta formula would have wrongly admitted (4+(8-4)=8≤8).
- `TestAdmitCPUResize_IncreaseWithinCeilingAdmitted` — the fitting mirror.
- `TestResizeContainer_AdmissionRejectsOverCeiling` / `_AllowsWithinCeiling`
  / `_AdmissionSkippedForDecrease` — the same three shapes, but end to end
  through `ResizeContainer` itself, not just the pure `admitCPUResize`
  helper.
- `TestIntegration_ResizeAdmissionNotEvaluatedForPeerForwardedContainer` —
  configures the local gate to reject *everything*, then resizes a
  container that lives on a peer; the resize must sail through unblocked.
  Verified this test actually catches the bug it targets: temporarily
  moving the admission check before the local/peer dispatch decision (the
  wrong placement) turns this red with `ResourceExhausted`, confirming the
  test pins the correct placement, not a tautology.

A known, pre-existing limitation flagged in the test file per the issue's
own guidance: `committedCoresExcluding`'s tenant-level exclusion is coarser
than the single container being resized (a tenant with more than one
container would have all of them excluded) — inherited from
`CreateContainer`'s existing use of the same helper, not introduced here,
and out of scope for this issue.

CI run: (pushed just now, watching — will confirm green before merge.)

## Notes for reviewers

- No change to `admitCPUCapacity`'s signature or behavior — `admitCPUResize`
  is a small wrapper, per the issue's explicit constraint (the cluster
  reconciler shares the unchanged function).
- Docs: `docs/CPU-CAPACITY-ADMISSION.md` / CLI help text (#1581) and
  `SystemInfo.committed_cpu_cores` (#1580) are separate follow-up issues
  from the same design doc (#1578) — not touched here.

Closes #1579

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CPU capacity checks now apply when increasing a container’s CPU allocation.
  * Resizes are rejected when the requested allocation exceeds the configured capacity limit.
  * CPU decreases and unchanged allocations continue without additional admission checks.
  * Resizes for containers hosted on another server are evaluated by the owning server.

* **Bug Fixes**
  * CPU admission behavior now consistently respects disabled, advisory, and enforcing capacity settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->