### PR TITLE
fix(tls): reconcile Caddy TLS automation subjects so a route can't serve on :80 with no certificate

### DIFF
--- a/internal/app/proxy.go
+++ b/internal/app/proxy.go
@@ -580,22 +580,34 @@ func (p *ProxyManager) EnsureTLSSubjects(domains []string) error {
 	}
 	defer resp.Body.Close()
 
+	// Anything other than 200 must abort. Treating a failed read as "no
+	// policies" would fall through to the create branch below, and POST to a
+	// Caddy array path APPENDS — so a transient admin-API error would graft a
+	// duplicate policy alongside the real ones. This runs on every sync tick,
+	// so a flapping admin API would accumulate them.
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("caddy returned %d reading TLS policies: %s",
+			resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read TLS policies: %w", err)
+	}
 	var policies []CaddyTLSAutomationPolicy
-	if resp.StatusCode == http.StatusOK {
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return fmt.Errorf("read TLS policies: %w", err)
-		}
-		// A TLS app that exists but has no policies serializes as `null`.
-		if err := json.Unmarshal(body, &policies); err != nil {
-			return fmt.Errorf("unmarshal TLS policies: %w", err)
-		}
+	// A TLS app that exists but has no policies serializes as `null`, which
+	// unmarshals to a nil slice — not an error.
+	if err := json.Unmarshal(body, &policies); err != nil {
+		return fmt.Errorf("unmarshal TLS policies: %w", err)
 	}
 
 	// Collect what's missing, deduplicating the input: two routes can share a
 	// hostname, and the same host must not land in the subjects array twice.
+	// Also note which policies are doing the covering — see below.
 	var missing []string
 	seen := make(map[string]bool, len(domains))
