### PR TITLE
fix(container): bound createUser's exec against a wedged Incus operation

### DIFF
--- a/pkg/core/container/identity_seeding_test.go
+++ b/pkg/core/container/identity_seeding_test.go
@@ -1,12 +1,16 @@
 package container
 
 import (
+	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/footprintai/containarium/pkg/core/incus/incustest"
 	"github.com/footprintai/containarium/pkg/core/ostype"
 )
+
+var errWedgedForTest = errors.New("command execution timed out (simulated wedge)")
 
 // The collapse contract (#1488 Finding 2): identity seeding pays one
 // in-guest exec per function, not one per command. Each Incus Exec is a
@@ -103,6 +107,60 @@ func TestCreateUser_SingleExecPerFamily(t *testing.T) {
 				t.Errorf("sudoers write = %q mode %q", w.path, w.mode)
 			}
 		})
+	}
+}
+
+// TestCreateUser_UsesTheBackendsTimedExecWhenAvailable: createUser must
+// route through ExecWithTimeout (not the bare, unbounded Exec) whenever the
+// backend offers it — this is the whole fix for cloud#1128, where an
+// unbounded exec against a wedged Incus operation hung the creating
+// goroutine forever instead of ever reaching the terminal ERROR state.
+func TestCreateUser_UsesTheBackendsTimedExecWhenAvailable(t *testing.T) {
+	var gotTimeout time.Duration
+	timedCalled := false
+	mock := incustest.NewMockBackend()
+	mock.ExecFunc = func(_ string, _ []string) error {
+		t.Fatal("createUser called the bare Exec instead of the backend's ExecWithTimeout")
+		return nil
+	}
+	mock.ExecWithTimeoutFunc = func(_ string, _ []string, timeout time.Duration) error {
+		timedCalled = true
+		gotTimeout = timeout
+		return nil
+	}
+	m := NewWithBackend(mock)
+
+	if err := m.createUser("alice-container", "alice", ostype.Debian); err != nil {
+		t.Fatalf("createUser: %v", err)
+	}
+	if !timedCalled {
+		t.Fatal("ExecWithTimeout was never called")
+	}
+	if gotTimeout != createUserTimeout {
+		t.Errorf("timeout = %s, want createUserTimeout (%s)", gotTimeout, createUserTimeout)
+	}
+}
+
+// TestCreateUser_WedgedExecReturnsAnErrorInsteadOfHanging: mutation-shaped
+// proof that a backend reporting a timeout actually surfaces as createUser
+// returning an error — not silently swallowed, not blocking forever.
+func TestCreateUser_WedgedExecReturnsAnErrorInsteadOfHanging(t *testing.T) {
+	mock := incustest.NewMockBackend()
+	mock.ExecWithTimeoutFunc = func(_ string, _ []string, timeout time.Duration) error {
+		return errWedgedForTest
+	}
+	m := NewWithBackend(mock)
+
+	done := make(chan error, 1)
+	go func() { done <- m.createUser("c", "alice", ostype.Debian) }()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("want an error when the backend reports a wedged exec, got nil")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("createUser did not return — it hung despite the backend reporting an error")
 	}
 }
 

