### PR TITLE
fix(release): stop clobbering hand-written release notes, and give every release a real changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,8 +97,14 @@ jobs:
         # Categorised from conventional-commit subjects since the previous
         # tag; anything not following the convention still lands in "Other"
         # so nothing is silently dropped.
+        env:
+          # github.ref_name is attacker-controllable (a tag name may contain
+          # shell metacharacters). Routing it through env makes the shell treat
+          # it as data; interpolating ${{ }} straight into a run block would
+          # let a crafted tag execute commands on the runner.
+          RELEASE_REF: ${{ github.ref_name }}
         run: |
-          REF="${{ github.ref_name }}"
+          REF="$RELEASE_REF"
           git rev-parse -q --verify "refs/tags/$REF" >/dev/null 2>&1 || REF=HEAD
           PREV="$(git describe --tags --abbrev=0 "${REF}^" 2>/dev/null || true)"
           if [ -n "$PREV" ]; then RANGE="${PREV}..${REF}"; else RANGE="$REF"; fi
@@ -219,7 +225,14 @@ jobs:
 
           # Changelog first, boilerplate under it — a reader wants to know
           # what changed before they read install instructions (#1600).
-          cat release_changelog.md release_notes.md > release_notes.combined.md
+          # Wrapped in markers so a workflow rerun REPLACES this block rather
+          # than appending a second copy (see "Apply release notes" below).
+          {
+            printf '%s\n' '<!-- generated-release-notes:start -->'
+            cat release_changelog.md
+            cat release_notes.md
+            printf '%s\n' '<!-- generated-release-notes:end -->'
+          } > release_notes.combined.md
           mv release_notes.combined.md release_notes.md
 
       - name: Create GitHub Release
@@ -230,12 +243,10 @@ jobs:
         with:
           tag_name: ${{ github.ref_name }}
           name: Containarium ${{ github.ref_name }}
-          body_path: release_notes.md
-          # Without this the action REPLACES the release body, silently
-          # destroying notes an author wrote at publish time — whoever wrote
-          # last won, and that depended on how long the build took (#1600).
-          # Same reasoning as append_files on the bundle job below.
-          append_body: true
+          # Deliberately no body/body_path here. This action REPLACES the body
+          # on update, which silently destroyed notes an author wrote at
+          # publish time (#1600), and append_body instead duplicates the block
+          # on any rerun. The body is composed idempotently in the next step.
           files: |
             bin/containarium-linux-amd64
             bin/containarium-darwin-amd64
@@ -251,6 +262,49 @@ jobs:
             bin/SHA256SUMS.txt
           draft: false
           prerelease: false
+
+      - name: Apply release notes
+        # Composes the release body idempotently (#1600).
+        #
+        # Two failure modes this avoids:
+        #   - REPLACING the body (what action-gh-release does by default)
+        #     silently destroyed notes an author wrote at publish time.
+        #   - APPENDING it (append_body: true) duplicates the whole generated
+        #     block on any workflow rerun for the same tag.
+        #
+        # So: strip any previously-generated block by its markers, keep
+        # everything else the author put there, and append a fresh block.
+        # Rerunning converges on the same body instead of growing it.
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # Untrusted: a tag name may contain shell metacharacters.
+          RELEASE_REF: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          gh release view "$RELEASE_REF" --json body --jq '.body' > existing_body.md 2>/dev/null || : > existing_body.md
+
+          # Drop a prior generated block, if this is a rerun.
+          python3 - <<'PYEOF' > preserved.md
+          import re
+          try:
+              body = open('existing_body.md').read()
+          except FileNotFoundError:
+              body = ''
+          body = re.sub(
+              r'<!-- generated-release-notes:start -->.*?<!-- generated-release-notes:end -->\n?',
+              '', body, flags=re.S)
+          print(body.rstrip())
+          PYEOF
+
+          if [ -s preserved.md ]; then
+            printf '\n\n' >> preserved.md
+          fi
+          cat preserved.md release_notes.md > final_body.md
+
+          gh release edit "$RELEASE_REF" --notes-file final_body.md
+          echo "release body applied ($(wc -l < final_body.md) lines; preserved $(wc -l < preserved.md) authored)"
 
   # Air-gapped install bundle (E3a/E3b).
   # Per prd/cloud/air-gapped-install-bundle.md, ship a self-contained

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -283,11 +283,16 @@ jobs:
         run: |
           set -euo pipefail
 
