### PR TITLE
docs(cpu-admission): fix K8s CPU-request wording merged before review finished

### DIFF
--- a/docs/CPU-CAPACITY-ADMISSION.md
+++ b/docs/CPU-CAPACITY-ADMISSION.md
@@ -16,7 +16,7 @@ advisory mode, logged) if it would push the host's committed cores past
 **This section is about the LXC/Incus backend specifically** — the runtime
 this gate applies to (see "Runtime" under "Semantics and scope" below; on
 K8s the gate no-ops entirely, and the analogous concept is the backend's own
-`--cpu-request`/`limits.requests.cpu` split, a separate mechanism, not this
+`--cpu-request`/`resources.requests.cpu` split, a separate mechanism, not this
 gate).
 
 On LXC/Incus, a box's `--cpu` (or `resize --cpu`) always bounds a *ceiling* —

--- a/docs/CPU-CAPACITY-ADMISSION.md
+++ b/docs/CPU-CAPACITY-ADMISSION.md
@@ -108,6 +108,13 @@ the network-policy engine was rolled out — observe first:
   actually creates the box. A pool/peer-routed create is forwarded to the target
   peer's own daemon, which runs *its* gate against *its* host — so no
   cross-host capacity view is needed, and each host enforces its own ceiling.
+- **Daemon-only — local CLI mode never runs it.** `containarium create`/
+  `resize` invoked without `--server` talks to Incus directly
+  (`internal/cmd/create.go`'s `createLocal`, `resize.go`'s
+  `runResizeLocal`) and never reaches the daemon's gRPC handlers this gate
+  lives in. A local-mode create/resize is not subject to this gate at all,
+  regardless of how it's configured — only requests that actually go
+  through a daemon (`--server ...`) are gated.
 - **What counts as committed.** The sum of every tenant container's committed
   cores (`CommittedCores` over its `limits.cpu` / `limits.cpu.allowance`). Two
   exclusions: **core-infra** containers (platform Postgres/Caddy — not tenant

--- a/internal/cmd/create.go
+++ b/internal/cmd/create.go
@@ -87,11 +87,14 @@ Examples:
   # Force recreate if container already exists
   containarium create alice --ssh-key ~/.ssh/id_rsa.pub --force
 
-Note on --cpu (LXC backend): it sets a ceiling this box may not exceed, not
-automatically a guaranteed floor. On a host without the CPU admission gate
-enabled and enforced (the default), a declared --cpu can go unmet under
-contention from other boxes — see docs/CPU-CAPACITY-ADMISSION.md for when
-it becomes a real guarantee and how to configure it. On the K8s backend,
+Note on --cpu (LXC backend, --server/daemon mode): it sets a ceiling this
+box may not exceed, not automatically a guaranteed floor. On a host without
+the CPU admission gate enabled and enforced (the default), a declared --cpu
+can go unmet under contention from other boxes — see
+docs/CPU-CAPACITY-ADMISSION.md for when it becomes a real guarantee and how
+to configure it. Local mode (no --server) talks to Incus directly and never
+goes through the daemon, so this gate does not apply there regardless of
+configuration. On the K8s backend,
 --cpu-request (a separate flag, mirrored on resize) is the mechanism for a
 scheduling reservation instead — Kubernetes uses it for placement and
 relative CPU weighting under contention, not as a hard runtime floor

--- a/internal/cmd/create.go
+++ b/internal/cmd/create.go
@@ -93,7 +93,9 @@ enabled and enforced (the default), a declared --cpu can go unmet under
 contention from other boxes — see docs/CPU-CAPACITY-ADMISSION.md for when
 it becomes a real guarantee and how to configure it. On the K8s backend,
 --cpu-request (a separate flag, mirrored on resize) is the mechanism for a
-guaranteed reservation instead.`,
+scheduling reservation instead — Kubernetes uses it for placement and
+relative CPU weighting under contention, not as a hard runtime floor
+(--cpu / resources.limits.cpu remains the runtime ceiling either way).`,
 	Args: cobra.ExactArgs(1),
 	RunE: runCreate,
 }
