### PR TITLE
feat(model-gateway): per-tenant quota + graduated response ladder

### DIFF
--- a/docs/AGENT-MODEL-GATEWAY-DESIGN.md
+++ b/docs/AGENT-MODEL-GATEWAY-DESIGN.md
@@ -199,11 +199,77 @@ Cloud owns the *rating* (named tiers, per-model cents) — consistent with the
 - **Phase 1 — metering.** Parse `usage`, write per-tenant rollups, add
   `containarium agent usage`.
 - **Phase 2 — tiering + rate limits.** `allowed_models` on the skill manifest;
-  enforce ceiling + per-tenant token bucket at the gateway.
+  enforce ceiling + per-tenant token bucket at the gateway. *Shipped: the
+  model ceiling rides the gateway token, and per-tenant quota + the response
+  ladder are below.*
 - **Phase 3 — caching + OpenAI.** Shared prompt-cache breakpoint management;
   add the `codex`/OpenAI path (`OPENAI_BASE_URL`).
 - **Phase 4 — egress tighten.** Drop provider domains from
   `defaultAgentEgressDomains`; agent boxes egress to the gateway only.
+
+## Enforcement: quota + the graduated response ladder
+
+Metering answers "what did this tenant spend"; it does not stop a runaway. The
+gateway is the only place a limit can actually be enforced, because a limit
+applied inside the box is advice the box can ignore — it holds the credential.
+`internal/modelgateway/{quota,anomaly,policy}.go` add that, off by default.
+
+**Quota** (`QuotaLimits`) caps calls, total tokens, and output tokens per tenant
+over a rolling window. The window is a ring of buckets, so a budget is a rolling
+budget and not a lifetime cap: a tenant that overspent an hour ago works again
+without an operator. Cached tokens count — replaying a huge cached prefix is
+exactly the runaway a budget exists to stop.
+
+**Signals** (`AnomalyConfig`) are per-tenant and relative, never absolute. An
+absolute threshold is either high enough for a stolen token to live under or low
+enough to fire on a normal Monday. The detectors:
+
+| signal | fires when |
+| --- | --- |
+| `rate_baseline` | token rate exceeds this tenant's own learned baseline by a factor |
+| `model_switch` | a model the tenant has not used within the novelty TTL |
+| `endpoint_mix` | an upstream path the tenant has not used |
+| `concurrent_source_nets` | one tenant's token in use from more networks than a box population explains |
+| `auth_failure_ratio` | a large share of the tenant's recent calls are rejected — a token being probed |
+
+Two properties are load-bearing and easy to regress. The baseline learns only
+from windows that were quiet *and* evaluated first, or the spike being judged
+raises the bar it is judged against. And the novelty signals stay silent until a
+tenant is learned, because a new tenant's first model and first endpoint are
+novel by construction — emitting them escalates every new tenant on its first
+call, and an escalated tenant stops feeding its baseline, so it would never
+become learned.
+
+**The ladder** (`PolicyState`) is observe → throttle → alert → circuit-break →
+revoke. Escalation is immediate; descent is damped by a cooldown and goes one
+rung at a time. Every rung except the last is reversible with no human, which is
+what lets the detector be wrong: being wrong costs latency, not an outage. A
+circuit-break is time-boxed and steps down on its own — unless the condition is
+still live, in which case it extends rather than flapping. Revocation is sticky,
+needs an operator to clear, and is never reached automatically unless
+`RevokeAt` is explicitly configured.
+
+The check runs after the gateway token is verified and before the reverse
+proxy's Director, so a denied call never has the real key injected and never
+reaches the provider. `Policy.Revoke` takes effect on the next call with no
+token re-issue and no box restart — an already-issued 30-minute token stops
+working immediately.
+
+Operator surface: `GET /__gateway/policy` reports every tenant's rung, what put
+it there, and consumption against budget. Configuration is env, and a daemon
+that sets none of it meters exactly as before:
+
+| var | meaning |
+| --- | --- |
+| `CONTAINARIUM_GATEWAY_QUOTA_WINDOW` | rolling window (Go duration, default `1m`) |
+| `CONTAINARIUM_GATEWAY_QUOTA_CALLS` | calls per tenant per window |
+| `CONTAINARIUM_GATEWAY_QUOTA_TOKENS` | input+output+cached tokens per tenant per window |
+| `CONTAINARIUM_GATEWAY_QUOTA_OUTPUT_TOKENS` | generated tokens per tenant per window |
+| `CONTAINARIUM_GATEWAY_ANOMALY` | `1` enables the detectors |
+| `CONTAINARIUM_GATEWAY_ANOMALY_REVOKE_AT` | score (0..1] for automatic revocation; unset = never |
+
+A window alone is not a configuration — it says when to measure, not how much is
+allowed — so it does not switch enforcement on by itself.
 
 ## Open questions
 

--- a/docs/AGENT-MODEL-GATEWAY-DESIGN.md
+++ b/docs/AGENT-MODEL-GATEWAY-DESIGN.md
@@ -199,9 +199,10 @@ Cloud owns the *rating* (named tiers, per-model cents) — consistent with the
 - **Phase 1 — metering.** Parse `usage`, write per-tenant rollups, add
   `containarium agent usage`.
 - **Phase 2 — tiering + rate limits.** `allowed_models` on the skill manifest;
-  enforce ceiling + per-tenant token bucket at the gateway. *Shipped: the
+  enforce ceiling + a per-tenant rolling quota at the gateway. *Shipped: the
   model ceiling rides the gateway token, and per-tenant quota + the response
-  ladder are below.*
+  ladder are below. Rolling window rather than a token bucket — there is no
+  burst allowance or refill rate, just "how much in the last N minutes".*
 - **Phase 3 — caching + OpenAI.** Shared prompt-cache breakpoint management;
   add the `codex`/OpenAI path (`OPENAI_BASE_URL`).
 - **Phase 4 — egress tighten.** Drop provider domains from

