### PR TITLE
fix(model-gateway): consult the jti revocation list on every model call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Model-gateway tokens can now actually be revoked.** `MintToken` has always
+  stamped a `jti` into every gateway token, but nothing consulted it:
+  `VerifyToken` checked signature, issuer and expiry, and `handleModel` checked
+  the provider and the allowed-model set. So an issued gateway token was good
+  until its TTL ran out, with no kill-switch.
+
+  That gap mattered most where the TTL is longest. A skill box's token lives 30
+  minutes; a recipe box's lives a **year**, and that year was chosen on the
+  stated assumption that revocation was the way to kill one early. It wasn't
+  there.
+
+  `handleModel` now checks the token's `jti` against a revocation list, after
+  the provider check and before the real provider key is touched — so a revoked
+  token never causes the key to be injected and never reaches the upstream. The
+  daemon supplies the same jti store it already uses for platform JWTs; that
+  store is issuer-agnostic, so `containarium token revoke --jti <id>` kills a
+  gateway token with no new verb, RPC, or schema.
+
+  The lookup **fails open**, matching the platform JWT path: by that point the
+  signature, issuer, expiry, tenant binding and model ceiling have all been
+  checked, so a database outage degrades to the protection that existed before
+  this check rather than taking every tenant's model traffic down with the
+  database. A daemon with no Postgres has no store to consult and logs a warning
+  at startup saying its gateway tokens cannot be killed early.
+
 ## [0.67.0] - 2026-08-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   store is issuer-agnostic, so `containarium token revoke --jti <id>` kills a
   gateway token with no new verb, RPC, or schema.
 
-  The lookup **fails open**, matching the platform JWT path: by that point the
-  signature, issuer, expiry, tenant binding and model ceiling have all been
-  checked, so a database outage degrades to the protection that existed before
+  The lookup **fails open**, matching the platform JWT path. The token's
+  signature, issuer, expiry and provider binding are already checked when it
+  runs, and the allowed-model ceiling is applied further down the same request,
+  so a database outage degrades to exactly the protection that existed before
   this check rather than taking every tenant's model traffic down with the
   database. A daemon with no Postgres has no store to consult and logs a warning
   at startup saying its gateway tokens cannot be killed early.

--- a/internal/modelgateway/gateway.go
+++ b/internal/modelgateway/gateway.go
@@ -36,6 +36,12 @@ type Config struct {
 	// path (a hold-back window over the assistant text; #670 layer 2). Streaming
 	// token metering is independent and always on. Fail-open regardless.
 	OutputFilter bool
+
+	// Revocations is the kill-switch for issued gateway tokens (see
+	// revocation.go). Nil disables the check, which is the pre-existing
+	// behavior — a standalone daemon with no Postgres has no revocation store
+	// to consult. Production wires the same store used for platform JWTs.
+	Revocations RevocationChecker
 }
 
 // Gateway brokers every agent box's model calls: it authenticates the box's
@@ -142,6 +148,15 @@ func (g *Gateway) handleModel(w http.ResponseWriter, r *http.Request) {
 	}
 	if claims.Provider != provName {
 		http.Error(w, "token not valid for provider "+provName, http.StatusForbidden)
+		return
+	}
+
+	// Kill-switch. Deliberately ahead of the key lookup and the Director, so a
+	// revoked token never causes the real provider key to be touched.
+	if g.isRevoked(r.Context(), claims.ID) {
+		g.cfg.Logger.Printf("model-gateway: REVOKED tenant=%s skill=%s provider=%s jti=%s",
+			claims.Tenant, claims.SkillID, provName, claims.ID)
+		http.Error(w, "gateway token revoked", http.StatusUnauthorized)
 		return
 	}
 

