### PR TITLE
fix(tls): ProvisionTLS must fail closed on a bad policy read, not POST a duplicate policy

### DIFF
--- a/internal/app/proxy.go
+++ b/internal/app/proxy.go
@@ -440,15 +440,28 @@ func (p *ProxyManager) ProvisionTLS(domain string) error {
 	}
 	defer resp.Body.Close()
 
+	// Anything other than 200 must abort. Treating a failed read as "this host
+	// has no policies" falls through to the create branch below, and POST to a
+	// Caddy admin API array path APPENDS — so a transient failure would graft a
+	// duplicate policy alongside the real ones rather than appending a subject
+	// to the existing one. Caddy matches the first policy whose subjects match,
+	// so a duplicate carrying different issuers can shadow the intended one
+	// (#1590).
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("caddy returned %d reading TLS policies: %s",
+			resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read TLS policies response: %w", err)
+	}
 	var policies []CaddyTLSAutomationPolicy
-	if resp.StatusCode == http.StatusOK {
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return fmt.Errorf("failed to read TLS policies response: %w", err)
-		}
-		if err := json.Unmarshal(body, &policies); err != nil {
-			return fmt.Errorf("failed to unmarshal TLS policies: %w", err)
-		}
+	// A TLS app that exists with no policies serializes as `null`, which
+	// unmarshals to a nil slice — not an error.
+	if err := json.Unmarshal(body, &policies); err != nil {
+		return fmt.Errorf("failed to unmarshal TLS policies: %w", err)
 	}
 
 	// Check if domain is already in a policy

--- a/internal/app/proxy_tls_policy_read_test.go
+++ b/internal/app/proxy_tls_policy_read_test.go
@@ -1,0 +1,87 @@
+package app
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// #1590: ProvisionTLS populated its policy slice only on a 200 and had no
+// else-branch, so any other status left the slice nil and control fell through
+// to the "no existing policies, create a new one" path. POST to a Caddy admin
+// API array path APPENDS, so a transient read failure (500/503, a proxy
+// hiccup, the admin API mid-reload) grafted a duplicate policy alongside the
+// real ones instead of appending a subject to the existing one.
+//
+// Duplicate policies aren't cosmetic: Caddy matches the first policy whose
+// subjects match, so a duplicate carrying different issuers can shadow the
+// intended one — and the caller got nil back either way.
+//
+// Same defect class fixed in EnsureTLSSubjects on #1589; this is the original.
+
+// askProxyOnPolicyGet serves a Caddy admin API whose TLS app reads fine but
+// whose policy read returns `status`, recording whether anything was written.
+func askProxyOnPolicyGet(t *testing.T, status int) (*ProxyManager, *bool) {
+	t.Helper()
+	wrote := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		// Report the TLS app as present so ensureTLSApp doesn't short-circuit
+		// into createTLSApp before we reach the policy read.
+		case r.URL.Path == "/config/apps/tls" && r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`{"automation":{"policies":[]}}`))
+		case r.URL.Path == "/config/apps/tls/automation/policies" && r.Method == http.MethodGet:
+			http.Error(w, "boom", status)
+		default:
+			wrote = true
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return NewProxyManager(srv.URL, "example.com"), &wrote
+}
+
+func TestProvisionTLS_ErrorsOnUnexpectedPolicyGetStatus(t *testing.T) {
+	for _, status := range []int{
+		http.StatusInternalServerError,
+		http.StatusServiceUnavailable,
+		http.StatusBadGateway,
+	} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			p, wrote := askProxyOnPolicyGet(t, status)
+
+			err := p.ProvisionTLS("app.example.com")
+			if err == nil {
+				t.Fatal("want an error when the policy read fails, got nil — falling through " +
+					"POSTs a duplicate policy that can shadow the real one (#1590)")
+			}
+			if *wrote {
+				t.Fatal("must not write configuration after a failed policy read")
+			}
+		})
+	}
+}
+
+// The success path must be untouched: a 200 still reads, appends, and writes.
+func TestProvisionTLS_StillAppendsOnHealthyRead(t *testing.T) {
+	srv, fc := newRWFakeCaddy(tlsConfigWithPolicy(
+		[]string{"other.example.com"},
+		[]CaddyTLSIssuer{NewACMEIssuer()},
+	))
+	defer srv.Close()
+
+	p := NewProxyManager(srv.URL, "example.com")
+
+	if err := p.ProvisionTLS("app.example.com"); err != nil {
+		t.Fatalf("ProvisionTLS: %v", err)
+	}
+
+	policies := readPolicies(t, fc)
+	if !hasSubject(policies, "app.example.com") {
+		t.Fatalf("subject not appended on the healthy path; subjects: %v", subjectsOf(policies))
+	}
+	if len(policies) != 1 {
+		t.Fatalf("want the subject appended to the existing policy, not a duplicate policy; got %d policies",
+			len(policies))
+	}
+}


### PR DESCRIPTION
Closes #1590

Follow-up to #1589, which fixed this same defect class in the new `EnsureTLSSubjects` but deliberately left the original instance alone to keep that PR scoped to #1584/#1585/#1586.

## The bug

`ProvisionTLS` populated its policy slice only on a `200`, with no `else`:

```go
var policies []CaddyTLSAutomationPolicy
if resp.StatusCode == http.StatusOK {
    // read + unmarshal
}
// ...falls through to: "no existing policies, create a new one" → POST
```

On any other status the slice stayed `nil` and control reached the create branch. POST to a Caddy admin-API array path **appends**, so a transient read failure — 500/503, a proxy hiccup, the admin API mid-reload — grafted a duplicate policy alongside the real ones rather than appending a subject to the existing one. The caller got `nil` back either way.

Duplicate policies aren't cosmetic: Caddy matches the first policy whose subjects match, so a duplicate carrying different issuers can shadow the intended one and quietly change how certificates are obtained for those hosts.

## What changed

Non-200 now returns an error and writes nothing. The 200 path is unchanged apart from hoisting the read out of the conditional.

## Test evidence

Written before the fix; both failed against the old code with the assertion message, not a compile error.

| Criterion | Test |
|---|---|
| 500 / 503 / 502 each return an error **and** write nothing | `TestProvisionTLS_ErrorsOnUnexpectedPolicyGetStatus` (table-driven) |
| Healthy read still appends to the existing policy, no duplicate | `TestProvisionTLS_StillAppendsOnHealthyRead` |

`go test ./internal/app/ -count=1` → `ok` locally; CI is the gate. No existing test modified or skipped.

## Review notes

- The write-detection in the test fixture asserts the *absence* of a write, which is the part that actually distinguishes this fix from "returns an error but still POSTed first".
- `TestProvisionTLS_StillAppendsOnHealthyRead` also asserts `len(policies) == 1`, so a regression that starts creating a second policy on the happy path fails too.
- No proto or generated code touched; no new dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * TLS provisioning now reports policy-read failures instead of proceeding with incomplete data.
  * Prevented duplicate TLS policies when policy retrieval encounters server errors.
  * Preserved correct behavior for successful policy reads, including appending to existing policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->