### PR TITLE
feat(system-info): add SystemInfo.committed_cpu_cores

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -13268,6 +13268,11 @@
         "storage": {
           "$ref": "#/definitions/BackendStorage",
           "description": "The storage pool backing this backend's containers, and whether that\npool isolates tenant volumes. Null when the pool could not be read —\n\"we don't know\" must stay distinguishable from \"isolated\". Carried on\nSystemInfo so peers report it through the GetSystemInfo fan-out that\nListBackends already uses, BYOC tunnel hosts included. See #1209."
+        },
+        "committedCpuCores": {
+          "type": "number",
+          "format": "double",
+          "description": "committed_cpu_cores is the sum of this host's TENANT containers'\ncommitted CPU (limits.cpu / limits.cpu.allowance, summed via\nincus.CommittedCores) — the \"how much is actually spoken for\" number\nthat pairs with total_cpus to answer \"is this host over its CPU\novercommit ceiling right now\" (#1580). A caller derives the ratio as\ncommitted_cpu_cores / total_cpus.\n\nThis is TENANT capacity, not total host capacity: the platform's own\ncore-infra containers (Postgres, Caddy, control-plane — not tenant\nworkload) are deliberately excluded, the same exclusion the CPU\nadmission gate (docs/CPU-CAPACITY-ADMISSION.md, #1029) already applies.\nAn operator combining this with total_cpus to size an overcommit factor\nmust still separately budget the host's own known core-infra CPU\nfootprint on top of it.\n\n0 on the K8s runtime, same as total_cpus (the Incus resource read\nno-ops there) — \"not applicable to this runtime,\" not \"nothing\ncommitted.\" See #1571/#1578 for the design this closes the visibility\nhalf of."
         }
       },
       "title": "SystemInfo contains information about the host system"

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -2721,6 +2721,12 @@ func (s *ContainerServer) GetSystemInfo(ctx context.Context, req *pb.GetSystemIn
 		// direct/in-network mode — so an agent can tell from get_system_info
 		// whether an external SSH/deploy entrypoint exists. See #1011.
 		SshIngressHost: s.sshHost,
+		// Tenant-committed CPU cores on this host — pairs with TotalCpus to
+		// answer "is this host over its CPU overcommit ceiling right now"
+		// (#1580). Reuses the same containers list already fetched above,
+		// and the same core-role exclusion the admission gate (#1029) uses,
+		// via committedTenantCores — one summation shared by both, not two.
+		CommittedCpuCores: committedTenantCores(containers, nil),
 	}
 
 	// The storage pool backing this backend's containers, and whether it

--- a/internal/server/cpu_admission.go
+++ b/internal/server/cpu_admission.go
@@ -124,16 +124,41 @@ func (s *ContainerServer) committedCoresExcluding(username string) (float64, err
 		return 0, err
 	}
 	selfName := username + "-container"
+	return committedTenantCores(containers, func(c *incus.ContainerInfo) bool {
+		return c.Name == selfName || c.Tenant == username
+	}), nil
+}
+
+// committedTenantCores sums incus.CommittedCores over containers, always
+// skipping core-role infra (postgres/caddy/control-plane — not tenant
+// workload), and any container for which skip returns true (skip may be nil
+// for a plain, unfiltered total).
+//
+// Shared between committedCoresExcluding (the admission check above, which
+// additionally excludes the tenant being (re)sized/created) and
+// SystemInfo.committed_cpu_cores (#1580, a plain total with no tenant
+// excluded) so there is one summation to keep correct, not two independent
+// copies that could drift apart.
+//
+// It deliberately reports TENANT capacity, not total host capacity: excluding
+// core-role containers means this total does not include the platform's own
+// Postgres/Caddy/control-plane CPU footprint. That is intentional — it is
+// the number an operator sizing a tenant-facing overcommit factor actually
+// wants — but it means committed_cpu_cores / total_cpus is a tenant-only
+// ratio; an operator must separately budget the host's known core-infra CPU
+// on top of it. See docs/architecture/cpu-reservation-and-overcommit-visibility.md
+// section A/B for the full discussion.
+func committedTenantCores(containers []incus.ContainerInfo, skip func(c *incus.ContainerInfo) bool) float64 {
 	var sum float64
 	for i := range containers {
 		c := &containers[i]
 		if c.Role.IsCoreRole() {
 			continue
 		}
-		if c.Name == selfName || c.Tenant == username {
+		if skip != nil && skip(c) {
 			continue
 		}
 		sum += incus.CommittedCores(c.CPU)
 	}
-	return sum, nil
+	return sum
 }

--- a/internal/server/cpu_admission_test.go
+++ b/internal/server/cpu_admission_test.go
@@ -134,3 +134,66 @@ func TestAdmitCPUCapacity_FailOpenOnUnknownCores(t *testing.T) {
 		t.Fatalf("must fail open when host cores unknown, got %v", err)
 	}
 }
