### PR TITLE
fix(sentinel): self-check must send a full ClientHello, not one byte — v0.68.0 crash-looped every sentinel

### DIFF
--- a/internal/sentinel/manager.go
+++ b/internal/sentinel/manager.go
@@ -1034,13 +1034,35 @@ func (m *Manager) startHTTPSProxy(backendIP string) {
 	log.Printf("[sentinel] HTTPS proxy started → fallback %s (SNI routing via primary registry)", fallback)
 }
 
+// selfCheckSNI is the ServerName the self-check probe presents. It is
+// deliberately unroutable (`.invalid` is reserved by RFC 2606) so the probe
+// exercises the SNI peek and routing decision without ever being forwarded
+// to a real backend — the pipeline reacts, no tenant connection is opened.
+const selfCheckSNI = "sentinel-self-check.invalid"
+
 // selfCheckProxyPath dials the sentinel's own HTTPS listener and verifies
 // the ConnMux → dispatch → routing pipeline actually reacts within timeout.
-// It does not care WHAT the pipeline does with the probe (forward the byte,
-// fail the SNI peek, dial-timeout to a fallback and close) — only that
-// something happens. A read that hits its own deadline with no data, EOF,
-// or reset is exactly the wedge this exists to catch: the listener is alive
-// (TCP accepts succeed) but nothing downstream is servicing connections.
+// It does not care WHAT the pipeline decides (complete a handshake, refuse
+// with a TLS alert, fail the SNI lookup and close) — only that something
+// happens. A handshake that hits its deadline with no reaction at all is the
+// wedge this exists to catch: the listener is alive (TCP accepts succeed) but
+// nothing downstream is servicing connections.
+//
+// The probe sends a complete TLS ClientHello, not a fragment (#1598). It
+// previously wrote a single record-layer byte (0x16) and waited to read one
+// back — but a TLS server handed one byte of a record header does exactly
+// what it should: it waits for the rest of the ClientHello. It neither
+// responds nor closes, so the probe timed out against a perfectly healthy
+// pipeline and the sentinel killed itself every ~2 minutes. Letting
+// crypto/tls compose the ClientHello gives the pipeline something it can
+// actually act on, so "no reaction" once again means what it claims to.
+//
+// The two failure kinds are kept distinct:
+//   - a TCP dial failure means our own listener is gone — reported as-is
+//   - a handshake timeout means accepted-but-not-serviced — the wedge
+//
+// Any other handshake outcome, including a certificate or protocol error, is
+// proof of life and reports healthy.
 func (m *Manager) selfCheckProxyPath(timeout time.Duration) error {
 	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(m.config.HTTPSPort))
 	conn, err := net.DialTimeout("tcp", addr, timeout)