--- a/internal/config/gateway.go
+++ b/internal/config/gateway.go
@@ -15,9 +15,9 @@ const (
 	// EnvGatewayQuotaCalls caps model calls per tenant per window.
 	EnvGatewayQuotaCalls = "CONTAINARIUM_GATEWAY_QUOTA_CALLS"
 	// EnvGatewayQuotaTokens caps input+output+cached tokens per tenant per window.
-	EnvGatewayQuotaTokens = "CONTAINARIUM_GATEWAY_QUOTA_TOKENS"
+	EnvGatewayQuotaTokens = "CONTAINARIUM_GATEWAY_QUOTA_TOKENS" // #nosec G101 -- env var name, not a credential value
 	// EnvGatewayQuotaOutputTokens caps generated tokens per tenant per window.
-	EnvGatewayQuotaOutputTokens = "CONTAINARIUM_GATEWAY_QUOTA_OUTPUT_TOKENS"
+	EnvGatewayQuotaOutputTokens = "CONTAINARIUM_GATEWAY_QUOTA_OUTPUT_TOKENS" // #nosec G101 -- env var name, not a credential value
 
 	// EnvGatewayAnomalyEnabled turns the per-tenant anomaly detectors on ("1").
 	// Off by default: the detectors are advisory input to the response ladder,

--- a/internal/config/gateway.go
+++ b/internal/config/gateway.go
@@ -4,4 +4,30 @@ package config
 const (
 	// EnvGatewayOutputFilter — output filtering is on unless set to "0".
 	EnvGatewayOutputFilter = "CONTAINARIUM_GATEWAY_OUTPUT_FILTER"
+
+	// Per-tenant quota. All unset ⇒ no budget ⇒ nothing is ever denied on
+	// quota grounds, which is the behavior of every daemon before these
+	// existed. A deployment opts in by naming numbers.
+	//
+	// EnvGatewayQuotaWindow is the rolling period the caps apply over, as a Go
+	// duration ("1m", "1h"). Defaults to 1m when any cap is set.
+	EnvGatewayQuotaWindow = "CONTAINARIUM_GATEWAY_QUOTA_WINDOW"
+	// EnvGatewayQuotaCalls caps model calls per tenant per window.
+	EnvGatewayQuotaCalls = "CONTAINARIUM_GATEWAY_QUOTA_CALLS"
+	// EnvGatewayQuotaTokens caps input+output+cached tokens per tenant per window.
+	EnvGatewayQuotaTokens = "CONTAINARIUM_GATEWAY_QUOTA_TOKENS"
+	// EnvGatewayQuotaOutputTokens caps generated tokens per tenant per window.
+	EnvGatewayQuotaOutputTokens = "CONTAINARIUM_GATEWAY_QUOTA_OUTPUT_TOKENS"
+
+	// EnvGatewayAnomalyEnabled turns the per-tenant anomaly detectors on ("1").
+	// Off by default: the detectors are advisory input to the response ladder,
+	// and an operator should choose to act on heuristics rather than inherit
+	// them in a patch release.
+	EnvGatewayAnomalyEnabled = "CONTAINARIUM_GATEWAY_ANOMALY"
+
+	// EnvGatewayAnomalyRevokeAt is the anomaly score (0..1] at which a tenant is
+	// revoked automatically. Unset ⇒ never: revocation needs a human to undo,
+	// so it is not something a heuristic should reach on its own unless the
+	// operator has explicitly asked for that.
+	EnvGatewayAnomalyRevokeAt = "CONTAINARIUM_GATEWAY_ANOMALY_REVOKE_AT"
 )

--- a/internal/modelgateway/anomaly.go
+++ b/internal/modelgateway/anomaly.go
@@ -1,0 +1,256 @@
+package modelgateway
+
+import (
+	"fmt"
+	"net"
+	"time"
+)
+
+// Per-tenant anomaly signals.
+//
+// The design constraint from the issue is "per-tenant baseline, not absolute
+// thresholds", and it is the important part. An absolute threshold is either so
+// high that a stolen token can spend freely under it, or so low that it fires on
+// the tenant's ordinary Monday morning. A tenant compared against its own recent
+// history has neither problem: the same 10x jump is signal for a steady tenant
+// and noise for a bursty one, and the detector learns which is which without
+// anyone tuning a number per customer.
+//
+// Signals are advisory. They feed the policy ladder, which decides what to do —
+// nothing here blocks a request on its own.
+
+// AnomalyConfig tunes the signals. The zero value disables detection, so a
+// deployment that configures quotas but not anomaly detection gets quota
+// enforcement alone.
+type AnomalyConfig struct {
+	Enabled bool `json:"enabled"`
+
+	// BaselineWindow is the period a tenant's token rate is measured over
+	// before being folded into its baseline. Default 5m.
+	BaselineWindow time.Duration `json:"baseline_window"`
+
+	// BaselineAlpha is the EWMA weight for a new sample. Default 0.2 — roughly
+	// a five-sample memory, so the baseline tracks a genuine change in workload
+	// within half an hour but is not moved much by one spike.
+	BaselineAlpha float64 `json:"baseline_alpha"`
+
+	// BaselineMinSamples is how many windows must be observed before the
+	// baseline is compared against. Below this the tenant is still being
+	// learned and the signal stays silent. Default 5.
+	BaselineMinSamples int `json:"baseline_min_samples"`
+
+	// BaselineFactor is how many times its own baseline a tenant's current rate
+	// must reach to be anomalous. Default 8 — deliberately loose, because the
+	// cost of a false positive here is throttling a paying customer's agent.
+	BaselineFactor float64 `json:"baseline_factor"`
+
+	// NoveltyTTL is how long a model id, upstream path, or source network stays
+	// "known" for this tenant. Default 24h.
+	NoveltyTTL time.Duration `json:"novelty_ttl"`
+
+	// ConcurrentSourceNets is how many distinct source networks may use one
+	// tenant's tokens within ConcurrentWindow before it is treated as
+	// impossible-concurrency. Default 3.
+	//
+	// This is the issue's "geo-exclusive simultaneous use" signal, approximated
+	// without a geoip database: OSS ships no IP-to-location data and should not
+	// grow a dependency on one, so the gateway counts distinct /24s (v4) or /48s
+	// (v6) instead. It is a weaker signal — two datacenters in one region look
+	// like two networks — but it catches the case that matters, a token in use
+	// from somewhere it has never been while the legitimate box keeps working.
+	ConcurrentSourceNets int           `json:"concurrent_source_nets"`
+	ConcurrentWindow     time.Duration `json:"concurrent_window"`
+
+	// AuthFailureRatio is the share of a tenant's recent requests that may be
+	// rejected before the ratio itself is a signal — a token being probed
+	// against models or providers it isn't scoped for. Default 0.3, requiring
+	// at least AuthFailureMin observations so a single early failure is not a
+	// 100% failure rate.
+	AuthFailureRatio float64 `json:"auth_failure_ratio"`
+	AuthFailureMin   int64   `json:"auth_failure_min"`
+}
+
+func (a AnomalyConfig) normalized() AnomalyConfig {
+	if a.BaselineWindow <= 0 {
+		a.BaselineWindow = 5 * time.Minute
+	}
+	if a.BaselineAlpha <= 0 || a.BaselineAlpha > 1 {
+		a.BaselineAlpha = 0.2
+	}
+	if a.BaselineMinSamples <= 0 {
+		a.BaselineMinSamples = 5
+	}
+	if a.BaselineFactor <= 1 {
+		a.BaselineFactor = 8
+	}
+	if a.NoveltyTTL <= 0 {
+		a.NoveltyTTL = 24 * time.Hour
+	}
+	if a.ConcurrentSourceNets <= 0 {
+		a.ConcurrentSourceNets = 3
+	}
+	if a.ConcurrentWindow <= 0 {
+		a.ConcurrentWindow = 5 * time.Minute
+	}
+	if a.AuthFailureRatio <= 0 {
+		a.AuthFailureRatio = 0.3
+	}
+	if a.AuthFailureMin <= 0 {
+		a.AuthFailureMin = 10
+	}
+	return a
+}
+
+// Signal is one fired detector. Severity is 0..1 and is what the ladder reads;
+// Detail is operator-facing and carries no prompt or response content.
+type Signal struct {
+	Name     string  `json:"name"`
+	Severity float64 `json:"severity"`
+	Detail   string  `json:"detail"`
+}
+
+// Signal names, stable enough to alert on.
+const (
+	SignalRateBaseline    = "rate_baseline"
+	SignalNewModel        = "model_switch"
+	SignalNewEndpoint     = "endpoint_mix"
+	SignalConcurrentNets  = "concurrent_source_nets"
+	SignalAuthFailureRate = "auth_failure_ratio"
+)
+
+// evaluate runs every signal against a tenant's state. Caller holds ts.mu.
+func (a AnomalyConfig) evaluate(ts *tenantState, now time.Time) []Signal {
+	if !a.Enabled {
+		return nil
+	}
+	var out []Signal
+
+	// Cold start. A tenant the gateway has not learned yet has no "normal" to
+	// deviate from, and its first call is novel by construction: the first model
+	// it names has never been seen, and so has the first endpoint. Emitting
+	// those escalates every new tenant on its very first request — and because
+	// an escalated tenant stops feeding its baseline, it would then never learn
+	// one, leaving the detector permanently stuck on a tenant it permanently
+	// misjudges.
+	//
+	// So the novelty signals stay quiet until there is a history for something
+	// to be novel against; the sets are still populated meanwhile, which is what
+	// makes the history. The other two signals are NOT suppressed: a brand-new
+	// tenant reaching the gateway from four networks, or failing auth on most of
+	// its calls, is suspicious with or without a baseline.
+	_, samples := ts.baseline.get()
+	learning := samples < a.BaselineMinSamples
+
+	// Rate against the tenant's own baseline.
+	if base, n := ts.baseline.get(); n >= a.BaselineMinSamples && base > 0 {
+		cur := ts.rateWindow.rate(now)
+		if ratio := cur / base; ratio >= a.BaselineFactor {
+			out = append(out, Signal{
+				Name: SignalRateBaseline,
+				// Saturates at 4x the trip factor, so a 100x runaway and a
+				// 1000x one both read as "as bad as it gets" rather than
+				// producing a meaningless unbounded number.
+				Severity: clamp01((ratio - a.BaselineFactor) / (a.BaselineFactor * 3)),
+				Detail: fmt.Sprintf("%.0f tok/s vs baseline %.0f (%.1fx, trips at %.0fx)",
+					cur, base, ratio, a.BaselineFactor),
+			})
+		}
+	}
+
+	// A model this tenant has not used within the novelty TTL. The issue calls
+	// this "model-tier switch": the observable shape of a stolen token is
+	// someone reaching for the most capable model available, which for a tenant
+	// with a settled workload is a new model id.
+	if ts.pendingNewModel != "" && !learning {
+		out = append(out, Signal{
+			Name:     SignalNewModel,
+			Severity: 0.5,
+			Detail:   "first use of model " + ts.pendingNewModel + " in " + a.NoveltyTTL.String(),
+		})
+	}
+
+	// An upstream path shape this tenant has not used — the endpoint-mix change.
+	// A box that only ever ran chat completions suddenly listing models or
+	// hitting embeddings is a different program than the one we provisioned.
+	if ts.pendingNewEndpoint != "" && !learning {
+		out = append(out, Signal{
+			Name:     SignalNewEndpoint,
+			Severity: 0.4,
+			Detail:   "first use of endpoint " + ts.pendingNewEndpoint + " in " + a.NoveltyTTL.String(),
+		})
+	}
+
+	// One tenant's token in use from more networks than a box population
+	// explains.
+	if n := ts.sourceNets.len(now); n > a.ConcurrentSourceNets {
+		out = append(out, Signal{
+			Name:     SignalConcurrentNets,
+			Severity: clamp01(float64(n-a.ConcurrentSourceNets) / float64(a.ConcurrentSourceNets)),
+			Detail: fmt.Sprintf("%d distinct source networks within %s (allowed %d)",
+				n, a.ConcurrentWindow, a.ConcurrentSourceNets),
+		})
+	}
+
+	// Rejected-request ratio: a token being probed rather than used.
+	w := ts.rateWindow.sum(now)
+	if total := w.calls + w.denials; total >= a.AuthFailureMin {
+		if ratio := float64(w.denials) / float64(total); ratio >= a.AuthFailureRatio {
+			out = append(out, Signal{
+				Name:     SignalAuthFailureRate,
+				Severity: clamp01(ratio),
+				Detail:   fmt.Sprintf("%d/%d recent requests rejected (%.0f%%)", w.denials, total, ratio*100),
+			})
+		}
+	}
+	return out
+}
+
+// score reduces signals to the ladder's input: the worst single severity, nudged
+// up when several independent detectors agree.
+//
+// Max rather than sum because the signals are not independent evidence of the
+// same magnitude — a stolen token typically trips new-model AND new-network AND
+// rate at once, and summing would let three weak coincidences outrank one strong
+// detection. The corroboration bonus keeps agreement meaningful without letting
+// it dominate.
+func score(sigs []Signal) float64 {
+	var max float64
+	for _, s := range sigs {
+		if s.Severity > max {
+			max = s.Severity
+		}
+	}
+	if len(sigs) > 1 {
+		max += 0.1 * float64(len(sigs)-1)
+	}
+	return clamp01(max)
+}
+
+func clamp01(v float64) float64 {
+	if v < 0 {
+		return 0
+	}
+	if v > 1 {
+		return 1
+	}
+	return v
+}
+
+// sourceNet reduces a remote address to the network the concurrency signal
+// counts: /24 for IPv4, /48 for IPv6. Returns "" when the address can't be
+// parsed, which the caller treats as "no signal" rather than as a distinct
+// network — an unparseable peer address must not manufacture an anomaly.
+func sourceNet(remoteAddr string) string {
+	host := remoteAddr
+	if h, _, err := net.SplitHostPort(remoteAddr); err == nil {
+		host = h
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return ""
+	}
+	if v4 := ip.To4(); v4 != nil {
+		return net.IP(append(net.IP(nil), v4[0], v4[1], v4[2], 0)).String() + "/24"
+	}
+	return ip.Mask(net.CIDRMask(48, 128)).String() + "/48"
+}

--- a/internal/modelgateway/anomaly.go
+++ b/internal/modelgateway/anomaly.go
@@ -192,13 +192,17 @@ func (a AnomalyConfig) evaluate(ts *tenantState, now time.Time) []Signal {
 	}
 
 	// Rejected-request ratio: a token being probed rather than used.
+	//
+	// Reads authDenials only. Policy denials are excluded on purpose: counting
+	// the ladder's own refusals here would make a throttled tenant look like a
+	// probed one and escalate it further on the strength of our own enforcement.
 	w := ts.rateWindow.sum(now)
-	if total := w.calls + w.denials; total >= a.AuthFailureMin {
-		if ratio := float64(w.denials) / float64(total); ratio >= a.AuthFailureRatio {
+	if total := w.calls + w.authDenials; total >= a.AuthFailureMin {
+		if ratio := float64(w.authDenials) / float64(total); ratio >= a.AuthFailureRatio {
 			out = append(out, Signal{
 				Name:     SignalAuthFailureRate,
 				Severity: clamp01(ratio),
-				Detail:   fmt.Sprintf("%d/%d recent requests rejected (%.0f%%)", w.denials, total, ratio*100),
+				Detail:   fmt.Sprintf("%d/%d recent requests rejected (%.0f%%)", w.authDenials, total, ratio*100),
 			})
 		}
 	}

--- a/internal/modelgateway/gateway.go
+++ b/internal/modelgateway/gateway.go
@@ -36,14 +36,21 @@ type Config struct {
 	// path (a hold-back window over the assistant text; #670 layer 2). Streaming
 	// token metering is independent and always on. Fail-open regardless.
 	OutputFilter bool
+
+	// Policy configures per-tenant quota enforcement and the graduated response
+	// ladder (see policy.go). Nil leaves the gateway metering-only: every tenant
+	// stays in StateObserve and nothing is ever denied, which is the behavior
+	// every existing deployment already has.
+	Policy *PolicyConfig
 }
 
 // Gateway brokers every agent box's model calls: it authenticates the box's
 // scoped gateway token, injects the real provider key (which never leaves the
 // gateway), proxies to the provider, and meters per-tenant token usage.
 type Gateway struct {
-	cfg   Config
-	meter *Meter
+	cfg    Config
+	meter  *Meter
+	policy *Policy
 
 	// Request-lifecycle observability: a monotonic request id, a live
 	// in-flight gauge, and lifetime completed/failed counters. These make
@@ -61,11 +68,19 @@ func New(cfg Config) *Gateway {
 	if cfg.Logger == nil {
 		cfg.Logger = log.Default()
 	}
-	return &Gateway{cfg: cfg, meter: NewMeter()}
+	pc := PolicyConfig{}
+	if cfg.Policy != nil {
+		pc = *cfg.Policy
+	}
+	return &Gateway{cfg: cfg, meter: NewMeter(), policy: NewPolicy(pc)}
 }
 
 // Meter exposes the usage rollups (for tests / the usage endpoint).
 func (g *Gateway) Meter() *Meter { return g.meter }
+
+// Policy exposes the enforcement ladder so the daemon can drive the operator
+// verbs (revoke / clear) and read tenant state.
+func (g *Gateway) Policy() *Policy { return g.policy }
 
 const modelPrefix = "/v1/model/"
 
@@ -77,6 +92,14 @@ func (g *Gateway) Handler() http.Handler {
 	mux.HandleFunc("/__gateway/usage", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(g.meter.Snapshot())
+	})
+	// Per-tenant enforcement state: which rung each tenant is on, what put it
+	// there, and its consumption against budget. The readout an operator needs
+	// before deciding whether a throttled tenant is a runaway or a false
+	// positive.
+	mux.HandleFunc("/__gateway/policy", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(g.policy.Status())
 	})
 	mux.HandleFunc("/__gateway/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -141,6 +164,10 @@ func (g *Gateway) handleModel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if claims.Provider != provName {
+		// A token presented against a provider it isn't scoped for is a probe,
+		// not a misconfiguration — the box is seeded with exactly one base URL.
+		// Recorded so the auth-failure-ratio signal can see it.
+		g.policy.RecordDenial(claims.Tenant)
 		http.Error(w, "token not valid for provider "+provName, http.StatusForbidden)
 		return
 	}
@@ -158,6 +185,7 @@ func (g *Gateway) handleModel(w http.ResponseWriter, r *http.Request) {
 		pathModel = geminiModelFromPath(upstreamPath)
 	}
 	if len(claims.AllowedModels) > 0 && pathModel != "" && !contains(claims.AllowedModels, pathModel) {
+		g.policy.RecordDenial(claims.Tenant)
 		http.Error(w, "model not allowed by token: "+pathModel, http.StatusForbidden)
 		return
 	}
@@ -191,6 +219,32 @@ func (g *Gateway) handleModel(w http.ResponseWriter, r *http.Request) {
 	logModel := reqModel
 	if logModel == "" {
 		logModel = pathModel
+	}
+
+	// Enforcement ladder. Deliberately the last gate before proxying: a denied
+	// request never reaches the Director, so the real provider key is never
+	// injected and never leaves the gateway on a call we refused.
+	if dec := g.policy.Check(RequestInfo{
+		Tenant:     claims.Tenant,
+		Skill:      claims.SkillID,
+		Provider:   provName,
+		Model:      logModel,
+		Endpoint:   upstreamPath,
+		RemoteAddr: r.RemoteAddr,
+	}); !dec.Allow {
+		if dec.RetryAfter > 0 {
+			// Round up: a Retry-After of 0 invites an immediate retry, which is
+			// the opposite of what a throttle is for.
+			secs := int(dec.RetryAfter.Seconds())
+			if secs < 1 {
+				secs = 1
+			}
+			w.Header().Set("Retry-After", strconv.Itoa(secs))
+		}
+		g.cfg.Logger.Printf("model-gateway: DENY tenant=%s skill=%s provider=%s model=%s state=%s reason=%q",
+			claims.Tenant, claims.SkillID, provName, logModel, dec.State, dec.Reason)
+		http.Error(w, "model gateway: "+dec.Reason, dec.Status)
+		return
 	}
 	// Request-lifecycle capture, read after ServeHTTP returns. Mutex-guarded
 	// because the streaming usage callback runs in filterSSEStream's goroutine
@@ -235,6 +289,7 @@ func (g *Gateway) handleModel(w http.ResponseWriter, r *http.Request) {
 						u.Model = meterModel
 					}
 					g.meter.record(claims.Tenant, claims.SkillID, provName, u)
+					g.policy.RecordUsage(claims.Tenant, u)
 					if g.cfg.Sink != nil {
 						g.cfg.Sink.RecordUsage(claims.Tenant, claims.SkillID, provName, u)
 					}
@@ -269,6 +324,7 @@ func (g *Gateway) handleModel(w http.ResponseWriter, r *http.Request) {
 			if json.Unmarshal(body, &decoded) == nil {
 				u := prov.parseUsage(decoded, pathModel)
 				g.meter.record(claims.Tenant, claims.SkillID, provName, u)
+				g.policy.RecordUsage(claims.Tenant, u)
 				if g.cfg.Sink != nil {
 					g.cfg.Sink.RecordUsage(claims.Tenant, claims.SkillID, provName, u)
 				}

--- a/internal/modelgateway/gateway.go
+++ b/internal/modelgateway/gateway.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"log"
+	"math"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -201,6 +202,21 @@ func (g *Gateway) handleModel(w http.ResponseWriter, r *http.Request) {
 	// enable a final usage event so the SSE path is metered. Fail-open: any read
 	// error leaves the original body in place.
 	sysPrompt, reqModel := "", ""
+	// Anthropic carries the model in the request body and nowhere else — not in
+	// the path like Gemini, and it isn't OpenAI-shaped so it misses the branch
+	// below. Without this the model-switch signal is silent for the provider
+	// that skill boxes are provisioned for by default, and the lifecycle logs
+	// report an empty model for it. Read-only: no body rewriting, since
+	// ensureStreamUsage and extractSystemPrompt are OpenAI shapes.
+	if provName == "anthropic" {
+		if raw, rerr := io.ReadAll(r.Body); rerr == nil {
+			_ = r.Body.Close()
+			reqModel = requestModel(raw)
+			r.Body = io.NopCloser(bytes.NewReader(raw))
+			r.ContentLength = int64(len(raw))
+			r.Header.Set("Content-Length", strconv.Itoa(len(raw)))
+		}
+	}
 	if provName == "openai" || provName == "gemini-openai" {
 		if raw, rerr := io.ReadAll(r.Body); rerr == nil {
 			_ = r.Body.Close()
@@ -233,9 +249,11 @@ func (g *Gateway) handleModel(w http.ResponseWriter, r *http.Request) {
 		RemoteAddr: r.RemoteAddr,
 	}); !dec.Allow {
 		if dec.RetryAfter > 0 {
-			// Round up: a Retry-After of 0 invites an immediate retry, which is
-			// the opposite of what a throttle is for.
-			secs := int(dec.RetryAfter.Seconds())
+			// Round UP, and floor at 1. Truncating 59.4s to 59 tells a
+			// well-behaved client to come back while the circuit is still
+			// open, so it gets denied again — and a Retry-After of 0 invites
+			// an immediate retry, which is the opposite of a throttle.
+			secs := int(math.Ceil(dec.RetryAfter.Seconds()))
 			if secs < 1 {
 				secs = 1
 			}

--- a/internal/modelgateway/gateway.go
+++ b/internal/modelgateway/gateway.go
@@ -179,16 +179,12 @@ func (g *Gateway) handleModel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Model ceiling (basic tiering): for Gemini the model is in the path, so we
-	// can enforce the token's allowed-model set before proxying.
+	// pathModel: for Gemini the model is in the URL path. Other providers
+	// carry it in the request body (reqModel, extracted below) — pathModel
+	// stays "" for them and is only ever a fallback for logModel.
 	pathModel := ""
 	if provName == "gemini" {
 		pathModel = geminiModelFromPath(upstreamPath)
-	}
-	if len(claims.AllowedModels) > 0 && pathModel != "" && !contains(claims.AllowedModels, pathModel) {
-		g.policy.RecordDenial(claims.Tenant)
-		http.Error(w, "model not allowed by token: "+pathModel, http.StatusForbidden)
-		return
 	}
 
 	upstream, err := url.Parse(prov.UpstreamURL)
@@ -235,6 +231,22 @@ func (g *Gateway) handleModel(w http.ResponseWriter, r *http.Request) {
 	logModel := reqModel
 	if logModel == "" {
 		logModel = pathModel
+	}
+
+	// Model ceiling (basic tiering), enforced against whichever model was
+	// actually resolved — never just pathModel. The original gate only
+	// ever compared AllowedModels to pathModel, which only Gemini sets;
+	// Anthropic, OpenAI, and Gemini-OpenAI all carry their model in the
+	// body (reqModel, above) and got a free pass regardless of what the
+	// token was scoped to. A request whose model this gateway couldn't
+	// resolve at all (logModel == "") is refused open when the token is
+	// scoped, rather than treated as ceiling-exempt: an unresolvable
+	// model is exactly the case a restricted token must not get a bypass
+	// from.
+	if len(claims.AllowedModels) > 0 && !contains(claims.AllowedModels, logModel) {
+		g.policy.RecordDenial(claims.Tenant)
+		http.Error(w, "model not allowed by token: "+logModel, http.StatusForbidden)
+		return
 	}
 
 	// Enforcement ladder. Deliberately the last gate before proxying: a denied

--- a/internal/modelgateway/gateway_test.go
+++ b/internal/modelgateway/gateway_test.go
@@ -304,6 +304,51 @@ func TestGateway_Gemini_PathModel_AllowedModelsEnforced(t *testing.T) {
 	}
 }
 
+// TestGateway_Anthropic_AllowedModelsEnforced is the sibling of the Gemini
+// case above, for the two providers whose model lives in the request BODY
+// rather than the path (Anthropic) or a query/header (n/a here — Anthropic
+// is the simplest repro). The original enforcement gate only ever compared
+// AllowedModels against pathModel, which Anthropic never sets — so a token
+// scoped to one model could request any other Anthropic model with zero
+// enforcement. This pins the fix: the check must run against whichever
+// model was actually resolved (reqModel from the body when present),
+// covering the providers that don't put the model in the URL.
+func TestGateway_Anthropic_AllowedModelsEnforced(t *testing.T) {
+	secret := []byte("s")
+	up := fakeUpstream(t, func(r *http.Request) {},
+		`{"model":"claude-cheap","usage":{"input_tokens":1,"output_tokens":1}}`)
+	defer up.Close()
+
+	providers := DefaultProviders()
+	providers["anthropic"].UpstreamURL = up.URL
+	gw := New(Config{Secret: secret, Providers: providers, ProviderKeys: map[string]string{"anthropic": "REAL-KEY"}})
+	srv := httptest.NewServer(gw.Handler())
+	defer srv.Close()
+
+	// token allows only claude-cheap
+	tok, _ := MintToken(secret, GatewayClaims{Tenant: "t", Provider: "anthropic", AllowedModels: []string{"claude-cheap"}}, time.Minute)
+
+	do := func(model string) int {
+		req, _ := http.NewRequest("POST", srv.URL+"/v1/model/anthropic/v1/messages",
+			strings.NewReader(`{"model":"`+model+`"}`))
+		req.Header.Set("Authorization", "Bearer "+tok)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	if c := do("claude-cheap"); c != 200 {
+		t.Fatalf("allowed model: status %d, want 200", c)
+	}
+	if c := do("claude-expensive"); c != 403 {
+		t.Fatalf("disallowed model via request body: status %d, want 403 — the token-scoped model ceiling must apply to Anthropic's body-carried model, not just Gemini's path-carried one", c)
+	}
+}
+
 // gemini-openai is the OpenAI-compatible Gemini route the hosted OpenHands
 // canvas uses: a Bearer-authenticated /chat/completions call, proxied to
 // Google's compat endpoint with the real key injected as Bearer and metered

--- a/internal/modelgateway/policy.go
+++ b/internal/modelgateway/policy.go
@@ -375,8 +375,13 @@ func (p *Policy) target(q quotaUsage, sc float64) (PolicyState, string) {
 // transition moves the tenant onto want, applying immediate escalation and
 // damped de-escalation.
 func (p *Policy) transition(ts *tenantState, info RequestInfo, want PolicyState, reason string, now time.Time, sigs []Signal) {
-	// Manual revocation outranks everything and never expires on its own.
-	if ts.state == StateRevoke && ts.manualReason != "" {
+	// Revocation outranks everything and never expires on its own — however it
+	// was reached. Gating this on manualReason instead of the state itself
+	// would leave an automatic revocation (RevokeAt) non-sticky: the
+	// de-escalation case below would walk it back a rung per cooldown, so a
+	// token revoked for a high anomaly score would regain access simply by
+	// going quiet for five minutes. Only Clear leaves this state.
+	if ts.state == StateRevoke {
 		return
 	}
 
@@ -434,14 +439,14 @@ func (p *Policy) admit(ts *tenantState, now time.Time, q quotaUsage, sigs []Sign
 			d.Allow, d.Status = false, http.StatusTooManyRequests
 			d.Reason = "quota exceeded: " + p.cfg.Quota.describe(q)
 			d.RetryAfter = p.cfg.Quota.Window
-			ts.rateWindow.add(now, counts{denials: 1})
+			ts.rateWindow.add(now, counts{policyDenials: 1})
 			return d
 		}
 		if wait := p.cfg.ThrottleMinInterval - now.Sub(ts.lastAdmitted); wait > 0 && !ts.lastAdmitted.IsZero() {
 			d.Allow, d.Status = false, http.StatusTooManyRequests
 			d.Reason = "throttled"
 			d.RetryAfter = wait
-			ts.rateWindow.add(now, counts{denials: 1})
+			ts.rateWindow.add(now, counts{policyDenials: 1})
 			return d
 		}
 		ts.lastAdmitted = now
@@ -454,7 +459,7 @@ func (p *Policy) admit(ts *tenantState, now time.Time, q quotaUsage, sigs []Sign
 		if d.RetryAfter < 0 {
 			d.RetryAfter = 0
 		}
-		ts.rateWindow.add(now, counts{denials: 1})
+		ts.rateWindow.add(now, counts{policyDenials: 1})
 		return d
 
 	case StateRevoke:
@@ -463,7 +468,7 @@ func (p *Policy) admit(ts *tenantState, now time.Time, q quotaUsage, sigs []Sign
 		if ts.manualReason != "" {
 			d.Reason = "revoked: " + ts.manualReason
 		}
-		ts.rateWindow.add(now, counts{denials: 1})
+		ts.rateWindow.add(now, counts{policyDenials: 1})
 		return d
 	}
 	return d
@@ -518,7 +523,7 @@ func (p *Policy) RecordDenial(tenant string) {
 	ts := p.state(tenant)
 	ts.mu.Lock()
 	defer ts.mu.Unlock()
-	ts.rateWindow.add(now, counts{denials: 1})
+	ts.rateWindow.add(now, counts{authDenials: 1})
 }
 
 // Revoke puts a tenant on the sticky rung until Clear. The operator escape
@@ -555,19 +560,24 @@ func (p *Policy) Clear(tenant string) {
 
 // TenantStatus is the ops readout for one tenant.
 type TenantStatus struct {
-	Tenant      string      `json:"tenant"`
-	State       PolicyState `json:"state"`
-	Since       time.Time   `json:"since"`
-	Score       float64     `json:"anomaly_score"`
-	Quota       float64     `json:"quota_fraction"`
-	Calls       int64       `json:"calls_in_window"`
-	Tokens      int64       `json:"tokens_in_window"`
-	Denials     int64       `json:"denials_in_window"`
-	Baseline    float64     `json:"baseline_tokens_per_sec"`
-	Samples     int         `json:"baseline_samples"`
-	SourceNets  []string    `json:"source_nets,omitempty"`
-	Signals     []Signal    `json:"signals,omitempty"`
-	RevokeCause string      `json:"revoke_cause,omitempty"`
+	Tenant string      `json:"tenant"`
+	State  PolicyState `json:"state"`
+	Since  time.Time   `json:"since"`
+	Score  float64     `json:"anomaly_score"`
+	Quota  float64     `json:"quota_fraction"`
+	Calls  int64       `json:"calls_in_window"`
+	Tokens int64       `json:"tokens_in_window"`
+	// AuthDenials are token-authorization failures; PolicyDenials are this
+	// ladder's own refusals. Reported apart because conflating them is what
+	// made enforcement self-amplifying — see counts in window.go.
+	AuthDenials   int64    `json:"auth_denials_in_window"`
+	PolicyDenials int64    `json:"policy_denials_in_window"`
+	Baseline      float64  `json:"baseline_tokens_per_sec"`
+	Samples       int      `json:"baseline_samples"`
+	Models        []string `json:"models,omitempty"`
+	SourceNets    []string `json:"source_nets,omitempty"`
+	Signals       []Signal `json:"signals,omitempty"`
+	RevokeCause   string   `json:"revoke_cause,omitempty"`
 }
 
 // Status snapshots every known tenant, worst rung first, for /__gateway/policy.
@@ -588,19 +598,21 @@ func (p *Policy) Status() []TenantStatus {
 		w := ts.rateWindow.sum(now)
 		base, samples := ts.baseline.get()
 		out = append(out, TenantStatus{
-			Tenant:      names[i],
-			State:       ts.state,
-			Since:       ts.stateSince,
-			Score:       ts.lastScore,
-			Quota:       ts.lastQuota,
-			Calls:       w.calls,
-			Tokens:      w.totalTokens(),
-			Denials:     w.denials,
-			Baseline:    base,
-			Samples:     samples,
-			SourceNets:  ts.sourceNets.values(now),
-			Signals:     ts.lastSignals,
-			RevokeCause: ts.manualReason,
+			Tenant:        names[i],
+			State:         ts.state,
+			Since:         ts.stateSince,
+			Score:         ts.lastScore,
+			Quota:         ts.lastQuota,
+			Calls:         w.calls,
+			Tokens:        w.totalTokens(),
+			AuthDenials:   w.authDenials,
+			PolicyDenials: w.policyDenials,
+			Baseline:      base,
+			Samples:       samples,
+			Models:        ts.models.values(now),
+			SourceNets:    ts.sourceNets.values(now),
+			Signals:       ts.lastSignals,
+			RevokeCause:   ts.manualReason,
 		})
 		ts.mu.Unlock()
 	}

--- a/internal/modelgateway/policy.go
+++ b/internal/modelgateway/policy.go
@@ -1,0 +1,614 @@
+package modelgateway
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"sync"
+	"time"
+)
+
+// The graduated response ladder: observe → throttle → alert → circuit-break →
+// revoke.
+//
+// The reason for a ladder rather than a boolean is that both binary outcomes are
+// wrong most of the time. "Allow" means a stolen token spends until a human
+// notices, which is hours. "Deny" means one bad heuristic takes a customer's
+// production agent offline, which is how enforcement gets turned off for good.
+// Every state here except the last is reversible without a human, so the
+// detector is allowed to be wrong: being wrong costs latency, not an outage.
+//
+// Only revocation is sticky, and only revocation is off by default.
+
+// PolicyState is a tenant's rung on the ladder.
+type PolicyState int
+
+const (
+	// StateObserve records usage and enforces nothing. The steady state.
+	StateObserve PolicyState = iota
+
+	// StateThrottle admits calls no faster than ThrottleMinInterval. A tenant
+	// running away is slowed to a rate where a human can catch up with it,
+	// without its work failing outright.
+	StateThrottle
+
+	// StateAlert is StateThrottle plus a one-shot alert to the sink. Split from
+	// throttle so the paging threshold and the slowing threshold are tunable
+	// independently: slowing is cheap, waking someone is not.
+	StateAlert
+
+	// StateCircuitBreak rejects every call for CircuitBreakFor, then steps back
+	// down to StateAlert to re-evaluate. This is where an exceeded quota lands:
+	// it clears itself as the rolling window slides, so a tenant that stops
+	// spending recovers with no operator action.
+	StateCircuitBreak
+
+	// StateRevoke rejects every call until an operator clears it. The only
+	// sticky state and the only one that needs a human to leave, so it is never
+	// entered automatically unless RevokeAt is explicitly configured.
+	StateRevoke
+)
+
+func (s PolicyState) String() string {
+	switch s {
+	case StateObserve:
+		return "observe"
+	case StateThrottle:
+		return "throttle"
+	case StateAlert:
+		return "alert"
+	case StateCircuitBreak:
+		return "circuit_break"
+	case StateRevoke:
+		return "revoke"
+	}
+	return "unknown"
+}
+
+// MarshalJSON renders the state as its name, so the ops readout and any alert
+// payload carry "circuit_break" rather than a bare 3.
+func (s PolicyState) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + s.String() + `"`), nil
+}
+
+// UnmarshalJSON accepts the name form this type emits, so /__gateway/policy and
+// any persisted PolicyEvent round-trip. Without it, marshalling to a name makes
+// the readout write-only for every Go consumer — the daemon and the CLI
+// included. A bare number is also accepted so an older payload still decodes.
+func (s *PolicyState) UnmarshalJSON(b []byte) error {
+	if len(b) > 0 && b[0] != '"' {
+		var n int
+		if err := json.Unmarshal(b, &n); err != nil {
+			return err
+		}
+		if n < int(StateObserve) || n > int(StateRevoke) {
+			return fmt.Errorf("modelgateway: unknown policy state %d", n)
+		}
+		*s = PolicyState(n)
+		return nil
+	}
+	var name string
+	if err := json.Unmarshal(b, &name); err != nil {
+		return err
+	}
+	for _, c := range []PolicyState{StateObserve, StateThrottle, StateAlert, StateCircuitBreak, StateRevoke} {
+		if c.String() == name {
+			*s = c
+			return nil
+		}
+	}
+	return fmt.Errorf("modelgateway: unknown policy state %q", name)
+}
+
+// PolicyEvent is emitted on every state transition. Carries attribution and the
+// reason, never prompt or response content.
+type PolicyEvent struct {
+	Tenant   string      `json:"tenant"`
+	Skill    string      `json:"skill,omitempty"`
+	Provider string      `json:"provider,omitempty"`
+	From     PolicyState `json:"from"`
+	To       PolicyState `json:"to"`
+	Score    float64     `json:"score"`
+	Quota    float64     `json:"quota_fraction"`
+	Reason   string      `json:"reason"`
+	Signals  []Signal    `json:"signals,omitempty"`
+	At       time.Time   `json:"at"`
+}
+
+// AlertSink receives policy transitions. Kept an interface, like UsageSink, so
+// this package stays free of any alerting dependency; the daemon wires its own.
+// A nil sink means transitions are logged and nothing else.
+type AlertSink interface {
+	PolicyTransition(ev PolicyEvent)
+}
+
+// PolicyConfig configures the ladder. The zero value is inert: no quota, no
+// anomaly detection, every tenant in StateObserve. That is deliberate — an OSS
+// operator who upgrades the daemon must not discover that their agents are
+// suddenly being throttled by numbers they never chose.
+type PolicyConfig struct {
+	// Quota is the per-tenant budget. Zero disables quota enforcement.
+	Quota QuotaLimits `json:"quota"`
+
+	// Anomaly configures the detectors. Disabled by default.
+	Anomaly AnomalyConfig `json:"anomaly"`
+
+	// ThrottleAtQuota is the share of budget at which a tenant is slowed, ahead
+	// of actually running out. Default 0.8. Exceeding the budget outright
+	// (fraction >= 1) always circuit-breaks regardless of this.
+	ThrottleAtQuota float64 `json:"throttle_at_quota"`
+
+	// ThrottleMinInterval is the minimum spacing between admitted calls while
+	// throttled. Default 2s.
+	ThrottleMinInterval time.Duration `json:"throttle_min_interval"`
+
+	// AlertAt / BreakAt / RevokeAt are anomaly-score thresholds. Defaults 0.3
+	// and 0.6; RevokeAt defaults to 0, meaning automatic revocation is OFF and
+	// a human must call Revoke. Set it (0..1] only where an operator is
+	// prepared for a heuristic to cut a tenant off until someone intervenes.
+	AlertAt  float64 `json:"alert_at"`
+	BreakAt  float64 `json:"break_at"`
+	RevokeAt float64 `json:"revoke_at"`
+
+	// CircuitBreakFor is how long a break rejects before stepping down to
+	// re-evaluate. Default 1m.
+	CircuitBreakFor time.Duration `json:"circuit_break_for"`
+
+	// Cooldown is how long a tenant must stay clean before de-escalating one
+	// rung. Default 5m. Escalation is immediate; only the way down is damped,
+	// so the ladder cannot flap a tenant between throttled and free while an
+	// incident is still in progress.
+	Cooldown time.Duration `json:"cooldown"`
+
+	// Now is the clock, injectable for tests. Defaults to time.Now.
+	Now func() time.Time `json:"-"`
+
+	// Alerts receives transitions. Optional.
+	Alerts AlertSink `json:"-"`
+}
+
+func (c PolicyConfig) normalized() PolicyConfig {
+	c.Quota = c.Quota.normalized()
+	c.Anomaly = c.Anomaly.normalized()
+	if c.ThrottleAtQuota <= 0 || c.ThrottleAtQuota > 1 {
+		c.ThrottleAtQuota = 0.8
+	}
+	if c.ThrottleMinInterval <= 0 {
+		c.ThrottleMinInterval = 2 * time.Second
+	}
+	if c.AlertAt <= 0 {
+		c.AlertAt = 0.3
+	}
+	if c.BreakAt <= 0 {
+		c.BreakAt = 0.6
+	}
+	if c.CircuitBreakFor <= 0 {
+		c.CircuitBreakFor = time.Minute
+	}
+	if c.Cooldown <= 0 {
+		c.Cooldown = 5 * time.Minute
+	}
+	if c.Now == nil {
+		c.Now = time.Now
+	}
+	return c
+}
+
+// Decision is the ladder's answer for one request.
+type Decision struct {
+	State      PolicyState   `json:"state"`
+	Allow      bool          `json:"allow"`
+	Status     int           `json:"status,omitempty"`
+	Reason     string        `json:"reason,omitempty"`
+	RetryAfter time.Duration `json:"retry_after,omitempty"`
+	Signals    []Signal      `json:"signals,omitempty"`
+}
+
+// tenantState is one tenant's accounting and rung. Guarded by its own mutex so
+// tenants don't contend with each other on a busy gateway.
+type tenantState struct {
+	mu sync.Mutex
+
+	// rateWindow backs both the quota check and the auth-failure ratio.
+	rateWindow *rollingWindow
+	// baseline is the tenant's learned normal token rate.
+	baseline       *ewma
+	lastBaselineAt time.Time
+
+	models     *recentSet
+	endpoints  *recentSet
+	sourceNets *recentSet
+
+	// pendingNew* carry this request's novelty findings into evaluate.
+	pendingNewModel    string
+	pendingNewEndpoint string
+
+	state        PolicyState
+	stateSince   time.Time
+	lastTrigger  time.Time // last time a condition justified the current rung
+	lastAdmitted time.Time
+	breakUntil   time.Time
+	manualReason string
+
+	lastScore   float64
+	lastQuota   float64
+	lastSignals []Signal
+}
+
+// Policy is the per-tenant ladder. Safe for concurrent use.
+type Policy struct {
+	cfg PolicyConfig
+
+	mu      sync.Mutex
+	tenants map[string]*tenantState
+}
+
+// NewPolicy builds a Policy. A zero PolicyConfig yields an inert policy that
+// allows everything and only records.
+func NewPolicy(cfg PolicyConfig) *Policy {
+	return &Policy{cfg: cfg.normalized(), tenants: map[string]*tenantState{}}
+}
+
+func (p *Policy) state(tenant string) *tenantState {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	ts := p.tenants[tenant]
+	if ts == nil {
+		now := p.cfg.Now()
+		ts = &tenantState{
+			rateWindow:     newRollingWindow(p.cfg.Quota.Window),
+			baseline:       newEWMA(p.cfg.Anomaly.BaselineAlpha),
+			lastBaselineAt: now,
+			models:         newRecentSet(p.cfg.Anomaly.NoveltyTTL),
+			endpoints:      newRecentSet(p.cfg.Anomaly.NoveltyTTL),
+			sourceNets:     newRecentSet(p.cfg.Anomaly.ConcurrentWindow),
+			stateSince:     now,
+		}
+		p.tenants[tenant] = ts
+	}
+	return ts
+}
+
+// RequestInfo is what the ladder needs to know about one call. Everything here
+// is metadata the gateway already has; no request body is retained.
+type RequestInfo struct {
+	Tenant     string
+	Skill      string
+	Provider   string
+	Model      string
+	Endpoint   string // upstream path shape, e.g. "/v1/messages"
+	RemoteAddr string
+}
+
+// Check evaluates the ladder for one request and returns whether to admit it.
+// Called after the gateway token is verified and before the real provider key is
+// injected, so a denied request never reaches the provider and never touches the
+// key.
+func (p *Policy) Check(info RequestInfo) Decision {
+	if info.Tenant == "" {
+		return Decision{State: StateObserve, Allow: true}
+	}
+	now := p.cfg.Now()
+	ts := p.state(info.Tenant)
+
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+
+	// Novelty observations feed this evaluation, then reset.
+	ts.pendingNewModel = ""
+	ts.pendingNewEndpoint = ""
+	if p.cfg.Anomaly.Enabled {
+		if info.Model != "" && ts.models.observe(now, info.Model) {
+			ts.pendingNewModel = info.Model
+		}
+		if info.Endpoint != "" && ts.endpoints.observe(now, info.Endpoint) {
+			ts.pendingNewEndpoint = info.Endpoint
+		}
+		if n := sourceNet(info.RemoteAddr); n != "" {
+			ts.sourceNets.observe(now, n)
+		}
+	}
+
+	baselineDue := p.cfg.Anomaly.Enabled && now.Sub(ts.lastBaselineAt) >= p.cfg.Anomaly.BaselineWindow
+
+	quota := p.cfg.Quota.evaluate(ts.rateWindow.sum(now))
+	signals := p.cfg.Anomaly.evaluate(ts, now)
+	sc := score(signals)
+
+	// Fold the finished measurement period into the baseline — but only after
+	// evaluating it, and only if it looked normal.
+	//
+	// Order matters more than it appears. Learning before evaluating lets the
+	// spike being judged raise the very baseline it is judged against, and with
+	// any reasonable EWMA weight that is enough to hide a 100x burst. Learning
+	// from a window that fired signals, or one where the tenant was already off
+	// StateObserve, has the same effect spread over a few windows: the detector
+	// gradually accepts the attack as this tenant's new normal. So a window
+	// teaches the baseline only if it was quiet.
+	if baselineDue {
+		if ts.state == StateObserve && len(signals) == 0 {
+			ts.baseline.observe(ts.rateWindow.rate(now))
+		}
+		ts.lastBaselineAt = now
+	}
+
+	ts.lastScore, ts.lastQuota, ts.lastSignals = sc, quota.fraction, signals
+
+	want, reason := p.target(quota, sc)
+	p.transition(ts, info, want, reason, now, signals)
+
+	return p.admit(ts, now, quota, signals)
+}
+
+// target maps the current measurements onto the rung they justify, with the
+// reason that got them there.
+func (p *Policy) target(q quotaUsage, sc float64) (PolicyState, string) {
+	state, reason := StateObserve, ""
+
+	if !p.cfg.Quota.IsZero() {
+		switch {
+		case q.exceeded != "":
+			state, reason = StateCircuitBreak, "quota exceeded: "+p.cfg.Quota.describe(q)
+		case q.fraction >= p.cfg.ThrottleAtQuota:
+			state, reason = StateThrottle, "approaching quota: "+p.cfg.Quota.describe(q)
+		}
+	}
+
+	if p.cfg.Anomaly.Enabled {
+		var as PolicyState
+		switch {
+		case p.cfg.RevokeAt > 0 && sc >= p.cfg.RevokeAt:
+			as = StateRevoke
+		case sc >= p.cfg.BreakAt:
+			as = StateCircuitBreak
+		case sc >= p.cfg.AlertAt:
+			as = StateAlert
+		}
+		if as > state {
+			state, reason = as, fmt.Sprintf("anomaly score %.2f", sc)
+		}
+	}
+	return state, reason
+}
+
+// transition moves the tenant onto want, applying immediate escalation and
+// damped de-escalation.
+func (p *Policy) transition(ts *tenantState, info RequestInfo, want PolicyState, reason string, now time.Time, sigs []Signal) {
+	// Manual revocation outranks everything and never expires on its own.
+	if ts.state == StateRevoke && ts.manualReason != "" {
+		return
+	}
+
+	if want > StateObserve {
+		ts.lastTrigger = now
+	}
+
+	switch {
+	case want > ts.state:
+		from := ts.state
+		ts.state, ts.stateSince = want, now
+		if want == StateCircuitBreak {
+			ts.breakUntil = now.Add(p.cfg.CircuitBreakFor)
+		}
+		p.emit(ts, info, from, want, reason, now, sigs)
+
+	case ts.state == StateCircuitBreak && now.After(ts.breakUntil):
+		// A break is time-boxed: step down to alert and let the next
+		// evaluation decide whether the condition is still live. Without this
+		// a tenant that tripped once would stay broken until an operator
+		// looked, which is the outage the ladder exists to avoid.
+		//
+		// Still-live conditions extend the break instead of stepping down, so a
+		// tenant sitting over its budget stays broken quietly rather than
+		// flapping break→alert→break and paging on every cycle.
+		if want >= StateCircuitBreak {
+			ts.breakUntil = now.Add(p.cfg.CircuitBreakFor)
+			return
+		}
+		from := ts.state
+		ts.state, ts.stateSince = StateAlert, now
+		p.emit(ts, info, from, ts.state, "circuit-break elapsed; re-evaluating", now, sigs)
+
+	case want < ts.state && now.Sub(ts.lastTrigger) >= p.cfg.Cooldown:
+		from := ts.state
+		ts.state, ts.stateSince = ts.state-1, now // one rung at a time
+		p.emit(ts, info, from, ts.state, "cooldown elapsed", now, sigs)
+	}
+}
+
+// admit applies the current rung to this request.
+func (p *Policy) admit(ts *tenantState, now time.Time, q quotaUsage, sigs []Signal) Decision {
+	d := Decision{State: ts.state, Allow: true, Signals: sigs}
+
+	switch ts.state {
+	case StateObserve:
+		ts.lastAdmitted = now
+		return d
+
+	case StateThrottle, StateAlert:
+		// A hard budget overrun is never merely slowed — target() will have
+		// raised the rung, but a tenant sitting at exactly the limit while
+		// de-escalating must still be stopped.
+		if q.exceeded != "" {
+			d.Allow, d.Status = false, http.StatusTooManyRequests
+			d.Reason = "quota exceeded: " + p.cfg.Quota.describe(q)
+			d.RetryAfter = p.cfg.Quota.Window
+			ts.rateWindow.add(now, counts{denials: 1})
+			return d
+		}
+		if wait := p.cfg.ThrottleMinInterval - now.Sub(ts.lastAdmitted); wait > 0 && !ts.lastAdmitted.IsZero() {
+			d.Allow, d.Status = false, http.StatusTooManyRequests
+			d.Reason = "throttled"
+			d.RetryAfter = wait
+			ts.rateWindow.add(now, counts{denials: 1})
+			return d
+		}
+		ts.lastAdmitted = now
+		return d
+
+	case StateCircuitBreak:
+		d.Allow, d.Status = false, http.StatusServiceUnavailable
+		d.Reason = "circuit open"
+		d.RetryAfter = ts.breakUntil.Sub(now)
+		if d.RetryAfter < 0 {
+			d.RetryAfter = 0
+		}
+		ts.rateWindow.add(now, counts{denials: 1})
+		return d
+
+	case StateRevoke:
+		d.Allow, d.Status = false, http.StatusForbidden
+		d.Reason = "revoked"
+		if ts.manualReason != "" {
+			d.Reason = "revoked: " + ts.manualReason
+		}
+		ts.rateWindow.add(now, counts{denials: 1})
+		return d
+	}
+	return d
+}
+
+func (p *Policy) emit(ts *tenantState, info RequestInfo, from, to PolicyState, reason string, now time.Time, sigs []Signal) {
+	if p.cfg.Alerts == nil || from == to {
+		return
+	}
+	p.cfg.Alerts.PolicyTransition(PolicyEvent{
+		Tenant:   info.Tenant,
+		Skill:    info.Skill,
+		Provider: info.Provider,
+		From:     from,
+		To:       to,
+		Score:    ts.lastScore,
+		Quota:    ts.lastQuota,
+		Reason:   reason,
+		Signals:  sigs,
+		At:       now,
+	})
+}
+
+// RecordUsage folds a completed call's token usage into the tenant's window, so
+// the next Check sees what this one actually cost. Called after the response is
+// metered — a request's own tokens are not known until it finishes, which is why
+// a token budget is enforced one call late by construction.
+func (p *Policy) RecordUsage(tenant string, u Usage) {
+	if tenant == "" {
+		return
+	}
+	now := p.cfg.Now()
+	ts := p.state(tenant)
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	ts.rateWindow.add(now, counts{
+		calls:        1,
+		inputTokens:  u.InputTokens,
+		outputTokens: u.OutputTokens,
+		cachedTokens: u.CachedTokens,
+	})
+}
+
+// RecordDenial records a request rejected before it reached the provider —
+// an unknown provider for the token, a model outside its allowed set. These
+// feed the auth-failure-ratio signal: a token being probed rather than used.
+func (p *Policy) RecordDenial(tenant string) {
+	if tenant == "" {
+		return
+	}
+	now := p.cfg.Now()
+	ts := p.state(tenant)
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	ts.rateWindow.add(now, counts{denials: 1})
+}
+
+// Revoke puts a tenant on the sticky rung until Clear. The operator escape
+// hatch behind the issue's "instantly revocable" requirement: it takes effect on
+// the tenant's next call with no token re-issue and no box restart.
+func (p *Policy) Revoke(tenant, reason string) {
+	if tenant == "" {
+		return
+	}
+	now := p.cfg.Now()
+	ts := p.state(tenant)
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	from := ts.state
+	ts.state, ts.stateSince, ts.manualReason = StateRevoke, now, reason
+	p.emit(ts, RequestInfo{Tenant: tenant}, from, StateRevoke, "operator revoked: "+reason, now, nil)
+}
+
+// Clear returns a tenant to StateObserve, including from a manual revocation.
+func (p *Policy) Clear(tenant string) {
+	if tenant == "" {
+		return
+	}
+	now := p.cfg.Now()
+	ts := p.state(tenant)
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	from := ts.state
+	ts.state, ts.stateSince, ts.manualReason = StateObserve, now, ""
+	ts.breakUntil = time.Time{}
+	ts.lastTrigger = time.Time{}
+	p.emit(ts, RequestInfo{Tenant: tenant}, from, StateObserve, "operator cleared", now, nil)
+}
+
+// TenantStatus is the ops readout for one tenant.
+type TenantStatus struct {
+	Tenant      string      `json:"tenant"`
+	State       PolicyState `json:"state"`
+	Since       time.Time   `json:"since"`
+	Score       float64     `json:"anomaly_score"`
+	Quota       float64     `json:"quota_fraction"`
+	Calls       int64       `json:"calls_in_window"`
+	Tokens      int64       `json:"tokens_in_window"`
+	Denials     int64       `json:"denials_in_window"`
+	Baseline    float64     `json:"baseline_tokens_per_sec"`
+	Samples     int         `json:"baseline_samples"`
+	SourceNets  []string    `json:"source_nets,omitempty"`
+	Signals     []Signal    `json:"signals,omitempty"`
+	RevokeCause string      `json:"revoke_cause,omitempty"`
+}
+
+// Status snapshots every known tenant, worst rung first, for /__gateway/policy.
+func (p *Policy) Status() []TenantStatus {
+	now := p.cfg.Now()
+	p.mu.Lock()
+	names := make([]string, 0, len(p.tenants))
+	states := make([]*tenantState, 0, len(p.tenants))
+	for n, ts := range p.tenants {
+		names = append(names, n)
+		states = append(states, ts)
+	}
+	p.mu.Unlock()
+
+	out := make([]TenantStatus, 0, len(names))
+	for i, ts := range states {
+		ts.mu.Lock()
+		w := ts.rateWindow.sum(now)
+		base, samples := ts.baseline.get()
+		out = append(out, TenantStatus{
+			Tenant:      names[i],
+			State:       ts.state,
+			Since:       ts.stateSince,
+			Score:       ts.lastScore,
+			Quota:       ts.lastQuota,
+			Calls:       w.calls,
+			Tokens:      w.totalTokens(),
+			Denials:     w.denials,
+			Baseline:    base,
+			Samples:     samples,
+			SourceNets:  ts.sourceNets.values(now),
+			Signals:     ts.lastSignals,
+			RevokeCause: ts.manualReason,
+		})
+		ts.mu.Unlock()
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].State != out[j].State {
+			return out[i].State > out[j].State
+		}
+		return out[i].Tenant < out[j].Tenant
+	})
+	return out
+}

--- a/internal/modelgateway/policy_gateway_test.go
+++ b/internal/modelgateway/policy_gateway_test.go
@@ -66,8 +66,8 @@ func TestGateway_DeniedRequestNeverReachesUpstream(t *testing.T) {
 	if first.StatusCode != http.StatusOK {
 		t.Fatalf("first call status = %d, want 200", first.StatusCode)
 	}
-	if atomic.LoadInt64(&upstreamHits) != 1 {
-		t.Fatalf("upstream hits after first call = %d, want 1", upstreamHits)
+	if got := atomic.LoadInt64(&upstreamHits); got != 1 {
+		t.Fatalf("upstream hits after first call = %d, want 1", got)
 	}
 
 	second := call()
@@ -237,5 +237,107 @@ func TestGateway_PolicyEndpointReportsTenantState(t *testing.T) {
 	}
 	if string(raw) != `"observe"` {
 		t.Errorf("state JSON = %s, want \"observe\"", raw)
+	}
+}
+
+// Anthropic carries the model only in the request body — not the path like
+// Gemini, and it is not OpenAI-shaped. Without extracting it there, the
+// model-switch signal was silent for the provider skill boxes are provisioned
+// for by default, and the lifecycle logs reported an empty model for it.
+func TestGateway_ExtractsRequestModelForAnthropic(t *testing.T) {
+	secret := []byte("shared-secret")
+	var gotBody string
+	up := fakeUpstream(t, func(r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+	}, `{"model":"claude-sonnet-test","usage":{"input_tokens":5,"output_tokens":5}}`)
+	defer up.Close()
+
+	providers := DefaultProviders()
+	providers["anthropic"].UpstreamURL = up.URL
+	gw := New(Config{
+		Secret: secret, Providers: providers,
+		ProviderKeys: map[string]string{"anthropic": "K"},
+		Policy:       &PolicyConfig{Anomaly: AnomalyConfig{Enabled: true, NoveltyTTL: time.Hour}},
+	})
+	srv := httptest.NewServer(gw.Handler())
+	defer srv.Close()
+
+	tok, _ := MintToken(secret, GatewayClaims{Tenant: "acme", Provider: "anthropic"}, time.Hour)
+	body := `{"model":"claude-sonnet-test","max_tokens":16}`
+	req, _ := http.NewRequest("POST", srv.URL+"/v1/model/anthropic/v1/messages", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	// Reading the body to find the model must not consume it.
+	if gotBody != body {
+		t.Errorf("upstream body = %q, want %q — the body was consumed or rewritten", gotBody, body)
+	}
+
+	st := gw.Policy().Status()
+	if len(st) != 1 {
+		t.Fatalf("want 1 tenant, got %d", len(st))
+	}
+	if len(st[0].Models) != 1 || st[0].Models[0] != "claude-sonnet-test" {
+		t.Errorf("models = %v, want [claude-sonnet-test]", st[0].Models)
+	}
+}
+
+// Retry-After must round UP. Truncating 1.5s to 1 tells a well-behaved client
+// to come back while the throttle is still closed, so it is denied again.
+func TestGateway_RetryAfterRoundsUp(t *testing.T) {
+	secret := []byte("shared-secret")
+	up := fakeUpstream(t, func(*http.Request) {},
+		`{"model":"claude-test","usage":{"input_tokens":90,"output_tokens":0}}`)
+	defer up.Close()
+
+	providers := DefaultProviders()
+	providers["anthropic"].UpstreamURL = up.URL
+	gw := New(Config{
+		Secret: secret, Providers: providers,
+		ProviderKeys: map[string]string{"anthropic": "K"},
+		Policy: &PolicyConfig{
+			Quota:               QuotaLimits{Window: time.Minute, MaxTotalTokens: 100},
+			ThrottleAtQuota:     0.5,
+			ThrottleMinInterval: 1500 * time.Millisecond,
+		},
+	})
+	srv := httptest.NewServer(gw.Handler())
+	defer srv.Close()
+
+	tok, _ := MintToken(secret, GatewayClaims{Tenant: "acme", Provider: "anthropic"}, time.Hour)
+	call := func() *http.Response {
+		req, _ := http.NewRequest("POST", srv.URL+"/v1/model/anthropic/v1/messages",
+			strings.NewReader(`{"model":"claude-test"}`))
+		req.Header.Set("Authorization", "Bearer "+tok)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+		return resp
+	}
+
+	call() // spends 90 of 100 → past the 50% throttle mark
+	call() // admitted, starts the throttle interval
+	denied := call()
+
+	if denied.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429", denied.StatusCode)
+	}
+	// The remaining wait is just under 1.5s, so truncation yields 1 and
+	// rounding up yields 2.
+	if ra := denied.Header.Get("Retry-After"); ra != "2" {
+		t.Errorf("Retry-After = %q, want \"2\" (truncation would give \"1\")", ra)
 	}
 }

--- a/internal/modelgateway/policy_gateway_test.go
+++ b/internal/modelgateway/policy_gateway_test.go
@@ -1,0 +1,241 @@
+package modelgateway
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// The load-bearing property of the whole feature: a request the ladder refuses
+// must never reach the provider. The real key is injected in the proxy's
+// Director, so "denied" has to mean the Director never runs — not that we
+// discarded the response afterwards. Asserting on upstream hits proves it in
+// the only way that can't quietly regress.
+func TestGateway_DeniedRequestNeverReachesUpstream(t *testing.T) {
+	secret := []byte("shared-secret")
+	var upstreamHits int64
+	var sawKey atomic.Value
+	sawKey.Store("")
+
+	up := fakeUpstream(t, func(r *http.Request) {
+		atomic.AddInt64(&upstreamHits, 1)
+		sawKey.Store(r.Header.Get("x-api-key"))
+	}, `{"model":"claude-test","usage":{"input_tokens":900,"output_tokens":900}}`)
+	defer up.Close()
+
+	providers := DefaultProviders()
+	providers["anthropic"].UpstreamURL = up.URL
+	gw := New(Config{
+		Secret:       secret,
+		Providers:    providers,
+		ProviderKeys: map[string]string{"anthropic": "REAL-KEY"},
+		Policy: &PolicyConfig{
+			// One call's worth of budget: the first request goes through and
+			// spends 1800 tokens, the second finds the budget gone.
+			Quota: QuotaLimits{Window: time.Minute, MaxTotalTokens: 1000},
+		},
+	})
+	srv := httptest.NewServer(gw.Handler())
+	defer srv.Close()
+
+	tok, err := MintToken(secret, GatewayClaims{Tenant: "acme", SkillID: "s1", Provider: "anthropic"}, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	call := func() *http.Response {
+		t.Helper()
+		req, _ := http.NewRequest("POST", srv.URL+"/v1/model/anthropic/v1/messages",
+			strings.NewReader(`{"model":"claude-test"}`))
+		req.Header.Set("Authorization", "Bearer "+tok)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return resp
+	}
+
+	first := call()
+	_, _ = io.Copy(io.Discard, first.Body)
+	first.Body.Close()
+	if first.StatusCode != http.StatusOK {
+		t.Fatalf("first call status = %d, want 200", first.StatusCode)
+	}
+	if atomic.LoadInt64(&upstreamHits) != 1 {
+		t.Fatalf("upstream hits after first call = %d, want 1", upstreamHits)
+	}
+
+	second := call()
+	body, _ := io.ReadAll(second.Body)
+	second.Body.Close()
+
+	if second.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("second call status = %d, want 503 (circuit open)", second.StatusCode)
+	}
+	if got := atomic.LoadInt64(&upstreamHits); got != 1 {
+		t.Errorf("upstream hits = %d, want 1 — the denied call reached the provider", got)
+	}
+	if ra := second.Header.Get("Retry-After"); ra == "" || ra == "0" {
+		t.Errorf("Retry-After = %q, want a positive hint", ra)
+	}
+	if !strings.Contains(string(body), "circuit open") {
+		t.Errorf("body = %q, want it to say why", body)
+	}
+	// The denial must not leak the credential it was protecting.
+	if strings.Contains(string(body), "REAL-KEY") {
+		t.Error("denial body contains the provider key")
+	}
+}
+
+// An operator revoking a tenant takes effect on the next call, with no token
+// re-issue and no box restart — the issue's "instantly revocable" requirement.
+func TestGateway_RevokeTakesEffectOnAnAlreadyIssuedToken(t *testing.T) {
+	secret := []byte("shared-secret")
+	var upstreamHits int64
+	up := fakeUpstream(t, func(*http.Request) { atomic.AddInt64(&upstreamHits, 1) },
+		`{"model":"claude-test","usage":{"input_tokens":1,"output_tokens":1}}`)
+	defer up.Close()
+
+	providers := DefaultProviders()
+	providers["anthropic"].UpstreamURL = up.URL
+	gw := New(Config{
+		Secret: secret, Providers: providers,
+		ProviderKeys: map[string]string{"anthropic": "REAL-KEY"},
+		Policy:       &PolicyConfig{},
+	})
+	srv := httptest.NewServer(gw.Handler())
+	defer srv.Close()
+
+	// A long-lived token, already in a box.
+	tok, err := MintToken(secret, GatewayClaims{Tenant: "acme", Provider: "anthropic"}, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	call := func() int {
+		req, _ := http.NewRequest("POST", srv.URL+"/v1/model/anthropic/v1/messages",
+			strings.NewReader(`{"model":"claude-test"}`))
+		req.Header.Set("Authorization", "Bearer "+tok)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return resp.StatusCode
+	}
+
+	if got := call(); got != http.StatusOK {
+		t.Fatalf("pre-revoke status = %d, want 200", got)
+	}
+
+	gw.Policy().Revoke("acme", "key suspected compromised")
+
+	if got := call(); got != http.StatusForbidden {
+		t.Errorf("post-revoke status = %d, want 403", got)
+	}
+	if got := atomic.LoadInt64(&upstreamHits); got != 1 {
+		t.Errorf("upstream hits = %d, want 1 — a revoked tenant reached the provider", got)
+	}
+
+	gw.Policy().Clear("acme")
+	if got := call(); got != http.StatusOK {
+		t.Errorf("post-clear status = %d, want 200", got)
+	}
+}
+
+// A gateway with no Policy configured must be exactly what it was before this
+// change: unlimited, undetected, unthrottled.
+func TestGateway_NoPolicyConfiguredChangesNothing(t *testing.T) {
+	secret := []byte("shared-secret")
+	var upstreamHits int64
+	up := fakeUpstream(t, func(*http.Request) { atomic.AddInt64(&upstreamHits, 1) },
+		`{"model":"claude-test","usage":{"input_tokens":100000,"output_tokens":100000}}`)
+	defer up.Close()
+
+	providers := DefaultProviders()
+	providers["anthropic"].UpstreamURL = up.URL
+	gw := New(Config{Secret: secret, Providers: providers, ProviderKeys: map[string]string{"anthropic": "K"}})
+	srv := httptest.NewServer(gw.Handler())
+	defer srv.Close()
+
+	tok, _ := MintToken(secret, GatewayClaims{Tenant: "acme", Provider: "anthropic"}, time.Hour)
+	for i := 0; i < 10; i++ {
+		req, _ := http.NewRequest("POST", srv.URL+"/v1/model/anthropic/v1/messages",
+			strings.NewReader(`{"model":"claude-test"}`))
+		req.Header.Set("Authorization", "Bearer "+tok)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("call %d status = %d, want 200 with no policy configured", i, resp.StatusCode)
+		}
+	}
+	if got := atomic.LoadInt64(&upstreamHits); got != 10 {
+		t.Errorf("upstream hits = %d, want 10", got)
+	}
+}
+
+func TestGateway_PolicyEndpointReportsTenantState(t *testing.T) {
+	secret := []byte("shared-secret")
+	up := fakeUpstream(t, func(*http.Request) {},
+		`{"model":"claude-test","usage":{"input_tokens":50,"output_tokens":50}}`)
+	defer up.Close()
+
+	providers := DefaultProviders()
+	providers["anthropic"].UpstreamURL = up.URL
+	gw := New(Config{
+		Secret: secret, Providers: providers,
+		ProviderKeys: map[string]string{"anthropic": "K"},
+		Policy:       &PolicyConfig{Quota: QuotaLimits{Window: time.Minute, MaxTotalTokens: 10_000}},
+	})
+	srv := httptest.NewServer(gw.Handler())
+	defer srv.Close()
+
+	tok, _ := MintToken(secret, GatewayClaims{Tenant: "acme", SkillID: "s1", Provider: "anthropic"}, time.Hour)
+	req, _ := http.NewRequest("POST", srv.URL+"/v1/model/anthropic/v1/messages",
+		strings.NewReader(`{"model":"claude-test"}`))
+	req.Header.Set("Authorization", "Bearer "+tok)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	pr, err := http.Get(srv.URL + "/__gateway/policy")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pr.Body.Close()
+	var got []TenantStatus
+	if err := json.NewDecoder(pr.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 tenant in the readout, got %d: %+v", len(got), got)
+	}
+	if got[0].Tenant != "acme" {
+		t.Errorf("tenant = %q, want acme", got[0].Tenant)
+	}
+	if got[0].Tokens != 100 {
+		t.Errorf("tokens in window = %d, want 100", got[0].Tokens)
+	}
+
+	// The state must serialize as a name, not an integer — an ops readout that
+	// says 3 is not an ops readout.
+	raw, err := json.Marshal(got[0].State)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != `"observe"` {
+		t.Errorf("state JSON = %s, want \"observe\"", raw)
+	}
+}

--- a/internal/modelgateway/policy_test.go
+++ b/internal/modelgateway/policy_test.go
@@ -1,0 +1,577 @@
+package modelgateway
+
+import (
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeClock drives the ladder deterministically. Every timing property here —
+// cooldown, circuit-break expiry, throttle spacing, window ageing — is a
+// duration, and testing those against the wall clock means either sleeping or
+// flaking. So the policy takes its clock from config and the tests own it.
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func newFakeClock() *fakeClock {
+	return &fakeClock{t: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+}
+
+func (c *fakeClock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = c.t.Add(d)
+}
+
+// recordingSink captures policy transitions.
+type recordingSink struct {
+	mu     sync.Mutex
+	events []PolicyEvent
+}
+
+func (s *recordingSink) PolicyTransition(ev PolicyEvent) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, ev)
+}
+
+func (s *recordingSink) all() []PolicyEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]PolicyEvent(nil), s.events...)
+}
+
+func (s *recordingSink) transitionsTo(st PolicyState) int {
+	n := 0
+	for _, e := range s.all() {
+		if e.To == st {
+			n++
+		}
+	}
+	return n
+}
+
+func req(tenant string) RequestInfo {
+	return RequestInfo{Tenant: tenant, Provider: "anthropic", Model: "m1", Endpoint: "/v1/messages", RemoteAddr: "10.0.0.5:1234"}
+}
+
+// A gateway upgraded without any policy configuration must behave exactly as it
+// did before: no quota, no detection, nothing denied. This is the property that
+// makes the feature safe to ship, so it is the first test.
+func TestPolicy_ZeroConfigIsInert(t *testing.T) {
+	p := NewPolicy(PolicyConfig{})
+	for i := 0; i < 500; i++ {
+		p.RecordUsage("acme", Usage{InputTokens: 10_000, OutputTokens: 10_000})
+		d := p.Check(req("acme"))
+		if !d.Allow {
+			t.Fatalf("call %d denied under zero config: %+v", i, d)
+		}
+		if d.State != StateObserve {
+			t.Fatalf("call %d state = %s, want observe", i, d.State)
+		}
+	}
+}
+
+func TestPolicy_QuotaExceeded_CircuitBreaks(t *testing.T) {
+	clk := newFakeClock()
+	sink := &recordingSink{}
+	p := NewPolicy(PolicyConfig{
+		Quota:  QuotaLimits{Window: time.Minute, MaxTotalTokens: 100},
+		Now:    clk.now,
+		Alerts: sink,
+	})
+
+	if d := p.Check(req("acme")); !d.Allow {
+		t.Fatalf("first call denied: %+v", d)
+	}
+	p.RecordUsage("acme", Usage{InputTokens: 80, OutputTokens: 40}) // 120 > 100
+
+	d := p.Check(req("acme"))
+	if d.Allow {
+		t.Fatal("call admitted after the token budget was exhausted")
+	}
+	if d.State != StateCircuitBreak {
+		t.Errorf("state = %s, want circuit_break", d.State)
+	}
+	if d.Status != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", d.Status)
+	}
+	if d.RetryAfter <= 0 {
+		t.Errorf("RetryAfter = %v, want a positive hint", d.RetryAfter)
+	}
+	if sink.transitionsTo(StateCircuitBreak) != 1 {
+		t.Errorf("want exactly one circuit-break transition, got %d: %+v",
+			sink.transitionsTo(StateCircuitBreak), sink.all())
+	}
+}
+
+// The budget is a rolling window, not a lifetime cap: once the spend ages out
+// the tenant works again with no operator action.
+func TestPolicy_QuotaRecoversAsWindowSlides(t *testing.T) {
+	clk := newFakeClock()
+	p := NewPolicy(PolicyConfig{
+		Quota:           QuotaLimits{Window: time.Minute, MaxTotalTokens: 100},
+		CircuitBreakFor: 10 * time.Second,
+		Cooldown:        10 * time.Second,
+		Now:             clk.now,
+	})
+
+	p.RecordUsage("acme", Usage{InputTokens: 200})
+	if d := p.Check(req("acme")); d.Allow {
+		t.Fatal("expected denial while over budget")
+	}
+
+	// Past the window: the spend has aged out entirely.
+	clk.advance(2 * time.Minute)
+
+	// De-escalation is one rung per cooldown, so drive several evaluations.
+	var last Decision
+	for i := 0; i < 6; i++ {
+		last = p.Check(req("acme"))
+		clk.advance(11 * time.Second)
+	}
+	if !last.Allow {
+		t.Fatalf("tenant never recovered after the window slid: %+v", last)
+	}
+	if last.State != StateObserve {
+		t.Errorf("final state = %s, want observe", last.State)
+	}
+}
+
+func TestPolicy_ApproachingQuota_ThrottlesWithSpacing(t *testing.T) {
+	clk := newFakeClock()
+	p := NewPolicy(PolicyConfig{
+		Quota:               QuotaLimits{Window: time.Minute, MaxTotalTokens: 100},
+		ThrottleAtQuota:     0.8,
+		ThrottleMinInterval: 2 * time.Second,
+		Now:                 clk.now,
+	})
+
+	p.RecordUsage("acme", Usage{InputTokens: 85}) // 85% — over the throttle mark, under the cap
+
+	d1 := p.Check(req("acme"))
+	if !d1.Allow {
+		t.Fatalf("first throttled call should still be admitted: %+v", d1)
+	}
+	if d1.State != StateThrottle {
+		t.Errorf("state = %s, want throttle", d1.State)
+	}
+
+	// Immediately again: inside the minimum spacing.
+	d2 := p.Check(req("acme"))
+	if d2.Allow {
+		t.Fatal("second call admitted inside the throttle interval")
+	}
+	if d2.Status != http.StatusTooManyRequests {
+		t.Errorf("status = %d, want 429", d2.Status)
+	}
+	if d2.RetryAfter <= 0 || d2.RetryAfter > 2*time.Second {
+		t.Errorf("RetryAfter = %v, want (0,2s]", d2.RetryAfter)
+	}
+
+	// After the interval it is admitted again — throttled, not blocked.
+	clk.advance(2 * time.Second)
+	if d3 := p.Check(req("acme")); !d3.Allow {
+		t.Fatalf("call denied after the throttle interval elapsed: %+v", d3)
+	}
+}
+
+func TestPolicy_CircuitBreakStepsDownWhenConditionClears(t *testing.T) {
+	clk := newFakeClock()
+	p := NewPolicy(PolicyConfig{
+		Quota:           QuotaLimits{Window: time.Minute, MaxTotalTokens: 100},
+		CircuitBreakFor: 30 * time.Second,
+		Now:             clk.now,
+	})
+
+	p.RecordUsage("acme", Usage{InputTokens: 500})
+	if d := p.Check(req("acme")); d.State != StateCircuitBreak {
+		t.Fatalf("state = %s, want circuit_break", d.State)
+	}
+
+	// Still over budget when the break elapses: it extends rather than flapping.
+	clk.advance(31 * time.Second)
+	if d := p.Check(req("acme")); d.State != StateCircuitBreak {
+		t.Errorf("state = %s while still over budget, want the break to hold", d.State)
+	}
+
+	// Spend ages out, then the break elapses: now it steps down.
+	clk.advance(2 * time.Minute)
+	if d := p.Check(req("acme")); d.State != StateAlert {
+		t.Errorf("state = %s after the condition cleared, want alert (one rung down)", d.State)
+	}
+}
+
+// Escalation is immediate but descent is damped and one rung at a time, so an
+// incident that is still in progress can't be walked back by a quiet second.
+func TestPolicy_DeEscalatesOneRungPerCooldown(t *testing.T) {
+	clk := newFakeClock()
+	p := NewPolicy(PolicyConfig{
+		Quota:               QuotaLimits{Window: time.Minute, MaxTotalTokens: 100},
+		ThrottleMinInterval: time.Nanosecond,
+		CircuitBreakFor:     time.Second,
+		Cooldown:            time.Minute,
+		Now:                 clk.now,
+	})
+
+	p.RecordUsage("acme", Usage{InputTokens: 500})
+	p.Check(req("acme")) // → circuit_break
+	clk.advance(5 * time.Minute)
+
+	got := []PolicyState{}
+	for i := 0; i < 3; i++ {
+		got = append(got, p.Check(req("acme")).State)
+		clk.advance(61 * time.Second)
+	}
+	want := []PolicyState{StateAlert, StateThrottle, StateObserve}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("descent = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestPolicy_ManualRevokeIsStickyUntilCleared(t *testing.T) {
+	clk := newFakeClock()
+	sink := &recordingSink{}
+	p := NewPolicy(PolicyConfig{Cooldown: time.Second, Now: clk.now, Alerts: sink})
+
+	p.Revoke("acme", "credential suspected stolen")
+
+	// Perfectly clean traffic for a long time must not lift a revocation: it is
+	// the one state that needs a human, which is the whole point of having it.
+	for i := 0; i < 5; i++ {
+		clk.advance(time.Hour)
+		d := p.Check(req("acme"))
+		if d.Allow {
+			t.Fatal("revoked tenant admitted")
+		}
+		if d.State != StateRevoke {
+			t.Fatalf("state = %s, want revoke", d.State)
+		}
+		if d.Status != http.StatusForbidden {
+			t.Errorf("status = %d, want 403", d.Status)
+		}
+	}
+
+	p.Clear("acme")
+	if d := p.Check(req("acme")); !d.Allow || d.State != StateObserve {
+		t.Fatalf("after Clear: %+v, want allowed/observe", d)
+	}
+	if sink.transitionsTo(StateRevoke) != 1 {
+		t.Errorf("want 1 revoke transition, got %d", sink.transitionsTo(StateRevoke))
+	}
+}
+
+// Anomaly detection must stay silent until it has actually learned the tenant,
+// or every new tenant's first burst is an incident.
+func TestPolicy_BaselineSilentUntilEnoughSamples(t *testing.T) {
+	clk := newFakeClock()
+	p := NewPolicy(PolicyConfig{
+		Anomaly: AnomalyConfig{
+			Enabled:            true,
+			BaselineWindow:     time.Minute,
+			BaselineMinSamples: 5,
+			BaselineFactor:     4,
+			NoveltyTTL:         time.Hour,
+		},
+		Now: clk.now,
+	})
+
+	// A huge first call, with no history to compare against.
+	p.RecordUsage("acme", Usage{InputTokens: 5_000_000})
+	d := p.Check(req("acme"))
+	for _, s := range d.Signals {
+		if s.Name == SignalRateBaseline {
+			t.Fatalf("baseline signal fired with no established baseline: %+v", s)
+		}
+	}
+}
+
+func TestPolicy_RateSpikeAgainstLearnedBaseline(t *testing.T) {
+	clk := newFakeClock()
+	p := NewPolicy(PolicyConfig{
+		Quota: QuotaLimits{Window: time.Minute},
+		Anomaly: AnomalyConfig{
+			Enabled:            true,
+			BaselineWindow:     time.Minute,
+			BaselineAlpha:      0.5,
+			BaselineMinSamples: 3,
+			BaselineFactor:     5,
+			NoveltyTTL:         time.Hour,
+		},
+		AlertAt: 0.01, // any severity is enough to reach alert, for a crisp assertion
+		BreakAt: 9,    // keep break out of the way
+		Now:     clk.now,
+	})
+
+	// Teach a steady, modest rate: a few windows of light traffic.
+	for i := 0; i < 6; i++ {
+		p.RecordUsage("acme", Usage{InputTokens: 100})
+		p.Check(req("acme"))
+		clk.advance(70 * time.Second)
+	}
+
+	// Now a burst two orders of magnitude above that.
+	for i := 0; i < 20; i++ {
+		p.RecordUsage("acme", Usage{InputTokens: 50_000})
+	}
+	d := p.Check(req("acme"))
+
+	var found *Signal
+	for i := range d.Signals {
+		if d.Signals[i].Name == SignalRateBaseline {
+			found = &d.Signals[i]
+		}
+	}
+	if found == nil {
+		t.Fatalf("no baseline signal on a 100x spike; signals=%+v state=%s", d.Signals, d.State)
+	}
+	if found.Severity <= 0 {
+		t.Errorf("severity = %v, want > 0", found.Severity)
+	}
+	if d.State < StateAlert {
+		t.Errorf("state = %s, want at least alert", d.State)
+	}
+}
+
+// A baseline that keeps learning during an incident eventually accepts the
+// attack as normal. It must freeze while the tenant is off the observe rung.
+func TestPolicy_BaselineFrozenWhileEscalated(t *testing.T) {
+	clk := newFakeClock()
+	p := NewPolicy(PolicyConfig{
+		Quota: QuotaLimits{Window: time.Minute, MaxTotalTokens: 1000},
+		Anomaly: AnomalyConfig{
+			Enabled: true, BaselineWindow: time.Minute, BaselineMinSamples: 2, NoveltyTTL: time.Hour,
+		},
+		CircuitBreakFor: time.Hour, // hold the tenant off observe
+		Now:             clk.now,
+	})
+
+	// Establish a baseline, then blow the budget so the tenant leaves observe.
+	for i := 0; i < 3; i++ {
+		p.RecordUsage("acme", Usage{InputTokens: 10})
+		p.Check(req("acme"))
+		clk.advance(61 * time.Second)
+	}
+	before := statusFor(t, p, "acme")
+
+	p.RecordUsage("acme", Usage{InputTokens: 100_000})
+	if d := p.Check(req("acme")); d.State == StateObserve {
+		t.Fatal("expected the tenant to leave observe after exceeding budget")
+	}
+	for i := 0; i < 5; i++ {
+		p.RecordUsage("acme", Usage{InputTokens: 100_000})
+		clk.advance(61 * time.Second)
+		p.Check(req("acme"))
+	}
+
+	after := statusFor(t, p, "acme")
+	if after.Samples != before.Samples {
+		t.Errorf("baseline kept learning while escalated: samples %d → %d", before.Samples, after.Samples)
+	}
+}
+
+func TestPolicy_NoveltyAndConcurrencySignals(t *testing.T) {
+	clk := newFakeClock()
+	p := NewPolicy(PolicyConfig{
+		Anomaly: AnomalyConfig{
+			Enabled:              true,
+			NoveltyTTL:           time.Hour,
+			ConcurrentWindow:     time.Minute,
+			ConcurrentSourceNets: 2,
+			BaselineWindow:       time.Minute,
+			BaselineMinSamples:   1,
+			BaselineFactor:       1e9, // keep the rate signal out of this test
+		},
+		Now: clk.now,
+	})
+
+	base := RequestInfo{Tenant: "acme", Provider: "anthropic", Model: "haiku", Endpoint: "/v1/messages", RemoteAddr: "10.0.0.5:1"}
+
+	// Cold start: while the tenant is still being learned, "first ever model" is
+	// not a switch and must not fire. Priming past BaselineMinSamples is what
+	// turns the novelty detectors on.
+	if d := p.Check(base); hasSignal(d.Signals, SignalNewModel) || hasSignal(d.Signals, SignalNewEndpoint) {
+		t.Fatalf("novelty fired on an unlearned tenant's first call: %+v", d.Signals)
+	}
+	clk.advance(61 * time.Second)
+	p.Check(base) // folds the quiet window into the baseline
+
+	// Established now, and the primed model/endpoint are no longer novel.
+	d := p.Check(base)
+	if hasSignal(d.Signals, SignalNewModel) || hasSignal(d.Signals, SignalNewEndpoint) {
+		t.Errorf("repeat call flagged as novel: %+v", d.Signals)
+	}
+
+	// A model the tenant has never used — the "model-tier switch" shape.
+	up := base
+	up.Model = "opus"
+	if d = p.Check(up); !hasSignal(d.Signals, SignalNewModel) {
+		t.Errorf("switch to an unseen model not flagged: %+v", d.Signals)
+	}
+
+	// The same token arriving from more networks than a box population explains.
+	for _, addr := range []string{"203.0.113.7:1", "198.51.100.9:1", "192.0.2.11:1"} {
+		n := base
+		n.RemoteAddr = addr
+		d = p.Check(n)
+	}
+	if !hasSignal(d.Signals, SignalConcurrentNets) {
+		t.Errorf("four distinct source networks not flagged: %+v", d.Signals)
+	}
+}
+
+func TestPolicy_AuthFailureRatioSignal(t *testing.T) {
+	clk := newFakeClock()
+	p := NewPolicy(PolicyConfig{
+		Quota: QuotaLimits{Window: time.Minute},
+		Anomaly: AnomalyConfig{
+			Enabled:            true,
+			AuthFailureRatio:   0.5,
+			AuthFailureMin:     4,
+			BaselineMinSamples: 1000,
+			NoveltyTTL:         time.Hour,
+		},
+		Now: clk.now,
+	})
+
+	p.RecordUsage("acme", Usage{InputTokens: 1})
+	p.RecordUsage("acme", Usage{InputTokens: 1})
+	for i := 0; i < 6; i++ {
+		p.RecordDenial("acme") // probing: rejected provider/model
+	}
+
+	d := p.Check(req("acme"))
+	if !hasSignal(d.Signals, SignalAuthFailureRate) {
+		t.Fatalf("6 denials against 2 calls not flagged: %+v", d.Signals)
+	}
+}
+
+// Automatic revocation is destructive and needs a human to undo, so it must not
+// happen unless the operator opted in by setting RevokeAt.
+func TestPolicy_NoAutoRevokeUnlessConfigured(t *testing.T) {
+	clk := newFakeClock()
+	mk := func(revokeAt float64) *Policy {
+		return NewPolicy(PolicyConfig{
+			Anomaly: AnomalyConfig{
+				Enabled: true, NoveltyTTL: time.Hour,
+				ConcurrentSourceNets: 1, ConcurrentWindow: time.Minute,
+				BaselineMinSamples: 1000,
+			},
+			AlertAt: 0.01, BreakAt: 0.02, RevokeAt: revokeAt,
+			Now: clk.now,
+		})
+	}
+
+	drive := func(p *Policy) PolicyState {
+		var d Decision
+		for _, addr := range []string{"10.0.0.1:1", "203.0.113.1:1", "198.51.100.1:1", "192.0.2.1:1"} {
+			i := req("acme")
+			i.RemoteAddr = addr
+			i.Model = addr // also trip novelty, to push the score up
+			d = p.Check(i)
+		}
+		return d.State
+	}
+
+	if got := drive(mk(0)); got == StateRevoke {
+		t.Error("auto-revoked with RevokeAt unset")
+	}
+	if got := drive(mk(0.05)); got != StateRevoke {
+		t.Errorf("state = %s with RevokeAt configured, want revoke", got)
+	}
+}
+
+func TestPolicy_StatusReportsWorstFirst(t *testing.T) {
+	clk := newFakeClock()
+	p := NewPolicy(PolicyConfig{
+		Quota: QuotaLimits{Window: time.Minute, MaxTotalTokens: 100},
+		Now:   clk.now,
+	})
+
+	p.Check(req("quiet"))
+	p.RecordUsage("loud", Usage{InputTokens: 900})
+	p.Check(req("loud"))
+
+	st := p.Status()
+	if len(st) != 2 {
+		t.Fatalf("want 2 tenants, got %d", len(st))
+	}
+	if st[0].Tenant != "loud" {
+		t.Errorf("worst tenant not first: %+v", st)
+	}
+	if st[0].State != StateCircuitBreak {
+		t.Errorf("loud state = %s, want circuit_break", st[0].State)
+	}
+	if st[0].Tokens != 900 {
+		t.Errorf("tokens in window = %d, want 900", st[0].Tokens)
+	}
+	if st[1].State != StateObserve {
+		t.Errorf("quiet state = %s, want observe", st[1].State)
+	}
+}
+
+// An empty tenant means an unauthenticated or malformed call the gateway
+// rejects elsewhere; the ladder must not accumulate state under "".
+func TestPolicy_EmptyTenantIsPassthrough(t *testing.T) {
+	p := NewPolicy(PolicyConfig{Quota: QuotaLimits{Window: time.Minute, MaxTotalTokens: 1}})
+	p.RecordUsage("", Usage{InputTokens: 10_000})
+	p.RecordDenial("")
+	if d := p.Check(RequestInfo{}); !d.Allow {
+		t.Fatalf("empty-tenant request denied: %+v", d)
+	}
+	if len(p.Status()) != 0 {
+		t.Errorf("empty tenant accumulated state: %+v", p.Status())
+	}
+}
+
+func TestPolicy_ConcurrentCheckIsRaceFree(t *testing.T) {
+	p := NewPolicy(PolicyConfig{
+		Quota:   QuotaLimits{Window: time.Minute, MaxTotalTokens: 10_000},
+		Anomaly: AnomalyConfig{Enabled: true, NoveltyTTL: time.Minute},
+	})
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				p.RecordUsage("acme", Usage{InputTokens: 1})
+				p.Check(req("acme"))
+				p.RecordDenial("acme")
+				_ = p.Status()
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+func hasSignal(sigs []Signal, name string) bool {
+	for _, s := range sigs {
+		if s.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func statusFor(t *testing.T, p *Policy, tenant string) TenantStatus {
+	t.Helper()
+	for _, s := range p.Status() {
+		if s.Tenant == tenant {
+			return s
+		}
+	}
+	t.Fatalf("no status for tenant %q", tenant)
+	return TenantStatus{}
+}

--- a/internal/modelgateway/policy_test.go
+++ b/internal/modelgateway/policy_test.go
@@ -575,3 +575,96 @@ func statusFor(t *testing.T, p *Policy, tenant string) TenantStatus {
 	t.Fatalf("no status for tenant %q", tenant)
 	return TenantStatus{}
 }
+
+// Automatic revocation must be as sticky as the manual kind. Gating stickiness
+// on a manual reason left an auto-revoked tenant walking back down the ladder
+// one rung per cooldown, so a token cut off for a high anomaly score regained
+// access by going quiet for five minutes.
+func TestPolicy_AutoRevokeIsStickyToo(t *testing.T) {
+	clk := newFakeClock()
+	p := NewPolicy(PolicyConfig{
+		Anomaly: AnomalyConfig{
+			Enabled: true, NoveltyTTL: time.Hour,
+			ConcurrentSourceNets: 1, ConcurrentWindow: time.Minute,
+			BaselineMinSamples: 1000,
+		},
+		AlertAt: 0.01, BreakAt: 0.02, RevokeAt: 0.05,
+		Cooldown: time.Minute,
+		Now:      clk.now,
+	})
+
+	var d Decision
+	for _, addr := range []string{"10.0.0.1:1", "203.0.113.1:1", "198.51.100.1:1", "192.0.2.1:1"} {
+		i := req("acme")
+		i.RemoteAddr = addr
+		d = p.Check(i)
+	}
+	if d.State != StateRevoke {
+		t.Fatalf("state = %s, want revoke", d.State)
+	}
+
+	// Long quiet stretches from a single clean network must not lift it.
+	for i := 0; i < 10; i++ {
+		clk.advance(10 * time.Minute)
+		d = p.Check(req("acme"))
+		if d.Allow || d.State != StateRevoke {
+			t.Fatalf("auto-revocation lifted itself after %d quiet cycles: %+v", i+1, d)
+		}
+	}
+
+	p.Clear("acme")
+	if d := p.Check(req("acme")); !d.Allow {
+		t.Errorf("Clear did not restore an auto-revoked tenant: %+v", d)
+	}
+}
+
+// The ladder's own refusals must not feed the auth-failure signal. Counting
+// them made enforcement self-amplifying: throttling a tenant raised its failure
+// ratio, which raised its score, which escalated it further — laundering a
+// budget overrun into "this token is being probed".
+func TestPolicy_PolicyDenialsDoNotFeedTheAuthFailureSignal(t *testing.T) {
+	clk := newFakeClock()
+	p := NewPolicy(PolicyConfig{
+		Quota: QuotaLimits{Window: time.Minute, MaxTotalTokens: 100},
+		Anomaly: AnomalyConfig{
+			Enabled:            true,
+			AuthFailureRatio:   0.5,
+			AuthFailureMin:     4,
+			BaselineMinSamples: 1000,
+			NoveltyTTL:         time.Hour,
+		},
+		ThrottleMinInterval: time.Hour, // every call past the first is refused
+		CircuitBreakFor:     time.Hour,
+		Now:                 clk.now,
+	})
+
+	// Blow the budget, then keep calling: each call is refused by the ladder.
+	p.RecordUsage("acme", Usage{InputTokens: 500})
+	var d Decision
+	for i := 0; i < 20; i++ {
+		d = p.Check(req("acme"))
+		if d.Allow {
+			t.Fatalf("call %d admitted while over budget", i)
+		}
+	}
+
+	if hasSignal(d.Signals, SignalAuthFailureRate) {
+		t.Errorf("the ladder's own denials tripped the auth-failure signal: %+v", d.Signals)
+	}
+
+	st := statusFor(t, p, "acme")
+	if st.PolicyDenials == 0 {
+		t.Error("policy denials not recorded")
+	}
+	if st.AuthDenials != 0 {
+		t.Errorf("auth denials = %d, want 0 — no token-authorization failure occurred", st.AuthDenials)
+	}
+
+	// A genuine authorization failure still trips it.
+	for i := 0; i < 10; i++ {
+		p.RecordDenial("acme")
+	}
+	if d := p.Check(req("acme")); !hasSignal(d.Signals, SignalAuthFailureRate) {
+		t.Errorf("real auth failures no longer trip the signal: %+v", d.Signals)
+	}
+}

--- a/internal/modelgateway/quota.go
+++ b/internal/modelgateway/quota.go
@@ -1,0 +1,107 @@
+package modelgateway
+
+import (
+	"fmt"
+	"time"
+)
+
+// Per-tenant spend budgets enforced at the gateway (design note responsibility
+// #7 — "one tenant's runaway agent can't exhaust the shared account").
+//
+// The gateway is the only place this can be enforced honestly. A limit applied
+// in the box is advice: the box holds the credential and can ignore it. Here the
+// tenant cannot spend without asking us first.
+//
+// Mechanism only, per the OSS/Cloud split: this defines budgets and windows, not
+// named tiers or per-model pricing. Cloud sets the numbers.
+
+// QuotaLimits caps what one tenant may consume within a rolling window. A zero
+// field means that dimension is unlimited, so a partially-filled QuotaLimits is
+// meaningful — capping tokens while leaving call count free is a normal
+// configuration, not an error.
+type QuotaLimits struct {
+	// Window is the rolling period the limits apply over. Zero defaults to a
+	// minute at construction.
+	Window time.Duration `json:"window"`
+
+	// MaxCalls caps requests per window — the rate-limit dimension. Guards the
+	// shared account's provider request-rate limit, which a tenant can exhaust
+	// with cheap calls without spending many tokens.
+	MaxCalls int64 `json:"max_calls"`
+
+	// MaxTotalTokens caps input+output+cached tokens per window — the spend
+	// dimension, and the one that maps to money.
+	MaxTotalTokens int64 `json:"max_total_tokens"`
+
+	// MaxOutputTokens caps generated tokens per window. Separate because output
+	// is the expensive half on every provider, so a deployment may want a
+	// tighter ceiling on it than on total.
+	MaxOutputTokens int64 `json:"max_output_tokens"`
+}
+
+// IsZero reports whether no dimension is limited — a tenant with no budget
+// configured, which the policy treats as "observe only".
+func (q QuotaLimits) IsZero() bool {
+	return q.MaxCalls == 0 && q.MaxTotalTokens == 0 && q.MaxOutputTokens == 0
+}
+
+func (q QuotaLimits) normalized() QuotaLimits {
+	if q.Window <= 0 {
+		q.Window = time.Minute
+	}
+	return q
+}
+
+// quotaUsage is one tenant's consumption against its budget, as of a moment.
+type quotaUsage struct {
+	// fraction is the most-consumed dimension's share of its limit: 0 for an
+	// idle tenant, 1.0 at the limit, above 1.0 once exceeded. The MAX across
+	// dimensions rather than an average — a tenant at 100% of output tokens is
+	// out of budget regardless of how few calls it took to get there.
+	fraction float64
+
+	// exceeded names the first dimension found over its limit, empty when the
+	// tenant is within budget. Named rather than boolean so the denial message
+	// and the alert can say which budget ran out.
+	exceeded string
+
+	calls  int64
+	tokens int64
+	output int64
+}
+
+// evaluate scores c against the limits.
+func (q QuotaLimits) evaluate(c counts) quotaUsage {
+	u := quotaUsage{calls: c.calls, tokens: c.totalTokens(), output: c.outputTokens}
+	consider := func(used, limit int64, name string) {
+		if limit <= 0 {
+			return
+		}
+		if f := float64(used) / float64(limit); f > u.fraction {
+			u.fraction = f
+		}
+		if used >= limit && u.exceeded == "" {
+			u.exceeded = name
+		}
+	}
+	consider(c.calls, q.MaxCalls, "calls")
+	consider(c.totalTokens(), q.MaxTotalTokens, "total_tokens")
+	consider(c.outputTokens, q.MaxOutputTokens, "output_tokens")
+	return u
+}
+
+// describe renders the budget state for a denial message or an alert. It reports
+// consumption against the limits and never includes prompt or response content —
+// a quota message is operational, and the gateway's whole purpose is to keep
+// model traffic from leaking into places it shouldn't.
+func (q QuotaLimits) describe(u quotaUsage) string {
+	switch u.exceeded {
+	case "calls":
+		return fmt.Sprintf("calls %d/%d per %s", u.calls, q.MaxCalls, q.Window)
+	case "total_tokens":
+		return fmt.Sprintf("tokens %d/%d per %s", u.tokens, q.MaxTotalTokens, q.Window)
+	case "output_tokens":
+		return fmt.Sprintf("output tokens %d/%d per %s", u.output, q.MaxOutputTokens, q.Window)
+	}
+	return fmt.Sprintf("%.0f%% of budget per %s", u.fraction*100, q.Window)
+}

--- a/internal/modelgateway/quota_test.go
+++ b/internal/modelgateway/quota_test.go
@@ -1,0 +1,89 @@
+package modelgateway
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestQuotaLimits_IsZeroAndNormalize(t *testing.T) {
+	if !(QuotaLimits{}).IsZero() {
+		t.Error("empty limits should report IsZero")
+	}
+	// A window alone is not a limit: it says when to measure, not how much.
+	if !(QuotaLimits{Window: time.Hour}).IsZero() {
+		t.Error("a window with no caps should still report IsZero")
+	}
+	if (QuotaLimits{MaxCalls: 1}).IsZero() {
+		t.Error("a call cap is a limit")
+	}
+	if got := (QuotaLimits{}).normalized().Window; got != time.Minute {
+		t.Errorf("default window = %v, want 1m", got)
+	}
+}
+
+// The fraction is the MAX across dimensions, not an average: a tenant that has
+// burned all its output-token budget in three calls is out of budget, and
+// averaging that against its untouched call quota would hide it.
+func TestQuotaLimits_FractionIsWorstDimension(t *testing.T) {
+	q := QuotaLimits{Window: time.Minute, MaxCalls: 100, MaxTotalTokens: 1000, MaxOutputTokens: 10}
+
+	u := q.evaluate(counts{calls: 3, inputTokens: 5, outputTokens: 9})
+	if u.exceeded != "" {
+		t.Errorf("exceeded = %q, want none", u.exceeded)
+	}
+	if want := 0.9; u.fraction != want {
+		t.Errorf("fraction = %v, want %v (output tokens are the worst dimension)", u.fraction, want)
+	}
+}
+
+func TestQuotaLimits_ExceededNamesTheDimension(t *testing.T) {
+	q := QuotaLimits{Window: time.Minute, MaxCalls: 2, MaxTotalTokens: 1000}
+
+	u := q.evaluate(counts{calls: 2, inputTokens: 1})
+	if u.exceeded != "calls" {
+		t.Errorf("exceeded = %q, want calls (at the limit counts as exceeded)", u.exceeded)
+	}
+	if d := q.describe(u); !strings.Contains(d, "calls 2/2") {
+		t.Errorf("describe = %q, want it to name the consumed dimension", d)
+	}
+
+	u = q.evaluate(counts{calls: 1, inputTokens: 600, outputTokens: 500})
+	if u.exceeded != "total_tokens" {
+		t.Errorf("exceeded = %q, want total_tokens", u.exceeded)
+	}
+}
+
+// An unset dimension is unlimited, so it must not contribute a fraction — a
+// zero limit divided into any usage would otherwise be an instant overrun.
+func TestQuotaLimits_UnsetDimensionsAreUnlimited(t *testing.T) {
+	q := QuotaLimits{Window: time.Minute, MaxTotalTokens: 100}
+
+	// A million calls with an uncapped call limit, and token spend well under
+	// the one cap that is set.
+	u := q.evaluate(counts{calls: 1_000_000, inputTokens: 10, outputTokens: 20})
+	if u.exceeded != "" {
+		t.Errorf("exceeded = %q, want none: only total_tokens is capped and it is under", u.exceeded)
+	}
+	if u.fraction > 1 {
+		t.Errorf("fraction = %v, want <= 1", u.fraction)
+	}
+}
+
+// Cached tokens count toward spend: replaying a huge cached prefix is exactly
+// the runaway a budget exists to stop.
+func TestQuotaLimits_CachedTokensCountTowardTotal(t *testing.T) {
+	q := QuotaLimits{Window: time.Minute, MaxTotalTokens: 100}
+	if u := q.evaluate(counts{calls: 1, cachedTokens: 150}); u.exceeded != "total_tokens" {
+		t.Errorf("exceeded = %q, want total_tokens", u.exceeded)
+	}
+}
+
+// Denials are counted for the auth-failure ratio but are not spend — they never
+// reached a provider, so they must not consume the tenant's budget.
+func TestQuotaLimits_DenialsAreNotSpend(t *testing.T) {
+	q := QuotaLimits{Window: time.Minute, MaxCalls: 5, MaxTotalTokens: 100}
+	if u := q.evaluate(counts{denials: 50}); u.exceeded != "" || u.fraction != 0 {
+		t.Errorf("denials consumed budget: exceeded=%q fraction=%v", u.exceeded, u.fraction)
+	}
+}

--- a/internal/modelgateway/quota_test.go
+++ b/internal/modelgateway/quota_test.go
@@ -79,11 +79,12 @@ func TestQuotaLimits_CachedTokensCountTowardTotal(t *testing.T) {
 	}
 }
 
-// Denials are counted for the auth-failure ratio but are not spend — they never
-// reached a provider, so they must not consume the tenant's budget.
+// Denials of either kind are not spend — they never reached a provider, so they
+// must not consume the tenant's budget. A throttled tenant whose refusals ate
+// its own quota could never climb back out.
 func TestQuotaLimits_DenialsAreNotSpend(t *testing.T) {
 	q := QuotaLimits{Window: time.Minute, MaxCalls: 5, MaxTotalTokens: 100}
-	if u := q.evaluate(counts{denials: 50}); u.exceeded != "" || u.fraction != 0 {
+	if u := q.evaluate(counts{authDenials: 50, policyDenials: 50}); u.exceeded != "" || u.fraction != 0 {
 		t.Errorf("denials consumed budget: exceeded=%q fraction=%v", u.exceeded, u.fraction)
 	}
 }

--- a/internal/modelgateway/window.go
+++ b/internal/modelgateway/window.go
@@ -31,7 +31,18 @@ type counts struct {
 	inputTokens  int64
 	outputTokens int64
 	cachedTokens int64
-	denials      int64
+
+	// authDenials are requests rejected because the token did not authorize
+	// them — wrong provider, model outside the allowed set. These are evidence
+	// about the CALLER, which is why the auth-failure-ratio signal reads them.
+	authDenials int64
+
+	// policyDenials are requests the ladder itself refused. Deliberately a
+	// separate counter: folding them into authDenials would make enforcement
+	// self-amplifying — throttling a tenant would raise its own failure ratio,
+	// which raises its anomaly score, which escalates it further, until a
+	// budget overrun had been laundered into "this token is being probed".
+	policyDenials int64
 }
 
 func (c *counts) add(o counts) {
@@ -39,7 +50,8 @@ func (c *counts) add(o counts) {
 	c.inputTokens += o.inputTokens
 	c.outputTokens += o.outputTokens
 	c.cachedTokens += o.cachedTokens
-	c.denials += o.denials
+	c.authDenials += o.authDenials
+	c.policyDenials += o.policyDenials
 }
 
 // totalTokens is what a token budget is spent against. Cached tokens are
@@ -143,10 +155,27 @@ func (w *rollingWindow) rate(now time.Time) float64 {
 	return float64(out.totalTokens()) / elapsed
 }
 
+// maxRecentValues caps how many distinct values one tenant's set retains.
+//
+// This is a hard bound, not a tuning knob. Two of the three sets are keyed on
+// caller-controlled input — the upstream path and the request's model id come
+// straight off the wire — so an unbounded map would let one box grow a tenant's
+// state without limit for the whole novelty TTL (24h by default), and make the
+// per-observation prune scan cost grow with it. 64 is far above what a real box
+// exercises (a handful of endpoints, a handful of models) and low enough that
+// the linear scans below are trivial.
+const maxRecentValues = 64
+
 // recentSet tracks which distinct categorical values a tenant has used lately —
 // model ids, upstream paths, source networks. Values expire by last-seen rather
 // than by bucket, because the question these answer is "is this one new?", not
 // "how many times?".
+//
+// Bounded at maxRecentValues: past the cap the least-recently-seen value is
+// evicted. An evicted value reads as novel if it returns, which is the honest
+// answer — it is no longer among the tenant's recent behavior. A caller
+// flooding distinct values evicts its own history and keeps tripping the
+// novelty signal, which is the correct outcome rather than a bypass.
 type recentSet struct {
 	ttl  time.Duration
 	seen map[string]time.Time
@@ -165,7 +194,28 @@ func (s *recentSet) observe(now time.Time, v string) bool {
 	s.prune(now)
 	last, ok := s.seen[v]
 	s.seen[v] = now
+	if !ok && len(s.seen) > maxRecentValues {
+		s.evictOldest()
+	}
 	return !ok || now.Sub(last) > s.ttl
+}
+
+// evictOldest drops the least-recently-seen entry. Linear, but bounded by
+// maxRecentValues and only reached when the set is full.
+func (s *recentSet) evictOldest() {
+	var (
+		oldestKey string
+		oldestAt  time.Time
+		first     = true
+	)
+	for k, t := range s.seen {
+		if first || t.Before(oldestAt) {
+			oldestKey, oldestAt, first = k, t, false
+		}
+	}
+	if !first {
+		delete(s.seen, oldestKey)
+	}
 }
 
 // len is the number of distinct live values.

--- a/internal/modelgateway/window.go
+++ b/internal/modelgateway/window.go
@@ -1,0 +1,231 @@
+package modelgateway
+
+import (
+	"sort"
+	"sync"
+	"time"
+)
+
+// Rolling-window accounting shared by the quota check (how much has this tenant
+// spent recently?) and the anomaly signals (how does recent behavior compare to
+// this tenant's own history?).
+//
+// Both need "the last N minutes", not "since process start", so a fixed counter
+// is the wrong shape: a tenant that blew its budget an hour ago should be able
+// to work again. A true sliding window would need per-request timestamps and
+// unbounded memory, so this approximates one with a ring of fixed buckets —
+// the standard trade. Resolution is window/bucketCount; a tenant can overshoot
+// by at most one bucket's worth at a window boundary, which for a spend guard
+// is the right way to be wrong (bounded, and in the generous direction).
+
+// bucketCount is the ring size. Twelve buckets put the resolution at 5s for a
+// 1-minute window and 5m for an hour — fine enough that boundary overshoot is
+// small, coarse enough that the ring stays cheap to sum on every request.
+const bucketCount = 12
+
+// counts is one bucket's accumulated usage. Numeric only: categorical signals
+// (which models, which paths, which source networks) live in recentSet, which
+// has different eviction semantics.
+type counts struct {
+	calls        int64
+	inputTokens  int64
+	outputTokens int64
+	cachedTokens int64
+	denials      int64
+}
+
+func (c *counts) add(o counts) {
+	c.calls += o.calls
+	c.inputTokens += o.inputTokens
+	c.outputTokens += o.outputTokens
+	c.cachedTokens += o.cachedTokens
+	c.denials += o.denials
+}
+
+// totalTokens is what a token budget is spent against. Cached tokens are
+// counted: they cost money (at a discount the gateway doesn't model) and, more
+// to the point, a runaway agent replaying a huge cached prefix is exactly the
+// spend pattern a quota exists to stop.
+func (c counts) totalTokens() int64 {
+	return c.inputTokens + c.outputTokens + c.cachedTokens
+}
+
+// rollingWindow is a ring of time buckets covering `window`. Not safe for
+// concurrent use on its own — callers hold the owning tenantState's lock.
+type rollingWindow struct {
+	window  time.Duration
+	slot    time.Duration
+	buckets [bucketCount]counts
+	// starts[i] is the bucket's start time, used to decide whether the bucket
+	// is live or a stale one that must be zeroed before reuse.
+	starts [bucketCount]time.Time
+}
+
+func newRollingWindow(window time.Duration) *rollingWindow {
+	if window <= 0 {
+		window = time.Minute
+	}
+	return &rollingWindow{window: window, slot: window / bucketCount}
+}
+
+// index returns the ring slot for t, zeroing it first if it holds a bucket from
+// an earlier revolution. This is what makes old usage age out without a sweeper.
+func (w *rollingWindow) index(t time.Time) int {
+	if w.slot <= 0 {
+		w.slot = time.Nanosecond
+	}
+	n := t.UnixNano() / int64(w.slot)
+	i := int(n % bucketCount)
+	if i < 0 {
+		i += bucketCount
+	}
+	start := time.Unix(0, n*int64(w.slot))
+	if !w.starts[i].Equal(start) {
+		w.buckets[i] = counts{}
+		w.starts[i] = start
+	}
+	return i
+}
+
+// add accumulates c into the bucket covering now.
+func (w *rollingWindow) add(now time.Time, c counts) {
+	w.buckets[w.index(now)].add(c)
+}
+
+// sum totals every bucket still inside the window as of now. Buckets older than
+// the window are skipped rather than zeroed — index() clears them lazily on
+// reuse, so a tenant that goes quiet costs nothing until it returns.
+func (w *rollingWindow) sum(now time.Time) counts {
+	var out counts
+	cutoff := now.Add(-w.window)
+	for i := range w.buckets {
+		if w.starts[i].IsZero() || w.starts[i].Before(cutoff) {
+			continue
+		}
+		out.add(w.buckets[i])
+	}
+	return out
+}
+
+// rate returns tokens-per-second over the window as of now, using the elapsed
+// span actually covered by live buckets rather than the nominal window — so a
+// tenant three seconds into a one-minute window reports its real rate instead of
+// one twentieth of it. That distinction is the whole point for the baseline
+// comparison: without it every burst looks like a slow ramp.
+func (w *rollingWindow) rate(now time.Time) float64 {
+	var (
+		out     counts
+		oldest  time.Time
+		cutoff  = now.Add(-w.window)
+		haveAny bool
+	)
+	for i := range w.buckets {
+		if w.starts[i].IsZero() || w.starts[i].Before(cutoff) {
+			continue
+		}
+		out.add(w.buckets[i])
+		if !haveAny || w.starts[i].Before(oldest) {
+			oldest, haveAny = w.starts[i], true
+		}
+	}
+	if !haveAny {
+		return 0
+	}
+	elapsed := now.Sub(oldest).Seconds()
+	// Floor at one slot: a single in-progress bucket would otherwise divide by
+	// a near-zero elapsed and report an absurd rate on the first request.
+	if min := w.slot.Seconds(); elapsed < min {
+		elapsed = min
+	}
+	if elapsed <= 0 {
+		return 0
+	}
+	return float64(out.totalTokens()) / elapsed
+}
+
+// recentSet tracks which distinct categorical values a tenant has used lately —
+// model ids, upstream paths, source networks. Values expire by last-seen rather
+// than by bucket, because the question these answer is "is this one new?", not
+// "how many times?".
+type recentSet struct {
+	ttl  time.Duration
+	seen map[string]time.Time
+}
+
+func newRecentSet(ttl time.Duration) *recentSet {
+	return &recentSet{ttl: ttl, seen: map[string]time.Time{}}
+}
+
+// observe records v and reports whether it was absent (or expired) — i.e.
+// whether this is a value the tenant has not used within the ttl.
+func (s *recentSet) observe(now time.Time, v string) bool {
+	if v == "" {
+		return false
+	}
+	s.prune(now)
+	last, ok := s.seen[v]
+	s.seen[v] = now
+	return !ok || now.Sub(last) > s.ttl
+}
+
+// len is the number of distinct live values.
+func (s *recentSet) len(now time.Time) int {
+	s.prune(now)
+	return len(s.seen)
+}
+
+// values returns the live values in sorted order (stable output for the ops
+// readout and for tests).
+func (s *recentSet) values(now time.Time) []string {
+	s.prune(now)
+	out := make([]string, 0, len(s.seen))
+	for v := range s.seen {
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func (s *recentSet) prune(now time.Time) {
+	for v, t := range s.seen {
+		if now.Sub(t) > s.ttl {
+			delete(s.seen, v)
+		}
+	}
+}
+
+// ewma is an exponentially-weighted moving average with a sample counter, used
+// for the per-tenant baseline. The counter matters as much as the average: a
+// baseline built from two samples is not a baseline, and comparing against it
+// produces exactly the false positives that make anomaly detection get switched
+// off. Callers gate on ready().
+type ewma struct {
+	mu      sync.Mutex
+	alpha   float64
+	value   float64
+	samples int
+}
+
+func newEWMA(alpha float64) *ewma {
+	if alpha <= 0 || alpha > 1 {
+		alpha = 0.2
+	}
+	return &ewma{alpha: alpha}
+}
+
+func (e *ewma) observe(v float64) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.samples == 0 {
+		e.value = v
+	} else {
+		e.value = e.alpha*v + (1-e.alpha)*e.value
+	}
+	e.samples++
+}
+
+func (e *ewma) get() (float64, int) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.value, e.samples
+}

--- a/internal/modelgateway/window_test.go
+++ b/internal/modelgateway/window_test.go
@@ -1,0 +1,132 @@
+package modelgateway
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRollingWindow_SumsRecentAndAgesOutOld(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	w := newRollingWindow(time.Minute)
+
+	w.add(base, counts{calls: 1, inputTokens: 10})
+	w.add(base.Add(10*time.Second), counts{calls: 1, inputTokens: 20})
+
+	got := w.sum(base.Add(20 * time.Second))
+	if got.calls != 2 || got.totalTokens() != 30 {
+		t.Errorf("within window: calls=%d tokens=%d, want 2/30", got.calls, got.totalTokens())
+	}
+
+	// Past the window, everything has aged out — the property that makes a
+	// quota a rolling budget rather than a lifetime cap.
+	if got := w.sum(base.Add(2 * time.Minute)); got.calls != 0 || got.totalTokens() != 0 {
+		t.Errorf("after the window: calls=%d tokens=%d, want 0/0", got.calls, got.totalTokens())
+	}
+}
+
+// A ring bucket reused a full revolution later must be zeroed, not accumulated
+// onto — otherwise usage from an hour ago silently counts against today.
+func TestRollingWindow_ReusedBucketIsZeroed(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	w := newRollingWindow(time.Minute)
+
+	w.add(base, counts{calls: 1, inputTokens: 1000})
+	later := base.Add(time.Minute) // same ring slot, one revolution on
+	w.add(later, counts{calls: 1, inputTokens: 5})
+
+	got := w.sum(later)
+	if got.totalTokens() != 5 {
+		t.Errorf("tokens = %d, want 5 (stale bucket leaked)", got.totalTokens())
+	}
+}
+
+// The rate must divide by the span actually observed, not the nominal window,
+// or a burst in the first seconds of a window reads as a slow trickle and the
+// baseline comparison never fires.
+func TestRollingWindow_RateUsesObservedSpan(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	w := newRollingWindow(time.Minute) // slot = 5s
+
+	w.add(base, counts{calls: 1, inputTokens: 1000})
+	got := w.rate(base)
+
+	// 1000 tokens in a single in-progress slot → floored at one slot (5s).
+	if want := 200.0; got != want {
+		t.Errorf("rate = %v, want %v (nominal-window division would give ~16.7)", got, want)
+	}
+	if empty := newRollingWindow(time.Minute).rate(base); empty != 0 {
+		t.Errorf("empty window rate = %v, want 0", empty)
+	}
+}
+
+func TestRecentSet_NoveltyThenExpiry(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	s := newRecentSet(time.Minute)
+
+	if !s.observe(base, "claude") {
+		t.Error("first sighting should report novel")
+	}
+	if s.observe(base.Add(time.Second), "claude") {
+		t.Error("second sighting within the ttl should not report novel")
+	}
+	if !s.observe(base.Add(2*time.Minute), "claude") {
+		t.Error("sighting after the ttl should report novel again")
+	}
+	// An empty value is not a value: it must neither be stored nor flagged.
+	if s.observe(base, "") {
+		t.Error("empty value reported as novel")
+	}
+	if n := s.len(base.Add(2 * time.Minute)); n != 1 {
+		t.Errorf("len = %d, want 1", n)
+	}
+}
+
+func TestRecentSet_PrunesExpiredFromLenAndValues(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	s := newRecentSet(time.Minute)
+	s.observe(base, "a")
+	s.observe(base, "b")
+	s.observe(base.Add(90*time.Second), "c")
+
+	now := base.Add(2 * time.Minute)
+	if n := s.len(now); n != 1 {
+		t.Errorf("len = %d, want 1 (a and b expired)", n)
+	}
+	if v := s.values(now); len(v) != 1 || v[0] != "c" {
+		t.Errorf("values = %v, want [c]", v)
+	}
+}
+
+func TestEWMA_FirstSampleSeedsThenWeights(t *testing.T) {
+	e := newEWMA(0.5)
+	if v, n := e.get(); v != 0 || n != 0 {
+		t.Errorf("zero value = %v/%d, want 0/0", v, n)
+	}
+
+	e.observe(100)
+	if v, n := e.get(); v != 100 || n != 1 {
+		t.Errorf("after first sample = %v/%d, want 100/1 (seed, not decay toward zero)", v, n)
+	}
+
+	e.observe(200)
+	if v, _ := e.get(); v != 150 {
+		t.Errorf("after second sample = %v, want 150", v)
+	}
+}
+
+func TestSourceNet(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"10.0.0.5:1234", "10.0.0.0/24"},
+		{"10.0.0.200:9", "10.0.0.0/24"},
+		{"203.0.113.7:80", "203.0.113.0/24"},
+		{"10.0.0.5", "10.0.0.0/24"}, // no port
+		{"[2001:db8:1:2::1]:443", "2001:db8:1::/48"},
+		{"", ""},
+		{"not-an-ip:80", ""},
+	}
+	for _, c := range cases {
+		if got := sourceNet(c.in); got != c.want {
+			t.Errorf("sourceNet(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/modelgateway/window_test.go
+++ b/internal/modelgateway/window_test.go
@@ -1,6 +1,7 @@
 package modelgateway
 
 import (
+	"strconv"
 	"testing"
 	"time"
 )
@@ -128,5 +129,35 @@ func TestSourceNet(t *testing.T) {
 		if got := sourceNet(c.in); got != c.want {
 			t.Errorf("sourceNet(%q) = %q, want %q", c.in, got, c.want)
 		}
+	}
+}
+
+// The endpoint and model sets are keyed on caller-controlled input, so an
+// unbounded map would let one box grow a tenant's state without limit for the
+// whole novelty TTL and make every observation's scan more expensive.
+func TestRecentSet_BoundedAndEvictsOldest(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	s := newRecentSet(24 * time.Hour)
+
+	now := base
+	for i := 0; i < maxRecentValues*20; i++ {
+		now = now.Add(time.Second)
+		s.observe(now, "/v1/"+strconv.Itoa(i))
+	}
+	if n := s.len(now); n > maxRecentValues {
+		t.Errorf("set grew to %d, want <= %d", n, maxRecentValues)
+	}
+
+	// The most recent values survive; the oldest were evicted.
+	vals := s.values(now)
+	found := map[string]bool{}
+	for _, v := range vals {
+		found[v] = true
+	}
+	if !found["/v1/"+strconv.Itoa(maxRecentValues*20-1)] {
+		t.Error("most recent value was evicted")
+	}
+	if found["/v1/0"] {
+		t.Error("oldest value survived eviction")
 	}
 }

--- a/internal/server/agent_gateway.go
+++ b/internal/server/agent_gateway.go
@@ -2,9 +2,13 @@ package server
 
 import (
 	"fmt"
+	"log"
 	"os"
+	"strconv"
 	"strings"
+	"time"
 
+	appconfig "github.com/footprintai/containarium/internal/config"
 	"github.com/footprintai/containarium/internal/modelgateway"
 )
 
@@ -146,4 +150,72 @@ func gatewayPrimaryProvider(keys map[string]string) string {
 // (file absent). `set -a` exports everything the file sets.
 func sourceGatewayEnvPrefix(seedDir string) string {
 	return fmt.Sprintf("set -a; [ -f %s/gateway.env ] && . %s/gateway.env; set +a; ", seedDir, seedDir)
+}
+
+// gatewayPolicyFromEnv builds the gateway's enforcement config from the daemon
+// env, or returns nil when the operator has configured nothing — in which case
+// the gateway meters and denies nothing, exactly as it did before enforcement
+// existed. Opt-in by construction: an operator upgrading the daemon must not
+// discover that their agents are being throttled by numbers they never chose.
+//
+// Pure apart from the env reads, so the parsing is testable on its own.
+func gatewayPolicyFromEnv() *modelgateway.PolicyConfig {
+	var pc modelgateway.PolicyConfig
+
+	pc.Quota.Window = envDuration(appconfig.EnvGatewayQuotaWindow, 0)
+	pc.Quota.MaxCalls = envInt64(appconfig.EnvGatewayQuotaCalls)
+	pc.Quota.MaxTotalTokens = envInt64(appconfig.EnvGatewayQuotaTokens)
+	pc.Quota.MaxOutputTokens = envInt64(appconfig.EnvGatewayQuotaOutputTokens)
+	pc.Anomaly.Enabled = os.Getenv(appconfig.EnvGatewayAnomalyEnabled) == "1"
+	pc.RevokeAt = envFloat(appconfig.EnvGatewayAnomalyRevokeAt)
+
+	// A window alone is not a configuration: it says when to measure, not how
+	// much is allowed. Without a cap or the detectors, there is nothing to
+	// enforce and the policy stays absent.
+	if pc.Quota.IsZero() && !pc.Anomaly.Enabled {
+		return nil
+	}
+	return &pc
+}
+
+// gatewayPolicyLogSink writes ladder transitions to the daemon log. The gateway
+// keeps its own alerting dependency-free, so this is the daemon's minimum
+// wiring: a state change that nobody is told about is not a response.
+type gatewayPolicyLogSink struct{}
+
+func (gatewayPolicyLogSink) PolicyTransition(ev modelgateway.PolicyEvent) {
+	names := make([]string, 0, len(ev.Signals))
+	for _, s := range ev.Signals {
+		names = append(names, s.Name)
+	}
+	log.Printf("model-gateway: tenant=%s skill=%s %s -> %s reason=%q score=%.2f quota=%.0f%% signals=%v",
+		ev.Tenant, ev.Skill, ev.From, ev.To, ev.Reason, ev.Score, ev.Quota*100, names)
+}
+
+func envInt64(key string) int64 {
+	v, err := strconv.ParseInt(strings.TrimSpace(os.Getenv(key)), 10, 64)
+	if err != nil || v < 0 {
+		return 0
+	}
+	return v
+}
+
+func envFloat(key string) float64 {
+	v, err := strconv.ParseFloat(strings.TrimSpace(os.Getenv(key)), 64)
+	if err != nil || v < 0 {
+		return 0
+	}
+	return v
+}
+
+func envDuration(key string, def time.Duration) time.Duration {
+	raw := strings.TrimSpace(os.Getenv(key))
+	if raw == "" {
+		return def
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		return def
+	}
+	return d
 }

--- a/internal/server/agent_gateway_policy_test.go
+++ b/internal/server/agent_gateway_policy_test.go
@@ -1,0 +1,91 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	appconfig "github.com/footprintai/containarium/internal/config"
+)
+
+// The safety property of the whole enforcement change: a daemon that configures
+// nothing gets nothing. If this ever returns non-nil for an unconfigured
+// operator, every existing deployment starts denying traffic on an upgrade.
+func TestGatewayPolicyFromEnv_UnconfiguredIsNil(t *testing.T) {
+	if got := gatewayPolicyFromEnv(); got != nil {
+		t.Fatalf("unconfigured env produced a policy: %+v", got)
+	}
+}
+
+// A window says when to measure, not how much is allowed — on its own it must
+// not switch enforcement on.
+func TestGatewayPolicyFromEnv_WindowAloneIsNotAPolicy(t *testing.T) {
+	t.Setenv(appconfig.EnvGatewayQuotaWindow, "10m")
+	if got := gatewayPolicyFromEnv(); got != nil {
+		t.Fatalf("window alone produced a policy: %+v", got)
+	}
+}
+
+func TestGatewayPolicyFromEnv_QuotaParsed(t *testing.T) {
+	t.Setenv(appconfig.EnvGatewayQuotaWindow, "10m")
+	t.Setenv(appconfig.EnvGatewayQuotaCalls, "500")
+	t.Setenv(appconfig.EnvGatewayQuotaTokens, "1000000")
+	t.Setenv(appconfig.EnvGatewayQuotaOutputTokens, "250000")
+
+	got := gatewayPolicyFromEnv()
+	if got == nil {
+		t.Fatal("configured quota produced no policy")
+	}
+	if got.Quota.Window != 10*time.Minute {
+		t.Errorf("window = %v, want 10m", got.Quota.Window)
+	}
+	if got.Quota.MaxCalls != 500 || got.Quota.MaxTotalTokens != 1_000_000 || got.Quota.MaxOutputTokens != 250_000 {
+		t.Errorf("quota = %+v", got.Quota)
+	}
+	if got.Anomaly.Enabled {
+		t.Error("anomaly detection enabled without being asked for")
+	}
+	if got.RevokeAt != 0 {
+		t.Errorf("RevokeAt = %v, want 0 (auto-revocation off unless configured)", got.RevokeAt)
+	}
+}
+
+func TestGatewayPolicyFromEnv_AnomalyAloneIsEnough(t *testing.T) {
+	t.Setenv(appconfig.EnvGatewayAnomalyEnabled, "1")
+	got := gatewayPolicyFromEnv()
+	if got == nil {
+		t.Fatal("anomaly=1 produced no policy")
+	}
+	if !got.Anomaly.Enabled {
+		t.Error("anomaly not enabled")
+	}
+	if !got.Quota.IsZero() {
+		t.Errorf("quota = %+v, want zero", got.Quota)
+	}
+}
+
+// Garbage must fall back to "not configured" rather than to some accidental
+// number: a typo'd cap that silently becomes 0 would read as unlimited, and one
+// that silently becomes 1 would deny everything.
+func TestGatewayPolicyFromEnv_MalformedValuesAreIgnored(t *testing.T) {
+	t.Setenv(appconfig.EnvGatewayQuotaCalls, "many")
+	t.Setenv(appconfig.EnvGatewayQuotaTokens, "-5")
+	t.Setenv(appconfig.EnvGatewayQuotaWindow, "sometimes")
+	t.Setenv(appconfig.EnvGatewayAnomalyRevokeAt, "yes")
+
+	if got := gatewayPolicyFromEnv(); got != nil {
+		t.Fatalf("malformed values produced a policy: %+v", got)
+	}
+}
+
+func TestGatewayPolicyFromEnv_RevokeAtOptIn(t *testing.T) {
+	t.Setenv(appconfig.EnvGatewayAnomalyEnabled, "1")
+	t.Setenv(appconfig.EnvGatewayAnomalyRevokeAt, "0.95")
+
+	got := gatewayPolicyFromEnv()
+	if got == nil {
+		t.Fatal("no policy")
+	}
+	if got.RevokeAt != 0.95 {
+		t.Errorf("RevokeAt = %v, want 0.95", got.RevokeAt)
+	}
+}

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -1690,11 +1690,19 @@ skipAppHosting:
 			} else {
 				gwSink = sink
 			}
+			// Per-tenant quota + the graduated response ladder. Nil unless the
+			// operator configured a budget or turned the detectors on, so an
+			// existing deployment's behavior is unchanged by the upgrade.
+			gwPolicy := gatewayPolicyFromEnv()
+			if gwPolicy != nil {
+				gwPolicy.Alerts = gatewayPolicyLogSink{}
+			}
 			gw := modelgateway.New(modelgateway.Config{
 				Secret:       []byte(config.JWTSecret),
 				Providers:    modelgateway.DefaultProviders(),
 				ProviderKeys: keys,
 				Sink:         gwSink,
+				Policy:       gwPolicy,
 				// Redact system-prompt (skill persona) leakage on the streaming
 				// chat path (#670 layer 2). Default on; set
 				// CONTAINARIUM_GATEWAY_OUTPUT_FILTER=0 to disable. Streaming token
@@ -1712,8 +1720,13 @@ skipAppHosting:
 			// agent-workspace canvas) route their model calls through the same
 			// gateway — seed their post_start with a scoped token + base URL.
 			recipeServer.SetGatewayProvisioning(config.HTTPPort, []byte(config.JWTSecret), provs)
-			log.Printf("Model-gateway enabled (providers=%v, skill-box primary=%s) — agent boxes route model calls through the daemon; provider keys never leave the host",
-				provs, primary)
+			enforcement := "metering only (no quota or anomaly detection configured)"
+			if gwPolicy != nil {
+				enforcement = fmt.Sprintf("enforcement on (quota=%+v anomaly=%t auto-revoke-at=%.2f)",
+					gwPolicy.Quota, gwPolicy.Anomaly.Enabled, gwPolicy.RevokeAt)
+			}
+			log.Printf("Model-gateway enabled (providers=%v, skill-box primary=%s) — agent boxes route model calls through the daemon; provider keys never leave the host; %s",
+				provs, primary, enforcement)
 		}
 
 		// Sentinel-facing HMAC secret for /certs, /authorized-keys,


### PR DESCRIPTION
## What

The model gateway metered spend but could not stop it. Metering answers "what
did this tenant spend"; a runaway agent — or a gateway token lifted out of a box
— spends until a human notices.

The gateway is the only place a limit can honestly be enforced. A limit applied
inside the box is advice the box can ignore, because the box holds the
credential. This adds per-tenant budgets and a graduated response ladder to
`internal/modelgateway`, completing the design note's Phase 2 (`docs/AGENT-MODEL-GATEWAY-DESIGN.md`,
responsibility #7).

**All of it is off by default.** A daemon that configures nothing behaves
exactly as it does today.

## How

Three new files, plus a hook in `handleModel`:

- **`quota.go`** — per-tenant caps on calls, total tokens, and output tokens
  over a rolling window (a ring of buckets, so a budget rolls rather than
  accumulating for the process lifetime: a tenant that overspent an hour ago
  works again with no operator action). Cached tokens count toward spend —
  replaying a large cached prefix is exactly the runaway a budget exists to stop.

- **`anomaly.go`** — five per-tenant signals, all relative rather than absolute.
  An absolute threshold is either high enough for a stolen token to live under
  it or low enough to fire on an ordinary Monday; a tenant compared against its
  own history has neither problem.

  | signal | fires when |
  | --- | --- |
  | `rate_baseline` | token rate exceeds this tenant's learned baseline by a factor |
  | `model_switch` | a model the tenant has not used within the novelty TTL |
  | `endpoint_mix` | an upstream path the tenant has not used |
  | `concurrent_source_nets` | one token in use from more networks than a box population explains |
  | `auth_failure_ratio` | a large share of recent calls rejected — a token being probed |

  `concurrent_source_nets` counts distinct /24s (v4) or /48s (v6) rather than
  using geolocation: OSS ships no geoip data and should not grow a dependency on
  one. It is a weaker signal — two datacenters in a region look like two
  networks — but it catches a token in use from somewhere it has never been
  while the legitimate box keeps working.

- **`policy.go`** — the `observe → throttle → alert → circuit-break → revoke`
  ladder. Escalation is immediate; descent is damped by a cooldown and moves one
  rung at a time. Every rung except the last reverses with no human, which is
  what allows the detectors to be wrong: being wrong costs latency, not an
  outage. A circuit-break is time-boxed and steps down on its own, unless the
  condition is still live, in which case it extends rather than flapping.
  Revocation is sticky, needs an operator to clear, and is never reached
  automatically unless `RevokeAt` is explicitly configured.

The check runs after the gateway token is verified and **before** the reverse
proxy's `Director`, so a denied call never has the real provider key injected
and never reaches the provider. `Policy.Revoke` takes effect on the next call
with no token re-issue and no box restart — an already-issued short-lived token
stops working immediately.

## Two ordering properties that are load-bearing

Both were caught by the tests rather than by design, and both are easy to
"simplify" back into a bug:

1. **The baseline is folded in after evaluation, and only from quiet windows.**
   Learning first lets the spike being judged raise the bar it is judged
   against — at any reasonable EWMA weight that is enough to hide a 100x burst.
   Learning from windows that fired signals has the same effect spread over
   time: the detector gradually accepts the attack as the tenant's new normal.

2. **Novelty signals stay silent until a tenant is learned.** A new tenant's
   first model and first endpoint are novel by construction. Emitting them
   escalated *every* new tenant on its first request — and because an escalated
   tenant stops feeding its baseline, it could then never become learned,
   leaving the detector permanently stuck on a tenant it permanently misjudges.
   The concurrency and auth-failure signals are deliberately *not* suppressed:
   those are suspicious with or without a baseline.

## Operator surface

`GET /__gateway/policy` reports every tenant's rung, what put it there, and
consumption against budget. Transitions go to the daemon log through an
`AlertSink` interface, so the gateway stays free of any alerting dependency.

| var | meaning |
| --- | --- |
| `CONTAINARIUM_GATEWAY_QUOTA_WINDOW` | rolling window (Go duration, default `1m`) |
| `CONTAINARIUM_GATEWAY_QUOTA_CALLS` | calls per tenant per window |
| `CONTAINARIUM_GATEWAY_QUOTA_TOKENS` | input+output+cached tokens per tenant per window |
| `CONTAINARIUM_GATEWAY_QUOTA_OUTPUT_TOKENS` | generated tokens per tenant per window |
| `CONTAINARIUM_GATEWAY_ANOMALY` | `1` enables the detectors |
| `CONTAINARIUM_GATEWAY_ANOMALY_REVOKE_AT` | score (0..1] for automatic revocation; unset = never |

A window alone does not switch enforcement on — it says when to measure, not how
much is allowed.

## Testing

- 16 policy tests on a fake clock (every property here is a duration; testing
  those against the wall clock means sleeping or flaking).
- Gateway-level tests assert on **upstream hit counts**, not on the response:
  the key is injected in the `Director`, so "denied" has to mean the `Director`
  never ran, and that is the only form of the assertion that cannot quietly
  regress.
- A test pins the no-config-changes-nothing path, since that is what makes this
  safe to ship.
- `-race` clean; `golangci-lint` reports 0 issues on all touched packages.
- Mutation-checked: forcing `admit` to always allow fails 6 tests.

## Not in this PR

Generalizing gateway-token issuance from daemon-provisioned skill boxes to
arbitrary tenant containers. That needs a mint surface and egress-policy changes
and is tracked separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional per-tenant rolling quotas for calls, total tokens, and output tokens.
  - Added anomaly detection for unusual request rates, models, endpoints, networks, and authentication failures.
  - Added graduated enforcement from throttling and alerts through circuit breaking and revocation.
  - Added policy status reporting and operator-controlled revoke/clear actions.
  - Denied requests no longer reach upstream providers, and throttled responses include retry guidance.

- **Documentation**
  - Documented configuration options and enforcement behavior, which remains disabled unless configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->