+	covering := make(map[int]bool)
 	for _, d := range domains {
 		if d == "" || seen[d] {
 			continue
@@ -603,10 +615,11 @@ func (p *ProxyManager) EnsureTLSSubjects(domains []string) error {
 		seen[d] = true
 
 		covered := false
-		for _, pol := range policies {
+		for i, pol := range policies {
 			for _, subject := range pol.Subjects {
 				if subjectCovers(subject, d) {
 					covered = true
+					covering[i] = true
 					break
 				}
 			}
@@ -619,7 +632,29 @@ func (p *ProxyManager) EnsureTLSSubjects(domains []string) error {
 		}
 	}
 
+	// A covering subject is only worth anything if its policy can actually be
+	// issued. A wildcard covered by a policy whose issuers predate DNS-01 is
+	// the #1066 trap one level up: `*.example.com` "covers" app.example.com on
+	// paper, but HTTP-01 / TLS-ALPN-01 categorically cannot solve a wildcard,
+	// so no certificate is ever obtained and the host shows exactly the #1584
+	// symptom. Skipping the repair because coverage looked satisfied is how
+	// this reconciler would recreate the bug it exists to fix.
+	//
+	// A no-op when DNS-01 isn't configured or the issuers already carry it, so
+	// the every-tick no-change path still performs no write.
+	repaired := false
+	for i := range policies {
+		if covering[i] && p.ensureDNSIssuers(&policies[i]) {
+			repaired = true
+		}
+	}
+
 	if len(missing) == 0 {
+		if repaired {
+			log.Printf("[ProxyManager] repaired issuers on TLS policies covering %d host(s) so "+
+				"their wildcard subject can actually be issued (#1066)", len(seen))
+			return p.patchTLSPolicies(url, policies)
+		}
 		return nil
 	}
 

--- a/internal/app/proxy.go
+++ b/internal/app/proxy.go
@@ -250,11 +250,25 @@ func (p *ProxyManager) addRouteWithProtocol(subdomain, containerIP string, port 
 		return fmt.Errorf("caddy returned error (status %d): %s", resp.StatusCode, string(body))
 	}
 
-	// Provision TLS certificate for the domain
+	// Provision TLS certificate for the domain.
+	//
+	// The route itself is already live at this point, so a TLS failure isn't
+	// returned as an error — doing so would tell the caller the route wasn't
+	// added, which is false, and invite a rollback of a working route.
+	//
+	// But it must not vanish either (#1585). This used to be a bare
+	// fmt.Printf to stdout: no timestamp, no prefix, invisible to the log
+	// scraping every other line in this file supports, and the caller
+	// (expose_port) reported unqualified success while HTTPS for the
+	// hostname was permanently dead.
+	//
+	// Two things make that safe now: this logs like everything else, and
+	// RouteSyncJob re-checks TLS subjects on every tick (#1584), so a failure
+	// here is repaired on the next sync rather than persisting forever.
 	if err := p.ProvisionTLS(fullDomain); err != nil {
-		// Log warning but don't fail - route is added, TLS might work with existing wildcard cert
-		// or the domain might already have a certificate
-		fmt.Printf("Warning: Failed to provision TLS for %s: %v\n", fullDomain, err)
+		log.Printf("[ProxyManager] route for %s is live but TLS provisioning failed: %v — "+
+			"HTTPS will fail for this host until the next route-sync tick reconciles it (#1584/#1585)",
+			fullDomain, err)
 	}
 
 	return nil
@@ -330,8 +344,6 @@ func (p *ProxyManager) RemoveTLSSubject(domain string) error {
 	return nil
 }
 
-// ProvisionTLS provisions a TLS certificate for the given domain via Caddy's on-demand TLS
-// or by adding it to the TLS automation policy
 // ensureDNSIssuers gives a policy's issuers the configured DNS-01 challenge
 // config, reporting whether it changed anything.
 //
@@ -393,6 +405,22 @@ func (p *ProxyManager) patchTLSPolicies(url string, policies []CaddyTLSAutomatio
 	return nil
 }
 
+// ProvisionTLS puts `domain` under Caddy's TLS automation by adding it as an
+// explicit subject in /config/apps/tls/automation/policies, bootstrapping the
+// TLS app first if this host has never had one.
+//
+// Note this is NOT on-demand issuance. Caddy's `on_demand` mode — where a cert
+// is minted lazily on first TLS handshake for an unknown SNI host, gated by an
+// `ask` endpoint — is never enabled anywhere in this codebase
+// (CaddyTLSAutomationPolicy.OnDemand is declared but never set; see #1586).
+// Every certificate this daemon obtains comes from an explicit subject written
+// here, or from the `*.<base-domain>` wildcard written by ProvisionWildcardTLS.
+//
+// The practical consequence, and the reason this distinction is worth a
+// comment: a hostname that never reaches this function never gets a
+// certificate, and Caddy reports that as a TLS handshake failure (alert 80,
+// "no peer certificate available") rather than an HTTP error. Reconciliation
+// for that state lives in EnsureTLSSubjects (#1584).
 func (p *ProxyManager) ProvisionTLS(domain string) error {
 	// Caddy's admin API returns 400 "invalid traversal path" when you
 	// PATCH/POST a sub-path whose parent doesn't exist yet. On a fresh
@@ -489,6 +517,148 @@ func (p *ProxyManager) ProvisionTLS(domain string) error {
 		return fmt.Errorf("caddy returned error creating TLS policy (status %d): %s", resp.StatusCode, string(body))
 	}
 
+	return nil
+}
+
+// subjectCovers reports whether TLS automation subject `subject` already
+// obtains a certificate valid for `domain`.
+//
+// Either the subject is the host itself, or it's a wildcard one label above
+// it. The one-label rule is the actual X.509/ACME semantic: `*.example.com`
+// covers `app.example.com` but NOT `a.b.example.com`. Getting this wrong in
+// either direction has a real cost — too permissive leaves a deeper host with
+// no certificate and no signal (#1584), too strict adds a redundant per-host
+// subject that burns Let's Encrypt rate-limit budget the wildcard exists to
+// conserve (#378).
+func subjectCovers(subject, domain string) bool {
+	if subject == domain {
+		return true
+	}
+	rest, ok := strings.CutPrefix(subject, "*.")
+	if !ok {
+		return false
+	}
+	// domain must be exactly one label deeper than the wildcard's base.
+	host, found := strings.CutSuffix(domain, "."+rest)
+	return found && host != "" && !strings.Contains(host, ".")
+}
+
+// EnsureTLSSubjects reconciles Caddy's TLS automation subjects against the set
+// of hostnames that should have certificates, adding any that are missing.
+//
+// This is the repair path for #1584. TLS subjects were previously written
+// exactly once, by ProvisionTLS at route-add time. If that write didn't land —
+// ProvisionTLS failed and the error was swallowed (#1585), Caddy reverted to
+// its stub config (#400), or the route reached Caddy some other way — nothing
+// ever put the subject back. RouteSyncJob couldn't help: it re-provisions only
+// when a route is MISSING from Caddy, and needsUpdate compares upstream IP,
+// port and protocol, never TLS subjects. "Route present, subject absent" was
+// therefore indistinguishable from "in sync", and the host served on :80 while
+// :443 returned `tls: internal error` — alert 80, no peer certificate — with
+// no error anywhere and no path to recovery short of manual admin-API surgery.
+//
+// Called on every sync tick, so the no-change case must be cheap and silent:
+// one GET, no write. Missing subjects are batched into a single write rather
+// than one call per domain, because rewriting the policy array repeatedly
+// churns certificate management for every subject on the host.
+//
+// Only adds. Removal stays with RemoveTLSSubject on the delete cascade, so a
+// transiently-empty route list can never strip live subjects.
+func (p *ProxyManager) EnsureTLSSubjects(domains []string) error {
+	if len(domains) == 0 {
+		return nil
+	}
+
+	if err := p.ensureTLSApp(); err != nil {
+		return fmt.Errorf("bootstrap TLS app: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/config/apps/tls/automation/policies", p.caddyAdminURL)
+	resp, err := p.httpClient.Get(url)
+	if err != nil {
+		return fmt.Errorf("get TLS policies: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var policies []CaddyTLSAutomationPolicy
+	if resp.StatusCode == http.StatusOK {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("read TLS policies: %w", err)
+		}
+		// A TLS app that exists but has no policies serializes as `null`.
+		if err := json.Unmarshal(body, &policies); err != nil {
+			return fmt.Errorf("unmarshal TLS policies: %w", err)
+		}
+	}
+
+	// Collect what's missing, deduplicating the input: two routes can share a
+	// hostname, and the same host must not land in the subjects array twice.
+	var missing []string
+	seen := make(map[string]bool, len(domains))
+	for _, d := range domains {
+		if d == "" || seen[d] {
+			continue
+		}
+		seen[d] = true
+
+		covered := false
+		for _, pol := range policies {
+			for _, subject := range pol.Subjects {
+				if subjectCovers(subject, d) {
+					covered = true
+					break
+				}
+			}
+			if covered {
+				break
+			}
+		}
+		if !covered {
+			missing = append(missing, d)
+		}
+	}
+
+	if len(missing) == 0 {
+		return nil
+	}
+
+	log.Printf("[ProxyManager] reconciling %d TLS subject(s) missing from Caddy's automation "+
+		"policies: %v — these hosts would otherwise serve on :80 with no certificate (#1584)",
+		len(missing), missing)
+
+	if len(policies) > 0 {
+		policies[0].Subjects = append(policies[0].Subjects, missing...)
+		// The policy we're appending to may predate DNS-01 being configured,
+		// in which case its issuers cannot satisfy the subject we just added
+		// and Caddy would never attempt it (#1066).
+		p.ensureDNSIssuers(&policies[0])
+		return p.patchTLSPolicies(url, policies)
+	}
+
+	// No policies at all — create one carrying every missing subject.
+	newPolicy := NewTLSPolicyWithDNS(missing, p.dnsChallenge)
+	policyJSON, err := json.Marshal([]CaddyTLSAutomationPolicy{newPolicy})
+	if err != nil {
+		return fmt.Errorf("marshal new TLS policy: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewReader(policyJSON))
+	if err != nil {
+		return fmt.Errorf("create TLS policy request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	postResp, err := p.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("create TLS policy: %w", err)
+	}
+	defer postResp.Body.Close()
+
+	if postResp.StatusCode != http.StatusOK && postResp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(postResp.Body)
+		return fmt.Errorf("caddy returned %d creating TLS policy: %s", postResp.StatusCode, string(body))
+	}
 	return nil
 }
 

--- a/internal/app/proxy_tls_subject_reconcile_test.go
+++ b/internal/app/proxy_tls_subject_reconcile_test.go
@@ -1,0 +1,254 @@
+package app
+
+import (
+	"testing"
+)
+
+// #1584: TLS automation subjects were written exactly once, at route-add time
+// (addRouteWithProtocol → ProvisionTLS). If that write didn't land — because
+// ProvisionTLS failed and the error was swallowed (#1585), or because the
+// route reached Caddy by some other path — nothing ever put the subject back.
+//
+// RouteSyncJob couldn't heal it either: syncHTTPRoutes only re-provisions when
+// the domain is MISSING from Caddy, and needsUpdate compares upstream IP, port
+// and protocol only. A route present in both the DB and Caddy but absent from
+// the TLS policy was therefore classified "in sync" on every tick, forever —
+// serving happily on :80 while :443 returned `tls: internal error` (alert 80,
+// no peer certificate) with no error and no log line anywhere.
+//
+// EnsureTLSSubjects is the reconciliation these tests lock down: it is
+// idempotent, batches its writes, and understands wildcard coverage so it
+// doesn't burn ACME budget re-issuing what `*.<base-domain>` already covers.
+
+// subjectsOf flattens every subject across every policy.
+func subjectsOf(policies []CaddyTLSAutomationPolicy) []string {
+	var out []string
+	for _, p := range policies {
+		out = append(out, p.Subjects...)
+	}
+	return out
+}
+
+func hasSubject(policies []CaddyTLSAutomationPolicy, want string) bool {
+	for _, s := range subjectsOf(policies) {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+// THE #1584 regression: the route serves on :80, the subject was never
+// written, and every prior tick considered that state correct.
+func TestEnsureTLSSubjects_AddsSubjectMissingFromPolicy(t *testing.T) {
+	srv, fc := newRWFakeCaddy(tlsConfigWithPolicy(
+		[]string{"other.example.com"},
+		[]CaddyTLSIssuer{NewACMEIssuer()},
+	))
+	defer srv.Close()
+
+	p := NewProxyManager(srv.URL, "example.com")
+
+	if err := p.EnsureTLSSubjects([]string{"app.example.com"}); err != nil {
+		t.Fatalf("EnsureTLSSubjects: %v", err)
+	}
+
+	policies := readPolicies(t, fc)
+	if !hasSubject(policies, "app.example.com") {
+		t.Fatalf("subject was not reconciled into any policy — the host would serve on :80 "+
+			"and never get a certificate (#1584); subjects: %v", subjectsOf(policies))
+	}
+}
+
+// Reconciliation runs on every sync tick, so a no-op must actually be a no-op.
+// Rewriting the policy array each tick would churn Caddy's config and could
+// restart certificate management for every subject on the host.
+func TestEnsureTLSSubjects_NoWriteWhenAllSubjectsPresent(t *testing.T) {
+	srv, fc := newRWFakeCaddy(tlsConfigWithPolicy(
+		[]string{"app.example.com", "api.example.com"},
+		[]CaddyTLSIssuer{NewACMEIssuer()},
+	))
+	defer srv.Close()
+
+	p := NewProxyManager(srv.URL, "example.com")
+	before := fc.puts
+
+	if err := p.EnsureTLSSubjects([]string{"app.example.com", "api.example.com"}); err != nil {
+		t.Fatalf("EnsureTLSSubjects: %v", err)
+	}
+
+	if fc.puts != before {
+		t.Fatalf("expected no config write when every subject is already present, got %d write(s)",
+			fc.puts-before)
+	}
+}
+
+// A `*.<base-domain>` wildcard already covers every direct child. Adding an
+// explicit per-host subject on top would make Caddy issue a redundant
+// single-host certificate, which is exactly the Let's Encrypt rate-limit
+// exposure the wildcard path (#378) exists to avoid.
+func TestEnsureTLSSubjects_WildcardCoversDirectChild(t *testing.T) {
+	srv, fc := newRWFakeCaddy(tlsConfigWithPolicy(
+		[]string{"*.example.com"},
+		[]CaddyTLSIssuer{NewACMEIssuer()},
+	))
+	defer srv.Close()
+
+	p := NewProxyManager(srv.URL, "example.com")
+	before := fc.puts
+
+	if err := p.EnsureTLSSubjects([]string{"app.example.com"}); err != nil {
+		t.Fatalf("EnsureTLSSubjects: %v", err)
+	}
+
+	if fc.puts != before {
+		t.Fatalf("wildcard *.example.com already covers app.example.com; adding an explicit "+
+			"subject burns ACME budget on a redundant cert (#378). Writes: %d", fc.puts-before)
+	}
+}
+
+// A wildcard is exactly one label deep — `*.example.com` does NOT cover
+// `a.b.example.com`. Treating it as covered would leave the deeper host with
+// no certificate and no signal, reintroducing #1584 for multi-label hosts.
+func TestEnsureTLSSubjects_WildcardDoesNotCoverDeeperLabel(t *testing.T) {
+	srv, fc := newRWFakeCaddy(tlsConfigWithPolicy(
+		[]string{"*.example.com"},
+		[]CaddyTLSIssuer{NewACMEIssuer()},
+	))
+	defer srv.Close()
+
+	p := NewProxyManager(srv.URL, "example.com")
+
+	if err := p.EnsureTLSSubjects([]string{"a.b.example.com"}); err != nil {
+		t.Fatalf("EnsureTLSSubjects: %v", err)
+	}
+
+	policies := readPolicies(t, fc)
+	if !hasSubject(policies, "a.b.example.com") {
+		t.Fatalf("*.example.com does not cover a.b.example.com, so it must be added explicitly; "+
+			"subjects: %v", subjectsOf(policies))
+	}
+}
+
+// Several routes can be missing subjects at once — after a Caddy config
+// rebuild, or on a host that hit #1585 repeatedly. One write, not N.
+func TestEnsureTLSSubjects_BatchesMissingSubjectsIntoOneWrite(t *testing.T) {
+	srv, fc := newRWFakeCaddy(tlsConfigWithPolicy(
+		[]string{"kept.example.com"},
+		[]CaddyTLSIssuer{NewACMEIssuer()},
+	))
+	defer srv.Close()
+
+	p := NewProxyManager(srv.URL, "example.com")
+	before := fc.puts
+
+	want := []string{"a.example.com", "b.example.com", "c.example.com"}
+	if err := p.EnsureTLSSubjects(want); err != nil {
+		t.Fatalf("EnsureTLSSubjects: %v", err)
+	}
+
+	if got := fc.puts - before; got != 1 {
+		t.Errorf("want exactly 1 batched write for 3 missing subjects, got %d", got)
+	}
+
+	policies := readPolicies(t, fc)
+	for _, w := range want {
+		if !hasSubject(policies, w) {
+			t.Errorf("subject %q missing after batch reconcile; subjects: %v", w, subjectsOf(policies))
+		}
+	}
+	if !hasSubject(policies, "kept.example.com") {
+		t.Error("reconciliation dropped a pre-existing subject — it must only add")
+	}
+}
+
+// A host whose TLS app has no policies at all (fresh Caddy, or one that just
+// reverted to the stub Caddyfile per #400) must still get its subjects.
+func TestEnsureTLSSubjects_CreatesPolicyWhenNoneExist(t *testing.T) {
+	srv, fc := newRWFakeCaddy(nil)
+	defer srv.Close()
+
+	p := NewProxyManager(srv.URL, "example.com")
+
+	if err := p.EnsureTLSSubjects([]string{"app.example.com"}); err != nil {
+		t.Fatalf("EnsureTLSSubjects: %v", err)
+	}
+
+	policies := readPolicies(t, fc)
+	if !hasSubject(policies, "app.example.com") {
+		t.Fatalf("no policy existed and none was created; subjects: %v", subjectsOf(policies))
+	}
+	if len(policies) == 0 || len(policies[0].Issuers) == 0 {
+		t.Fatal("created policy has no issuers — Caddy would never attempt the certificate")
+	}
+}
+
+// A policy that predates DNS-01 carries issuers that cannot solve a wildcard
+// (#1066). Reconciliation appends to that same policy, so it must repair the
+// issuers the way ProvisionTLS does — otherwise the reconciled subject sits
+// there unissued, which is the very symptom #1584 is about.
+func TestEnsureTLSSubjects_RepairsIssuersWhenAppending(t *testing.T) {
+	srv, fc := newRWFakeCaddy(tlsConfigWithPolicy(
+		[]string{"other.example.com"},
+		[]CaddyTLSIssuer{NewACMEIssuer(), NewZeroSSLIssuer()},
+	))
+	defer srv.Close()
+
+	p := NewProxyManager(srv.URL, "example.com").WithDNSChallenge(testDNSChallenge())
+
+	if err := p.EnsureTLSSubjects([]string{"app.example.com"}); err != nil {
+		t.Fatalf("EnsureTLSSubjects: %v", err)
+	}
+
+	policies := readPolicies(t, fc)
+	if len(policies) != 1 {
+		t.Fatalf("want 1 policy, got %d", len(policies))
+	}
+	assertAllIssuersSolveDNS(t, policies[0])
+}
+
+// Empty input must not touch Caddy — a host with no routes yet reconciles on
+// every tick too.
+func TestEnsureTLSSubjects_EmptyInputIsNoOp(t *testing.T) {
+	srv, fc := newRWFakeCaddy(tlsConfigWithPolicy(
+		[]string{"app.example.com"},
+		[]CaddyTLSIssuer{NewACMEIssuer()},
+	))
+	defer srv.Close()
+
+	p := NewProxyManager(srv.URL, "example.com")
+	before := fc.puts
+
+	if err := p.EnsureTLSSubjects(nil); err != nil {
+		t.Fatalf("EnsureTLSSubjects(nil): %v", err)
+	}
+	if fc.puts != before {
+		t.Fatalf("empty input wrote to Caddy %d time(s)", fc.puts-before)
+	}
+}
+
+// The same domain appearing twice (two routes, one hostname) must not produce
+// a duplicate subject entry.
+func TestEnsureTLSSubjects_DeduplicatesInput(t *testing.T) {
+	srv, fc := newRWFakeCaddy(tlsConfigWithPolicy(
+		[]string{"kept.example.com"},
+		[]CaddyTLSIssuer{NewACMEIssuer()},
+	))
+	defer srv.Close()
+
+	p := NewProxyManager(srv.URL, "example.com")
+
+	if err := p.EnsureTLSSubjects([]string{"app.example.com", "app.example.com"}); err != nil {
+		t.Fatalf("EnsureTLSSubjects: %v", err)
+	}
+
+	var count int
+	for _, s := range subjectsOf(readPolicies(t, fc)) {
+		if s == "app.example.com" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("want subject exactly once, got %d occurrences", count)
+	}
+}

--- a/internal/app/proxy_tls_subject_reconcile_test.go
+++ b/internal/app/proxy_tls_subject_reconcile_test.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -250,5 +252,92 @@ func TestEnsureTLSSubjects_DeduplicatesInput(t *testing.T) {
 	}
 	if count != 1 {
 		t.Fatalf("want subject exactly once, got %d occurrences", count)
+	}
+}
+
+// --- CodeRabbit review findings on PR #1589 ---
+
+// A non-200 on the policies GET left `policies` empty, and the code then fell
+// through to the "no policies exist" branch and POSTed a fresh one. POST to a
+// Caddy array path APPENDS, so a transient admin-API failure would graft a
+// duplicate policy alongside the real ones — and this reconciler runs every
+// tick, so a flapping admin API would accumulate them. Fail instead.
+func TestEnsureTLSSubjects_ErrorsOnUnexpectedPolicyGetStatus(t *testing.T) {
+	var wrote bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		// ensureTLSApp's probe: report the app as present so we reach the
+		// policies GET rather than short-circuiting into createTLSApp.
+		case r.URL.Path == "/config/apps/tls" && r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`{"automation":{"policies":[]}}`))
+		case r.URL.Path == "/config/apps/tls/automation/policies" && r.Method == http.MethodGet:
+			http.Error(w, "boom", http.StatusInternalServerError)
+		default:
+			wrote = true
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer srv.Close()
+
+	p := NewProxyManager(srv.URL, "example.com")
+
+	err := p.EnsureTLSSubjects([]string{"app.example.com"})
+	if err == nil {
+		t.Fatal("want an error when the policies GET returns an unexpected status, got nil — " +
+			"falling through would POST a duplicate policy")
+	}
+	if wrote {
+		t.Fatal("must not write configuration after a failed policies read")
+	}
+}
+
+// The wildcard-coverage shortcut can reintroduce #1066 one level up: a policy
+// holding `*.example.com` with pre-DNS-01 issuers covers app.example.com on
+// paper, but those issuers categorically cannot solve a wildcard, so the cert
+// is never issued and the host has no certificate — exactly the #1584 symptom,
+// reached by skipping the repair ProvisionTLS would have done.
+func TestEnsureTLSSubjects_RepairsIssuersOfCoveringWildcardPolicy(t *testing.T) {
+	srv, fc := newRWFakeCaddy(tlsConfigWithPolicy(
+		[]string{"*.example.com"},
+		[]CaddyTLSIssuer{NewACMEIssuer(), NewZeroSSLIssuer()}, // no DNS-01
+	))
+	defer srv.Close()
+
+	p := NewProxyManager(srv.URL, "example.com").WithDNSChallenge(testDNSChallenge())
+
+	if err := p.EnsureTLSSubjects([]string{"app.example.com"}); err != nil {
+		t.Fatalf("EnsureTLSSubjects: %v", err)
+	}
+
+	policies := readPolicies(t, fc)
+	if len(policies) != 1 {
+		t.Fatalf("want 1 policy, got %d", len(policies))
+	}
+	assertAllIssuersSolveDNS(t, policies[0])
+
+	// Still no redundant per-host subject — the wildcard genuinely covers it
+	// once its issuers can solve it.
+	if hasSubject(policies, "app.example.com") {
+		t.Error("wildcard covers this host; an explicit subject burns ACME budget (#378)")
+	}
+}
+
+// Repairing covering policies must stay silent when there is nothing to repair,
+// or the every-tick reconciler churns Caddy's config forever.
+func TestEnsureTLSSubjects_NoWriteWhenCoveringWildcardIssuersAlreadySolveDNS(t *testing.T) {
+	srv, fc := newRWFakeCaddy(tlsConfigWithPolicy(
+		[]string{"*.example.com"},
+		issuersFor(testDNSChallenge()),
+	))
+	defer srv.Close()
+
+	p := NewProxyManager(srv.URL, "example.com").WithDNSChallenge(testDNSChallenge())
+	before := fc.puts
+
+	if err := p.EnsureTLSSubjects([]string{"app.example.com"}); err != nil {
+		t.Fatalf("EnsureTLSSubjects: %v", err)
+	}
+	if fc.puts != before {
+		t.Fatalf("issuers already solve DNS-01; want no write, got %d", fc.puts-before)
 	}
 }

--- a/internal/app/route_sync.go
+++ b/internal/app/route_sync.go
@@ -217,7 +217,47 @@ func (j *RouteSyncJob) sync(ctx context.Context) error {
 		}
 	}
 
+	// Reconcile TLS automation subjects for every route that should have a
+	// certificate. Deliberately AFTER syncHTTPRoutes, so routes added on this
+	// tick are included, and deliberately not gated on that call succeeding —
+	// the subjects of already-synced routes still need checking when one route
+	// fails.
+	//
+	// syncHTTPRoutes only provisions TLS for routes it ADDS to Caddy; a route
+	// already present takes the needsUpdate path, which never looks at TLS
+	// subjects. Without this call a route whose subject went missing is never
+	// repaired (#1584).
+	if err := j.syncTLSSubjects(dbRoutes); err != nil {
+		log.Printf("[RouteSyncJob] TLS subject reconcile error: %v", err)
+	}
+
 	return nil
+}
+
+// syncTLSSubjects ensures every active route that Caddy terminates TLS for has
+// a subject in Caddy's TLS automation policies (#1584).
+//
+// Excludes TLS-passthrough routes: those terminate TLS at the backend, so
+// Caddy must not chase a certificate for them. Excludes inactive routes for
+// the same reason RemoveTLSSubject exists — no point spending ACME budget on a
+// hostname nothing serves.
+func (j *RouteSyncJob) syncTLSSubjects(dbRoutes []*RouteRecord) error {
+	if j.proxyManager == nil {
+		return nil
+	}
+
+	domains := make([]string, 0, len(dbRoutes))
+	for _, r := range dbRoutes {
+		if r == nil || !r.Active || r.FullDomain == "" {
+			continue
+		}
+		if r.Protocol == string(RouteProtocolTLSPassthrough) {
+			continue
+		}
+		domains = append(domains, r.FullDomain)
+	}
+
+	return j.proxyManager.EnsureTLSSubjects(domains)
 }
 
 // syncHTTPRoutes synchronizes HTTP/gRPC routes to the Caddy HTTP server

--- a/internal/app/route_sync_tls_reconcile_test.go
+++ b/internal/app/route_sync_tls_reconcile_test.go
@@ -1,0 +1,133 @@
+package app
+
+import (
+	"testing"
+)
+
+// #1584 at the sync-loop level. The reported host was serving its route on
+// :80 with no certificate on :443, and every 5s tick left it that way:
+//
+//   - syncHTTPRoutes re-provisions (AddRoute → ProvisionTLS) only when the
+//     domain is MISSING from Caddy. This route was present.
+//   - needsUpdate, the branch taken when the route IS present, compares
+//     upstream IP, upstream port and protocol. It never looked at TLS
+//     automation subjects.
+//
+// So "route exists, subject doesn't" was indistinguishable from "in sync".
+// syncTLSSubjects closes that hole.
+
+func httpRoute(domain string) *RouteRecord {
+	return &RouteRecord{
+		FullDomain: domain,
+		TargetIP:   "10.0.3.7",
+		TargetPort: 8080,
+		Protocol:   string(RouteProtocolHTTP),
+		Active:     true,
+	}
+}
+
+// The exact reported state: route live in Caddy and in the DB, subject absent.
+// Before the fix this tick was a no-op and the host stayed certificate-less.
+func TestSyncTLSSubjects_ReconcilesRoutePresentInCaddyButMissingSubject(t *testing.T) {
+	srv, fc := newRWFakeCaddy(tlsConfigWithPolicy(
+		[]string{"unrelated.example.com"},
+		[]CaddyTLSIssuer{NewACMEIssuer()},
+	))
+	defer srv.Close()
+
+	p := NewProxyManager(srv.URL, "example.com")
+	j := &RouteSyncJob{proxyManager: p}
+
+	routes := []*RouteRecord{httpRoute("app.example.com")}
+	if err := j.syncTLSSubjects(routes); err != nil {
+		t.Fatalf("syncTLSSubjects: %v", err)
+	}
+
+	if !hasSubject(readPolicies(t, fc), "app.example.com") {
+		t.Fatal("sync tick did not reconcile the missing TLS subject — the host serves on :80 " +
+			"and returns `tls: internal error` on :443 indefinitely (#1584)")
+	}
+}
+
+// gRPC routes reach Caddy through AddGRPCRoute, the same ProvisionTLS path,
+// so they are equally exposed to #1584 and must reconcile identically.
+func TestSyncTLSSubjects_CoversGRPCRoutes(t *testing.T) {
+	srv, fc := newRWFakeCaddy(tlsConfigWithPolicy(
+		[]string{"unrelated.example.com"},
+		[]CaddyTLSIssuer{NewACMEIssuer()},
+	))
+	defer srv.Close()
+
+	p := NewProxyManager(srv.URL, "example.com")
+	j := &RouteSyncJob{proxyManager: p}
+
+	grpc := httpRoute("grpc.example.com")
+	grpc.Protocol = string(RouteProtocolGRPC)
+
+	if err := j.syncTLSSubjects([]*RouteRecord{grpc}); err != nil {
+		t.Fatalf("syncTLSSubjects: %v", err)
+	}
+
+	if !hasSubject(readPolicies(t, fc), "grpc.example.com") {
+		t.Fatal("gRPC route did not get a TLS subject reconciled (#1584)")
+	}
+}
+
+// TLS-passthrough routes terminate TLS at the backend, not at Caddy, so Caddy
+// must NOT try to obtain a certificate for them. Provisioning one would send
+// Caddy after a cert for a hostname it never terminates.
+func TestSyncTLSSubjects_SkipsTLSPassthroughRoutes(t *testing.T) {
+	srv, fc := newRWFakeCaddy(tlsConfigWithPolicy(
+		[]string{"unrelated.example.com"},
+		[]CaddyTLSIssuer{NewACMEIssuer()},
+	))
+	defer srv.Close()
+
+	p := NewProxyManager(srv.URL, "example.com")
+	j := &RouteSyncJob{proxyManager: p}
+
+	pt := httpRoute("passthrough.example.com")
+	pt.Protocol = string(RouteProtocolTLSPassthrough)
+
+	if err := j.syncTLSSubjects([]*RouteRecord{pt}); err != nil {
+		t.Fatalf("syncTLSSubjects: %v", err)
+	}
+
+	if hasSubject(readPolicies(t, fc), "passthrough.example.com") {
+		t.Fatal("TLS-passthrough route must not get a Caddy TLS subject — Caddy does not " +
+			"terminate TLS for it")
+	}
+}
+
+// Inactive routes aren't served, so chasing certificates for them wastes ACME
+// budget — the same reasoning RemoveTLSSubject applies on the delete cascade.
+func TestSyncTLSSubjects_SkipsInactiveRoutes(t *testing.T) {
+	srv, fc := newRWFakeCaddy(tlsConfigWithPolicy(
+		[]string{"unrelated.example.com"},
+		[]CaddyTLSIssuer{NewACMEIssuer()},
+	))
+	defer srv.Close()
+
+	p := NewProxyManager(srv.URL, "example.com")
+	j := &RouteSyncJob{proxyManager: p}
+
+	inactive := httpRoute("sleeping.example.com")
+	inactive.Active = false
+
+	if err := j.syncTLSSubjects([]*RouteRecord{inactive}); err != nil {
+		t.Fatalf("syncTLSSubjects: %v", err)
+	}
+
+	if hasSubject(readPolicies(t, fc), "sleeping.example.com") {
+		t.Fatal("inactive route should not have a TLS subject provisioned")
+	}
+}
+
+// A nil proxy manager must not panic the sync loop — other tests construct
+// RouteSyncJob as a bare struct literal, and the L4-only paths do too.
+func TestSyncTLSSubjects_NilProxyManagerIsNoOp(t *testing.T) {
+	j := &RouteSyncJob{}
+	if err := j.syncTLSSubjects([]*RouteRecord{httpRoute("app.example.com")}); err != nil {
+		t.Fatalf("want nil error with no proxy manager, got %v", err)
+	}
+}


### PR DESCRIPTION
Closes #1584
Closes #1585
Closes #1586

Three findings from a QA session on 2026-08-27, all in the TLS-subject lifecycle of `internal/app`. They're filed separately because they're independently reviewable defects, but they're one mechanism and one story, so they ship as one small PR rather than three PRs touching the same 40 lines.

## The bug

A hostname served correctly on `:80` while `:443` returned `tls: internal error` (alert 80, `no peer certificate available`) — and stayed that way indefinitely.

TLS automation subjects were written exactly once, by `ProvisionTLS` at route-add time. If that write didn't land, nothing put it back:

- `syncHTTPRoutes` re-provisions only when a route is **missing** from Caddy.
- `needsUpdate` — the branch taken when the route **is** present — compared upstream IP, port, and protocol. It never looked at TLS subjects.

So "route present, subject absent" was indistinguishable from "in sync". Every 5s tick agreed the host was fine.

## What changed

- **`ProxyManager.EnsureTLSSubjects`** (#1584) — idempotent reconciliation of TLS subjects against the routes that should have certificates. One GET and **no write** in the no-change case (it runs every tick, so a no-op has to actually be a no-op); missing subjects batched into a **single** write; **adds only**, so a transiently-empty route list can never strip live subjects. Removal stays with `RemoveTLSSubject` on the delete cascade.
- **`subjectCovers`** — wildcard coverage using the real one-label rule: `*.example.com` covers `app.example.com` but **not** `a.b.example.com`. Both directions have a cost — too permissive leaves deeper hosts with no cert (the original bug), too strict adds a redundant per-host subject that burns the Let's Encrypt budget the wildcard exists to conserve (#378).
- **`RouteSyncJob.syncTLSSubjects`** — wires it into the sync loop, after `syncHTTPRoutes` so routes added this tick are included, and not gated on that call succeeding. Skips TLS-passthrough routes (Caddy doesn't terminate TLS for them) and inactive routes.
- **#1585** — `addRouteWithProtocol` now logs the `ProvisionTLS` failure via `log.Printf` with the `[ProxyManager]` prefix instead of a bare `fmt.Printf` to stdout. It still doesn't return an error: the route *is* live, so failing the call would tell the caller something false and invite a rollback of a working route. What made the swallow harmful was that it was permanent and invisible — the reconciler above fixes the first, this fixes the second.
- **#1586** — documents that `ProvisionTLS` is explicit-subject automation, **not** on-demand issuance, and deletes the orphaned comment fragment that claimed otherwise. That fragment wasn't even attached to `ProvisionTLS` — it had drifted to dangle above `ensureDNSIssuers`'s own doc comment.

## Test evidence

14 new tests, all written before the implementation. `go test ./internal/app/ -count=1` → `ok` (full package, no existing test modified or skipped).

| Acceptance criterion | Test |
|---|---|
| Missing subject is reconciled (#1584 core) | `TestEnsureTLSSubjects_AddsSubjectMissingFromPolicy` |
| Route in Caddy+DB but no subject → repaired | `TestSyncTLSSubjects_ReconcilesRoutePresentInCaddyButMissingSubject` |
| No-op tick performs no write | `TestEnsureTLSSubjects_NoWriteWhenAllSubjectsPresent` |
| Wildcard covers direct child (no ACME waste) | `TestEnsureTLSSubjects_WildcardCoversDirectChild` |
| Wildcard does NOT cover deeper label | `TestEnsureTLSSubjects_WildcardDoesNotCoverDeeperLabel` |
| N missing → 1 write, existing subjects kept | `TestEnsureTLSSubjects_BatchesMissingSubjectsIntoOneWrite` |
| Fresh/stub Caddy with no policies | `TestEnsureTLSSubjects_CreatesPolicyWhenNoneExist` |
| Appending repairs pre-DNS-01 issuers (#1066) | `TestEnsureTLSSubjects_RepairsIssuersWhenAppending` |
| Empty input is a no-op | `TestEnsureTLSSubjects_EmptyInputIsNoOp` |
| Duplicate input → one subject | `TestEnsureTLSSubjects_DeduplicatesInput` |
| gRPC routes reconcile too | `TestSyncTLSSubjects_CoversGRPCRoutes` |
| TLS-passthrough routes skipped | `TestSyncTLSSubjects_SkipsTLSPassthroughRoutes` |
| Inactive routes skipped | `TestSyncTLSSubjects_SkipsInactiveRoutes` |
| Nil proxy manager doesn't panic the loop | `TestSyncTLSSubjects_NilProxyManagerIsNoOp` |

The tests' initial red was a compile error (missing method), which proves little, so the load-bearing one was mutation-checked: dropping the one-label rule from `subjectCovers` fails `TestEnsureTLSSubjects_WildcardDoesNotCoverDeeperLabel` with the expected message, not a compile error.

## Review notes

- **Look first at** `syncTLSSubjects`'s placement in `sync()` — it's intentionally outside the `l4ProxyManager != nil` guard and not short-circuited by a `syncHTTPRoutes` error.
- **`subjectCovers` is the subtle one.** It uses `strings.CutPrefix`/`CutSuffix` and rejects an empty host label, so `*.example.com` does not "cover" `.example.com`.
- No design-doc deviation; no proto or generated code touched; no new dependencies.

## Not fixed here

- **How the reported host reached this state is still open** — `syncHTTPRoutes` reaps Caddy routes absent from the DB, so a purely out-of-band HTTP-only route should have been deleted rather than served. Either the route was in the DB with a failed `ProvisionTLS`, or that edge isn't daemon-managed. This PR makes the state self-healing either way; the provenance question is recorded in #1584.
- **On-demand issuance is still unreachable.** #1586 documents that rather than wiring it, because the consumer is cloud-side. Filed as FootprintAI/Containarium-cloud#1344 — the `/internal/tls-allow` ask hook there is fully built, routed, and unit-tested, and never receives a single probe.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically reconciles missing TLS certificate subjects for active HTTP and gRPC routes.
  * Supports wildcard certificate coverage and repairs certificate issuer settings.
  * Creates or updates TLS policies as needed while preserving existing subjects.
  * Processes certificate subject updates in batches and avoids unnecessary changes.

* **Bug Fixes**
  * TLS provisioning failures no longer prevent route creation.
  * TLS reconciliation safely skips inactive and passthrough routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->