### PR TITLE
docs: stop claiming Caddy issues certificates on-demand — it never has

### DIFF
--- a/docs/APP-HOSTING-SUMMARY.md
+++ b/docs/APP-HOSTING-SUMMARY.md
@@ -61,7 +61,13 @@ Containarium's App Hosting feature enables users to deploy web applications dire
 
 ### TLS Certificate Management
 
-- **Automatic**: Caddy provisions Let's Encrypt certificates on-demand
+- **Automatic**: Caddy obtains Let's Encrypt certificates for hostnames the
+  daemon registers as TLS automation subjects — on `expose_port` / route
+  registration, or from the `*.<base-domain>` wildcard. This is *not*
+  on-demand issuance: Caddy's `on_demand` mode is not enabled anywhere in
+  this codebase (see #1586), so a hostname the daemon never registers gets
+  no certificate and fails the TLS handshake rather than being minted on
+  first request.
 - **Zero configuration**: No manual certificate management needed
 - **Auto-renewal**: Certificates renewed before expiration
 - **Storage**: Certificates stored in Caddy's persistent volume

--- a/examples/helloworld-python/README.md
+++ b/examples/helloworld-python/README.md
@@ -39,7 +39,11 @@ mcp__<your-cluster>__expose_port(
 )
 ```
 
-That's it. The first request to `https://helloworld.demo.containarium.dev/` will trigger Caddy's ACME-on-demand to mint the cert, then proxy through to the Python server.
+That's it. Registering the route also registers the hostname as a Caddy TLS
+automation subject, so Caddy obtains the certificate for it (or it's already
+covered by the cluster's `*.<base-domain>` wildcard) and proxies through to the
+Python server. Certificates come from that registration, not from issuance on
+first request — Caddy's ACME-on-demand mode is not enabled (see #1586).
 
 ### Via CLI
 


### PR DESCRIPTION
Part of the OSS half of FootprintAI/Containarium-cloud#1344. Follows #1586, which documented the same gap in code comments.

## The problem

Two documents told readers that certificates are minted lazily on first request. They aren't, and never have been.

Caddy's `on_demand` mode is not enabled anywhere in this codebase:

- `CaddyTLSAutomationPolicy.OnDemand` (`internal/app/caddy_types.go:170`) is declared and never assigned — and with `omitempty` on a `bool`, `false` never even serializes.
- `CaddyTLSAutomation` (`internal/app/caddy_types.go:203-206`) has exactly one field, `Policies`. It **cannot express** the automation-level `on_demand: {ask: "..."}` block that Caddy requires alongside the per-policy flag, so the one field that does exist could not be used on its own even if something set it.

Certificates come only from explicit TLS automation subjects written at route registration (`ProvisionTLS`), plus the `*.<base-domain>` wildcard.

## What changed

| File | Was | Why it mattered |
|---|---|---|
| `docs/APP-HOSTING-SUMMARY.md` | "Caddy provisions Let's Encrypt certificates on-demand" | Misdescribes the mechanism; invites BYOD/custom-domain designs that assume first-request issuance |
| `examples/helloworld-python/README.md` | "The first request … will trigger Caddy's ACME-on-demand to mint the cert" | **Actively misleading** — anyone following this example for a hostname the daemon hasn't registered gets a TLS handshake failure (`alert 80`, no peer certificate), which is exactly the #1584 symptom |

Both now describe the real mechanism and name the constraint.

## Review notes

- Docs only — no code, no tests, no behaviour change.
- The `#1586` cross-references point at the issue that established the finding, so a future reader who wants on-demand has the thread.
- **Not addressed here:** whether on-demand *should* be wired. That's the open question on Containarium-cloud#1344, where a fully-built `/internal/tls-allow` ask hook has been waiting for a caller that doesn't exist. Enabling it would reverse the deliberate choice recorded in `ProvisionWildcardTLS`'s doc comment, which names the wildcard as "the per-cluster alternative to per-subdomain on-demand issuance" chosen to eliminate Let's Encrypt rate-limit exposure (#378).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that TLS certificates are issued only for registered routes and the base-domain wildcard.
  * Documented that on-demand certificate issuance is disabled.
  * Noted that unregistered hostnames fail the TLS handshake rather than receiving certificates on first request.
  * Updated deployment guidance to explain when certificates are obtained during route registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->