### PR TITLE
feat(hostcheck): posture check for a tunnel token left on ExecStart

### DIFF
--- a/internal/hostcheck/posture.go
+++ b/internal/hostcheck/posture.go
@@ -54,6 +54,7 @@ type posturePaths struct {
 	sshdConfig     string // /etc/ssh/sshd_config
 	sshdConfigDir  string // /etc/ssh/sshd_config.d
 	aptPeriodic    string // /etc/apt/apt.conf.d/20auto-upgrades
+	tunnelUnit     string // /etc/systemd/system/containarium-tunnel.service
 	incusDataDir   string // /var/lib/incus — the volume that holds tenant data
 	recoveryDir    string // /mnt/incus-data — where containarium-recovery.yaml is written (#1154)
 	metadataDialer func() error
@@ -68,6 +69,7 @@ func defaultPosturePaths() posturePaths {
 		sshdConfig:     "/etc/ssh/sshd_config",
 		sshdConfigDir:  "/etc/ssh/sshd_config.d",
 		aptPeriodic:    "/etc/apt/apt.conf.d/20auto-upgrades",
+		tunnelUnit:     "/etc/systemd/system/containarium-tunnel.service",
 		incusDataDir:   "/var/lib/incus",
 		recoveryDir:    DefaultRecoveryDir,
 		metadataDialer: dialMetadataServer,
@@ -95,6 +97,7 @@ func runPosture(p posturePaths) []Check {
 		unattendedUpgradesCheck(p),
 		metadataReachableCheck(p),
 		recoveryConfigDurableCheck(p),
+		tunnelTokenExposedCheck(p),
 	}
 	for i := range checks {
 		checks[i].Kind = KindPosture
@@ -458,6 +461,72 @@ func metadataReachableCheck(p posturePaths) Check {
 	}
 	c.Detail = "169.254.169.254:80 is reachable from the host: a workload that escapes its container can reach instance credentials"
 	return c
+}
+
+// --- tunnel token exposure --------------------------------------------
+
+// tunnelTokenExposedCheck reports whether the pool-join tunnel unit still
+// carries its authentication token on the (world-readable, 0644) ExecStart
+// line — the pattern this repo's own commit a9cc8a4 moved off of
+// ("fix(cmd): tunnel-handshake token via EnvironmentFile, not ExecStart",
+// #965): current `pool join` writes the token to a root-only (0600)
+// EnvironmentFile= instead. A host joined before that fix, or whose unit
+// was hand-edited back to the old form, keeps a live bearer-equivalent
+// credential readable by any local user via `systemctl show -p ExecStart`,
+// `ps`, or journald (cloud#1074).
+//
+// OK means the token is NOT on the ExecStart line. A missing unit is
+// reported as unknown rather than an implicit pass: the host may simply
+// not be tunnel-joined, but that is indistinguishable here from "the unit
+// was moved/renamed", so it stays unknown per rule 1 above.
+func tunnelTokenExposedCheck(p posturePaths) Check {
+	c := Check{Name: "tunnel unit does not carry its token on ExecStart"}
+
+	data, err := os.ReadFile(p.tunnelUnit) // #nosec G304 -- package-owned constant, overridden only by tests
+	if err != nil {
+		c.Detail = fmt.Sprintf("could not determine: reading %s: %v", p.tunnelUnit, err)
+		return c
+	}
+
+	execStart := extractExecStart(string(data))
+	if execStart == "" {
+		c.Detail = fmt.Sprintf("could not determine: no ExecStart= line found in %s", p.tunnelUnit)
+		return c
+	}
+	if strings.Contains(execStart, "--token") {
+		c.Detail = fmt.Sprintf("%s's ExecStart carries --token — rotate this host's tunnel token and re-run "+
+			"`containarium pool join` to regenerate the unit via EnvironmentFile=", p.tunnelUnit)
+		return c
+	}
+	c.OK = true
+	c.Detail = "ExecStart does not carry --token"
+	return c
+}
+
+// extractExecStart concatenates a (possibly line-continued with a trailing
+// "\") ExecStart= directive's value out of a systemd unit file's raw text.
+// Returns "" if the unit has no ExecStart= line at all.
+func extractExecStart(unit string) string {
+	var parts []string
+	inExecStart := false
+	for _, raw := range strings.Split(unit, "\n") {
+		line := strings.TrimRight(raw, "\r")
+		if !inExecStart {
+			if !strings.HasPrefix(line, "ExecStart=") {
+				continue
+			}
+			inExecStart = true
+		}
+		cont := strings.HasSuffix(line, `\`)
+		parts = append(parts, strings.TrimSuffix(line, `\`))
+		if !cont {
+			break
+		}
+	}
+	if !inExecStart {
+		return ""
+	}
+	return strings.Join(parts, " ")
 }
 
 // dialMetadataServer attempts a short TCP connect to the link-local

--- a/internal/hostcheck/posture.go
+++ b/internal/hostcheck/posture.go
@@ -47,32 +47,34 @@ import (
 // real host — a posture check that can only be tested on a correctly
 // hardened machine is a posture check nobody will ever run red.
 type posturePaths struct {
-	procMounts     string // /proc/mounts
-	sysBlock       string // /sys/block
-	efiVars        string // /sys/firmware/efi/efivars
-	auditdPID      string // /run/auditd.pid
-	sshdConfig     string // /etc/ssh/sshd_config
-	sshdConfigDir  string // /etc/ssh/sshd_config.d
-	aptPeriodic    string // /etc/apt/apt.conf.d/20auto-upgrades
-	tunnelUnit     string // /etc/systemd/system/containarium-tunnel.service
-	incusDataDir   string // /var/lib/incus — the volume that holds tenant data
-	recoveryDir    string // /mnt/incus-data — where containarium-recovery.yaml is written (#1154)
-	metadataDialer func() error
+	procMounts       string // /proc/mounts
+	sysBlock         string // /sys/block
+	efiVars          string // /sys/firmware/efi/efivars
+	auditdPID        string // /run/auditd.pid
+	sshdConfig       string // /etc/ssh/sshd_config
+	sshdConfigDir    string // /etc/ssh/sshd_config.d
+	aptPeriodic      string // /etc/apt/apt.conf.d/20auto-upgrades
+	tunnelUnit       string // /etc/systemd/system/containarium-tunnel.service
+	tunnelUnitDropIn string // /etc/systemd/system/containarium-tunnel.service.d
+	incusDataDir     string // /var/lib/incus — the volume that holds tenant data
+	recoveryDir      string // /mnt/incus-data — where containarium-recovery.yaml is written (#1154)
+	metadataDialer   func() error
 }
 
 func defaultPosturePaths() posturePaths {
 	return posturePaths{
-		procMounts:     "/proc/mounts",
-		sysBlock:       "/sys/block",
-		efiVars:        "/sys/firmware/efi/efivars",
-		auditdPID:      "/run/auditd.pid",
-		sshdConfig:     "/etc/ssh/sshd_config",
-		sshdConfigDir:  "/etc/ssh/sshd_config.d",
-		aptPeriodic:    "/etc/apt/apt.conf.d/20auto-upgrades",
-		tunnelUnit:     "/etc/systemd/system/containarium-tunnel.service",
-		incusDataDir:   "/var/lib/incus",
-		recoveryDir:    DefaultRecoveryDir,
-		metadataDialer: dialMetadataServer,
+		procMounts:       "/proc/mounts",
+		sysBlock:         "/sys/block",
+		efiVars:          "/sys/firmware/efi/efivars",
+		auditdPID:        "/run/auditd.pid",
+		sshdConfig:       "/etc/ssh/sshd_config",
+		sshdConfigDir:    "/etc/ssh/sshd_config.d",
+		aptPeriodic:      "/etc/apt/apt.conf.d/20auto-upgrades",
+		tunnelUnit:       "/etc/systemd/system/containarium-tunnel.service",
+		tunnelUnitDropIn: "/etc/systemd/system/containarium-tunnel.service.d",
+		incusDataDir:     "/var/lib/incus",
+		recoveryDir:      DefaultRecoveryDir,
+		metadataDialer:   dialMetadataServer,
 	}
 }
 
@@ -482,51 +484,128 @@ func metadataReachableCheck(p posturePaths) Check {
 func tunnelTokenExposedCheck(p posturePaths) Check {
 	c := Check{Name: "tunnel unit does not carry its token on ExecStart"}
 
-	data, err := os.ReadFile(p.tunnelUnit) // #nosec G304 -- package-owned constant, overridden only by tests
+	execStart, ok, err := effectiveExecStart(p.tunnelUnit, p.tunnelUnitDropIn)
 	if err != nil {
 		c.Detail = fmt.Sprintf("could not determine: reading %s: %v", p.tunnelUnit, err)
 		return c
 	}
-
-	execStart := extractExecStart(string(data))
-	if execStart == "" {
-		c.Detail = fmt.Sprintf("could not determine: no ExecStart= line found in %s", p.tunnelUnit)
+	if !ok {
+		c.Detail = fmt.Sprintf("could not determine: no effective ExecStart= found for %s (base file or its .service.d drop-ins)", p.tunnelUnit)
 		return c
 	}
 	if strings.Contains(execStart, "--token") {
-		c.Detail = fmt.Sprintf("%s's ExecStart carries --token — rotate this host's tunnel token and re-run "+
+		c.Detail = fmt.Sprintf("%s's effective ExecStart carries --token — rotate this host's tunnel token and re-run "+
 			"`containarium pool join` to regenerate the unit via EnvironmentFile=", p.tunnelUnit)
 		return c
 	}
 	c.OK = true
-	c.Detail = "ExecStart does not carry --token"
+	c.Detail = "effective ExecStart does not carry --token"
 	return c
 }
 
-// extractExecStart concatenates a (possibly line-continued with a trailing
-// "\") ExecStart= directive's value out of a systemd unit file's raw text.
-// Returns "" if the unit has no ExecStart= line at all.
-func extractExecStart(unit string) string {
-	var parts []string
-	inExecStart := false
-	for _, raw := range strings.Split(unit, "\n") {
-		line := strings.TrimRight(raw, "\r")
-		if !inExecStart {
-			if !strings.HasPrefix(line, "ExecStart=") {
+// effectiveExecStart resolves the EFFECTIVE ExecStart= across unitPath and
+// its .service.d/ drop-ins, in systemd's own override order — drop-ins
+// apply, lexically sorted, AFTER the base file. A check that reads only
+// the base file can be defeated by a drop-in the base file has no idea
+// about (cloud#1074 review follow-up): nothing in this repo creates a
+// drop-in for the TUNNEL unit today, but the daemon unit's OWN drop-in
+// (renderPoolDropIn) already establishes the override idiom this resolves
+// — a bare "ExecStart=" directive (this codebase's documented reset
+// convention) clears whatever was accumulated so far, and a subsequent
+// non-empty "ExecStart=<cmd>" sets the new effective value. Built on
+// extractExecStart, which already distinguishes "no ExecStart= line in
+// this source" ("") from "an explicit bare reset" (the literal string
+// "ExecStart=") — see its own doc comment.
+//
+// Returns ok=false if NO source (base or any drop-in) ever set an
+// effective ExecStart= — unknown, not a pass, per rule 1 above.
+func effectiveExecStart(unitPath, dropInDir string) (string, bool, error) {
+	base, err := os.ReadFile(unitPath) // #nosec G304 -- package-owned constant, overridden only by tests
+	if err != nil {
+		return "", false, err
+	}
+	sources := []string{string(base)}
+
+	entries, derr := os.ReadDir(dropInDir) // #nosec G304 -- package-owned constant, overridden only by tests
+	if derr == nil {
+		var names []string
+		for _, e := range entries {
+			if strings.HasSuffix(e.Name(), ".conf") {
+				names = append(names, e.Name())
+			}
+		}
+		sort.Strings(names) // systemd globs *.conf; lexical order is what it gets
+		for _, n := range names {
+			d, rerr := os.ReadFile(filepath.Join(dropInDir, filepath.Base(n))) // #nosec G304 -- dropInDir is package-owned/test-overridden; n is Base()-bounded
+			if rerr != nil {
 				continue
 			}
-			inExecStart = true
-		}
-		cont := strings.HasSuffix(line, `\`)
-		parts = append(parts, strings.TrimSuffix(line, `\`))
-		if !cont {
-			break
+			sources = append(sources, string(d))
 		}
 	}
-	if !inExecStart {
+
+	// Every source can itself contain MULTIPLE ExecStart= directives — the
+	// reset-then-set idiom (renderPoolDropIn's own pattern) puts both in
+	// ONE drop-in file — so each source's directives are walked and
+	// applied in order, not just its first.
+	current := ""
+	found := false
+	for _, src := range sources {
+		for _, v := range allExecStartDirectives(src) {
+			switch {
+			case strings.TrimSpace(v) == "ExecStart=":
+				// Bare reset: systemd's documented idiom for a drop-in to
+				// clear the base unit's ExecStart before setting its own —
+				// this codebase's own renderPoolDropIn uses exactly this.
+				current, found = "", false
+			default:
+				current, found = v, true
+			}
+		}
+	}
+	return current, found, nil
+}
+
+// extractExecStart concatenates a (possibly line-continued with a trailing
+// "\") ExecStart= directive's value out of a systemd unit file's raw text —
+// the FIRST one found. Returns "" if the unit has no ExecStart= line at
+// all. Kept as the single-directive convenience wrapper over
+// allExecStartDirectives.
+func extractExecStart(unit string) string {
+	d := allExecStartDirectives(unit)
+	if len(d) == 0 {
 		return ""
 	}
-	return strings.Join(parts, " ")
+	return d[0]
+}
+
+// allExecStartDirectives returns EVERY ExecStart= directive found in unit,
+// in order, each with its own (possibly line-continued via a trailing "\")
+// value joined. Unlike taking just the first, this is what
+// effectiveExecStart needs: a single drop-in file commonly contains BOTH a
+// bare reset ("ExecStart=") and its replacement together, and both must be
+// seen to resolve correctly.
+func allExecStartDirectives(unit string) []string {
+	var directives []string
+	lines := strings.Split(unit, "\n")
+	for i := 0; i < len(lines); i++ {
+		line := strings.TrimRight(lines[i], "\r")
+		if !strings.HasPrefix(line, "ExecStart=") {
+			continue
+		}
+		var parts []string
+		for {
+			cont := strings.HasSuffix(line, `\`)
+			parts = append(parts, strings.TrimSuffix(line, `\`))
+			if !cont || i+1 >= len(lines) {
+				break
+			}
+			i++
+			line = strings.TrimRight(lines[i], "\r")
+		}
+		directives = append(directives, strings.Join(parts, " "))
+	}
+	return directives
 }
 
 // dialMetadataServer attempts a short TCP connect to the link-local

--- a/internal/hostcheck/posture_test.go
+++ b/internal/hostcheck/posture_test.go
@@ -25,15 +25,16 @@ func tempPaths(t *testing.T) (posturePaths, string) {
 	t.Helper()
 	dir := t.TempDir()
 	return posturePaths{
-		procMounts:    filepath.Join(dir, "mounts"),
-		sysBlock:      filepath.Join(dir, "sys-block"),
-		efiVars:       filepath.Join(dir, "efivars"),
-		auditdPID:     filepath.Join(dir, "auditd.pid"),
-		sshdConfig:    filepath.Join(dir, "sshd_config"),
-		sshdConfigDir: filepath.Join(dir, "sshd_config.d"),
-		aptPeriodic:   filepath.Join(dir, "20auto-upgrades"),
-		tunnelUnit:    filepath.Join(dir, "containarium-tunnel.service"),
-		incusDataDir:  "/var/lib/incus",
+		procMounts:       filepath.Join(dir, "mounts"),
+		sysBlock:         filepath.Join(dir, "sys-block"),
+		efiVars:          filepath.Join(dir, "efivars"),
+		auditdPID:        filepath.Join(dir, "auditd.pid"),
+		sshdConfig:       filepath.Join(dir, "sshd_config"),
+		sshdConfigDir:    filepath.Join(dir, "sshd_config.d"),
+		aptPeriodic:      filepath.Join(dir, "20auto-upgrades"),
+		tunnelUnit:       filepath.Join(dir, "containarium-tunnel.service"),
+		tunnelUnitDropIn: filepath.Join(dir, "containarium-tunnel.service.d"),
+		incusDataDir:     "/var/lib/incus",
 		// Default to "blocked", the desirable state, so a test that isn't
 		// about the metadata check doesn't accidentally depend on the
 		// network of the machine running it.
@@ -409,6 +410,79 @@ func TestTunnelTokenExposedCheck(t *testing.T) {
 		c := tunnelTokenExposedCheck(p)
 		if c.OK || !strings.Contains(c.Detail, "could not determine") {
 			t.Errorf("no ExecStart= should be unknown, got OK=%v %q", c.OK, c.Detail)
+		}
+	})
+
+	// The CodeRabbit follow-up on cloud#1074: a check that reads only the
+	// base unit file can be defeated by a drop-in overriding ExecStart=.
+	t.Run("drop-in overriding ExecStart with --token fails even though the base file is safe", func(t *testing.T) {
+		p, _ := tempPaths(t)
+		write(t, p.tunnelUnit, "[Unit]\nDescription=Containarium Tunnel Client\n\n"+
+			"[Service]\nType=simple\n"+
+			"EnvironmentFile=/etc/containarium/tunnel-token.env\n"+
+			"ExecStart=/usr/local/bin/containarium tunnel --spot-id fts-13700k --pool fts\n"+
+			"Restart=always\n")
+		write(t, filepath.Join(p.tunnelUnitDropIn, "10-override.conf"),
+			"[Service]\nExecStart=\n"+
+				"ExecStart=/usr/local/bin/containarium tunnel --token abc123scopedtoken --spot-id fts-13700k --pool fts\n")
+
+		c := tunnelTokenExposedCheck(p)
+		if c.OK {
+			t.Error("a drop-in overriding ExecStart with --token must fail this check even though the base file is safe")
+		}
+		if !strings.Contains(c.Detail, "--token") {
+			t.Errorf("detail should name what was found, got %q", c.Detail)
+		}
+	})
+
+	t.Run("drop-in overriding ExecStart with the safe form passes", func(t *testing.T) {
+		p, _ := tempPaths(t)
+		// Base file is deliberately the STALE/unsafe pattern; the drop-in
+		// (lexically after it, systemd's own override order) replaces it
+		// with the safe EnvironmentFile= form — the effective command must
+		// be judged by what actually runs, not by the base file alone.
+		write(t, p.tunnelUnit, "[Unit]\nDescription=Containarium Tunnel Client\n\n"+
+			"[Service]\nType=simple\n"+
+			"ExecStart=/usr/local/bin/containarium tunnel --token abc123scopedtoken --spot-id fts-13700k --pool fts\n"+
+			"Restart=always\n")
+		write(t, filepath.Join(p.tunnelUnitDropIn, "10-override.conf"),
+			"[Service]\nExecStart=\n"+
+				"ExecStart=/usr/local/bin/containarium tunnel --spot-id fts-13700k --pool fts\n")
+
+		c := tunnelTokenExposedCheck(p)
+		if !c.OK {
+			t.Errorf("a drop-in replacing the stale base ExecStart with the safe form must pass: %s", c.Detail)
+		}
+	})
+
+	t.Run("drop-in with no ExecStart directive leaves the base file's value in effect", func(t *testing.T) {
+		p, _ := tempPaths(t)
+		write(t, p.tunnelUnit, "[Unit]\nDescription=Containarium Tunnel Client\n\n"+
+			"[Service]\nType=simple\n"+
+			"ExecStart=/usr/local/bin/containarium tunnel --token abc123scopedtoken --spot-id fts-13700k --pool fts\n"+
+			"Restart=always\n")
+		write(t, filepath.Join(p.tunnelUnitDropIn, "10-unrelated.conf"), "[Service]\nRestart=on-failure\n")
+
+		c := tunnelTokenExposedCheck(p)
+		if c.OK {
+			t.Error("a drop-in with no ExecStart= directive must not mask the base file's --token")
+		}
+	})
+
+	t.Run("multiple drop-ins apply in lexical order, later wins", func(t *testing.T) {
+		p, _ := tempPaths(t)
+		write(t, p.tunnelUnit, "[Unit]\nDescription=Containarium Tunnel Client\n\n"+
+			"[Service]\nType=simple\n"+
+			"ExecStart=/usr/local/bin/containarium tunnel --spot-id fts-13700k --pool fts\n"+
+			"Restart=always\n")
+		write(t, filepath.Join(p.tunnelUnitDropIn, "10-first.conf"),
+			"[Service]\nExecStart=\nExecStart=/usr/local/bin/containarium tunnel --token abc123scopedtoken --pool fts\n")
+		write(t, filepath.Join(p.tunnelUnitDropIn, "90-later.conf"),
+			"[Service]\nExecStart=\nExecStart=/usr/local/bin/containarium tunnel --spot-id fts-13700k --pool fts\n")
+
+		c := tunnelTokenExposedCheck(p)
+		if !c.OK {
+			t.Errorf("the lexically-last drop-in must win: %s", c.Detail)
 		}
 	})
 }

--- a/internal/hostcheck/posture_test.go
+++ b/internal/hostcheck/posture_test.go
@@ -32,6 +32,7 @@ func tempPaths(t *testing.T) (posturePaths, string) {
 		sshdConfig:    filepath.Join(dir, "sshd_config"),
 		sshdConfigDir: filepath.Join(dir, "sshd_config.d"),
 		aptPeriodic:   filepath.Join(dir, "20auto-upgrades"),
+		tunnelUnit:    filepath.Join(dir, "containarium-tunnel.service"),
 		incusDataDir:  "/var/lib/incus",
 		// Default to "blocked", the desirable state, so a test that isn't
 		// about the metadata check doesn't accidentally depend on the
@@ -353,6 +354,92 @@ func TestSSHDConfigCheck(t *testing.T) {
 			t.Errorf("missing sshd_config should be unknown, got OK=%v %q", c.OK, c.Detail)
 		}
 	})
+}
+
+func TestTunnelTokenExposedCheck(t *testing.T) {
+	t.Run("missing unit is unknown not pass", func(t *testing.T) {
+		p, _ := tempPaths(t)
+		c := tunnelTokenExposedCheck(p)
+		if c.OK || !strings.Contains(c.Detail, "could not determine") {
+			t.Errorf("missing tunnel unit should be unknown, got OK=%v %q", c.OK, c.Detail)
+		}
+	})
+
+	t.Run("stale pre-#965 unit with --token on ExecStart fails", func(t *testing.T) {
+		p, _ := tempPaths(t)
+		write(t, p.tunnelUnit, "[Unit]\nDescription=Containarium Tunnel Client\n\n"+
+			"[Service]\nType=simple\n"+
+			"ExecStart=/usr/local/bin/containarium tunnel --sentinel-addr asia-east1.containarium.dev:443 "+
+			"--token abc123scopedtoken --spot-id fts-13700k --ports 22,8080,443 --pool fts\n"+
+			"Restart=always\n")
+		c := tunnelTokenExposedCheck(p)
+		if c.OK {
+			t.Error("--token on the ExecStart line must fail this check")
+		}
+		if !strings.Contains(c.Detail, "--token") {
+			t.Errorf("detail should name what was found, got %q", c.Detail)
+		}
+		if strings.Contains(c.Detail, "abc123scopedtoken") {
+			t.Errorf("detail must not echo the token value itself, got %q", c.Detail)
+		}
+	})
+
+	t.Run("current EnvironmentFile form passes, continuation lines included", func(t *testing.T) {
+		p, _ := tempPaths(t)
+		// Mirrors internal/cmd.renderTunnelUnit's actual output shape (#965):
+		// the token lives in EnvironmentFile=, never on ExecStart.
+		write(t, p.tunnelUnit, "[Unit]\nDescription=Containarium Tunnel Client (fts pool)\n\n"+
+			"[Service]\nType=simple\n"+
+			"EnvironmentFile=/etc/containarium/tunnel-token.env\n"+
+			"ExecStart=/usr/local/bin/containarium tunnel \\\n"+
+			"  --sentinel-addr asia-east1.containarium.dev:443 \\\n"+
+			"  --spot-id fts-13700k \\\n"+
+			"  --ports 22,8080,443 \\\n"+
+			"  --pool fts\n"+
+			"Restart=always\n")
+		c := tunnelTokenExposedCheck(p)
+		if !c.OK {
+			t.Errorf("EnvironmentFile= form must pass: %s", c.Detail)
+		}
+	})
+
+	t.Run("unit with no ExecStart line is unknown not pass", func(t *testing.T) {
+		p, _ := tempPaths(t)
+		write(t, p.tunnelUnit, "[Unit]\nDescription=broken unit\n")
+		c := tunnelTokenExposedCheck(p)
+		if c.OK || !strings.Contains(c.Detail, "could not determine") {
+			t.Errorf("no ExecStart= should be unknown, got OK=%v %q", c.OK, c.Detail)
+		}
+	})
+}
+
+func TestExtractExecStart(t *testing.T) {
+	tests := []struct {
+		name, unit, want string
+	}{
+		{
+			name: "single line",
+			unit: "[Service]\nExecStart=/usr/local/bin/containarium tunnel --token x\nRestart=always\n",
+			want: "ExecStart=/usr/local/bin/containarium tunnel --token x",
+		},
+		{
+			name: "continuation lines joined",
+			unit: "ExecStart=/usr/local/bin/containarium tunnel \\\n--spot-id x \\\npool fts\nRestart=always\n",
+			want: "ExecStart=/usr/local/bin/containarium tunnel  --spot-id x  pool fts",
+		},
+		{
+			name: "absent",
+			unit: "[Unit]\nDescription=x\n",
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractExecStart(tt.unit); got != tt.want {
+				t.Errorf("extractExecStart() = %q, want %q", got, tt.want)
+			}
+		})
+	}
 }
 
 func TestAptPeriodicEnabled(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds a `doctor` host-security-posture check (`internal/hostcheck`) that
  flags a `containarium-tunnel.service` unit whose `ExecStart=` still
  embeds `--token`, instead of the current `EnvironmentFile=` form
  (#965/v0.51.6).
- A host joined before that fix — or whose unit was hand-edited back to
  the old form — keeps a live, bearer-equivalent tunnel token readable by
  any local user via `systemctl show -p ExecStart`, `ps`, or journald.
  This check lets an operator find that with `containarium doctor`
  instead of reading unit files by hand across a fleet.
- Non-blocking, like every other posture check (`Required: false`) — it
  never affects `doctor`'s exit code or the daemon's self-check.

## Why

`#965` already fixed how `pool join` *writes* the unit. Nothing detects a
unit that predates that fix, so a stale install is invisible short of a
manual audit. This closes that gap the same way the other posture checks
(`#1103`) do: read the evidence, report unknown when it can't be measured,
never claim a pass with no evidence.

## Test evidence

- `TestTunnelTokenExposedCheck`: missing unit → unknown; `--token` on
  ExecStart → fails (and the detail doesn't echo the token value); the
  current `EnvironmentFile=` form (continuation lines included) → passes;
  no `ExecStart=` line at all → unknown.
- `TestExtractExecStart`: single-line, continuation-joined, and absent
  cases.
- Mutation-checked: reverting the `--token` detection to a no-op turns the
  first case red, confirming the test isn't vacuous.
- `go build ./...`, `go vet ./...`, `gofmt -l` all clean.
- Full `internal/hostcheck` and `internal/cmd` suites green locally.

No proto/API surface touched; no behavior change to `pool join` itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a posture check that detects tunnel authentication tokens embedded in system service startup commands.
  * Supports startup-command continuations, environment-file configurations, and service drop-in overrides.
  * Evaluates the effective startup command across multiple configuration files and directives.
  * Reports exposed tokens as a security issue without revealing the token value.

* **Bug Fixes**
  * Missing, malformed, or absent effective service configurations are now reported as unknown rather than incorrectly passing or failing.
  * Correctly handles command resets and precedence among service drop-ins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->