@@ -142,7 +144,7 @@ func init() {
 	// with --no-ssh-key. Enforce "exactly one of the two" in runCreate (cobra's
 	// MarkFlagRequired can't express the either/or).
 	createCmd.MarkFlagsMutuallyExclusive("ssh-key", "no-ssh-key")
-	createCmd.Flags().StringVar(&cpuLimit, "cpu", "4", "CPU limit (number of cores). LXC backend: a ceiling, not automatically a floor — see docs/CPU-CAPACITY-ADMISSION.md for when it's actually guaranteed. K8s backend: pair with --cpu-request for a guaranteed reservation.")
+	createCmd.Flags().StringVar(&cpuLimit, "cpu", "4", "CPU limit (number of cores). LXC backend: a ceiling, not automatically a floor — see docs/CPU-CAPACITY-ADMISSION.md for when it's actually guaranteed. K8s backend: pair with --cpu-request for a scheduling reservation (not a runtime floor).")
 	createCmd.Flags().StringVar(&memoryLimit, "memory", "4GB", "Memory limit (e.g., 4GB, 2048MB)")
 	createCmd.Flags().StringVar(&diskLimit, "disk", "50GB", "Disk limit (e.g., 50GB, 100GB)")
 	createCmd.Flags().StringVar(&staticIP, "static-ip", "", "Static IP address (e.g., 10.100.0.100) - empty for DHCP")

--- a/internal/cmd/resize.go
+++ b/internal/cmd/resize.go
@@ -50,12 +50,14 @@ Resource Limits:
   Disk:   Size with unit (e.g., 50GB, 100GB, 500GB)
 
 Notes:
-  - CPU (LXC backend): raising --cpu always runs, but it only raises the
-    box's ceiling. Whether it delivers any additional CPU depends on the
-    host's CPU admission gate (off by default) — see "CPU is a ceiling,
-    not automatically a floor" below before using resize as a remedy for
-    a slow box. On the K8s backend the ceiling/floor split is instead
-    --cpu (limit) vs --cpu-request (reservation) — see below.
+  - CPU (LXC backend): raising --cpu is subject to the CPU admission gate
+    (off by default) — an enforced, over-ceiling resize is rejected; when
+    the gate is off, it only raises the box's ceiling and whether that
+    delivers any additional CPU depends on the same gate — see "CPU is a
+    ceiling, not automatically a floor" below before using resize as a
+    remedy for a slow box. On the K8s backend the ceiling/reservation
+    split is instead --cpu (limit) vs --cpu-request (reservation) — see
+    below.
   - Memory: Check usage before decreasing (avoid OOM kills)
   - Disk: Can only increase (cannot shrink below usage)
   - LXC backend: all changes are instant with no downtime
@@ -75,7 +77,8 @@ CPU is a ceiling, not automatically a floor (LXC backend):
   place, and raising it changes nothing. See
   docs/CPU-CAPACITY-ADMISSION.md for how to check and configure this.
   On the K8s backend this gate does not apply; use --cpu-request instead
-  for a guaranteed reservation.`,
+  for a scheduling reservation (placement and relative weighting under
+  contention, not a hard runtime floor).`,
 	Args: cobra.ExactArgs(1),
 	RunE: runResize,
 }

--- a/internal/cmd/resize.go
+++ b/internal/cmd/resize.go
@@ -50,14 +50,16 @@ Resource Limits:
   Disk:   Size with unit (e.g., 50GB, 100GB, 500GB)
 
 Notes:
-  - CPU (LXC backend): raising --cpu is subject to the CPU admission gate
-    (off by default) — an enforced, over-ceiling resize is rejected; when
-    the gate is off, it only raises the box's ceiling and whether that
-    delivers any additional CPU depends on the same gate — see "CPU is a
-    ceiling, not automatically a floor" below before using resize as a
-    remedy for a slow box. On the K8s backend the ceiling/reservation
-    split is instead --cpu (limit) vs --cpu-request (reservation) — see
-    below.
+  - CPU (LXC backend, --server/daemon mode): raising --cpu is subject to
+    the CPU admission gate (off by default) — an enforced, over-ceiling
+    resize is rejected; when the gate is off, it only raises the box's
+    ceiling and whether that delivers any additional CPU depends on the
+    same gate — see "CPU is a ceiling, not automatically a floor" below
+    before using resize as a remedy for a slow box. Local mode (no
+    --server) talks to Incus directly and never goes through the daemon,
+    so this gate does not apply there regardless of configuration. On the
+    K8s backend the ceiling/reservation split is instead --cpu (limit) vs
+    --cpu-request (reservation) — see below.
   - Memory: Check usage before decreasing (avoid OOM kills)
   - Disk: Can only increase (cannot shrink below usage)
   - LXC backend: all changes are instant with no downtime
@@ -68,7 +70,8 @@ Notes:
     reservation is unchanged even when --cpu/--memory move the ceiling.
     Ignored on the LXC backend.
 
-CPU is a ceiling, not automatically a floor (LXC backend):
+CPU is a ceiling, not automatically a floor (LXC backend, --server/daemon
+mode — local mode never runs this gate):
   A box's declared CPU bounds what it may use, but on an oversubscribed
   host that says nothing about what it actually gets. "resize --cpu
   bigger" only helps if the host's CPU admission gate is enabled AND


### PR DESCRIPTION
## Summary

PR #1592 was merged (apparently by an earlier `--auto` attempt) at commit
`eff08ea`, before a second CodeRabbit review pass on that same PR finished
and before I could push its fixes — so the 3 findings from that second pass
never made it into main. This PR carries just that fix commit, cherry-picked
onto current main.

CodeRabbit's second-pass findings, all verified valid:

- `limits.requests.cpu` isn't a real Kubernetes resource path — corrected to
  `resources.requests.cpu`.
- "guaranteed reservation" overstated what K8s `--cpu-request` gives: per
  Kubernetes' own docs, requests drive scheduling and relative CPU weight
  under contention, not a hard runtime floor — reworded to "scheduling
  reservation" at all three flagged locations, with a one-clause
  explanation of what that actually means.
- "raising --cpu always runs" stopped being true once #1579/#1587 merged:
  `ResizeContainer`'s LXC path now routes CPU increases through the
  admission gate, and an enforced over-ceiling resize is rejected. Reworded
  to state the resize is subject to the gate, not exempt from it.

No behavior change — documentation and CLI help text only, same as #1592's
own scope.

## Test plan

```
go build ./... && go vet ./...   # clean
go test ./internal/cmd/...        # PASS
gofmt -l internal/ docs/          # clean
```

Verified by rendering `containarium resize --help` and `containarium create
--help` with the corrected wording.

Related to #1581 (already closed by #1592 — this is a same-scope follow-up
correction, not new scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that Kubernetes CPU requests reserve scheduling capacity and influence contention weighting, but do not guarantee runtime CPU.
  - Confirmed that CPU limits define the runtime ceiling.
  - Documented that CPU admission checks apply to daemon-mediated create and resize operations only; local operations bypass these checks.
  - Clarified that LXC CPU increases may be rejected when they exceed the enforced capacity ceiling.
  - Corrected the Kubernetes CPU request reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->