### PR TITLE
docs(cpu-admission): document the gate as the floor mechanism

### DIFF
--- a/docs/CPU-CAPACITY-ADMISSION.md
+++ b/docs/CPU-CAPACITY-ADMISSION.md
@@ -13,16 +13,25 @@ advisory mode, logged) if it would push the host's committed cores past
 
 ## When a declared CPU is a real floor, not just a ceiling
 
-A box's `--cpu` (or `resize --cpu`) always bounds a *ceiling* — the hard CFS
-quota #1034 gives every numeric CPU request. Whether that number is also a
-**floor** — a guarantee the box actually gets that much CPU under
-contention — depends entirely on this gate's configuration, and only one
-configuration delivers that guarantee:
+**This section is about the LXC/Incus backend specifically** — the runtime
+this gate applies to (see "Runtime" under "Semantics and scope" below; on
+K8s the gate no-ops entirely, and the analogous concept is the backend's own
+`--cpu-request`/`limits.requests.cpu` split, a separate mechanism, not this
+gate).
+
+On LXC/Incus, a box's `--cpu` (or `resize --cpu`) always bounds a *ceiling* —
+the hard CFS quota #1034 gives every numeric CPU request. Whether that
+number is also a **floor** — a guarantee the box actually gets that much CPU
+under contention — depends entirely on this gate's configuration, and only
+one configuration delivers that guarantee:
 
 - **The gate must be enforced, not merely advisory.** `--cpu-overcommit-enforce`
   off (the default posture even with a factor set) blocks nothing — a host
   can already be arbitrarily oversubscribed.
-- **The factor must be `1` or less.** A factor above `1` is *deliberate*
+- **The factor must be greater than `0` and no greater than `1`
+  (`0 < factor ≤ 1`).** `0` (or negative) does not mean "strict" — it
+  disables the gate entirely (see "Configuration" below), which is the
+  ceiling-only case, not a floor. A factor above `1` is *deliberate*
   overcommit: the example later in this doc (`--cpu-overcommit-factor 4
   --cpu-overcommit-enforce`) explicitly permits committed quotas up to 4×
   physical capacity, which is a ceiling-only regime by design, not a floor.
@@ -36,15 +45,15 @@ configuration delivers that guarantee:
   factor slightly under `1`, or `(physical_cores − core_infra_cores) /
   physical_cores`), not exactly `1`.
 
-Any other configuration — the off-by-default posture, advisory mode, or a
-factor above `1` — means a declared CPU is a **ceiling only**. That is a
-deliberate, named trade-off documented here, not an oversight: existing
-fleets are frequently already well past 1× overcommit (see below), and nothing
-about `resize --cpu <bigger>` on such a host changes what it delivers, because
-the box was never CPU-starved by its own ceiling in the first place — it was
-starved by every co-located box's ceiling being unenforced together. Reaching
-for a bigger `--cpu` is not the remedy; enabling and enforcing this gate
-(with realistic headroom) is.
+Any other configuration on LXC/Incus — the off-by-default posture, advisory
+mode, a factor of `0` or below, or a factor above `1` — means a declared CPU
+is a **ceiling only**. That is a deliberate, named trade-off documented
+here, not an oversight: existing fleets are frequently already well past 1×
+overcommit (see below), and nothing about `resize --cpu <bigger>` on such a
+host changes what it delivers, because the box was never CPU-starved by its
+own ceiling in the first place — it was starved by every co-located box's
+ceiling being unenforced together. Reaching for a bigger `--cpu` is not the
+remedy; enabling and enforcing this gate (with realistic headroom) is.
 
 `get_system_info` / `SystemInfo.committed_cpu_cores` (paired with
 `total_cpus`) gives an operator or agent a live read on how committed a host

--- a/docs/CPU-CAPACITY-ADMISSION.md
+++ b/docs/CPU-CAPACITY-ADMISSION.md
@@ -11,6 +11,45 @@ This is an **opt-in** admission gate: when enabled, a create is refused (or, in
 advisory mode, logged) if it would push the host's committed cores past
 `logical_cpus × factor` (Incus counts logical CPUs — vCPUs incl. SMT threads — matching the unit `limits.cpu` uses).
 
