### PR TITLE
fix(tls): drop a route's TLS subject when the route is reaped

### DIFF
--- a/internal/app/proxy_selfheal_test.go
+++ b/internal/app/proxy_selfheal_test.go
@@ -70,6 +70,42 @@ func newRWFakeCaddy(initial map[string]interface{}) (*httptest.Server, *rwFakeCa
 		}
 		_ = json.NewEncoder(w).Encode(node)
 	})
+	// DELETE /id/<route-id> — real Caddy's @id addressing, used by
+	// ProxyManager.RemoveRoute. Removes the matching route from the http
+	// server's route list. Additive: no pre-existing test uses this path.
+	mux.HandleFunc("/id/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		id := strings.TrimPrefix(r.URL.Path, "/id/")
+		apps, _ := fc.config["apps"].(map[string]interface{})
+		httpApp, _ := apps["http"].(map[string]interface{})
+		servers, _ := httpApp["servers"].(map[string]interface{})
+		srv, _ := servers[DefaultCaddyServerName].(map[string]interface{})
+		routes, _ := srv["routes"].([]interface{})
+
+		kept := make([]interface{}, 0, len(routes))
+		found := false
+		for _, rt := range routes {
+			m, _ := rt.(map[string]interface{})
+			if m != nil {
+				if got, _ := m["@id"].(string); got == id {
+					found = true
+					continue
+				}
+			}
+			kept = append(kept, rt)
+		}
+		if !found {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		srv["routes"] = kept
+		fc.puts++
+		w.WriteHeader(http.StatusOK)
+	})
+
 	mux.HandleFunc("/load", func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
 		var newCfg map[string]interface{}

--- a/internal/app/route_sync.go
+++ b/internal/app/route_sync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"sync"
 	"time"
 )
@@ -310,6 +311,35 @@ func (j *RouteSyncJob) syncHTTPRoutes(dbRoutes []*RouteRecord) error {
 				continue
 			}
 			removed++
+
+			// The route is gone; its TLS automation subject must go too
+			// (#1618). RemoveRoute only deletes the route, and
+			// EnsureTLSSubjects is add-only by design, so without this the
+			// subject survives forever: Caddy keeps trying to obtain a
+			// certificate for a hostname that routes nowhere, and repeated
+			// failed validations accumulate against the ACME account — Let's
+			// Encrypt pauses accounts that rack them up. RemoveTLSSubject's
+			// own doc names that cost; previously only the container-delete
+			// cascade called it, so a route removed any other way leaked one.
+			//
+			// Deliberately AFTER a successful RemoveRoute: dropping the
+			// subject while the route still serves would strand a live
+			// hostname with no certificate, which is #1584's symptom.
+			//
+			// Wildcards are skipped. `*.<base-domain>` is per-cluster
+			// (ProvisionWildcardTLS), not route-derived, and covers every
+			// sibling host — removing it because one route disappeared would
+			// take TLS away from all of them.
+			if strings.HasPrefix(domain, "*.") {
+				continue
+			}
+			if err := j.proxyManager.RemoveTLSSubject(domain); err != nil {
+				// Non-fatal: the route is already gone, which is the
+				// user-visible half. A leftover subject costs ACME retries,
+				// not availability, and the next reap attempt will retry.
+				log.Printf("[RouteSyncJob] Removed route %s but failed to drop its TLS subject: %v "+
+					"— it will keep retrying ACME until cleaned up (#1618)", domain, err)
+			}
 		}
 	}
 