@@ -1050,22 +1072,23 @@ func (m *Manager) selfCheckProxyPath(timeout time.Duration) error {
 	defer func() { _ = conn.Close() }()
 
 	_ = conn.SetDeadline(time.Now().Add(timeout))
-	// A single TLS record-layer byte (0x16) so ConnMux.route() sends this
-	// down the HTTPS path rather than mistaking it for a tunnel handshake
-	// (which starts with '{').
-	if _, err := conn.Write([]byte{0x16}); err != nil {
-		return fmt.Errorf("write probe: %w", err)
-	}
 
-	buf := make([]byte, 1)
-	if _, err := conn.Read(buf); err != nil {
+	// InsecureSkipVerify is correct here and not a weakening: this is a
+	// liveness probe against our own loopback listener that sends no data
+	// and reads no response body. Verifying the peer would make the probe
+	// fail on exactly the certificate problems it is not measuring — and
+	// during an incident the served cert may legitimately be a fallback.
+	tlsConn := tls.Client(conn, &tls.Config{
+		ServerName:         selfCheckSNI,
+		InsecureSkipVerify: true, // #nosec G402 -- liveness probe, see above
+	})
+	if err := tlsConn.Handshake(); err != nil {
 		var netErr net.Error
 		if errors.As(err, &netErr) && netErr.Timeout() {
 			return fmt.Errorf("proxy path unresponsive after %s: %w", timeout, err)
 		}
-		// Any other outcome (EOF, connection reset, a real backend
-		// response) proves the pipeline reacted within the deadline —
-		// only a hard timeout indicates the wedge.
+		// Alert, EOF, reset, unknown-SNI refusal: the pipeline serviced the
+		// connection within the deadline, which is all this probe asserts.
 	}
 	return nil
 }

--- a/internal/sentinel/self_check_clienthello_test.go
+++ b/internal/sentinel/self_check_clienthello_test.go
@@ -51,7 +51,7 @@ func TestSelfCheckProxyPath_HealthyTLSServerIsNotAWedge(t *testing.T) {
 // Accepts TCP, never reads, never writes.
 func TestSelfCheckProxyPath_WedgedListenerStillDetected(t *testing.T) {
 	w := newWedgedListener(t)
-	defer w.Close()
+	defer func() { _ = w.Close() }()
 
 	m := selfCheckManager(w.port)
 
@@ -73,7 +73,7 @@ func TestSelfCheckProxyPath_ImmediateCloseIsHealthy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 	go func() {
 		for {
 			conn, err := ln.Accept()
@@ -98,7 +98,7 @@ func TestSelfCheckProxyPath_TLSAlertIsHealthy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 	go func() {
 		for {
 			conn, err := ln.Accept()
@@ -106,7 +106,7 @@ func TestSelfCheckProxyPath_TLSAlertIsHealthy(t *testing.T) {
 				return
 			}
 			go func(c net.Conn) {
-				defer c.Close()
+				defer func() { _ = c.Close() }()
 				// A tls.Server with no certificates reads the ClientHello
 				// and answers with a handshake failure alert.
 				_ = tls.Server(c, &tls.Config{}).Handshake()

--- a/internal/sentinel/self_check_clienthello_test.go
+++ b/internal/sentinel/self_check_clienthello_test.go
@@ -1,0 +1,139 @@
+package sentinel
+
+import (
+	"crypto/tls"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// #1598: selfCheckProxyPath wrote a SINGLE TLS record-layer byte (0x16) and
+// then waited to read a byte back, treating a read timeout as "the proxy
+// pipeline is wedged". Three consecutive failures exit the process.
+//
+// A TLS server handed one byte of a record header does the correct thing:
+// it waits for the rest of the ClientHello. It does not respond, and it does
+// not EOF — so the probe timed out against a perfectly healthy pipeline,
+// and the sentinel killed itself every ~2 minutes. In production both
+// sentinels reached NRestarts=43 and 20 within minutes of v0.68.0, and while
+// looping they served a self-signed fallback certificate to every visitor.
+//
+// The probe has to send something a TLS server can actually act on. These
+// tests pin that: a real TLS peer must read as healthy, and only a genuine
+// wedge (accepts TCP, nothing downstream ever services the connection) may
+// be reported as a failure.
+
+// selfCheckManager builds a Manager whose self-check probes the given port.
+func selfCheckManager(port int) *Manager {
+	return &Manager{config: Config{HTTPSPort: port}}
+}
+
+// THE regression: a real TLS server. Under the one-byte probe this timed out,
+// because the server was still waiting for the rest of the ClientHello.
+func TestSelfCheckProxyPath_HealthyTLSServerIsNotAWedge(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	port := srv.Listener.Addr().(*net.TCPAddr).Port
+	m := selfCheckManager(port)
+
+	if err := m.selfCheckProxyPath(5 * time.Second); err != nil {
+		t.Fatalf("healthy TLS server reported as wedged (#1598): %v", err)
+	}
+}
+
+// A genuine wedge must still be caught — that is the whole point of #1512.
+// Accepts TCP, never reads, never writes.
+func TestSelfCheckProxyPath_WedgedListenerStillDetected(t *testing.T) {
+	w := newWedgedListener(t)
+	defer w.Close()
+
+	m := selfCheckManager(w.port)
+
+	err := m.selfCheckProxyPath(1500 * time.Millisecond)
+	if err == nil {
+		t.Fatal("a wedged pipeline must be reported as a failure — this is the condition " +
+			"the self-check exists to catch (#1512)")
+	}
+	if !strings.Contains(err.Error(), "unresponsive") {
+		t.Errorf("want an 'unresponsive' wedge error, got: %v", err)
+	}
+}
+
+// A peer that reacts by closing the connection is healthy, not wedged: the
+// pipeline demonstrably serviced the connection. This is what an SNI router
+// does when it cannot route the requested name.
+func TestSelfCheckProxyPath_ImmediateCloseIsHealthy(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+
+	m := selfCheckManager(ln.Addr().(*net.TCPAddr).Port)
+
+	if err := m.selfCheckProxyPath(3 * time.Second); err != nil {
+		t.Fatalf("a peer that closes the connection reacted, so it is not a wedge: %v", err)
+	}
+}
+
+// A peer that reads the ClientHello and replies with a TLS alert has also
+// reacted. Only a timeout means wedged — an alert is a healthy refusal.
+func TestSelfCheckProxyPath_TLSAlertIsHealthy(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				// A tls.Server with no certificates reads the ClientHello
+				// and answers with a handshake failure alert.
+				_ = tls.Server(c, &tls.Config{}).Handshake()
+			}(conn)
+		}
+	}()
+
+	m := selfCheckManager(ln.Addr().(*net.TCPAddr).Port)
+
+	if err := m.selfCheckProxyPath(3 * time.Second); err != nil {
+		t.Fatalf("a TLS alert is a reaction, not a wedge: %v", err)
+	}
+}
+
+// Nothing listening at all is a dial failure, not a pipeline wedge, but it
+// must still surface as an error rather than a false pass.
+func TestSelfCheckProxyPath_NoListenerIsAnError(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close() // free the port so the dial is refused
+
+	m := selfCheckManager(port)
+
+	if err := m.selfCheckProxyPath(2 * time.Second); err == nil {
+		t.Fatal("dialing a closed port must report an error")
+	}
+}


### PR DESCRIPTION
Closes #1598

## The bug

`selfCheckProxyPath` (added in #1512) wrote **one** TLS record-layer byte and waited to read one back:

```go
conn.Write([]byte{0x16})     // a single record-layer byte
buf := make([]byte, 1)
conn.Read(buf)               // a timeout here == "the pipeline is wedged"
```

A TLS server handed one byte of a record header does exactly the right thing: **it waits for the rest of the ClientHello.** It doesn't respond, and it doesn't close. So the probe timed out against a perfectly healthy pipeline, and three consecutive timeouts exit the process.

In production both sentinels reached `NRestarts=43` and `20` within minutes of v0.68.0, restarting roughly every two minutes. While looping, the sentinel terminated TLS itself with the self-signed `O=Containarium Sentinel` fallback certificate — so every visitor to every sentinel-fronted hostname got a `NET::ERR_CERT_AUTHORITY_INVALID` interstitial. That is how it was found: a user reported the browser warning.

The check reported the backend healthy seconds before each suicide:

```
[sentinel] backend tunnel-containarium-byoc-1 (127.0.0.72) is healthy
[sentinel] self-check failed (2/3 consecutive): proxy path unresponsive after 20s
```

## The fix

Let `crypto/tls` compose a complete ClientHello, so the pipeline has something it can actually act on. The ServerName is a deliberately unroutable `.invalid` name (RFC 2606), so the probe exercises the SNI peek and routing decision **without ever being forwarded to a real backend** — no tenant connection is opened per check.

The two failure kinds are now distinct, which a single read could not express:

| Outcome | Verdict |
|---|---|
| TCP dial fails | error — our own listener is gone |
| Handshake times out | **wedge** — accepted but never serviced (what #1512 targets) |
| TLS alert / EOF / reset / unknown-SNI refusal | healthy — the pipeline reacted |
| Handshake completes | healthy |

`InsecureSkipVerify` is set with a `#nosec G402` and a comment: this is a liveness probe against our own loopback listener that sends no data and reads no body. Verifying the peer would make it fail on the certificate problems it is not measuring — and during an incident the served cert may legitimately *be* the fallback.

## Test evidence

Written before the fix. `TestSelfCheckProxyPath_HealthyTLSServerIsNotAWedge` reproduces the production outage in a unit test — it fails against the old code with the exact production error string:

```
healthy TLS server reported as wedged (#1598):
  proxy path unresponsive after 5s: read tcp 127.0.0.1:...: i/o timeout
```

| Criterion | Test |
|---|---|
| A real TLS peer is not a wedge (the regression) | `TestSelfCheckProxyPath_HealthyTLSServerIsNotAWedge` |
| A genuine wedge is still caught (#1512 preserved) | `TestSelfCheckProxyPath_WedgedListenerStillDetected` |
| Immediate close is a reaction, not a wedge | `TestSelfCheckProxyPath_ImmediateCloseIsHealthy` |
| TLS alert is a reaction, not a wedge | `TestSelfCheckProxyPath_TLSAlertIsHealthy` |
| No listener still errors (not a false pass) | `TestSelfCheckProxyPath_NoListenerIsAnError` |

Full `internal/sentinel` package green locally (`26.9s`), including the existing #1512 self-check suite — no existing test modified or skipped. CI is the gate.

**Mutation-verified**: stubbing out the timeout branch (so the probe can never report a wedge) fails `TestSelfCheckProxyPath_WedgedListenerStillDetected`. The detection #1512 added is genuinely still under test, not just passing because the check went permissive.

## Review notes

- **Look first at** the dial/handshake split — it's what lets "our listener is gone" and "our listener is wedged" stay separate verdicts.
- The `#nosec G402` is deliberate and justified inline; flag it if you disagree.
- Not changed: `SelfCheckFailureThreshold`, the 20s timeout, or the exit-on-threshold behaviour. The mechanism was sound; only the probe was wrong.

## Deployment

Both production sentinels are currently rolled back to **v0.66.0** and stable. v0.68.0's release notes carry a `[!CAUTION]` block warning against sentinel deployment; that should be removed once a release carrying this fix supersedes it. Primaries were unaffected throughout and remain on v0.68.0.

## Separately worth considering

Failing open onto a self-signed certificate turns any sentinel fault into a fleet-wide trust failure, and a cert-authority warning is indistinguishable from a real attack — it teaches users to click through. Refusing the connection would be a better failure mode. Noted in #1598; out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proxy self-checks to more accurately distinguish unresponsive HTTPS pipelines from healthy connections that close, refuse, or return TLS alerts.
  * Reduced false positives when evaluating TLS connection responsiveness.

* **Tests**
  * Added coverage for healthy TLS servers, stalled listeners, immediate closures, TLS alerts, and refused connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->