+## When a declared CPU is a real floor, not just a ceiling
+
+A box's `--cpu` (or `resize --cpu`) always bounds a *ceiling* — the hard CFS
+quota #1034 gives every numeric CPU request. Whether that number is also a
+**floor** — a guarantee the box actually gets that much CPU under
+contention — depends entirely on this gate's configuration, and only one
+configuration delivers that guarantee:
+
+- **The gate must be enforced, not merely advisory.** `--cpu-overcommit-enforce`
+  off (the default posture even with a factor set) blocks nothing — a host
+  can already be arbitrarily oversubscribed.
+- **The factor must be `1` or less.** A factor above `1` is *deliberate*
+  overcommit: the example later in this doc (`--cpu-overcommit-factor 4
+  --cpu-overcommit-enforce`) explicitly permits committed quotas up to 4×
+  physical capacity, which is a ceiling-only regime by design, not a floor.
+- **The operator must leave headroom for the host's own core-infra CPU.**
+  The gate's committed-cores accounting excludes core-role containers (the
+  platform's own Postgres/Caddy/control-plane, not tenant workload — see
+  "What counts as committed" below), so a factor of exactly `1` still lets
+  the *host* be pushed past its true physical capacity once core-infra CPU
+  is added on top of a maxed tenant commitment. Size the tenant-facing
+  factor to leave room for the host's known core-infra footprint (e.g. a
+  factor slightly under `1`, or `(physical_cores − core_infra_cores) /
+  physical_cores`), not exactly `1`.
+
+Any other configuration — the off-by-default posture, advisory mode, or a
+factor above `1` — means a declared CPU is a **ceiling only**. That is a
+deliberate, named trade-off documented here, not an oversight: existing
+fleets are frequently already well past 1× overcommit (see below), and nothing
+about `resize --cpu <bigger>` on such a host changes what it delivers, because
+the box was never CPU-starved by its own ceiling in the first place — it was
+starved by every co-located box's ceiling being unenforced together. Reaching
+for a bigger `--cpu` is not the remedy; enabling and enforcing this gate
+(with realistic headroom) is.
+
+`get_system_info` / `SystemInfo.committed_cpu_cores` (paired with
+`total_cpus`) gives an operator or agent a live read on how committed a host
+currently is, without grepping the advisory logs below.
+
 ## Why opt-in, and why a *factor* rather than a hard 1×
 
 CPU is compressible — modest overcommit is normal and desirable, because tenants
@@ -103,7 +142,6 @@ containarium daemon --placement-cpu-aware
 
 - **Local participation in ranking.** Today an in-pool healthy local backend
   still wins unconditionally; a future option could rank local alongside peers.
-- **A read surface for current commitment.** The advisory logs expose the
-  numbers; a first-class report (extending `GetSystemInfo` with committed cores)
-  would let operators see a host's overcommit — and a peer's — without grepping
-  logs.
+- **Check-then-act race under concurrent operations.** Two concurrent
+  creates/resizes can each admit against a stale committed-cores snapshot and
+  jointly exceed the ceiling — see #1588.

--- a/internal/cmd/create.go
+++ b/internal/cmd/create.go
@@ -85,7 +85,13 @@ Examples:
   containarium create charlie --ssh-key ~/.ssh/id_rsa.pub --labels team=dev,project=web
 
   # Force recreate if container already exists
-  containarium create alice --ssh-key ~/.ssh/id_rsa.pub --force`,
+  containarium create alice --ssh-key ~/.ssh/id_rsa.pub --force
+
+Note on --cpu: it sets a ceiling this box may not exceed, not automatically
+a guaranteed floor. On a host without the CPU admission gate enabled and
+enforced (the default), a declared --cpu can go unmet under contention from
+other boxes — see docs/CPU-CAPACITY-ADMISSION.md for when it becomes a real
+guarantee and how to configure it.`,
 	Args: cobra.ExactArgs(1),
 	RunE: runCreate,
 }
