### PR TITLE
ci(incus-create): free disk space + diagnostic at the point 3 runs failed

### DIFF
--- a/.github/workflows/incus-create.yml
+++ b/.github/workflows/incus-create.yml
@@ -75,21 +75,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      # #1614: this lane is disk-heavy (a 20G ZFS pool, a full Incus
-      # install, a distro image pull, and two separate `go` builds/test
-      # runs) on a stock ubuntu-latest runner. Three CI runs failed with an
-      # identical signature — dozens of core stdlib packages suddenly
-      # unresolvable partway through the SAME job, right as the SECOND go
-      # invocation started, seconds after the FIRST one finished cleanly —
-      # which points at something evicting part of the Go toolchain
-      # mid-job rather than a toolchain that was never installed right.
-      # ubuntu-latest ships ~20-30G of preinstalled toolchains this lane
-      # never touches (dotnet, the Android SDK, GHC); freeing them before
-      # anything disk-heavy starts is the standard, low-risk mitigation for
-      # exactly this failure class. The before/after df -h is the
-      # diagnostic #1614 asked for — if the failure recurs, these numbers
-      # confirm or rule out disk pressure with real evidence instead of
-      # another guess.
+      # #1614's actual root cause turned out NOT to be disk pressure — a
+      # live run of this exact step showed 86G free before, 102G after,
+      # nowhere near tight (the real cause, fixed at the "Create an
+      # encrypted container" step below, was a root-owned Go build cache).
+      # Kept anyway as ordinary hygiene: ubuntu-latest ships ~20-30G of
+      # preinstalled toolchains this lane never touches, freeing them
+      # before anything disk-heavy starts costs nothing and gives every
+      # later step more headroom.
       - name: Free disk space
         run: |
           set -euo pipefail
@@ -261,13 +254,21 @@ jobs:
           JWT_SECRET: lane-only-secret-not-a-credential
         run: |
           set -euo pipefail
-          # #1614 diagnostic: this exact point — the second `go build` in
-          # the job, seconds after the first `go test` finished clean — is
-          # precisely where 3 prior runs lost the stdlib. If it recurs,
-          # this line puts real disk numbers next to the failure instead
-          # of leaving it a guess.
-          df -h /
-          go build -o /tmp/containarium ./cmd/containarium
+          # #1614, root-caused: this build used to run as the plain runner
+          # user, right after the PRIOR step's `sudo -E env "PATH=$PATH" go
+          # test` — which runs AS ROOT but with $HOME still pointing at
+          # /home/runner (that's what -E preserves), so it writes fresh
+          # build-cache entries into /home/runner/.cache/go-build OWNED BY
+          # ROOT. This build then couldn't read its own cache: "open
+          # .../go-build/...: permission denied" was the actual error,
+          # buried under a wall of "package X is not in std" — Go's import
+          # resolution reports an unreadable cache entry that way, which is
+          # what made three prior runs look like random toolchain
+          # corruption instead of a deterministic ownership mismatch.
+          # Matching the prior step's privilege level (sudo -E, same
+          # preserved $PATH/$HOME) makes both go invocations share the
+          # cache under the SAME effective owner.
+          sudo -E env "PATH=$PATH" go build -o /tmp/containarium ./cmd/containarium
           sudo mkdir -p /etc/containarium/keys
 
           # --standalone skips the core LXCs (Postgres, Caddy). With no

--- a/.github/workflows/incus-create.yml
+++ b/.github/workflows/incus-create.yml
@@ -75,6 +75,28 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
+      # #1614: this lane is disk-heavy (a 20G ZFS pool, a full Incus
+      # install, a distro image pull, and two separate `go` builds/test
+      # runs) on a stock ubuntu-latest runner. Three CI runs failed with an
+      # identical signature — dozens of core stdlib packages suddenly
+      # unresolvable partway through the SAME job, right as the SECOND go
+      # invocation started, seconds after the FIRST one finished cleanly —
+      # which points at something evicting part of the Go toolchain
+      # mid-job rather than a toolchain that was never installed right.
+      # ubuntu-latest ships ~20-30G of preinstalled toolchains this lane
+      # never touches (dotnet, the Android SDK, GHC); freeing them before
+      # anything disk-heavy starts is the standard, low-risk mitigation for
+      # exactly this failure class. The before/after df -h is the
+      # diagnostic #1614 asked for — if the failure recurs, these numbers
+      # confirm or rule out disk pressure with real evidence instead of
+      # another guess.
+      - name: Free disk space
+        run: |
+          set -euo pipefail
+          echo "--- before ---"; df -h /
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost || true
+          echo "--- after ---"; df -h /
+
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
@@ -239,6 +261,12 @@ jobs:
           JWT_SECRET: lane-only-secret-not-a-credential
         run: |
           set -euo pipefail
+          # #1614 diagnostic: this exact point — the second `go build` in
+          # the job, seconds after the first `go test` finished clean — is
+          # precisely where 3 prior runs lost the stdlib. If it recurs,
+          # this line puts real disk numbers next to the failure instead
+          # of leaving it a guess.
+          df -h /
           go build -o /tmp/containarium ./cmd/containarium
           sudo mkdir -p /etc/containarium/keys
 


### PR DESCRIPTION
Addresses #1614.

## Summary

The \`Daemon Create() against real Incus on ZFS\` lane failed 3 times
in a row (on PR #1612, unrelated to this change) with an identical
signature: dozens of core stdlib packages suddenly unresolvable
partway through the job. The failure lands precisely at the SECOND
\`go\` invocation in the job, seconds after the FIRST one (a 345s \`go
test\` run) finished clean — see #1614 for the exact timestamps. That
rules out "the toolchain was never installed right" and points at
something evicting part of the Go toolchain mid-job.

## What this does

- **Frees ~20-30G** of preinstalled toolchains this lane never touches
  (dotnet, Android SDK, GHC) before anything disk-heavy starts (ZFS
  pool, Incus, image pull) — the standard, low-risk mitigation for
  disk-pressure-triggered \`hostedtoolcache\` eviction, which is the
  leading hypothesis in #1614. Does **not** touch
  \`/opt/hostedtoolcache/go\`, where \`setup-go\` just installed the
  toolchain this whole lane depends on.
- **\`df -h\`** right before the exact \`go build\` that failed 3 times,
  so if it recurs, the failure carries real disk numbers instead of
  another guess.

## What this does NOT claim

This is a hypothesis-driven mitigation, not a confirmed fix — I don't
have a runner trace proving disk pressure was the mechanism, only the
precise before/after timing. That's why the diagnostic travels with
the mitigation rather than standing alone: if the failure recurs with
\`df -h\` showing headroom, that rules out disk pressure and narrows the
search; if it doesn't recur, that's supporting evidence without having
proven it in isolation first.

## Validation

- \`python3 -c 'import yaml; yaml.safe_load(...)'\` parses clean.
- \`actionlint\` reports no issues.
- This workflow triggers on changes to
  \`.github/workflows/incus-create.yml\` itself, so this PR's own CI run
  is a live test of the change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved build workflow consistency by aligning build steps with the environment used during testing.
  * Updated workflow diagnostics to better distinguish disk-space issues from build-cache permission problems.
  * Enhanced reliability of daemon builds by preserving the required build environment and permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->