--- a/internal/modelgateway/revocation.go
+++ b/internal/modelgateway/revocation.go
@@ -1,0 +1,64 @@
+package modelgateway
+
+import (
+	"context"
+	"log"
+	"time"
+)
+
+// Token revocation — the kill-switch for an issued gateway token.
+//
+// MintToken has always stamped a `jti` into every gateway token; until now
+// nothing consulted it. That left the gateway's credential contract
+// two-thirds implemented: tokens are scoped and expiring, but not revocable,
+// so a leaked one was usable until its TTL ran out. For a skill box that is
+// thirty minutes. For a recipe box (`recipeGatewayTokenTTL`) it is a year, and
+// that TTL was chosen on the explicit assumption that revocation was the
+// kill-switch — so this is the check that assumption needs.
+//
+// The interface is declared here, narrow and local, so this package keeps no
+// dependency on internal/auth. The daemon satisfies it with the same
+// revocation store it already wires for platform JWTs: that store is keyed on
+// jti alone and is issuer-agnostic, so `containarium token revoke --jti <id>`
+// kills a gateway token with no new verb, RPC, or schema.
+
+// RevocationChecker reports whether a token id has been revoked.
+//
+// Implementations must be safe for concurrent use — this is consulted on every
+// proxied model call.
+type RevocationChecker interface {
+	// IsRevoked returns true if the given jti has been revoked. An empty jti
+	// must return (false, nil).
+	IsRevoked(ctx context.Context, jti string) (bool, error)
+}
+
+// revocationLookupTimeout bounds a single revocation lookup so a slow database
+// cannot stall the model path. Mirrors auth.TokenManager.ValidateToken.
+const revocationLookupTimeout = 500 * time.Millisecond
+
+// isRevoked reports whether this token has been killed.
+//
+// Fails OPEN — on a lookup error the call is allowed, with a warning. That
+// matches the platform JWT path and is the right trade for a kill-switch
+// rather than a primary gate: the token's signature, issuer, expiry, tenant
+// binding, and model ceiling have all already been checked by this point, so a
+// database outage degrades us to the protection we had before this check
+// existed instead of taking every tenant's model traffic down with the
+// database.
+//
+// An empty jti short-circuits without a lookup: tokens minted before jti
+// existed carry none, and asking the store about "" is a pointless round trip.
+func (g *Gateway) isRevoked(ctx context.Context, jti string) bool {
+	if g.cfg.Revocations == nil || jti == "" {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(ctx, revocationLookupTimeout)
+	defer cancel()
+
+	revoked, err := g.cfg.Revocations.IsRevoked(ctx, jti)
+	if err != nil {
+		log.Printf("model-gateway: revocation lookup failed for jti=%s: %v (allowing; the revocation list is a kill-switch, not the primary gate)", jti, err)
+		return false
+	}
+	return revoked
+}

--- a/internal/modelgateway/revocation.go
+++ b/internal/modelgateway/revocation.go
@@ -40,10 +40,14 @@ const revocationLookupTimeout = 500 * time.Millisecond
 //
 // Fails OPEN — on a lookup error the call is allowed, with a warning. That
 // matches the platform JWT path and is the right trade for a kill-switch
-// rather than a primary gate: the token's signature, issuer, expiry, tenant
-// binding, and model ceiling have all already been checked by this point, so a
-// database outage degrades us to the protection we had before this check
-// existed instead of taking every tenant's model traffic down with the
+// rather than a primary gate.
+//
+// What survives a fail-open, precisely: the token's signature, issuer, expiry
+// and provider binding are already checked when this runs, and the
+// allowed-model ceiling is applied further down the same request — failing
+// open resumes handleModel, it does not skip to the proxy. So a database
+// outage degrades us to exactly the protection we had before this check
+// existed, instead of taking every tenant's model traffic down with the
 // database.
 //
 // An empty jti short-circuits without a lookup: tokens minted before jti

--- a/internal/modelgateway/revocation_test.go
+++ b/internal/modelgateway/revocation_test.go
@@ -1,0 +1,248 @@
+package modelgateway
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeRevocations is a stub revocation store. `err` makes every lookup fail, so
+// the fail-open path is exercised without a real database.
+type fakeRevocations struct {
+	mu      sync.Mutex
+	revoked map[string]bool
+	err     error
+	asked   []string
+}
+
+func newFakeRevocations() *fakeRevocations {
+	return &fakeRevocations{revoked: map[string]bool{}}
+}
+
+func (f *fakeRevocations) IsRevoked(_ context.Context, jti string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.asked = append(f.asked, jti)
+	if f.err != nil {
+		return false, f.err
+	}
+	return f.revoked[jti], nil
+}
+
+func (f *fakeRevocations) revoke(jti string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.revoked[jti] = true
+}
+
+func (f *fakeRevocations) lookups() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.asked...)
+}
+
+// revocationHarness builds a gateway whose upstream counts hits, so every test
+// can assert the thing that actually matters: a refused call must not reach the
+// provider, because that is where the real key is injected.
+type revocationHarness struct {
+	srv    *httptest.Server
+	secret []byte
+	hits   *int64
+	revs   *fakeRevocations
+}
+
+func newRevocationHarness(t *testing.T, revs *fakeRevocations) *revocationHarness {
+	t.Helper()
+	secret := []byte("shared-secret")
+	var hits int64
+	up := fakeUpstream(t, func(*http.Request) { atomic.AddInt64(&hits, 1) },
+		`{"model":"claude-test","usage":{"input_tokens":1,"output_tokens":1}}`)
+	t.Cleanup(up.Close)
+
+	providers := DefaultProviders()
+	providers["anthropic"].UpstreamURL = up.URL
+
+	cfg := Config{
+		Secret: secret, Providers: providers,
+		ProviderKeys: map[string]string{"anthropic": "REAL-KEY"},
+	}
+	// Deliberately assigned only when non-nil: passing a typed nil would make
+	// the interface non-nil and defeat the gateway's own nil guard.
+	if revs != nil {
+		cfg.Revocations = revs
+	}
+	srv := httptest.NewServer(New(cfg).Handler())
+	t.Cleanup(srv.Close)
+
+	return &revocationHarness{srv: srv, secret: secret, hits: &hits, revs: revs}
+}
+
+func (h *revocationHarness) call(t *testing.T, tok string) *http.Response {
+	t.Helper()
+	req, _ := http.NewRequest("POST", h.srv.URL+"/v1/model/anthropic/v1/messages",
+		strings.NewReader(`{"model":"claude-test"}`))
+	req.Header.Set("Authorization", "Bearer "+tok)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+	return resp
+}
+
+func (h *revocationHarness) upstreamHits() int64 { return atomic.LoadInt64(h.hits) }
+
+// mintAndRead mints a token and recovers its jti, since revoking one means
+// knowing the id the mint generated.
+func mintAndRead(t *testing.T, secret []byte, c GatewayClaims, ttl time.Duration) (string, string) {
+	t.Helper()
+	tok, err := MintToken(secret, c, ttl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claims, err := VerifyToken(secret, tok)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claims.ID == "" {
+		t.Fatal("minted token carries no jti — nothing to revoke")
+	}
+	return tok, claims.ID
+}
+
+// The point of the whole change: a revoked token stops working before its TTL,
+// and never reaches the provider.
+func TestGateway_RevokedTokenIsRefused(t *testing.T) {
+	revs := newFakeRevocations()
+	h := newRevocationHarness(t, revs)
+
+	// A year-long token, the shape a recipe box actually gets.
+	tok, jti := mintAndRead(t, h.secret, GatewayClaims{Tenant: "acme", Provider: "anthropic"}, 365*24*time.Hour)
+
+	if got := h.call(t, tok).StatusCode; got != http.StatusOK {
+		t.Fatalf("pre-revocation status = %d, want 200", got)
+	}
+	if h.upstreamHits() != 1 {
+		t.Fatalf("upstream hits = %d, want 1", h.upstreamHits())
+	}
+
+	revs.revoke(jti)
+
+	resp := h.call(t, tok)
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("post-revocation status = %d, want 401", resp.StatusCode)
+	}
+	if got := h.upstreamHits(); got != 1 {
+		t.Errorf("upstream hits = %d, want 1 — a revoked token reached the provider", got)
+	}
+}
+
+// Revoking one token must not affect another, including one for the same
+// tenant. This is the property the in-memory tenant-level brake cannot give.
+func TestGateway_RevocationIsPerToken(t *testing.T) {
+	revs := newFakeRevocations()
+	h := newRevocationHarness(t, revs)
+
+	leaked, leakedJTI := mintAndRead(t, h.secret, GatewayClaims{Tenant: "acme", Provider: "anthropic"}, time.Hour)
+	good, _ := mintAndRead(t, h.secret, GatewayClaims{Tenant: "acme", Provider: "anthropic"}, time.Hour)
+
+	revs.revoke(leakedJTI)
+
+	if got := h.call(t, leaked).StatusCode; got != http.StatusUnauthorized {
+		t.Errorf("revoked token status = %d, want 401", got)
+	}
+	if got := h.call(t, good).StatusCode; got != http.StatusOK {
+		t.Errorf("sibling token status = %d, want 200 — revoking one token killed the tenant", got)
+	}
+}
+
+// A database outage must not take every tenant's model traffic down with it.
+// By this point the signature, issuer, expiry, tenant binding and model ceiling
+// have all been checked, so failing open degrades to the protection that
+// existed before this check, rather than to an outage.
+func TestGateway_RevocationLookupFailureFailsOpen(t *testing.T) {
+	revs := newFakeRevocations()
+	revs.err = errors.New("connection refused")
+	h := newRevocationHarness(t, revs)
+
+	tok, _ := mintAndRead(t, h.secret, GatewayClaims{Tenant: "acme", Provider: "anthropic"}, time.Hour)
+
+	if got := h.call(t, tok).StatusCode; got != http.StatusOK {
+		t.Errorf("status = %d, want 200 — a revocation-store outage must not block model traffic", got)
+	}
+	if got := h.upstreamHits(); got != 1 {
+		t.Errorf("upstream hits = %d, want 1", got)
+	}
+}
+
+// No store configured (a standalone daemon with no Postgres) must behave
+// exactly as before the check existed.
+func TestGateway_NoRevocationStoreConfigured(t *testing.T) {
+	h := newRevocationHarness(t, nil)
+
+	tok, _ := mintAndRead(t, h.secret, GatewayClaims{Tenant: "acme", Provider: "anthropic"}, time.Hour)
+	for i := 0; i < 3; i++ {
+		if got := h.call(t, tok).StatusCode; got != http.StatusOK {
+			t.Fatalf("call %d status = %d, want 200 with no revocation store", i, got)
+		}
+	}
+	if got := h.upstreamHits(); got != 3 {
+		t.Errorf("upstream hits = %d, want 3", got)
+	}
+}
+
+// An empty jti must not cost a lookup. Tokens minted before jti existed carry
+// none, and asking the store about "" is a pointless round trip on every call.
+func TestGateway_EmptyJTISkipsTheLookup(t *testing.T) {
+	revs := newFakeRevocations()
+	gw := New(Config{
+		Secret:       []byte("s"),
+		Providers:    DefaultProviders(),
+		ProviderKeys: map[string]string{"anthropic": "K"},
+		Revocations:  revs,
+	})
+
+	if gw.isRevoked(context.Background(), "") {
+		t.Error("empty jti reported as revoked")
+	}
+	if got := revs.lookups(); len(got) != 0 {
+		t.Errorf("lookups = %v, want none for an empty jti", got)
+	}
+
+	// A real id is looked up.
+	if gw.isRevoked(context.Background(), "abc123") {
+		t.Error("unrevoked jti reported as revoked")
+	}
+	if got := revs.lookups(); len(got) != 1 || got[0] != "abc123" {
+		t.Errorf("lookups = %v, want [abc123]", got)
+	}
+}
+
+// The check must not be reachable only through the happy path: a token for the
+// wrong provider is already refused earlier, and that must stay true.
+func TestGateway_RevocationDoesNotDisturbExistingChecks(t *testing.T) {
+	revs := newFakeRevocations()
+	h := newRevocationHarness(t, revs)
+
+	tok, _ := mintAndRead(t, h.secret, GatewayClaims{Tenant: "acme", Provider: "openai"}, time.Hour)
+
+	// Presented against anthropic: refused on the provider check, before the
+	// revocation lookup is reached.
+	if got := h.call(t, tok).StatusCode; got != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 for a provider mismatch", got)
+	}
+	if got := revs.lookups(); len(got) != 0 {
+		t.Errorf("revocation was consulted for a request refused earlier: %v", got)
+	}
+	if got := h.upstreamHits(); got != 0 {
+		t.Errorf("upstream hits = %d, want 0", got)
+	}
+}

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -1690,11 +1690,29 @@ skipAppHosting:
 			} else {
 				gwSink = sink
 			}