+
+// TestCommittedTenantCores_TotalExcludesOnlyCoreRole is the SystemInfo report
+// case (#1580, no username to exclude): every tenant container counts,
+// core-role infra does not.
+func TestCommittedTenantCores_TotalExcludesOnlyCoreRole(t *testing.T) {
+	containers := []incus.ContainerInfo{
+		{Name: "postgres", CPU: "4", Role: incus.RolePostgres},
+		tenant("alice", "2"),
+		tenant("bob", "1.5"),
+	}
+	got := committedTenantCores(containers, nil)
+	if want := 3.5; got != want {
+		t.Errorf("committedTenantCores(total) = %v, want %v (2 + 1.5, core-role excluded)", got, want)
+	}
+}
+
+// TestCommittedTenantCores_SkipExcludesMatchedContainers verifies the skip
+// predicate composes correctly with the core-role exclusion — this is the
+// exact shape committedCoresExcluding uses, pinned here so the shared helper
+// can't silently regress admission behavior while being reused for reporting.
+func TestCommittedTenantCores_SkipExcludesMatchedContainers(t *testing.T) {
+	containers := []incus.ContainerInfo{
+		{Name: "postgres", CPU: "8", Role: incus.RolePostgres},
+		tenant("me", "8"),
+		tenant("other", "4"),
+	}
+	got := committedTenantCores(containers, func(c *incus.ContainerInfo) bool {
+		return c.Tenant == "me"
+	})
+	if want := 4.0; got != want {
+		t.Errorf("committedTenantCores(skip me) = %v, want %v (core-role and \"me\" excluded, only \"other\" counts)", got, want)
+	}
+}
+
+// TestCommittedTenantCores_EmptyIsZero: no containers at all sums to zero,
+// not an error or a panic.
+func TestCommittedTenantCores_EmptyIsZero(t *testing.T) {
+	if got := committedTenantCores(nil, nil); got != 0 {
+		t.Errorf("committedTenantCores(nil) = %v, want 0", got)
+	}
+}
+
+// TestCommittedCoresExcluding_UnchangedAfterRefactor pins that
+// committedCoresExcluding's own observable behavior (used for admission) is
+// unchanged now that its summation is shared with the SystemInfo report via
+// committedTenantCores — the existing TestAdmitCPUCapacity_ExcludesCoreAndSelf
+// exercises this indirectly through admitCPUCapacity; this test calls the
+// method directly so a regression here fails with a smaller, more direct
+// signal.
+func TestCommittedCoresExcluding_UnchangedAfterRefactor(t *testing.T) {
+	s := seedServer(t, 8, []incus.ContainerInfo{
+		{Name: "postgres", CPU: "8", Role: incus.RolePostgres},
+		tenant("me", "8"),
+		tenant("other", "4"),
+	})
+	got, err := s.committedCoresExcluding("me")
+	if err != nil {
+		t.Fatalf("committedCoresExcluding: %v", err)
+	}
+	if want := 4.0; got != want {
+		t.Errorf("committedCoresExcluding(\"me\") = %v, want %v", got, want)
+	}
+}