--- a/internal/app/route_sync_orphan_subject_test.go
+++ b/internal/app/route_sync_orphan_subject_test.go
@@ -1,0 +1,192 @@
+package app
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// #1618: syncHTTPRoutes reaps a Caddy route that no longer exists in the DB,
+// but RemoveRoute only deletes the ROUTE. The TLS automation subject that
+// route created stays behind forever — EnsureTLSSubjects (#1584) is add-only
+// by design, so nothing on the reconcile path can ever clean it up.
+//
+// The orphan is not inert. Caddy keeps trying to obtain a certificate for a
+// hostname that routes nowhere, and repeated failed validations accumulate
+// against the ACME account — Let's Encrypt pauses accounts that rack them up.
+// RemoveTLSSubject's own doc comment names exactly this cost; only the
+// container-delete cascade was calling it.
+//
+// Observed live: one orphaned subject accounted for effectively all
+// certificate-obtain errors on a production host while every other subject
+// sat quiet.
+
+// caddyConfigWithRoutesAndPolicy builds a fake Caddy config carrying both an
+// http server with routes and a TLS policy, so the reap path can be driven
+// end to end.
+func caddyConfigWithRoutesAndPolicy(t *testing.T, hosts []string, subjects []string) map[string]interface{} {
+	t.Helper()
+
+	routes := make([]interface{}, 0, len(hosts))
+	for _, h := range hosts {
+		// AddRoute stores @id as the subdomain with the base domain stripped,
+		// and RemoveRoute reconstructs it the same way — the fixture has to
+		// match or the delete-by-id lookup misses.
+		id := strings.TrimSuffix(h, ".example.com")
+		r := caddyRouteJSON{
+			ID:    id,
+			Match: []CaddyMatchTyped{{Host: []string{h}}},
+			Handle: []CaddyHandler{CaddyReverseProxyHandler{
+				Handler:   "reverse_proxy",
+				Upstreams: []CaddyUpstreamTyped{{Dial: "10.0.3.9:8080"}},
+			}},
+		}
+		raw, err := json.Marshal(r)
+		if err != nil {
+			t.Fatalf("marshal route: %v", err)
+		}
+		var any interface{}
+		if err := json.Unmarshal(raw, &any); err != nil {
+			t.Fatalf("unmarshal route: %v", err)
+		}
+		routes = append(routes, any)
+	}
+
+	polRaw, err := json.Marshal([]CaddyTLSAutomationPolicy{{
+		Subjects: subjects,
+		Issuers:  []CaddyTLSIssuer{NewACMEIssuer()},
+	}})
+	if err != nil {
+		t.Fatalf("marshal policy: %v", err)
+	}
+	var policies []interface{}
+	if err := json.Unmarshal(polRaw, &policies); err != nil {
+		t.Fatalf("unmarshal policy: %v", err)
+	}
+
+	return map[string]interface{}{
+		"apps": map[string]interface{}{
+			"http": map[string]interface{}{
+				"servers": map[string]interface{}{
+					DefaultCaddyServerName: map[string]interface{}{"routes": routes},
+				},
+			},
+			"tls": map[string]interface{}{
+				"automation": map[string]interface{}{"policies": policies},
+			},
+		},
+	}
+}
+
+func activeRoute(domain string) *RouteRecord {
+	return &RouteRecord{
+		FullDomain: domain,
+		TargetIP:   "10.0.3.9",
+		TargetPort: 8080,
+		Protocol:   string(RouteProtocolHTTP),
+		Active:     true,
+	}
+}
+
+// THE #1618 regression: a route present in Caddy but gone from the DB is
+// reaped, and its TLS subject must go with it.
+func TestSyncHTTPRoutes_ReapingARouteAlsoRemovesItsTLSSubject(t *testing.T) {
+	srv, fc := newRWFakeCaddy(caddyConfigWithRoutesAndPolicy(t,
+		[]string{"kept.example.com", "gone.example.com"},
+		[]string{"kept.example.com", "gone.example.com"},
+	))
+	defer srv.Close()
+
+	p := NewProxyManager(srv.URL, "example.com")
+	j := &RouteSyncJob{proxyManager: p}
+
+	// Only "kept" remains in the DB — "gone" was deactivated or deleted.
+	if err := j.syncHTTPRoutes([]*RouteRecord{activeRoute("kept.example.com")}); err != nil {
+		t.Fatalf("syncHTTPRoutes: %v", err)
+	}
+
+	policies := readPolicies(t, fc)
+	if hasSubject(policies, "gone.example.com") {
+		t.Fatalf("reaped route's TLS subject was left behind — Caddy will retry ACME for it "+
+			"forever, burning rate-limit budget with no route and no host (#1618); subjects: %v",
+			subjectsOf(policies))
+	}
+	if !hasSubject(policies, "kept.example.com") {
+		t.Fatalf("a still-active route's subject must not be removed; subjects: %v", subjectsOf(policies))
+	}
+}
+
+// A wildcard subject is per-cluster (ProvisionWildcardTLS), not route-derived,
+// and covers hosts beyond the one being reaped. Removing it would take TLS
+// away from every sibling — strictly worse than the orphan being fixed.
+func TestSyncHTTPRoutes_ReapNeverRemovesWildcardSubject(t *testing.T) {
+	srv, fc := newRWFakeCaddy(caddyConfigWithRoutesAndPolicy(t,
+		[]string{"*.example.com"},
+		[]string{"*.example.com", "kept.example.com"},
+	))
+	defer srv.Close()
+
+	p := NewProxyManager(srv.URL, "example.com")
+	j := &RouteSyncJob{proxyManager: p}
+
+	// The DB has no route named "*.example.com", so the reap path sees it as
+	// removable. It must be skipped anyway.
+	if err := j.syncHTTPRoutes([]*RouteRecord{activeRoute("kept.example.com")}); err != nil {
+		t.Fatalf("syncHTTPRoutes: %v", err)
+	}
+
+	policies := readPolicies(t, fc)
+	if !hasSubject(policies, "*.example.com") {
+		t.Fatalf("wildcard subject was removed — every host it covers loses TLS; subjects: %v",
+			subjectsOf(policies))
+	}
+}
+
+// Steady state must stay silent: nothing to reap means no writes at all, so a
+// quiet fleet doesn't churn Caddy's config every tick.
+func TestSyncHTTPRoutes_NoReapMeansNoSubjectWrites(t *testing.T) {
+	srv, fc := newRWFakeCaddy(caddyConfigWithRoutesAndPolicy(t,
+		[]string{"kept.example.com"},
+		[]string{"kept.example.com"},
+	))
+	defer srv.Close()
+
+	p := NewProxyManager(srv.URL, "example.com")
+	j := &RouteSyncJob{proxyManager: p}
+	before := fc.puts
+
+	if err := j.syncHTTPRoutes([]*RouteRecord{activeRoute("kept.example.com")}); err != nil {
+		t.Fatalf("syncHTTPRoutes: %v", err)
+	}
+
+	if fc.puts != before {
+		t.Fatalf("in-sync tick performed %d config write(s); it must be a no-op", fc.puts-before)
+	}
+}
+
+// Several routes can disappear at once (a container delete, a batch cleanup).
+// Every orphan must go, not just the first.
+func TestSyncHTTPRoutes_ReapsAllOrphanedSubjects(t *testing.T) {
+	srv, fc := newRWFakeCaddy(caddyConfigWithRoutesAndPolicy(t,
+		[]string{"kept.example.com", "a.example.com", "b.example.com"},
+		[]string{"kept.example.com", "a.example.com", "b.example.com"},
+	))
+	defer srv.Close()
+
+	p := NewProxyManager(srv.URL, "example.com")
+	j := &RouteSyncJob{proxyManager: p}
+
+	if err := j.syncHTTPRoutes([]*RouteRecord{activeRoute("kept.example.com")}); err != nil {
+		t.Fatalf("syncHTTPRoutes: %v", err)
+	}
+
+	policies := readPolicies(t, fc)
+	for _, gone := range []string{"a.example.com", "b.example.com"} {
+		if hasSubject(policies, gone) {
+			t.Errorf("orphaned subject %q survived the reap; subjects: %v", gone, subjectsOf(policies))
+		}
+	}
+	if !hasSubject(policies, "kept.example.com") {
+		t.Error("active route's subject was removed")
+	}
+}