@@ -134,7 +140,7 @@ func init() {
 	// with --no-ssh-key. Enforce "exactly one of the two" in runCreate (cobra's
 	// MarkFlagRequired can't express the either/or).
 	createCmd.MarkFlagsMutuallyExclusive("ssh-key", "no-ssh-key")
-	createCmd.Flags().StringVar(&cpuLimit, "cpu", "4", "CPU limit (number of cores)")
+	createCmd.Flags().StringVar(&cpuLimit, "cpu", "4", "CPU limit (number of cores). A ceiling, not automatically a floor: see docs/CPU-CAPACITY-ADMISSION.md for when this box is actually guaranteed to get it.")
 	createCmd.Flags().StringVar(&memoryLimit, "memory", "4GB", "Memory limit (e.g., 4GB, 2048MB)")
 	createCmd.Flags().StringVar(&diskLimit, "disk", "50GB", "Disk limit (e.g., 50GB, 100GB)")
 	createCmd.Flags().StringVar(&staticIP, "static-ip", "", "Static IP address (e.g., 10.100.0.100) - empty for DHCP")

--- a/internal/cmd/create.go
+++ b/internal/cmd/create.go
@@ -87,11 +87,13 @@ Examples:
   # Force recreate if container already exists
   containarium create alice --ssh-key ~/.ssh/id_rsa.pub --force
 
-Note on --cpu: it sets a ceiling this box may not exceed, not automatically
-a guaranteed floor. On a host without the CPU admission gate enabled and
-enforced (the default), a declared --cpu can go unmet under contention from
-other boxes — see docs/CPU-CAPACITY-ADMISSION.md for when it becomes a real
-guarantee and how to configure it.`,
+Note on --cpu (LXC backend): it sets a ceiling this box may not exceed, not
+automatically a guaranteed floor. On a host without the CPU admission gate
+enabled and enforced (the default), a declared --cpu can go unmet under
+contention from other boxes — see docs/CPU-CAPACITY-ADMISSION.md for when
+it becomes a real guarantee and how to configure it. On the K8s backend,
+--cpu-request (a separate flag, mirrored on resize) is the mechanism for a
+guaranteed reservation instead.`,
 	Args: cobra.ExactArgs(1),
 	RunE: runCreate,
 }
@@ -140,7 +142,7 @@ func init() {
 	// with --no-ssh-key. Enforce "exactly one of the two" in runCreate (cobra's
 	// MarkFlagRequired can't express the either/or).
 	createCmd.MarkFlagsMutuallyExclusive("ssh-key", "no-ssh-key")
-	createCmd.Flags().StringVar(&cpuLimit, "cpu", "4", "CPU limit (number of cores). A ceiling, not automatically a floor: see docs/CPU-CAPACITY-ADMISSION.md for when this box is actually guaranteed to get it.")
+	createCmd.Flags().StringVar(&cpuLimit, "cpu", "4", "CPU limit (number of cores). LXC backend: a ceiling, not automatically a floor — see docs/CPU-CAPACITY-ADMISSION.md for when it's actually guaranteed. K8s backend: pair with --cpu-request for a guaranteed reservation.")
 	createCmd.Flags().StringVar(&memoryLimit, "memory", "4GB", "Memory limit (e.g., 4GB, 2048MB)")
 	createCmd.Flags().StringVar(&diskLimit, "disk", "50GB", "Disk limit (e.g., 50GB, 100GB)")
 	createCmd.Flags().StringVar(&staticIP, "static-ip", "", "Static IP address (e.g., 10.100.0.100) - empty for DHCP")

--- a/internal/cmd/resize.go
+++ b/internal/cmd/resize.go
@@ -50,11 +50,12 @@ Resource Limits:
   Disk:   Size with unit (e.g., 50GB, 100GB, 500GB)
 
 Notes:
-  - CPU: Raising --cpu is always safe to run, but it only raises the box's
-    ceiling. Whether it delivers any additional CPU depends on the host's
-    CPU admission gate (off by default) — see "CPU is a ceiling, not
-    automatically a floor" below before using resize as a remedy for a
-    slow box.
+  - CPU (LXC backend): raising --cpu always runs, but it only raises the
+    box's ceiling. Whether it delivers any additional CPU depends on the
+    host's CPU admission gate (off by default) — see "CPU is a ceiling,
+    not automatically a floor" below before using resize as a remedy for
+    a slow box. On the K8s backend the ceiling/floor split is instead
+    --cpu (limit) vs --cpu-request (reservation) — see below.
   - Memory: Check usage before decreasing (avoid OOM kills)
   - Disk: Can only increase (cannot shrink below usage)
   - LXC backend: all changes are instant with no downtime
@@ -65,14 +66,16 @@ Notes:
     reservation is unchanged even when --cpu/--memory move the ceiling.
     Ignored on the LXC backend.
 
-CPU is a ceiling, not automatically a floor:
+CPU is a ceiling, not automatically a floor (LXC backend):
   A box's declared CPU bounds what it may use, but on an oversubscribed
   host that says nothing about what it actually gets. "resize --cpu
   bigger" only helps if the host's CPU admission gate is enabled AND
   enforced AND its overcommit factor leaves headroom for the increase —
   otherwise the box was never CPU-starved by its own ceiling in the first
   place, and raising it changes nothing. See
-  docs/CPU-CAPACITY-ADMISSION.md for how to check and configure this.`,
+  docs/CPU-CAPACITY-ADMISSION.md for how to check and configure this.
+  On the K8s backend this gate does not apply; use --cpu-request instead
+  for a guaranteed reservation.`,
 	Args: cobra.ExactArgs(1),
 	RunE: runResize,
 }