+			// Kill-switch for issued gateway tokens: the SAME jti revocation
+			// store already wired for platform JWTs. It is issuer-agnostic
+			// (keyed on jti alone), so `containarium token revoke --jti <id>`
+			// kills a gateway token too — no new verb, RPC, or schema.
+			//
+			// Assigned through a nil check rather than directly: a nil
+			// *auth.PgRevocationStore placed in an interface field yields a
+			// NON-nil interface holding a nil pointer, so the `Revocations ==
+			// nil` guard in the gateway would not fire and every model call
+			// would dereference nil. A daemon without Postgres reaches here
+			// with a nil store, so this is the common path, not a corner case.
+			var gwRevocations modelgateway.RevocationChecker
+			if revocationStoreLocal != nil {
+				gwRevocations = revocationStoreLocal
+			} else {
+				log.Printf("Warning: model-gateway has no revocation store (no Postgres) — issued gateway tokens cannot be killed before they expire")
+			}
 			gw := modelgateway.New(modelgateway.Config{
 				Secret:       []byte(config.JWTSecret),
 				Providers:    modelgateway.DefaultProviders(),
 				ProviderKeys: keys,
 				Sink:         gwSink,
+				Revocations:  gwRevocations,
 				// Redact system-prompt (skill persona) leakage on the streaming
 				// chat path (#670 layer 2). Default on; set
 				// CONTAINARIUM_GATEWAY_OUTPUT_FILTER=0 to disable. Streaming token


### PR DESCRIPTION
## What

`MintToken` has always stamped a `jti` into every model-gateway token, and
nothing ever consulted it. `VerifyToken` checks signature, issuer and expiry;
`handleModel` checks the provider and the allowed-model set. There was no
kill-switch, so an issued gateway token was usable until its TTL ran out.

That matters most where the TTL is longest. `recipeGatewayTokenTTL` is a **year**,
and its own comment says the year is safe because the kill-switch is revocation
rather than expiry:

```go
// recipeGatewayTokenTTL bounds a workspace recipe's gateway token. Unlike a
// skill run (minutes), a recipe box like agent-workspace is long-lived, so the
// token must outlive a session — here a year. The kill-switch is revocation
// (#752), not expiry; refreshing a live box's token is a follow-up.
```

That control was not in the tree. `git grep 'IsRevoked\|RevocationChecker\|claims.ID' -- internal/modelgateway/`
returned nothing, and nothing wired a revocation store into the gateway. PR #752
is titled and described as exactly this change, but the branch that merged under
it is `feat/container-attribution-endpoint-746` and the files it landed are the
container-attribution endpoint. This PR implements what that one described.

## How

- A narrow local `RevocationChecker` interface (`IsRevoked(ctx, jti)`) on
  `modelgateway.Config`, so the package keeps no `internal/auth` import.
- `handleModel` checks `claims.ID` **after** the provider check and **before**
  the key lookup, so a revoked token never causes the real provider key to be
  touched and never reaches the `Director`.
- The daemon supplies the same jti store it already wires for platform JWTs. It
  is keyed on jti alone and issuer-agnostic, so `containarium token revoke --jti <id>`
  kills a gateway token — no new verb, RPC, or schema.
- **Fails open** on a lookup error, matching `auth.TokenManager.ValidateToken`.
  Signature, issuer, expiry and provider binding are checked before it runs, and
  the allowed-model ceiling is applied further down the *same* request — failing
  open resumes `handleModel` rather than skipping to the proxy. So a store
  outage degrades to exactly the protection that existed before this check,
  rather than taking every tenant's model traffic down with the database.
- An empty `jti` short-circuits without a lookup — tokens minted before `jti`
  existed carry none.

## The nil trap, called out because it bites silently

The daemon assigns the store through an explicit nil check rather than passing
it straight in. A nil `*auth.PgRevocationStore` placed in an interface field
yields a **non-nil interface holding a nil pointer**, which sails past the
gateway's own `Revocations == nil` guard and dereferences nil on every model
call. A daemon without Postgres reaches that line with a nil store, so this is
the common path, not a corner case — it now also logs that its gateway tokens
cannot be killed early.

## Testing

- A revoked token is refused **and the upstream is never hit**. That is the
  assertion that cannot quietly regress: the key is injected in the `Director`,
  so "refused" has to mean the `Director` never ran.
- Revocation is per-token, not per-tenant: killing a leaked token leaves a
  sibling token for the same tenant working.
- Fail-open on a lookup error; no store configured behaves exactly as before;
  an empty jti costs no lookup; an earlier check still short-circuits ahead of
  this one.
- Mutation-checked: disabling the gate fails two tests. Race clean,
  `golangci-lint` 0 issues.

## Follow-ups, not in this PR

- Revisit the 365-day `recipeGatewayTokenTTL` now that there is something to
  revoke with.
- Re-open whatever tracking issue #752 closed.
- In-box token refresh, so a long-lived box can hold a short-lived token — the
  "follow-up" the TTL comment refers to.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Revoked gateway tokens are rejected before requests reach upstream services.
  - Added configurable per-tenant policies for model access, quota enforcement, anomaly detection, and usage metering.
  - Added a policy status endpoint and gateway alerts.
  - Added enforcement across providers, including model restrictions and retry guidance.
  - Streaming and non-streaming usage are recorded for policy accounting.

- **Bug Fixes**
  - Revocation checks remain isolated per token and preserve existing validation.
  - Gateways without PostgreSQL continue operating with a warning when early revocation is unavailable.

- **Documentation**
  - Added unreleased changelog notes describing gateway token revocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->