--- a/pkg/pb/containarium/v1/config.pb.go
+++ b/pkg/pb/containarium/v1/config.pb.go
@@ -1182,9 +1182,29 @@ type SystemInfo struct {
 	// "we don't know" must stay distinguishable from "isolated". Carried on
 	// SystemInfo so peers report it through the GetSystemInfo fan-out that
 	// ListBackends already uses, BYOC tunnel hosts included. See #1209.
-	Storage       *BackendStorage `protobuf:"bytes,23,opt,name=storage,proto3" json:"storage,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Storage *BackendStorage `protobuf:"bytes,23,opt,name=storage,proto3" json:"storage,omitempty"`
+	// committed_cpu_cores is the sum of this host's TENANT containers'
+	// committed CPU (limits.cpu / limits.cpu.allowance, summed via
+	// incus.CommittedCores) — the "how much is actually spoken for" number
+	// that pairs with total_cpus to answer "is this host over its CPU
+	// overcommit ceiling right now" (#1580). A caller derives the ratio as
+	// committed_cpu_cores / total_cpus.
+	//
+	// This is TENANT capacity, not total host capacity: the platform's own
+	// core-infra containers (Postgres, Caddy, control-plane — not tenant
+	// workload) are deliberately excluded, the same exclusion the CPU
+	// admission gate (docs/CPU-CAPACITY-ADMISSION.md, #1029) already applies.
+	// An operator combining this with total_cpus to size an overcommit factor
+	// must still separately budget the host's own known core-infra CPU
+	// footprint on top of it.
+	//
+	// 0 on the K8s runtime, same as total_cpus (the Incus resource read
+	// no-ops there) — "not applicable to this runtime," not "nothing
+	// committed." See #1571/#1578 for the design this closes the visibility
+	// half of.
+	CommittedCpuCores float64 `protobuf:"fixed64,24,opt,name=committed_cpu_cores,json=committedCpuCores,proto3" json:"committed_cpu_cores,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *SystemInfo) Reset() {
@@ -1376,6 +1396,13 @@ func (x *SystemInfo) GetStorage() *BackendStorage {
 		return x.Storage
 	}
 	return nil
+}
+
+func (x *SystemInfo) GetCommittedCpuCores() float64 {
+	if x != nil {
+		return x.CommittedCpuCores
+	}
+	return 0
 }
 
 // BackendStorage describes the storage pool backing a backend's containers.
@@ -4928,7 +4955,7 @@ const file_containarium_v1_config_proto_rawDesc = "" +
 	"updateMask\"a\n" +
 	"\x14UpdateConfigResponse\x12\x18\n" +
 	"\amessage\x18\x01 \x01(\tR\amessage\x12/\n" +
-	"\x06config\x18\x02 \x01(\v2\x17.containarium.v1.ConfigR\x06config\"\xb5\a\n" +
+	"\x06config\x18\x02 \x01(\v2\x17.containarium.v1.ConfigR\x06config\"\xe5\a\n" +
 	"\n" +
 	"SystemInfo\x12#\n" +
 	"\rincus_version\x18\x01 \x01(\tR\fincusVersion\x12\x0e\n" +
@@ -4956,7 +4983,8 @@ const file_containarium_v1_config_proto_rawDesc = "" +
 	"\x17otel_collector_endpoint\x18\x14 \x01(\tR\x15otelCollectorEndpoint\x12%\n" +
 	"\x0edaemon_version\x18\x15 \x01(\tR\rdaemonVersion\x12(\n" +
 	"\x10ssh_ingress_host\x18\x16 \x01(\tR\x0esshIngressHost\x129\n" +
-	"\astorage\x18\x17 \x01(\v2\x1f.containarium.v1.BackendStorageR\astorage\"\xbe\x01\n" +
+	"\astorage\x18\x17 \x01(\v2\x1f.containarium.v1.BackendStorageR\astorage\x12.\n" +
+	"\x13committed_cpu_cores\x18\x18 \x01(\x01R\x11committedCpuCores\"\xbe\x01\n" +
 	"\x0eBackendStorage\x12\x12\n" +
 	"\x04pool\x18\x01 \x01(\tR\x04pool\x126\n" +
 	"\x06driver\x18\x02 \x01(\x0e2\x1e.containarium.v1.StorageDriverR\x06driver\x12?\n" +