--- a/internal/cmd/resize.go
+++ b/internal/cmd/resize.go
@@ -50,7 +50,11 @@ Resource Limits:
   Disk:   Size with unit (e.g., 50GB, 100GB, 500GB)
 
 Notes:
-  - CPU: Always safe to increase or decrease
+  - CPU: Raising --cpu is always safe to run, but it only raises the box's
+    ceiling. Whether it delivers any additional CPU depends on the host's
+    CPU admission gate (off by default) — see "CPU is a ceiling, not
+    automatically a floor" below before using resize as a remedy for a
+    slow box.
   - Memory: Check usage before decreasing (avoid OOM kills)
   - Disk: Can only increase (cannot shrink below usage)
   - LXC backend: all changes are instant with no downtime
@@ -59,7 +63,16 @@ Notes:
   - --cpu-request/--memory-request (K8s backend only): the scheduler
     reservation, separate from the ceiling. Left unspecified, the existing
     reservation is unchanged even when --cpu/--memory move the ceiling.
-    Ignored on the LXC backend.`,
+    Ignored on the LXC backend.
+
+CPU is a ceiling, not automatically a floor:
+  A box's declared CPU bounds what it may use, but on an oversubscribed
+  host that says nothing about what it actually gets. "resize --cpu
+  bigger" only helps if the host's CPU admission gate is enabled AND
+  enforced AND its overcommit factor leaves headroom for the increase —
+  otherwise the box was never CPU-starved by its own ceiling in the first
+  place, and raising it changes nothing. See
+  docs/CPU-CAPACITY-ADMISSION.md for how to check and configure this.`,
 	Args: cobra.ExactArgs(1),
 	RunE: runResize,
 }


### PR DESCRIPTION
## Summary

- `containarium resize --help` said "CPU: Always safe to increase or
  decrease" — true in that the operation always runs, but reads as though
  raising `--cpu` produces more CPU. It doesn't, unless the host's CPU
  admission gate is enabled, enforced, at a factor ≤1, with headroom left
  for core-infra. That fact lived only in `docs/CPU-CAPACITY-ADMISSION.md`,
  which an operator reaching for `resize --cpu` as a remedy has no reason to
  have read.
- `docs/CPU-CAPACITY-ADMISSION.md` gains a new top section ("When a declared
  CPU is a real floor, not just a ceiling") stating the floor's actual
  preconditions explicitly — matching the design doc's (#1578) corrected
  framing after independent review tightened the same claim. Also updates
  "Not covered here": the read-surface gap #1580 closes is done, replaced
  with the check-then-act race #1588 found instead.
- `resize --help` and `create --help` each gain a short section/note
  pointing at the doc, placed where an operator would read it at the exact
  point they'd reach for `--cpu`/`resize --cpu` as a remedy for a slow box.
- No behavior change — documentation and CLI help text only, per the
  issue's own scope.

## Test plan

Prose/help-text only, per the issue's own test plan. Confirmed no
golden/snapshot test exists over CLI `--help` output (`internal/cmd`'s test
suite doesn't assert on `Long` text). Verified by rendering both commands:

```
go run ./cmd/containarium resize --help
go run ./cmd/containarium create --help
```

```
go build ./... && go vet ./...   # clean
go test ./internal/cmd/...        # PASS
gofmt -l internal/                # clean
```

## Notes for reviewers

- References `SystemInfo.committed_cpu_cores` (#1580/PR #1591) — that field
  isn't merged yet as of this PR, but is expected to land first; the
  reference is accurate once it does. Flag if you'd rather this PR wait for
  #1591 to merge before referencing it by name.

Closes #1581

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that CPU ceilings and admission guarantees apply to the LXC/Incus backend.
  * Documented Kubernetes CPU requests as the mechanism for guaranteed reservations, separate from CPU limits.
  * Explained that practical CPU guarantees require enforced factors between 0 and 1, with sufficient infrastructure headroom.
  * Clarified that zero or negative factors disable admission.
  * Documented a concurrent check-then-act race that can affect creates and resizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->