-          gh release view "$RELEASE_REF" --json body --jq '.body' > existing_body.md 2>/dev/null || : > existing_body.md
+          # Deliberately NOT tolerant of failure. The release was created by
+          # the step above, so a read error here is anomalous — and treating
+          # it as "empty body" would overwrite authored notes with generated
+          # ones, which is the exact data loss #1600 is about. Fail instead;
+          # a rerun is idempotent and safe.
+          gh release view "$RELEASE_REF" --json body --jq '.body' > existing_body.md
 
           # Drop a prior generated block, if this is a rerun.
           python3 - <<'PYEOF' > preserved.md
-          import re
+          import re, sys
           try:
               body = open('existing_body.md').read()
           except FileNotFoundError:
@@ -295,7 +300,10 @@ jobs:
           body = re.sub(
               r'<!-- generated-release-notes:start -->.*?<!-- generated-release-notes:end -->\n?',
               '', body, flags=re.S)
-          print(body.rstrip())
+          # write(), not print(): print's trailing newline would make an empty
+          # body a 1-byte file that passes the -s test below, producing three
+          # blank lines above the generated block.
+          sys.stdout.write(body.rstrip())
           PYEOF
 
           if [ -s preserved.md ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          # Full history + tags: the changelog step below diffs this ref
+          # against the previous tag, which a depth-1 clone cannot see.
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v7
@@ -86,6 +90,47 @@ jobs:
         # Produces bin/agent-runtime-bundle.tar.gz, pulled in-box by
         # scripts/install-agent-runtime.sh alongside agent-box-linux-amd64.
         run: make bundle-agent-runtime
+
+      - name: Generate changelog
+        # The boilerplate below is identical on every release, so without
+        # this a release page never says what actually changed in it (#1600).
+        # Categorised from conventional-commit subjects since the previous
+        # tag; anything not following the convention still lands in "Other"
+        # so nothing is silently dropped.
+        run: |
+          REF="${{ github.ref_name }}"
+          git rev-parse -q --verify "refs/tags/$REF" >/dev/null 2>&1 || REF=HEAD
+          PREV="$(git describe --tags --abbrev=0 "${REF}^" 2>/dev/null || true)"
+          if [ -n "$PREV" ]; then RANGE="${PREV}..${REF}"; else RANGE="$REF"; fi
+
+          emit() {
+            out="$(git log --no-merges --pretty=format:'%s' $RANGE 2>/dev/null | grep -E "$2" || true)"
+            [ -z "$out" ] && return 0
+            printf '### %s\n\n' "$1"
+            printf '%s\n' "$out" | sed -E 's/^[a-z]+(\([^)]*\))?!?: *//' | sed 's/^/- /'
+            printf '\n'
+          }
+
+          {
+            printf '## What changed\n\n'
+            emit "Added"         '^feat(\(|:|!)'
+            emit "Fixed"         '^fix(\(|:|!)'
+            emit "Documentation" '^docs(\(|:|!)'
+            emit "Internal"      '^(chore|refactor|test|ci|build|perf)(\(|:|!)'
+            OTHER="$(git log --no-merges --pretty=format:'%s' $RANGE 2>/dev/null | grep -vE '^(feat|fix|docs|chore|refactor|test|ci|build|perf)(\(|:|!)' || true)"
+            if [ -n "$OTHER" ]; then
+              printf '### Other\n\n'
+              printf '%s\n' "$OTHER" | sed 's/^/- /'
+              printf '\n'
+            fi
+            if [ -n "$PREV" ]; then
+              printf '**Full diff**: https://github.com/footprintai/containarium/compare/%s...%s\n\n' "$PREV" "$REF"
+            fi
+            printf -- '---\n\n'
+          } > release_changelog.md
+
+          echo "--- generated changelog ---"
+          cat release_changelog.md
 
       - name: Create release notes
         id: release_notes
@@ -172,6 +217,11 @@ jobs:
           See [README.md](https://github.com/footprintai/containarium#quick-start) for the full agent-native walkthrough.
           EOF
 
+          # Changelog first, boilerplate under it — a reader wants to know
+          # what changed before they read install instructions (#1600).
+          cat release_changelog.md release_notes.md > release_notes.combined.md
+          mv release_notes.combined.md release_notes.md
+
       - name: Create GitHub Release
         # Tag pushes only. A rehearsal builds every artifact above and stops
         # here — that is the whole point of the workflow_dispatch trigger.
@@ -181,6 +231,11 @@ jobs:
           tag_name: ${{ github.ref_name }}
           name: Containarium ${{ github.ref_name }}
           body_path: release_notes.md
+          # Without this the action REPLACES the release body, silently
+          # destroying notes an author wrote at publish time — whoever wrote
+          # last won, and that depended on how long the build took (#1600).
+          # Same reasoning as append_files on the bundle job below.
+          append_body: true
           files: |
             bin/containarium-linux-amd64
             bin/containarium-darwin-amd64


### PR DESCRIPTION
Closes #1600

## The bug

`release.yml` wrote a **static** boilerplate body to `release_notes.md` (heredoc, line 93) and passed it to `softprops/action-gh-release@v3` as `body_path`. That action **replaces** an existing release body by default — so notes written at publish time were destroyed once the build finished. Whoever wrote last won, and that depended on build duration. No error, no warning.

Both recent releases lost their notes to this:

- **v0.68.0** — Added / Fixed / Documentation plus a *Known limitations* section flagging the pre-existing CPU-admission race (#1588) and that #1584's TLS repair is forward-looking only.
- **v0.68.1** — everything. Its page carried **no mention that it fixes a blocker** (#1598: sentinel crash-loop serving a self-signed cert to every visitor). That's a deployment-safety gap, not a formatting one.

The second, quieter half: the boilerplate is *identical on every release*. It's install instructions and a binary table with **no changelog at all** — so absent a hand-edit that survived the race, a release page never said what shipped.

## What changed

| Change | Why |
|---|---|
| `append_body: true` on the release step | Anything already in the body survives; boilerplate lands underneath. Mirrors the `append_files` comment already on the bundle job. |
| New **Generate changelog** step | Categorises conventional-commit subjects since the previous tag into Added / Fixed / Documentation / Internal, plus a compare link. Emitted **above** the boilerplate — what changed matters more than install steps. |
| `fetch-depth: 0` on the release job's checkout | A depth-1 clone can't see the previous tag the changelog diffs against. |

An **"Other"** bucket catches subjects that don't follow conventional commits, so nothing is silently dropped. The generator also handles the rehearsal path: on `workflow_dispatch` the ref is a branch, not a tag, so it falls back to `HEAD` instead of failing.

## Test evidence

A workflow can't be unit-tested, so I tested the part that can be: extracted the step's `run` script **from the parsed YAML** and executed it against real history. That also proves the escaping survives the YAML round-trip, which was the main risk in a shell-heredoc-inside-YAML change.

Against `v0.68.1` — exactly the changelog that release should have had:

```
## What changed

### Fixed
- self-check must send a full ClientHello, not one byte — v0.68.0 crash-looped every sentinel (#1599)

### Documentation
- fix K8s CPU-request wording merged before review finished (#1595)

**Full diff**: .../compare/v0.68.0...v0.68.1
```

Against `v0.68.0` — correctly splits 3 Added / 5 Fixed / 3 Documentation across the 11 commits in that range. Against a **branch ref** — falls back to `HEAD` and still emits a valid changelog.

`yaml.safe_load` parses the workflow cleanly.

## Review notes

- **Look first at** the `emit()` shell function's regex escaping — it's the part most likely to break subtly, and it's why I ran the extracted script rather than trusting inspection.
- The temp file is **`release_changelog.md`**, not `changelog.md`. The repo already has `CHANGELOG.md`; on Linux CI they're distinct, but they collide on case-insensitive filesystems. I found this the hard way — a local `rm changelog.md` deleted the repo's `CHANGELOG.md` (restored, not in this diff).
- No behaviour change for the rehearsal trigger: it still builds and publishes nothing.

## Not addressed here

Option 4 from the issue — failing loudly when the body has unexpected content — is unnecessary once `append_body` means nothing is destroyed. Option 2 (move the boilerplate out of the workflow into the README) is a reasonable follow-up but is a docs restructure, not this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Improvements**
  * Release notes now include categorized changes generated from the history since the previous release.
  * Unclassified changes are grouped under an “Other” section.
  * Existing authored release notes are preserved while generated content is appended.
  * Re-running the release process refreshes generated content without creating duplicate sections.
  * Release publication handles tag information more safely and reliably.
  * Release processing now reports failures when existing release content cannot be retrieved and avoids adding unnecessary blank lines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->