### PR TITLE
feat(sentinel): DELETE /sentinel/tunnel-tokens, the inverse of registration

### DIFF
--- a/internal/sentinel/binaryserver.go
+++ b/internal/sentinel/binaryserver.go
@@ -113,6 +113,12 @@ func buildBinaryServerMux(binaryPath string, manager *Manager) *http.ServeMux {
 	// admin secret (CONTAINARIUM_SENTINEL_ADMIN_SECRET), not the
 	// cluster-wide daemon HMAC secret. See TunnelTokenRegisterHandler.
 	mux.Handle("/sentinel/tunnel-tokens", auth.SentinelHMACMiddleware(manager.adminSecret, manager.TunnelTokenRegisterHandler()))
+	// Its inverse (cloud#999 step 4) — a distinct method pattern on the
+	// SAME path (Go 1.22+ ServeMux: a method-specific pattern is more
+	// specific than a bare one and both may be registered), so DELETE
+	// routes here while every other method still reaches the register
+	// handler's own method check above. See TunnelTokenDeregisterHandler.
+	mux.Handle("DELETE /sentinel/tunnel-tokens", auth.SentinelHMACMiddleware(manager.adminSecret, manager.TunnelTokenDeregisterHandler()))
 
 	// Cloud pushes the authoritative BYOC public-ingress bindings
 	// (subdomain → tunnel host) here. Gated by the admin secret (an

--- a/internal/sentinel/manager.go
+++ b/internal/sentinel/manager.go
@@ -498,6 +498,25 @@ func (m *Manager) persistTunnelToken(token string, pools []Pool) error {
 	return SaveTunnelTokenStore(path, entries)
 }
 
+// unpersistTunnelToken removes token from the on-disk dynamic tunnel-token
+// store (cloud#999 step 4) so a future sentinel restart does not re-apply
+// a registration this process just revoked via TokenPolicy.Deny.
+// Best-effort at the call site, same reasoning as persistTunnelToken: the
+// in-memory policy is already updated either way, and a disk hiccup here
+// must not fail a legitimate deregistration.
+func (m *Manager) unpersistTunnelToken(token string) error {
+	path := m.tunnelTokenStorePath
+	if path == "" {
+		path = DefaultTunnelTokenStorePath
+	}
+	entries, err := LoadTunnelTokenStore(path)
+	if err != nil {
+		return err
+	}
+	entries = removeTunnelTokenEntry(entries, token)
+	return SaveTunnelTokenStore(path, entries)
+}
+
 // SetAdminSecret wires the secret that gates POST
 // /sentinel/tunnel-tokens. Tests can use this to inject a secret
 // without setting CONTAINARIUM_SENTINEL_ADMIN_SECRET in the

--- a/internal/sentinel/manager.go
+++ b/internal/sentinel/manager.go
@@ -219,6 +219,14 @@ type Manager struct {
 	// silently forget it. Empty means DefaultTunnelTokenStorePath; tests
 	// override via SetTunnelTokenStorePath to use a tmp dir.
 	tunnelTokenStorePath string
+	// tunnelTokenStoreMu serializes the WHOLE load-modify-save sequence in
+	// persistTunnelToken/unpersistTunnelToken (cloud#999 step 4 review
+	// follow-up): without it, a register racing a deregister (or two
+	// concurrent deregisters) can both read the same on-disk snapshot,
+	// and whichever writes second silently discards the other's change —
+	// a revoked token could reappear, or a freshly-registered one could
+	// vanish, purely from write-order luck.
+	tunnelTokenStoreMu sync.Mutex
 
 	// pki holds the operator-bootstrapped peer-CA and the sentinel's
 	// own server cert. Set when CONTAINARIUM_CA_KEY_FILE points at a
@@ -486,6 +494,8 @@ func (m *Manager) SetTunnelTokenStorePath(path string) {
 // across a restart, and a disk hiccup here must not block a legitimate
 // BYOC join.
 func (m *Manager) persistTunnelToken(token string, pools []Pool) error {
+	m.tunnelTokenStoreMu.Lock()
+	defer m.tunnelTokenStoreMu.Unlock()
 	path := m.tunnelTokenStorePath
 	if path == "" {
 		path = DefaultTunnelTokenStorePath
@@ -505,6 +515,8 @@ func (m *Manager) persistTunnelToken(token string, pools []Pool) error {
 // in-memory policy is already updated either way, and a disk hiccup here
 // must not fail a legitimate deregistration.
 func (m *Manager) unpersistTunnelToken(token string) error {
+	m.tunnelTokenStoreMu.Lock()
+	defer m.tunnelTokenStoreMu.Unlock()
 	path := m.tunnelTokenStorePath
 	if path == "" {
 		path = DefaultTunnelTokenStorePath

--- a/internal/sentinel/token_policy_test.go
+++ b/internal/sentinel/token_policy_test.go
@@ -57,6 +57,28 @@ func TestTokenPolicy_AllowReplaces(t *testing.T) {
 	assert.NoError(t, p.Validate("t", "lab"))
 }
 
+func TestTokenPolicy_Deny(t *testing.T) {
+	p := NewTokenPolicy()
+	p.Allow("t", "prod")
+	require.NoError(t, p.Validate("t", "prod"))
+
+	p.Deny("t")
+	err := p.Validate("t", "prod")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid token")
+}
+
+// Denying a token nobody ever Allow'd must not panic and must leave the
+// policy otherwise unaffected — a decommission racing (or repeating) a
+// deregister is the normal case, not an error condition.
+func TestTokenPolicy_DenyUnknownTokenIsANoOp(t *testing.T) {
+	p := NewTokenPolicy()
+	p.Allow("other", "prod")
+
+	assert.NotPanics(t, func() { p.Deny("never-registered") })
+	assert.NoError(t, p.Validate("other", "prod"))
+}
+
 func TestPolicyFromCLI(t *testing.T) {
 	t.Run("legacy token only", func(t *testing.T) {
 		p, err := PolicyFromCLI("legacy", nil)

--- a/internal/sentinel/tunnel_auth.go
+++ b/internal/sentinel/tunnel_auth.go
@@ -38,6 +38,17 @@ func (tp *TokenPolicy) Allow(token string, pools ...Pool) {
 	tp.rules[token] = pools
 }
 
+// Deny removes token's rule, so a future handshake presenting it is
+// rejected exactly as if it had never been registered. A token that was
+// never Allow'd is a no-op, not an error — a decommission caller cannot
+// know in advance whether registration ever landed, and the end state is
+// identical either way.
+func (tp *TokenPolicy) Deny(token string) {
+	tp.mu.Lock()
+	defer tp.mu.Unlock()
+	delete(tp.rules, token)
+}
+
 // PolicyFromCLI builds a TokenPolicy from a single back-compat token (any
 // pool allowed) plus a list of "token=pool1,pool2,…" specs. Either may be
 // empty. Returns an error if any spec is malformed. The returned policy is

--- a/internal/sentinel/tunnel_token_handler.go
+++ b/internal/sentinel/tunnel_token_handler.go
@@ -122,13 +122,22 @@ func (m *Manager) TunnelTokenDeregisterHandler() http.HandlerFunc {
 			return
 		}
 		m.tunnelPolicy.Deny(req.Token)
-		// Best-effort, same reasoning as the register side: the in-memory
-		// policy is already updated either way, and a disk hiccup here must
-		// not fail a legitimate deregistration — it only risks the token
-		// coming back on a future restart, which is the pre-existing #936
-		// failure mode in the opposite direction, not a new one.
+		// The in-memory Deny above stays applied even on a persist failure
+		// below — that's the safe direction, and undoing it would put a
+		// token BACK in effect that the caller just asked to revoke.
+		//
+		// But unlike the register side's best-effort persist (a disk
+		// hiccup there just means a legitimate host has to re-register —
+		// annoying, not dangerous), reporting SUCCESS here when the durable
+		// record wasn't actually written is a real problem: this is the
+		// call a decommission flow depends on to make sure a revoked token
+		// can never come back, and a caller that believed 204 has no reason
+		// to retry. Report the failure as retryable instead (review
+		// follow-up on cloud#999 step 4).
 		if err := m.unpersistTunnelToken(req.Token); err != nil {
-			log.Printf("[sentinel] WARNING: failed to persist tunnel token deregistration (may reappear after a restart): %v", err)
+			log.Printf("[sentinel] ERROR: failed to persist tunnel token deregistration (token denied in-memory now, but the on-disk store still lists it and it WILL reappear on the next restart): %v", err)
+			http.Error(w, `{"error":"token denied but persistence failed; retry"}`, http.StatusInternalServerError)
+			return
 		}
 		w.WriteHeader(http.StatusNoContent)
 	}

--- a/internal/sentinel/tunnel_token_handler.go
+++ b/internal/sentinel/tunnel_token_handler.go
@@ -76,3 +76,60 @@ func (m *Manager) TunnelTokenRegisterHandler() http.HandlerFunc {
 		w.WriteHeader(http.StatusNoContent)
 	}
 }
+
+// TunnelTokenDeregisterRequest is the JSON body sent to
+// TunnelTokenDeregisterHandler to revoke a previously-registered token.
+type TunnelTokenDeregisterRequest struct {
+	// Token is the tunnel-handshake token to revoke — the inverse of
+	// TunnelTokenRegisterRequest.Token.
+	Token string `json:"token"`
+}
+
+// TunnelTokenDeregisterHandler is TunnelTokenRegisterHandler's inverse
+// (cloud#999 step 4): it makes a previously-registered tunnel token stop
+// validating, without a sentinel restart. Exists so decommissioning a BYOC
+// host can purge its tunnel-token registration from the sentinel — until
+// now, RegisterTunnelToken had no way to be undone short of restarting the
+// sentinel with a different --tunnel-token-policy.
+//
+// Gated by the SAME admin secret as registration (deliberately not the
+// cluster-wide daemon HMAC secret) — deregistering another host's token is
+// at least as sensitive a capability as registering one; a compromised
+// daemon must not be able to knock any other host off its tunnel just
+// because it holds the intra-cluster keysync secret.
+//
+// Deregistering a token that was never registered (or already was) is
+// success, not an error: a decommission caller cannot know in advance
+// whether registration ever landed, and the end state — this token does
+// not validate — is identical either way.
+func (m *Manager) TunnelTokenDeregisterHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+			return
+		}
+		if m.tunnelPolicy == nil {
+			http.Error(w, `{"error":"tunnel mode not enabled on this sentinel","code":501}`, http.StatusNotImplemented)
+			return
+		}
+		var req TunnelTokenDeregisterRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, `{"error":"invalid json"}`, http.StatusBadRequest)
+			return
+		}
+		if req.Token == "" {
+			http.Error(w, `{"error":"token is required"}`, http.StatusBadRequest)
+			return
+		}
+		m.tunnelPolicy.Deny(req.Token)
+		// Best-effort, same reasoning as the register side: the in-memory
+		// policy is already updated either way, and a disk hiccup here must
+		// not fail a legitimate deregistration — it only risks the token
+		// coming back on a future restart, which is the pre-existing #936
+		// failure mode in the opposite direction, not a new one.
+		if err := m.unpersistTunnelToken(req.Token); err != nil {
+			log.Printf("[sentinel] WARNING: failed to persist tunnel token deregistration (may reappear after a restart): %v", err)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}

--- a/internal/sentinel/tunnel_token_handler_test.go
+++ b/internal/sentinel/tunnel_token_handler_test.go
@@ -166,6 +166,201 @@ func TestTunnelTokenRegisterHandler_RejectsUnsignedRequest(t *testing.T) {
 	}
 }
 
+// TestTunnelTokenDeregisterHandler_RemovesARegisteredToken is the whole
+// point of #999 step 4: a token the sentinel currently accepts must stop
+// validating after deregistration, the exact inverse of
+// TestTunnelTokenRegisterHandler_RegistersFreshToken.
+func TestTunnelTokenDeregisterHandler_RemovesARegisteredToken(t *testing.T) {
+	m := newManagerForTunnelTokenTest(t, true)
+	m.tunnelPolicy.Allow("live-token", PoolAny)
+	if err := m.tunnelPolicy.Validate("live-token", ""); err != nil {
+		t.Fatalf("sanity check: token should validate before deregistration: %v", err)
+	}
+
+	body, _ := json.Marshal(TunnelTokenDeregisterRequest{Token: "live-token"})
+	req := httptest.NewRequest(http.MethodDelete, "/sentinel/tunnel-tokens", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	auth.SignSentinelRequest(req, []byte(tunnelTokenAdminSecret))
+	rec := httptest.NewRecorder()
+	handler := auth.SentinelHMACMiddleware([]byte(tunnelTokenAdminSecret), m.TunnelTokenDeregisterHandler())
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if err := m.tunnelPolicy.Validate("live-token", ""); err == nil {
+		t.Fatal("token still valid after deregistration")
+	}
+}
+
+// TestTunnelTokenDeregisterHandler_PersistsAcrossRestart: the inverse of
+// TestTunnelTokenRegisterHandler_PersistsAcrossRestart — a deregistered
+// token must not come back after a restart re-applies the persisted store.
+func TestTunnelTokenDeregisterHandler_PersistsAcrossRestart(t *testing.T) {
+	m := newManagerForTunnelTokenTest(t, true)
+
+	registerBody, _ := json.Marshal(TunnelTokenRegisterRequest{Token: "byoc-token", Pools: []Pool{"asia-east1"}})
+	registerReq := httptest.NewRequest(http.MethodPost, "/sentinel/tunnel-tokens", bytes.NewReader(registerBody))
+	registerReq.Header.Set("Content-Type", "application/json")
+	auth.SignSentinelRequest(registerReq, []byte(tunnelTokenAdminSecret))
+	rec := httptest.NewRecorder()
+	auth.SentinelHMACMiddleware([]byte(tunnelTokenAdminSecret), m.TunnelTokenRegisterHandler()).ServeHTTP(rec, registerReq)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("register status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	deregisterBody, _ := json.Marshal(TunnelTokenDeregisterRequest{Token: "byoc-token"})
+	deregisterReq := httptest.NewRequest(http.MethodDelete, "/sentinel/tunnel-tokens", bytes.NewReader(deregisterBody))
+	deregisterReq.Header.Set("Content-Type", "application/json")
+	auth.SignSentinelRequest(deregisterReq, []byte(tunnelTokenAdminSecret))
+	rec = httptest.NewRecorder()
+	auth.SentinelHMACMiddleware([]byte(tunnelTokenAdminSecret), m.TunnelTokenDeregisterHandler()).ServeHTTP(rec, deregisterReq)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("deregister status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	// "Restart": a brand-new policy loaded from the persisted store, as
+	// internal/cmd/sentinel.go's loadPersistedTunnelTokens does at startup.
+	freshPolicy := NewTokenPolicy()
+	entries, err := LoadTunnelTokenStore(m.tunnelTokenStorePath)
+	if err != nil {
+		t.Fatalf("LoadTunnelTokenStore: %v", err)
+	}
+	ApplyTunnelTokenStore(entries, freshPolicy)
+
+	if err := freshPolicy.Validate("byoc-token", "asia-east1"); err == nil {
+		t.Fatal("deregistered token came back after a simulated restart — the removal did not persist")
+	}
+}
+
+func TestTunnelTokenDeregisterHandler_501WhenTunnelModeDisabled(t *testing.T) {
+	m := newManagerForTunnelTokenTest(t, false) // no SetTunnelPolicy call
+
+	body, _ := json.Marshal(TunnelTokenDeregisterRequest{Token: "x"})
+	req := httptest.NewRequest(http.MethodDelete, "/sentinel/tunnel-tokens", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	auth.SignSentinelRequest(req, []byte(tunnelTokenAdminSecret))
+	rec := httptest.NewRecorder()
+	handler := auth.SentinelHMACMiddleware([]byte(tunnelTokenAdminSecret), m.TunnelTokenDeregisterHandler())
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotImplemented {
+		t.Fatalf("want 501, got %d", rec.Code)
+	}
+}
+
+func TestTunnelTokenDeregisterHandler_400OnMissingToken(t *testing.T) {
+	m := newManagerForTunnelTokenTest(t, true)
+
+	body, _ := json.Marshal(TunnelTokenDeregisterRequest{})
+	req := httptest.NewRequest(http.MethodDelete, "/sentinel/tunnel-tokens", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	auth.SignSentinelRequest(req, []byte(tunnelTokenAdminSecret))
+	rec := httptest.NewRecorder()
+	handler := auth.SentinelHMACMiddleware([]byte(tunnelTokenAdminSecret), m.TunnelTokenDeregisterHandler())
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", rec.Code)
+	}
+}
+
+func TestTunnelTokenDeregisterHandler_RejectsUnsignedRequest(t *testing.T) {
+	m := newManagerForTunnelTokenTest(t, true)
+
+	body, _ := json.Marshal(TunnelTokenDeregisterRequest{Token: "x"})
+	req := httptest.NewRequest(http.MethodDelete, "/sentinel/tunnel-tokens", bytes.NewReader(body)) // no SignSentinelRequest
+	rec := httptest.NewRecorder()
+	handler := auth.SentinelHMACMiddleware([]byte(tunnelTokenAdminSecret), m.TunnelTokenDeregisterHandler())
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("unsigned request must be rejected; got %d", rec.Code)
+	}
+}
+
+// TestTunnelTokenDeregisterHandler_UnknownTokenIsNoContentNotError:
+// deregistering a token that isn't currently registered must succeed —
+// decommission callers cannot know in advance whether registration ever
+// landed (e.g. the register call itself failed, or this is a retry), and
+// the end state ("this token does not validate") is identical either way.
+func TestTunnelTokenDeregisterHandler_UnknownTokenIsNoContentNotError(t *testing.T) {
+	m := newManagerForTunnelTokenTest(t, true)
+
+	body, _ := json.Marshal(TunnelTokenDeregisterRequest{Token: "never-registered"})
+	req := httptest.NewRequest(http.MethodDelete, "/sentinel/tunnel-tokens", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	auth.SignSentinelRequest(req, []byte(tunnelTokenAdminSecret))
+	rec := httptest.NewRecorder()
+	handler := auth.SentinelHMACMiddleware([]byte(tunnelTokenAdminSecret), m.TunnelTokenDeregisterHandler())
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("want 204 for an already-absent token, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestTunnelTokenDeregisterHandler_AdminSecretIndependentOfHMACSecret is
+// the deregister sibling of the same register-side guard: possessing the
+// cluster-wide daemon HMAC secret must not be sufficient to deregister
+// another host's tunnel token — that would let any enrolled daemon knock
+// any other host off its tunnel.
+func TestTunnelTokenDeregisterHandler_AdminSecretIndependentOfHMACSecret(t *testing.T) {
+	m := &Manager{backends: NewBackendPool()}
+	m.SetHMACSecret([]byte(phase05Secret)) // cluster-wide daemon secret
+	m.SetAdminSecret([]byte(tunnelTokenAdminSecret))
+	m.SetTunnelPolicy(NewTokenPolicy())
+
+	body, _ := json.Marshal(TunnelTokenDeregisterRequest{Token: "x"})
+	req := httptest.NewRequest(http.MethodDelete, "/sentinel/tunnel-tokens", bytes.NewReader(body))
+	auth.SignSentinelRequest(req, []byte(phase05Secret)) // signed with the WRONG secret
+	rec := httptest.NewRecorder()
+	handler := auth.SentinelHMACMiddleware(m.adminSecret, m.TunnelTokenDeregisterHandler())
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("HMAC secret must not authorize admin token deregistration; got %d", rec.Code)
+	}
+}
+
+// TestTunnelTokenDeregisterHandler_AndRegisterCoexistOnOneMux confirms the
+// two handlers can be mounted on the SAME path (POST=register,
+// DELETE=deregister via Go 1.22+ ServeMux method patterns) without either
+// one intercepting the other's method — a routing-wiring regression here
+// would silently 405 one side.
+func TestTunnelTokenDeregisterHandler_AndRegisterCoexistOnOneMux(t *testing.T) {
+	m := newManagerForTunnelTokenTest(t, true)
+	mux := http.NewServeMux()
+	mux.Handle("/sentinel/tunnel-tokens", auth.SentinelHMACMiddleware(m.adminSecret, m.TunnelTokenRegisterHandler()))
+	mux.Handle("DELETE /sentinel/tunnel-tokens", auth.SentinelHMACMiddleware(m.adminSecret, m.TunnelTokenDeregisterHandler()))
+
+	registerBody, _ := json.Marshal(TunnelTokenRegisterRequest{Token: "mux-token"})
+	registerReq := httptest.NewRequest(http.MethodPost, "/sentinel/tunnel-tokens", bytes.NewReader(registerBody))
+	registerReq.Header.Set("Content-Type", "application/json")
+	auth.SignSentinelRequest(registerReq, []byte(tunnelTokenAdminSecret))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, registerReq)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("register via mux: status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if err := m.tunnelPolicy.Validate("mux-token", ""); err != nil {
+		t.Fatalf("token not registered via mux: %v", err)
+	}
+
+	deregisterBody, _ := json.Marshal(TunnelTokenDeregisterRequest{Token: "mux-token"})
+	deregisterReq := httptest.NewRequest(http.MethodDelete, "/sentinel/tunnel-tokens", bytes.NewReader(deregisterBody))
+	deregisterReq.Header.Set("Content-Type", "application/json")
+	auth.SignSentinelRequest(deregisterReq, []byte(tunnelTokenAdminSecret))
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, deregisterReq)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("deregister via mux: status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if err := m.tunnelPolicy.Validate("mux-token", ""); err == nil {
+		t.Fatal("token still valid after deregistration via mux")
+	}
+}
+
 // TestTunnelTokenRegisterHandler_AdminSecretIndependentOfHMACSecret guards
 // the core security property of #799's fix: possessing the cluster-wide
 // daemon HMAC secret (CONTAINARIUM_SENTINEL_AUTH_SECRET) must NOT be

--- a/internal/sentinel/tunnel_token_handler_test.go
+++ b/internal/sentinel/tunnel_token_handler_test.go
@@ -3,8 +3,11 @@ package sentinel
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"sync"
 	"testing"
 
 	"github.com/footprintai/containarium/internal/auth"
@@ -300,6 +303,41 @@ func TestTunnelTokenDeregisterHandler_UnknownTokenIsNoContentNotError(t *testing
 	}
 }
 
+// TestTunnelTokenDeregisterHandler_PersistFailureIsAServerErrorNot204 is
+// the review follow-up on cloud#999 step 4: reporting 204 when the durable
+// record wasn't actually written would tell a decommission caller "done"
+// for a token that WILL reappear after the next restart, with no reason
+// to retry. The in-memory Deny must still take effect immediately (the
+// safe direction) even though the response reports failure.
+func TestTunnelTokenDeregisterHandler_PersistFailureIsAServerErrorNot204(t *testing.T) {
+	m := newManagerForTunnelTokenTest(t, true)
+	m.tunnelPolicy.Allow("live-token", PoolAny)
+
+	// Force SaveTunnelTokenStore to fail: point the store path at
+	// "<blocker-file>/tunnel-tokens.json", so its os.MkdirAll(dir) fails
+	// because "blocker" already exists as a regular file, not a directory.
+	blocker := t.TempDir() + "/blocker"
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatalf("create blocker file: %v", err)
+	}
+	m.SetTunnelTokenStorePath(blocker + "/tunnel-tokens.json")
+
+	body, _ := json.Marshal(TunnelTokenDeregisterRequest{Token: "live-token"})
+	req := httptest.NewRequest(http.MethodDelete, "/sentinel/tunnel-tokens", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	auth.SignSentinelRequest(req, []byte(tunnelTokenAdminSecret))
+	rec := httptest.NewRecorder()
+	handler := auth.SentinelHMACMiddleware([]byte(tunnelTokenAdminSecret), m.TunnelTokenDeregisterHandler())
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("want 500 when persistence fails, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if err := m.tunnelPolicy.Validate("live-token", ""); err == nil {
+		t.Fatal("token must still be denied in-memory even though the response reported a persist failure")
+	}
+}
+
 // TestTunnelTokenDeregisterHandler_AdminSecretIndependentOfHMACSecret is
 // the deregister sibling of the same register-side guard: possessing the
 // cluster-wide daemon HMAC secret must not be sufficient to deregister
@@ -358,6 +396,84 @@ func TestTunnelTokenDeregisterHandler_AndRegisterCoexistOnOneMux(t *testing.T) {
 	}
 	if err := m.tunnelPolicy.Validate("mux-token", ""); err == nil {
 		t.Fatal("token still valid after deregistration via mux")
+	}
+}
+
+// TestConcurrentRegisterAndDeregister_NoLostUpdates is the regression test
+// for the CodeRabbit review follow-up on cloud#999 step 4: persist/unpersist
+// each do an unserialized load-modify-save against the SAME on-disk file,
+// so a register racing a deregister (or two concurrent calls of either)
+// could read the same snapshot and have whichever writes second silently
+// discard the other's change. Runs enough concurrent registrations that a
+// lost update would show up as a missing entry in the final store; with
+// tunnelTokenStoreMu serializing the whole sequence, none can be lost.
+func TestConcurrentRegisterAndDeregister_NoLostUpdates(t *testing.T) {
+	m := newManagerForTunnelTokenTest(t, true)
+	const n = 50
+
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			token := fmt.Sprintf("concurrent-token-%d", i)
+			body, _ := json.Marshal(TunnelTokenRegisterRequest{Token: token})
+			req := httptest.NewRequest(http.MethodPost, "/sentinel/tunnel-tokens", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			auth.SignSentinelRequest(req, []byte(tunnelTokenAdminSecret))
+			rec := httptest.NewRecorder()
+			m.TunnelTokenRegisterHandler()(rec, req)
+			if rec.Code != http.StatusNoContent {
+				t.Errorf("register %s: status = %d", token, rec.Code)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	entries, err := LoadTunnelTokenStore(m.tunnelTokenStorePath)
+	if err != nil {
+		t.Fatalf("LoadTunnelTokenStore: %v", err)
+	}
+	if len(entries) != n {
+		t.Fatalf("persisted store has %d entries, want %d — concurrent registrations lost an update", len(entries), n)
+	}
+
+	// Now deregister half of them concurrently, alongside no further
+	// registrations, and confirm exactly the other half survives.
+	wg = sync.WaitGroup{}
+	for i := 0; i < n; i += 2 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			token := fmt.Sprintf("concurrent-token-%d", i)
+			body, _ := json.Marshal(TunnelTokenDeregisterRequest{Token: token})
+			req := httptest.NewRequest(http.MethodDelete, "/sentinel/tunnel-tokens", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			auth.SignSentinelRequest(req, []byte(tunnelTokenAdminSecret))
+			rec := httptest.NewRecorder()
+			m.TunnelTokenDeregisterHandler()(rec, req)
+			if rec.Code != http.StatusNoContent {
+				t.Errorf("deregister %s: status = %d", token, rec.Code)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	entries, err = LoadTunnelTokenStore(m.tunnelTokenStorePath)
+	if err != nil {
+		t.Fatalf("LoadTunnelTokenStore after deregister: %v", err)
+	}
+	if len(entries) != n/2 {
+		t.Fatalf("persisted store has %d entries after deregistering half, want %d — a concurrent deregister lost an update or a register reappeared", len(entries), n/2)
+	}
+	for _, e := range entries {
+		var idx int
+		if _, err := fmt.Sscanf(e.Token, "concurrent-token-%d", &idx); err != nil {
+			t.Fatalf("unexpected surviving token %q", e.Token)
+		}
+		if idx%2 == 0 {
+			t.Errorf("token %q should have been deregistered but survived", e.Token)
+		}
 	}
 }
 

--- a/internal/sentinel/tunnel_token_store.go
+++ b/internal/sentinel/tunnel_token_store.go
@@ -104,3 +104,17 @@ func upsertTunnelTokenEntry(entries []TunnelTokenEntry, token string, pools []Po
 	}
 	return append(entries, TunnelTokenEntry{Token: token, Pools: pools})
 }
+
+// removeTunnelTokenEntry drops the entry matching token, if any. Pure —
+// used by the deregister handler to build the next full entry set before
+// calling SaveTunnelTokenStore. A token not present is a no-op: entries is
+// returned unchanged (same slice, no copy), mirroring upsert's use of the
+// caller-supplied slice as the working set.
+func removeTunnelTokenEntry(entries []TunnelTokenEntry, token string) []TunnelTokenEntry {
+	for i := range entries {
+		if entries[i].Token == token {
+			return append(entries[:i], entries[i+1:]...)
+		}
+	}
+	return entries
+}

--- a/internal/sentinel/tunnel_token_store.go
+++ b/internal/sentinel/tunnel_token_store.go
@@ -105,16 +105,20 @@ func upsertTunnelTokenEntry(entries []TunnelTokenEntry, token string, pools []Po
 	return append(entries, TunnelTokenEntry{Token: token, Pools: pools})
 }
 
-// removeTunnelTokenEntry drops the entry matching token, if any. Pure —
-// used by the deregister handler to build the next full entry set before
-// calling SaveTunnelTokenStore. A token not present is a no-op: entries is
-// returned unchanged (same slice, no copy), mirroring upsert's use of the
-// caller-supplied slice as the working set.
+// removeTunnelTokenEntry drops EVERY entry matching token, not just the
+// first — a persisted store should never carry duplicates for the same
+// token, but if one somehow exists (a prior bug, a hand-edited file, a
+// lost race), stopping at the first match would leave the duplicate
+// behind to reappear on the next restart, silently undoing the
+// deregistration (CodeRabbit review follow-up on cloud#999 step 4). Pure
+// — used by the deregister handler to build the next full entry set
+// before calling SaveTunnelTokenStore. A token not present is a no-op.
 func removeTunnelTokenEntry(entries []TunnelTokenEntry, token string) []TunnelTokenEntry {
-	for i := range entries {
-		if entries[i].Token == token {
-			return append(entries[:i], entries[i+1:]...)
+	kept := entries[:0]
+	for _, e := range entries {
+		if e.Token != token {
+			kept = append(kept, e)
 		}
 	}
-	return entries
+	return kept
 }

--- a/internal/sentinel/tunnel_token_store_test.go
+++ b/internal/sentinel/tunnel_token_store_test.go
@@ -97,6 +97,23 @@ func TestRemoveTunnelTokenEntry_DropsTheMatchingEntry(t *testing.T) {
 	}
 }
 
+// TestRemoveTunnelTokenEntry_DropsAllDuplicates: a persisted store should
+// never carry duplicates for the same token, but if one somehow exists (a
+// prior bug, a hand-edited file, a lost race), removal must not stop at
+// the first match — a surviving duplicate would reappear on the next
+// restart and silently undo the deregistration.
+func TestRemoveTunnelTokenEntry_DropsAllDuplicates(t *testing.T) {
+	entries := []TunnelTokenEntry{
+		{Token: "tok-a", Pools: []Pool{PoolAny}},
+		{Token: "tok-b", Pools: []Pool{"lab"}},
+		{Token: "tok-a", Pools: []Pool{"prod"}},
+	}
+	got := removeTunnelTokenEntry(entries, "tok-a")
+	if len(got) != 1 || got[0].Token != "tok-b" {
+		t.Fatalf("expected only tok-b to survive, got %+v", got)
+	}
+}
+
 func TestRemoveTunnelTokenEntry_UnknownTokenIsANoOp(t *testing.T) {
 	entries := []TunnelTokenEntry{{Token: "tok-a", Pools: []Pool{PoolAny}}}
 	got := removeTunnelTokenEntry(entries, "does-not-exist")

--- a/internal/sentinel/tunnel_token_store_test.go
+++ b/internal/sentinel/tunnel_token_store_test.go
@@ -83,6 +83,28 @@ func TestUpsertTunnelTokenEntry_ReplacesExistingPools(t *testing.T) {
 	}
 }
 
+func TestRemoveTunnelTokenEntry_DropsTheMatchingEntry(t *testing.T) {
+	entries := []TunnelTokenEntry{
+		{Token: "tok-a", Pools: []Pool{PoolAny}},
+		{Token: "tok-b", Pools: []Pool{"lab"}},
+	}
+	got := removeTunnelTokenEntry(entries, "tok-a")
+	if len(got) != 1 {
+		t.Fatalf("expected 1 entry left, got %d: %+v", len(got), got)
+	}
+	if got[0].Token != "tok-b" {
+		t.Errorf("wrong entry survived: %+v", got)
+	}
+}
+
+func TestRemoveTunnelTokenEntry_UnknownTokenIsANoOp(t *testing.T) {
+	entries := []TunnelTokenEntry{{Token: "tok-a", Pools: []Pool{PoolAny}}}
+	got := removeTunnelTokenEntry(entries, "does-not-exist")
+	if len(got) != 1 || got[0].Token != "tok-a" {
+		t.Errorf("removing an unknown token changed the set: %+v", got)
+	}
+}
+
 func TestSaveTunnelTokenStore_FileMode(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "tunnel-tokens.json")
 	if err := SaveTunnelTokenStore(path, []TunnelTokenEntry{{Token: "tok-a", Pools: []Pool{PoolAny}}}); err != nil {


### PR DESCRIPTION
## Summary

\`POST /sentinel/tunnel-tokens\` (\`TunnelTokenRegisterHandler\`) has had
no way to be undone short of restarting the sentinel with a different
\`--tunnel-token-policy\`. Adds its inverse:

- \`TokenPolicy.Deny(token)\` — removes the in-memory rule, symmetric
  with \`Allow\`. Denying a token that was never \`Allow\`'d is a no-op,
  not an error.
- \`removeTunnelTokenEntry\` — the un-persist counterpart to
  \`upsertTunnelTokenEntry\`, so a deregistered token doesn't come back
  after a restart re-applies the on-disk store.
- \`Manager.unpersistTunnelToken\`, mirroring \`persistTunnelToken\`.
- \`TunnelTokenDeregisterHandler\`, mounted at \`DELETE
  /sentinel/tunnel-tokens\` — a Go 1.22+ ServeMux method-specific
  pattern coexisting with the existing bare-path route (POST still
  reaches the register handler unchanged). Gated by the same admin
  secret as registration, deliberately not the cluster-wide daemon
  HMAC secret — deregistering another host's token is at least as
  sensitive as registering one.

Deregistering an unknown or already-removed token returns **204**, not
an error — a caller cannot know in advance whether registration ever
landed, and the end state is identical either way.

## Why, and what this deliberately does not do

This is the concrete ask from a downstream issue: a BYOC host
decommission flow needs to purge its tunnel-token registration from the
sentinel, and the register-side client had no inverse to call.

**Not included**: wiring this into any retire/decommission
orchestration. That design explicitly calls for sentinel-state purge to
be *retried* (unlike one-shot host-facing steps, since the sentinel is
ours and retrying it holds no customer credential) — a background-
reconciler shape of its own, deserving its own design pass rather than
a rushed call added to this PR.

## Test evidence

- \`token_policy_test.go\`: \`Deny\` removes a rule; denying an
  unregistered token doesn't panic and leaves the policy otherwise
  unaffected.
- \`tunnel_token_store_test.go\`: \`removeTunnelTokenEntry\` drops the
  matching entry; an unknown token is a no-op.
- \`tunnel_token_handler_test.go\`: register-then-deregister round trip;
  deregistration persists across a simulated restart (inverse of the
  existing #936 persistence regression guard); 501 when tunnel mode
  disabled; 400 on missing token; 401 on unsigned request; 401 when
  signed with the wrong (cluster HMAC, not admin) secret; 204 for an
  unknown token; and a mux-level test proving POST and DELETE coexist
  on the same path without either intercepting the other's method.
- Mutation-verified: neutering \`TokenPolicy.Deny\`'s \`delete()\` turns
  both the policy-level and handler-level round-trip tests red;
  restored and re-verified green.
- \`go build ./...\`, \`go vet ./...\`, \`gofmt -l\` clean.
- \`internal/sentinel\` suite green locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added API support for deregistering tunnel tokens.
  * Deregistered tokens are removed from active authorization and persistent storage.
  * Unknown tokens can be safely deregistered without errors.

* **Bug Fixes**
  * Improved validation for invalid or unauthorized requests.
  * Ensured duplicate records are fully removed and changes persist after restart.
  * Prevented concurrent registrations and deregistrations from overwriting updates.
  * Persistence failures now return a server error while keeping the token denied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->