### PR DESCRIPTION
Closes #1618

## The bug

`syncHTTPRoutes` reaps a Caddy route that's no longer in the DB, but `RemoveRoute` only deletes the **route**. The TLS automation subject that route created stays behind — and nothing can ever clean it up:

- `EnsureTLSSubjects` (#1584) is **add-only by design**, so a transiently-empty route list can't strip live subjects.
- `RemoveTLSSubject` exists and does the right thing, but its own doc scopes it to "the container-delete cascade" — a route removed any other way never reaches it.

The orphan isn't inert. Caddy keeps trying to obtain a certificate for a hostname that routes nowhere, and repeated failed validations accumulate against the ACME account — **Let's Encrypt pauses accounts** that rack them up. `RemoveTLSSubject`'s own comment names that exact cost.

Seen live on a production host: one orphaned subject accounted for effectively **all** certificate-obtain errors while the other twelve subjects sat quiet. Clearing it took two manual steps, because one doesn't imply the other.

## What changed

`RemoveTLSSubject(domain)` alongside the reap, with three deliberate constraints:

| Constraint | Why |
|---|---|
| Only **after** a successful `RemoveRoute` | Dropping the subject while the route still serves strands a live hostname with no cert — #1584's symptom, in reverse |
| **Wildcards skipped** | `*.<base-domain>` is per-cluster (`ProvisionWildcardTLS`), not route-derived; removing it because one route vanished takes TLS from every sibling |
| Failure is **non-fatal** | The route is already gone (the user-visible half); a leftover subject costs ACME retries, not availability, and the next reap retries |

Also teaches the shared fake Caddy to serve `DELETE /id/<route-id>` — how `RemoveRoute` actually deletes. Without it the reap path can't be driven end to end. Purely additive; no existing test uses that path.

## Test evidence

Written first; the two regression tests failed against the old code with the assertion message.

| Criterion | Test |
|---|---|
| Reaped route's subject is removed (the regression) | `TestSyncHTTPRoutes_ReapingARouteAlsoRemovesItsTLSSubject` |
| Active route's subject is untouched | same test, second assertion |
| Wildcard subject never removed | `TestSyncHTTPRoutes_ReapNeverRemovesWildcardSubject` |
| In-sync tick performs zero writes | `TestSyncHTTPRoutes_NoReapMeansNoSubjectWrites` |
| All orphans go, not just the first | `TestSyncHTTPRoutes_ReapsAllOrphanedSubjects` |

Full `internal/app` package green — important here, since I modified a shared test fake.

**Mutation-verified**: stubbing out the `RemoveTLSSubject` call fails both regression tests. The easy wrong fix — removing subjects too eagerly — is guarded by the wildcard and no-write tests.

## Review notes

- **Look first at** the placement inside the `if err := RemoveRoute(...)` success path. That ordering is the whole safety argument.
- One test-fixture subtlety worth knowing: `AddRoute` stores `@id` as the subdomain with the base domain **stripped**, and `RemoveRoute` reconstructs it the same way. My first fixture used full hostnames as `@id` and every delete 404'd — the fixture was wrong, not the fix.

## Not addressed here

**Orphans that already exist on running hosts.** This stops the leak at its source but won't clean up historical ones. A reconcile-based sweep would, but it has to distinguish route-derived subjects from deliberately-provisioned ones (apex, wildcard, operator-added) or it becomes a destructive change — on the host where this was found, subjects outnumbered routes even after cleanup. Called out in #1618 rather than smuggled in here.

**#1584 needs no work** — it was closed by #1589 and has been shipping in v0.68.0/v0.68.1 across the fleet since.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed stale TLS automation entries when HTTP routes are deleted.
  * Preserved wildcard and active-route TLS entries during cleanup.
  * Improved route deletion responses for unsupported methods and missing routes.
  * Prevented unnecessary configuration updates when no routes require cleanup.

* **Tests**
  * Added coverage for route reconciliation, TLS subject cleanup, wildcard preservation, and batch orphan removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->