--- a/proto/containarium/v1/config.proto
+++ b/proto/containarium/v1/config.proto
@@ -219,6 +219,27 @@ message SystemInfo {
   // SystemInfo so peers report it through the GetSystemInfo fan-out that
   // ListBackends already uses, BYOC tunnel hosts included. See #1209.
   BackendStorage storage = 23;
+
+  // committed_cpu_cores is the sum of this host's TENANT containers'
+  // committed CPU (limits.cpu / limits.cpu.allowance, summed via
+  // incus.CommittedCores) — the "how much is actually spoken for" number
+  // that pairs with total_cpus to answer "is this host over its CPU
+  // overcommit ceiling right now" (#1580). A caller derives the ratio as
+  // committed_cpu_cores / total_cpus.
+  //
+  // This is TENANT capacity, not total host capacity: the platform's own
+  // core-infra containers (Postgres, Caddy, control-plane — not tenant
+  // workload) are deliberately excluded, the same exclusion the CPU
+  // admission gate (docs/CPU-CAPACITY-ADMISSION.md, #1029) already applies.
+  // An operator combining this with total_cpus to size an overcommit factor
+  // must still separately budget the host's own known core-infra CPU
+  // footprint on top of it.
+  //
+  // 0 on the K8s runtime, same as total_cpus (the Incus resource read
+  // no-ops there) — "not applicable to this runtime," not "nothing
+  // committed." See #1571/#1578 for the design this closes the visibility
+  // half of.
+  double committed_cpu_cores = 24;
 }
 
 // StorageDriver identifies the incus storage-pool driver backing a backend's


### PR DESCRIPTION
## Summary

- `SystemInfo` already carries `total_cpus` but nothing about how many cores
  are currently committed against it. `docs/CPU-CAPACITY-ADMISSION.md`'s
  "Not covered here" section already names this gap directly ("A read
  surface for current commitment... would let operators see a host's
  overcommit... without grepping logs").
- New `SystemInfo.committed_cpu_cores` field (`double`, field 24), populated
  by summing `incus.CommittedCores` over the host's tenant containers — a
  caller derives the overcommit ratio client-side as
  `committed_cpu_cores / total_cpus`.
- Refactored `committedCoresExcluding`'s summation loop into a shared
  `committedTenantCores(containers, skip)` helper: the admission check
  (`internal/server/cpu_admission.go`) passes a skip predicate excluding the
  tenant being (re)sized/created, the new `GetSystemInfo` populator passes
  `nil` for a plain total. One summation shared by both, not two independent
  copies that could drift — per the issue's explicit ask.
- Documented explicitly (proto comment + code comment) that this is
  **tenant** capacity, not total host capacity: core-role containers
  (Postgres/Caddy/control-plane) are excluded, same as the admission gate
  excludes them, so an operator combining this with `total_cpus` must still
  separately budget the host's own known core-infra CPU footprint.
- K8s runtime: `0`, same no-op as `total_cpus` already has there.

## Test evidence

`GetSystemInfo` itself calls `incus.New()` directly and can't be unit-tested
end-to-end without a live Incus daemon — confirmed no existing test does
(`admin_only_handlers_test.go` only tests its auth gate). Followed the
codebase's existing pattern for this (`hostLoadFromSystemInfo` is tested as
a standalone unit, not through the full RPC) and tested the actual new
logic directly:

- `TestCommittedTenantCores_TotalExcludesOnlyCoreRole` — the SystemInfo
  case: every tenant container counts, core-role infra doesn't.
- `TestCommittedTenantCores_SkipExcludesMatchedContainers` — the admission
  case: skip predicate composes with the core-role exclusion.
- `TestCommittedTenantCores_EmptyIsZero` — no containers, no panic.
- `TestCommittedCoresExcluding_UnchangedAfterRefactor` — proves the
  refactor didn't change `committedCoresExcluding`'s existing observable
  behavior (the admission gate's own pre-existing tests all still pass
  unchanged too).

All confirmed red before the implementation (undefined `committedTenantCores`).

```
go build ./... && go vet ./... && go vet -tags k8s ./...   # clean
go test ./internal/... ./pkg/...                             # PASS
gofmt -l internal/ pkg/ proto/                                # clean
```

## Notes for reviewers

- This branch was rebased onto main after #1587 (the sibling #1579
  implementation) merged first — both touch `cpu_admission.go`/
  `cpu_admission_test.go`; resolved cleanly, no logic overlap
  (`admitCPUResize` from #1587 is untouched by this refactor).
- `docs/CPU-CAPACITY-ADMISSION.md` / CLI help text (#1581) is a separate
  follow-up from the same design doc (#1578) — not touched here.

Closes #1580

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - System information now reports the total CPU cores committed to tenant containers.
  - The value is provided as a floating-point number for Incus hosts and reports zero in Kubernetes environments.

- **Bug Fixes**
  - CPU commitment calculations now consistently exclude core infrastructure containers and support excluding a specified tenant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->