--- a/pkg/core/container/manager.go
+++ b/pkg/core/container/manager.go
@@ -823,6 +823,23 @@ chown -R "$1:$1" "$home/.config"`
 	}
 }
 
+// timedExecer is the optional capability a Manager's incus backend can
+// offer: an Exec bounded by an explicit deadline instead of blocking
+// forever on a wedged operation. Detected via type assertion so a backend
+// that doesn't implement it (test doubles that predate it) falls back to
+// the ordinary, unbounded Exec — mirrors the compactSigner pattern in
+// containarium-cloud's internal/auth/metrics_token.go.
+type timedExecer interface {
+	ExecWithTimeout(containerName string, command []string, timeout time.Duration) error
+}
+
+// createUserTimeout bounds createUser's exec (cloud#1128): a wedged Incus
+// operation has previously hung this step forever, which pins the
+// container's reported state at CREATING with no terminal state ever
+// reached — the goroutine that would report ERROR never gets that far. A
+// var (not const) so tests can shrink it.
+var createUserTimeout = 60 * time.Second
+
 // createUser creates a user in the container with sudo access.
 //
 // The three account commands run as ONE `sh -c` exec, not three: each
@@ -840,7 +857,13 @@ func (m *Manager) createUser(containerName, username string, family ostype.OSFam
 		// (ignored when the group doesn't exist), as it always was.
 		" && { " + shellJoin([]string{"usermod", "-aG", "podman", username}) + " || true; }"
 
-	if err := m.incus.Exec(containerName, []string{"/bin/sh", "-c", script}); err != nil {
+	execFn := m.incus.Exec
+	if te, ok := m.incus.(timedExecer); ok {
+		execFn = func(name string, cmd []string) error {
+			return te.ExecWithTimeout(name, cmd, createUserTimeout)
+		}
+	}
+	if err := execFn(containerName, []string{"/bin/sh", "-c", script}); err != nil {
 		return fmt.Errorf("failed to create user: %w", err)
 	}
 

--- a/pkg/core/incus/client.go
+++ b/pkg/core/incus/client.go
@@ -2,6 +2,8 @@ package incus
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -1359,7 +1361,8 @@ func stateWithRetry(what string, attempt func() (*api.InstanceState, string, err
 	return state, etag, err
 }
 
-// Exec executes a command inside a container
+// Exec executes a command inside a container. Unbounded wait — see
+// ExecWithTimeout for a caller that needs a deadline instead.
 func (c *Client) Exec(containerName string, command []string) error {
 	req := api.InstanceExecPost{
 		Command:     command,
@@ -1376,6 +1379,49 @@ func (c *Client) Exec(containerName string, command []string) error {
 		}
 		return nil
 	})
+}
+
+// ExecWithTimeout is Exec bounded by an explicit deadline (cloud#1128):
+// op.Wait() has no deadline of its own, so a wedged Incus operation — same
+// class of liblxc-socket flakiness this file already retries around for
+// GetInstanceState (isTransientStateErr, citing OSS #931) — blocks the
+// caller forever instead of surfacing an error. Deliberately a separate
+// method rather than a change to Exec's own behavior: Exec backs steps
+// (package installs, stack setup) that can legitimately run for minutes,
+// and a blanket default here would risk turning a slow-but-real operation
+// into a false "wedged" failure.
+func (c *Client) ExecWithTimeout(containerName string, command []string, timeout time.Duration) error {
+	req := api.InstanceExecPost{
+		Command:     command,
+		WaitForWS:   true,
+		Interactive: false,
+	}
+	return execWithRetry("exec "+containerName, func() error {
+		op, err := c.server.ExecInstance(containerName, req, nil)
+		if err != nil {
+			return fmt.Errorf("failed to execute command: %w", err)
+		}
+		return waitWithTimeout(timeout, op.WaitContext)
+	})
+}
+
+// waitWithTimeout bounds wait (an Operation.WaitContext-shaped call) by
+// timeout. Split out from ExecWithTimeout (mirroring waitForIP /
+// stateWithRetry elsewhere in this file) so the bounding behavior is unit-
+// tested without a real Incus server. A context.DeadlineExceeded is
+// reported as "wedged" rather than merely "cancelled" — this caller never
+// cancelled anything, so the distinction matters to whoever reads the log.
+func waitWithTimeout(timeout time.Duration, wait func(ctx context.Context) error) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	err := wait(ctx)
+	if errors.Is(err, context.DeadlineExceeded) {
+		return fmt.Errorf("command execution timed out after %s (operation never completed — likely wedged, not merely slow)", timeout)
+	}
+	if err != nil {
+		return fmt.Errorf("command execution failed: %w", err)
+	}
+	return nil
 }
 
 // waitNetPollMin and waitNetPollMax bound the WaitForNetwork poll interval.

--- a/pkg/core/incus/exec_timeout_test.go
+++ b/pkg/core/incus/exec_timeout_test.go
@@ -1,0 +1,81 @@
+package incus
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// waitWithTimeout bounds an Operation.WaitContext-shaped call (cloud#1128):
+// op.Wait() has no deadline of its own, so a wedged Incus operation — same
+// class of liblxc-socket flakiness this file already retries around for
+// GetInstanceState (isTransientStateErr, citing OSS #931) — blocks its
+// caller forever instead of surfacing an error. The Incus SDK's
+// Operation.WaitContext performs a genuine `select` on ctx.Done() (verified
+// against github.com/lxc/incus/v6/client), so a deadline-bound context
+// actually interrupts a wedged wait; wait below simulates exactly that
+// select by blocking on ctx.Done() itself, mirroring what the real SDK does
+// when the underlying operation never completes.
+
+func TestWaitWithTimeout_WedgedOperationTimesOutRatherThanHangingForever(t *testing.T) {
+	wedged := func(ctx context.Context) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	start := time.Now()
+	err := waitWithTimeout(20*time.Millisecond, wedged)
+	elapsed := time.Since(start)
+
+	if elapsed > 2*time.Second {
+		t.Fatalf("waitWithTimeout blocked for %s — not bounded by the timeout", elapsed)
+	}
+	if err == nil {
+		t.Fatal("wedged operation must return an error, not nil")
+	}
+	if !strings.Contains(err.Error(), "wedged") {
+		t.Errorf("error should say the operation looks wedged, not just cancelled: %q", err.Error())
+	}
+}
+
+func TestWaitWithTimeout_SuccessPassesThrough(t *testing.T) {
+	ok := func(ctx context.Context) error { return nil }
+	if err := waitWithTimeout(time.Second, ok); err != nil {
+		t.Fatalf("want nil, got %v", err)
+	}
+}
+
+// A genuine command failure (the operation completed, just with an error)
+// must be distinguishable from a timeout — a caller retrying on "wedged"
+// should not retry a real, already-finished failure the same way.
+func TestWaitWithTimeout_RealErrorIsNotReportedAsATimeout(t *testing.T) {
+	realErr := errors.New("command exited with code 1")
+	fails := func(ctx context.Context) error { return realErr }
+
+	err := waitWithTimeout(time.Second, fails)
+	if err == nil || !errors.Is(err, realErr) {
+		t.Fatalf("want the real error wrapped, got %v", err)
+	}
+	if strings.Contains(err.Error(), "wedged") {
+		t.Errorf("a real command failure must not be described as wedged: %q", err.Error())
+	}
+}
+
+// The context passed to wait must actually carry the requested deadline —
+// otherwise waitWithTimeout could time out on its own goroutine bookkeeping
+// while still handing wait an unbounded context.
+func TestWaitWithTimeout_PassesADeadlineBoundContext(t *testing.T) {
+	var sawDeadline bool
+	check := func(ctx context.Context) error {
+		_, sawDeadline = ctx.Deadline()
+		return nil
+	}
+	if err := waitWithTimeout(time.Second, check); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !sawDeadline {
+		t.Error("wait was called with a context that has no deadline")
+	}
+}

--- a/pkg/core/incus/incustest/mock.go
+++ b/pkg/core/incus/incustest/mock.go
@@ -36,6 +36,7 @@ type MockBackend struct {
 	ListContainersFunc        func() ([]incus.ContainerInfo, error)
 	WaitForNetworkFunc        func(containerName string, timeout time.Duration) (string, error)
 	ExecFunc                  func(containerName string, command []string) error
+	ExecWithTimeoutFunc       func(containerName string, command []string, timeout time.Duration) error
 	ExecWithOutputFunc        func(containerName string, command []string) (string, string, error)
 	ExecWithExitCodeFunc      func(containerName string, command []string) (string, string, int, error)
 	WriteFileFunc             func(containerName, path string, content []byte, mode string) error
@@ -153,6 +154,17 @@ func (m *MockBackend) Exec(containerName string, command []string) error {
 		return m.ExecFunc(containerName, command)
 	}
 	return nil
+}
+
+// ExecWithTimeout defaults to Exec's own behavior when ExecWithTimeoutFunc
+// is unset, so every existing test that only sets ExecFunc keeps working
+// unchanged even though MockBackend now also satisfies the (optional,
+// type-asserted) timed-exec capability real callers can detect.
+func (m *MockBackend) ExecWithTimeout(containerName string, command []string, timeout time.Duration) error {
+	if m.ExecWithTimeoutFunc != nil {
+		return m.ExecWithTimeoutFunc(containerName, command, timeout)
+	}
+	return m.Exec(containerName, command)
 }
 
 func (m *MockBackend) ExecWithOutput(containerName string, command []string) (string, string, error) {


### PR DESCRIPTION
## Summary

- \`Client.Exec\` calls \`op.Wait()\` with no deadline — a wedged Incus
  operation (same class of liblxc-socket flakiness this package already
  retries around for \`GetInstanceState\`, citing OSS #931) blocks
  forever instead of erroring.
- \`createUser\` — the post-launch Linux-user-provisioning step, one
  \`Exec\` call on every container create — has no timeout of its own.
  A wedge there means the async create goroutine never returns, so it
  never reaches the \`pendingCreations\` \`Done\`/\`Error\` write
  \`GetContainer\` already knows how to turn into
  \`CONTAINER_STATE_ERROR\`. The container sits at \`CREATING\` forever,
  with a real, running (but userless) box underneath it — repro'd
  downstream as a cloud-side issue (backend \`tunnel-fts-13700k\`,
  reproduced 3× identically).
- Adds \`Client.ExecWithTimeout\`, bounded via the SDK's
  \`Operation.WaitContext\` (confirmed against the SDK source: it does
  a genuine \`select\` on \`ctx.Done()\`, so a deadline actually
  interrupts a wedged wait rather than being decorative).
  \`createUser\` reaches for it through an optional \`timedExecer\`
  capability, type-asserted rather than added to \`Exec\`'s own default
  behavior — other \`Exec\` callers (package installs, stack setup) can
  legitimately run for minutes, and a blanket timeout there risks
  turning a slow-but-real operation into a false "wedged" failure.

## Test evidence

- \`pkg/core/incus\`: \`TestWaitWithTimeout_WedgedOperationTimesOutRatherThanHangingForever\`
  (a \`wait\` closure that blocks on \`ctx.Done()\`, mirroring exactly
  what the real SDK's \`WaitContext\` does when the underlying
  operation never completes — times out with a "wedged" error, bounded
  well under the test's own 2s ceiling), \`_SuccessPassesThrough\`,
  \`_RealErrorIsNotReportedAsATimeout\`, \`_PassesADeadlineBoundContext\`.
- \`pkg/core/container\`: \`TestCreateUser_UsesTheBackendsTimedExecWhenAvailable\`,
  \`TestCreateUser_WedgedExecReturnsAnErrorInsteadOfHanging\` (bounded
  5s test timeout as its own mutation-catch — if \`createUser\` ever
  goes back to hanging, this test times out instead of passing
  silently).
- Mutation-verified: disabling the \`timedExecer\` type-assertion
  routing turns both new \`createUser\` tests red; restored and
  re-verified green.
- Existing \`createUser\`/\`addSSHKeys\` tests unchanged and pass — the
  mock backend's new \`ExecWithTimeout\` defaults to \`Exec\`'s own
  behavior, so no other test needed touching.
- \`go build ./...\`, \`go vet ./...\`, \`gofmt -l\` clean.
- \`pkg/core/incus\`, \`pkg/core/incus/incustest\`, \`pkg/core/container\`
  suites green locally.

## Scope note

This fixes the mechanism that pins the container at \`CREATING\`
forever (a wedged exec never returning). It does not add a *new*
timeout/retry to the user-provisioning step beyond the one bound added
here, and does not touch \`get_container\`'s error-state reporting —
that path already exists and already does the right thing; it just
couldn't be reached while the goroutine was stuck.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User creation now has a 60-second timeout when supported by the container backend.
  * Backend failures are reported promptly instead of leaving user creation stuck indefinitely.
  * Timeout and command errors now produce clearer failure results.
* **Reliability**
  * Existing backends without timeout support continue to function as before.
  * Transient execution retries remain supported while enforcing the configured deadline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->