### PR TITLE
feat(secrets): admin RPC to set/clear a tenant's per-tenant KMS key (#1630)

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -5081,6 +5081,47 @@
         ]
       }
     },
+    "/v1/secrets/{username}/kms-key": {
+      "post": {
+        "summary": "Set or clear a tenant's per-tenant KMS key",
+        "description": "Re-wraps the tenant's existing secrets under the given GCP KMS CryptoKey (or back to the shared KEK if kek_resource_name is empty). Requires CONTAINARIUM_KMS_BACKEND=gcp. Admin role + explicit secrets:write scope required, unconditionally.",
+        "operationId": "ContainerService_SetTenantKMSKey",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/SetTenantKMSKeyResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "username",
+            "description": "Username (tenant) whose KEK to set or clear.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SetTenantKMSKeyBody"
+            }
+          }
+        ],
+        "tags": [
+          "Secrets"
+        ]
+      }
+    },
     "/v1/secrets/{username}/refresh": {
       "post": {
         "summary": "Re-stamp tenant secrets into the LXC env",
@@ -12841,6 +12882,29 @@
         "secret": {
           "$ref": "#/definitions/SecretMetadata",
           "description": "Resulting metadata after the write."
+        }
+      }
+    },
+    "SetTenantKMSKeyBody": {
+      "type": "object",
+      "properties": {
+        "kekResourceName": {
+          "type": "string",
+          "description": "GCP Cloud KMS CryptoKey resource name\n(projects/P/locations/L/keyRings/R/cryptoKeys/K) that this tenant's\nsecrets will be wrapped under going forward. The daemon re-wraps\nevery existing secret the tenant owns under this key.\n\nEmpty clears the override: existing secrets are re-wrapped back\nunder the daemon's shared KEK (CONTAINARIUM_GCP_KMS_KEY_NAME)\nbefore the tenant's own key can be invalidated by whoever manages\nit upstream.\n\nRequires CONTAINARIUM_KMS_BACKEND=gcp — per-tenant keys are not\nyet supported for the vault/aws/inproc backends."
+        }
+      },
+      "description": "SetTenantKMSKeyRequest sets or clears a tenant's per-tenant KEK for\nsecrets envelope encryption. This is a privileged, admin-only\noperation performed ON BEHALF OF a tenant — unlike SetSecret/GetSecret,\nit always requires the admin role and an explicitly granted\nsecrets:write scope, even when the caller's own subject equals\nusername, because changing which key encrypts a tenant's secrets is\nnot something a tenant does to itself in the platform's actual usage."
+    },
+    "SetTenantKMSKeyResponse": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string",
+          "description": "Operator-facing summary, including how many secrets were re-wrapped."
+        },
+        "hasTenantKey": {
+          "type": "boolean",
+          "description": "True if the tenant now has a per-tenant key (kek_resource_name was\nnon-empty in the request); false if cleared back to the shared KEK."
         }
       }
     },

--- a/internal/client/grpc.go
+++ b/internal/client/grpc.go
@@ -468,6 +468,22 @@ func (c *GRPCClient) RefreshSecrets(username string) (string, int32, error) {
 	return resp.Message, resp.Stamped, nil
 }
 
+// SetTenantKMSKey sets (or, with an empty keyResourceName, clears) a
+// tenant's per-tenant KMS key via gRPC (#1630). Admin role + explicit
+// secrets:write scope required on the token — see
+// ContainerServer.SetTenantKMSKey's doc comment.
+func (c *GRPCClient) SetTenantKMSKey(username, keyResourceName string) (string, bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	resp, err := c.client.SetTenantKMSKey(ctx, &pb.SetTenantKMSKeyRequest{
+		Username: username, KekResourceName: keyResourceName,
+	})
+	if err != nil {
+		return "", false, fmt.Errorf("set tenant kms key: %w", err)
+	}
+	return resp.Message, resp.HasTenantKey, nil
+}
+
 // ResizeContainer changes a container's CPU / memory / disk via gRPC.
 // Empty string for any field means "no change". Disk can only grow —
 // the server rejects shrinks. memoryRequest/cpuRequest are the K8s

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -991,6 +991,34 @@ func (c *HTTPClient) RefreshSecrets(username string) (string, int32, error) {
 	return result.Message, result.Stamped, nil
 }
 
+// SetTenantKMSKey sets (or, with an empty keyResourceName, clears) a
+// tenant's per-tenant KMS key via HTTP (#1630). Admin role + explicit
+// secrets:write scope required on the token.
+func (c *HTTPClient) SetTenantKMSKey(username, keyResourceName string) (string, bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	body, err := json.Marshal(setTenantKMSKeyRequest{KekResourceName: keyResourceName})
+	if err != nil {
+		return "", false, fmt.Errorf("marshal request: %w", err)
+	}
+	path := fmt.Sprintf("/v1/secrets/%s/kms-key", url.PathEscape(username))
+	resp, err := c.doRequest(ctx, http.MethodPost, path, body)
+	if err != nil {
+		return "", false, fmt.Errorf("set tenant kms key: %w", err)
+	}
+	defer drainClose(resp)
+	b, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return "", false, parseErr(b, resp.StatusCode, "set tenant kms key")
+	}
+	var result struct {
+		Message      string `json:"message"`
+		HasTenantKey bool   `json:"hasTenantKey"`
+	}
+	_ = json.Unmarshal(b, &result)
+	return result.Message, result.HasTenantKey, nil
+}
+
 // parseErr is a tiny helper used across the secrets HTTP methods to
 // surface the server's structured error body (`{"error":"..."}`)
 // when present, falling back to the status code otherwise.

--- a/internal/client/http_requests.go
+++ b/internal/client/http_requests.go
@@ -140,6 +140,13 @@ type setSecretRequest struct {
 	Delivery string `json:"delivery,omitempty"`
 }
 
+// setTenantKMSKeyRequest is POST /v1/secrets/{username}/kms-key (#1630).
+// username is path-bound (like RefreshSecretsRequest's), not repeated
+// in the body.
+type setTenantKMSKeyRequest struct {
+	KekResourceName string `json:"kek_resource_name,omitempty"`
+}
+
 // setMetricsExportRequest is POST /v1/system/metrics-export.
 type setMetricsExportRequest struct {
 	Enabled bool `json:"enabled"`

--- a/internal/client/http_secrets_test.go
+++ b/internal/client/http_secrets_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
@@ -149,5 +150,79 @@ func TestListSecretsReportsDecodeFailure(t *testing.T) {
 	}
 	if _, err := c.ListSecrets("alice"); err == nil {
 		t.Error("a malformed response must be an error, not an empty list")
+	}
+}
+
+// TestSetTenantKMSKeyDecodesGatewayCamelCase (#1630) pins the same class
+// of bug TestListSecretsDecodesGatewayCamelCase guards against:
+// grpc-gateway emits lowerCamelCase (hasTenantKey), not the Go struct's
+// snake_case json tag (has_tenant_key) — decoding against the wrong key
+// silently produces the zero value instead of an error.
+func TestSetTenantKMSKeyDecodesGatewayCamelCase(t *testing.T) {
+	var gotPath, gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		b := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(b)
+		gotBody = string(b)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"message":"tenant alice now on its own KMS key","hasTenantKey":true}`))
+	}))
+	defer srv.Close()
+
+	c, err := NewHTTPClient(srv.URL, "tok")
+	if err != nil {
+		t.Fatalf("NewHTTPClient: %v", err)
+	}
+	msg, hasKey, err := c.SetTenantKMSKey("alice", "projects/p/locations/l/keyRings/r/cryptoKeys/k")
+	if err != nil {
+		t.Fatalf("SetTenantKMSKey: %v", err)
+	}
+	if !hasKey {
+		t.Error("hasTenantKey decoded false; the gateway sent true — camelCase mismatch")
+	}
+	if msg != "tenant alice now on its own KMS key" {
+		t.Errorf("message = %q", msg)
+	}
+	if gotPath != "/v1/secrets/alice/kms-key" {
+		t.Errorf("path = %q, want /v1/secrets/alice/kms-key", gotPath)
+	}
+	// username must NOT be repeated in the body — it's path-bound, same
+	// convention as RefreshSecretsRequest.
+	if strings.Contains(gotBody, "username") {
+		t.Errorf("body should not repeat the path-bound username: %s", gotBody)
+	}
+	if !strings.Contains(gotBody, "kek_resource_name") {
+		t.Errorf("body missing kek_resource_name: %s", gotBody)
+	}
+}
+
+// Clearing (empty keyResourceName) must still round-trip cleanly — the
+// json tag is `omitempty`, so the field is simply absent from the body,
+// which the server-side proto treats identically to an explicit "".
+func TestSetTenantKMSKeyClearOmitsField(t *testing.T) {
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(b)
+		gotBody = string(b)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"message":"tenant alice reverted to the shared KEK","hasTenantKey":false}`))
+	}))
+	defer srv.Close()
+
+	c, err := NewHTTPClient(srv.URL, "tok")
+	if err != nil {
+		t.Fatalf("NewHTTPClient: %v", err)
+	}
+	_, hasKey, err := c.SetTenantKMSKey("alice", "")
+	if err != nil {
+		t.Fatalf("SetTenantKMSKey (clear): %v", err)
+	}
+	if hasKey {
+		t.Error("expected hasTenantKey=false after clear")
+	}
+	if strings.Contains(gotBody, "kek_resource_name") {
+		t.Errorf("empty key should omit the field entirely: %s", gotBody)
 	}
 }

--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -96,6 +96,40 @@ without restarting the box.`,
 	RunE: runSecretsRefresh,
 }
 
+var secretsSetKMSKeyCmd = &cobra.Command{
+	Use:   "set-kms-key <username> <key-resource-name>",
+	Short: "Set a tenant's per-tenant KMS key for secrets (admin only)",
+	Long: `Sets username's own GCP Cloud KMS CryptoKey as the key their secrets
+are wrapped under going forward, and re-wraps every secret they
+currently own under it (#1630).
+
+Requires the daemon's CONTAINARIUM_KMS_BACKEND=gcp, and a token with
+the admin role AND the secrets:write scope granted EXPLICITLY — the
+admin role alone is not enough for this RPC, unlike the other
+'secrets' subcommands. Mint one with:
+  containarium token generate --roles admin --scopes secrets:write ...
+
+key-resource-name is a full GCP Cloud KMS CryptoKey resource path:
+  projects/<project>/locations/<location>/keyRings/<ring>/cryptoKeys/<key>
+
+Use 'secrets clear-kms-key' to revert username to the shared KEK.`,
+	Args: cobra.ExactArgs(2),
+	RunE: runSecretsSetKMSKey,
+}
+
+var secretsClearKMSKeyCmd = &cobra.Command{
+	Use:   "clear-kms-key <username>",
+	Short: "Revert a tenant to the shared KMS key (admin only)",
+	Long: `Reverts username from its own per-tenant KMS key back to the
+daemon's shared KEK, re-wrapping every secret they currently own.
+Idempotent — clearing a tenant with no override still succeeds.
+
+Same authz requirement as 'secrets set-kms-key': admin role + the
+secrets:write scope granted explicitly on the token.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runSecretsClearKMSKey,
+}
+
 // secretsDelivery is the value bound to `--delivery` on
 // `secrets set` (Phase 4.3 Phase A). Allowed values: "",
 // "env" (default; server normalizes ""→"env"), "file"
@@ -116,6 +150,8 @@ func init() {
 	secretsCmd.AddCommand(secretsListCmd)
 	secretsCmd.AddCommand(secretsDeleteCmd)
 	secretsCmd.AddCommand(secretsRefreshCmd)
+	secretsCmd.AddCommand(secretsSetKMSKeyCmd)
+	secretsCmd.AddCommand(secretsClearKMSKeyCmd)
 }
 
 func runSecretsSet(cmd *cobra.Command, args []string) error {
@@ -315,4 +351,65 @@ func secretDeliveryLabel(d pb.SecretDelivery) string {
 	default:
 		return ""
 	}
+}
+
+func runSecretsSetKMSKey(cmd *cobra.Command, args []string) error {
+	username, keyResourceName := args[0], args[1]
+	if serverAddr == "" {
+		return fmt.Errorf("--server is required for secrets commands")
+	}
+
+	var msg string
+	var hasKey bool
+	var err error
+	if httpMode {
+		h, herr := client.NewHTTPClient(serverAddr, authToken)
+		if herr != nil {
+			return herr
+		}
+		defer func() { _ = h.Close() }()
+		msg, hasKey, err = h.SetTenantKMSKey(username, keyResourceName)
+	} else {
+		g, gerr := client.NewGRPCClient(serverAddr, certsDir, insecure)
+		if gerr != nil {
+			return gerr
+		}
+		defer func() { _ = g.Close() }()
+		msg, hasKey, err = g.SetTenantKMSKey(username, keyResourceName)
+	}
+	if err != nil {
+		return err
+	}
+	fmt.Printf("✓ %s (has_tenant_key=%v)\n", msg, hasKey)
+	return nil
+}
+
+func runSecretsClearKMSKey(cmd *cobra.Command, args []string) error {
+	username := args[0]
+	if serverAddr == "" {
+		return fmt.Errorf("--server is required for secrets commands")
+	}
+
+	var msg string
+	var err error
+	if httpMode {
+		h, herr := client.NewHTTPClient(serverAddr, authToken)
+		if herr != nil {
+			return herr
+		}
+		defer func() { _ = h.Close() }()
+		msg, _, err = h.SetTenantKMSKey(username, "")
+	} else {
+		g, gerr := client.NewGRPCClient(serverAddr, certsDir, insecure)
+		if gerr != nil {
+			return gerr
+		}
+		defer func() { _ = g.Close() }()
+		msg, _, err = g.SetTenantKMSKey(username, "")
+	}
+	if err != nil {
+		return err
+	}
+	fmt.Printf("✓ %s\n", msg)
+	return nil
 }

--- a/internal/secrets/kms_factory.go
+++ b/internal/secrets/kms_factory.go
@@ -87,6 +87,37 @@ func LoadKMSClient(masterKey []byte) (corecrypto.KMSClient, string, error) {
 	}
 }
 
+// TenantKMSFactory builds a KMSClient scoped to one caller-supplied key
+// resource name, reusing the daemon's own KMS auth config (token/token
+// file/endpoint/timeout). Returns an error if the resource name is
+// malformed for the backend.
+type TenantKMSFactory func(keyResourceName string) (corecrypto.KMSClient, error)
+
+// LoadTenantKMSFactory returns a TenantKMSFactory for per-tenant KEKs
+// (#1630) — platform-managed keys in the SAME GCP project the daemon's
+// shared KEK lives in, not cross-project BYOK (that's a later,
+// separately-scoped feature).
+//
+// Returns (nil, nil) when CONTAINARIUM_KMS_BACKEND isn't "gcp": per-tenant
+// keys aren't supported for the other backends yet, and a nil factory is
+// how internal/secrets.Store knows to reject SetTenantKMSKey up front
+// rather than silently no-op it.
+func LoadTenantKMSFactory() (TenantKMSFactory, error) {
+	backend := strings.ToLower(strings.TrimSpace(os.Getenv(config.EnvKMSBackend)))
+	if backend != KMSBackendGCP {
+		return nil, nil
+	}
+	cfg, err := gcpConfigFromEnv()
+	if err != nil {
+		return nil, fmt.Errorf("KMS backend gcp: %w", err)
+	}
+	return func(keyResourceName string) (corecrypto.KMSClient, error) {
+		perTenant := cfg
+		perTenant.KeyName = keyResourceName
+		return corecrypto.NewGCPKMS(perTenant)
+	}, nil
+}
+
 // vaultConfigFromEnv reads the Vault Transit config from env. Required:
 // CONTAINARIUM_VAULT_ADDR, CONTAINARIUM_VAULT_TOKEN (or _TOKEN_FILE),
 // CONTAINARIUM_VAULT_TRANSIT_KEY. Optional: CONTAINARIUM_VAULT_TRANSIT_MOUNT

--- a/internal/secrets/kms_factory_test.go
+++ b/internal/secrets/kms_factory_test.go
@@ -1,8 +1,12 @@
 package secrets
 
 import (
+	"context"
 	"crypto/rand"
+	"encoding/json"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -405,5 +409,120 @@ func TestLoadKMSClient_AWSTimeoutParse(t *testing.T) {
 	t.Setenv("CONTAINARIUM_AWS_KMS_TIMEOUT", "garbage")
 	if _, _, err := LoadKMSClient(mkMaster(t)); err == nil {
 		t.Fatal("malformed duration should error")
+	}
+}
+
+// --- LoadTenantKMSFactory (#1630) ---
+
+func TestLoadTenantKMSFactory_NilWhenBackendIsNotGCP(t *testing.T) {
+	for _, backend := range []string{"", "none", "inproc", "vault", "aws"} {
+		t.Run(backend, func(t *testing.T) {
+			clearKMSEnv(t)
+			if backend != "" {
+				t.Setenv("CONTAINARIUM_KMS_BACKEND", backend)
+			}
+			// vault/aws would otherwise error on missing config — but
+			// LoadTenantKMSFactory must return before ever reading
+			// their env vars, since only "gcp" is in scope for #1630.
+			f, err := LoadTenantKMSFactory()
+			if err != nil {
+				t.Fatalf("unexpected error for backend %q: %v", backend, err)
+			}
+			if f != nil {
+				t.Fatalf("backend %q: expected nil factory", backend)
+			}
+		})
+	}
+}
+
+// fakeTenantKMSEndpoint is a minimal local stand-in for Cloud KMS's
+// :encrypt endpoint — no real network call, no real ADC. Base64s the
+// plaintext back as the "ciphertext" so the test only needs to check
+// which key resource path the request was addressed to, which is the
+// thing under test here (per-tenant routing), not the crypto itself
+// (already covered in pkg/core/secrets/kms_gcp_test.go).
+func fakeTenantKMSEndpoint(t *testing.T, gotPath *string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*gotPath = r.URL.Path
+		var body struct {
+			Plaintext string `json:"plaintext"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"ciphertext": body.Plaintext})
+	}))
+}
+
+func TestLoadTenantKMSFactory_GCPBuildsAClientPerKey(t *testing.T) {
+	clearKMSEnv(t)
+	var gotPath string
+	srv := fakeTenantKMSEndpoint(t, &gotPath)
+	defer srv.Close()
+
+	t.Setenv("CONTAINARIUM_KMS_BACKEND", "gcp")
+	t.Setenv("CONTAINARIUM_GCP_KMS_KEY_NAME", factoryTestKeyName)
+	t.Setenv("CONTAINARIUM_GCP_KMS_TOKEN", "access-token-xyz")
+	t.Setenv("CONTAINARIUM_GCP_KMS_ENDPOINT", srv.URL)
+
+	f, err := LoadTenantKMSFactory()
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if f == nil {
+		t.Fatal("expected a non-nil factory for backend=gcp")
+	}
+
+	otherKey := "projects/p/locations/us-west1/keyRings/r/cryptoKeys/tenant-1"
+	client, err := f(otherKey)
+	if err != nil {
+		t.Fatalf("build client for tenant key: %v", err)
+	}
+	if client == nil {
+		t.Fatal("expected a non-nil client")
+	}
+
+	// The built client must be scoped to the KEY PASSED TO THE FACTORY,
+	// not the daemon's shared CONTAINARIUM_GCP_KMS_KEY_NAME.
+	dek := make([]byte, corecrypto.DEKSize)
+	if _, err := io.ReadFull(rand.Reader, dek); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	_, kekID, err := client.Wrap(context.Background(), dek)
+	if err != nil {
+		t.Fatalf("Wrap against fake endpoint: %v", err)
+	}
+	if kekID != "gcp:"+otherKey {
+		t.Fatalf("kek_id = %q; want %q (the per-tenant key, not the shared one)", kekID, "gcp:"+otherKey)
+	}
+	wantPath := "/v1/" + otherKey + ":encrypt"
+	if gotPath != wantPath {
+		t.Fatalf("request path = %q; want %q — the client called the wrong key's endpoint", gotPath, wantPath)
+	}
+}
+
+func TestLoadTenantKMSFactory_GCPPropagatesConfigError(t *testing.T) {
+	clearKMSEnv(t)
+	t.Setenv("CONTAINARIUM_KMS_BACKEND", "gcp")
+	// No CONTAINARIUM_GCP_KMS_KEY_NAME / token — gcpConfigFromEnv must
+	// error, and LoadTenantKMSFactory must surface that rather than
+	// silently returning a factory that will fail on first use.
+	if _, err := LoadTenantKMSFactory(); err == nil {
+		t.Fatal("missing shared GCP config should error, not return a usable factory")
+	}
+}
+
+func TestLoadTenantKMSFactory_RejectsMalformedKeyResourceName(t *testing.T) {
+	clearKMSEnv(t)
+	t.Setenv("CONTAINARIUM_KMS_BACKEND", "gcp")
+	t.Setenv("CONTAINARIUM_GCP_KMS_KEY_NAME", factoryTestKeyName)
+	t.Setenv("CONTAINARIUM_GCP_KMS_TOKEN", "access-token-xyz")
+
+	f, err := LoadTenantKMSFactory()
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if _, err := f("not-a-key-resource-name"); err == nil {
+		t.Fatal("malformed per-tenant key resource name should be rejected (NewGCPKMS's own shape check)")
 	}
 }

--- a/internal/secrets/store.go
+++ b/internal/secrets/store.go
@@ -585,10 +585,7 @@ func (s *Store) ClearTenantKMSKey(ctx context.Context, username string) error {
 
 // rewrapTenant re-encrypts every secret username owns under whatever
 // resolveEncryptKMS currently resolves for username — i.e., the
-// override SetTenantKMSKey/ClearTenantKMSKey just committed. Reuses
-// Get (decrypts via each row's own kek_id) + Set (re-encrypts via the
-// current resolver) rather than any bespoke SQL, so it inherits both
-// functions' existing tests and correctness.
+// override SetTenantKMSKey/ClearTenantKMSKey just committed.
 //
 // Not optimized to skip rows already on the target key — tenants carry
 // a handful of secrets, not thousands, so a harmless re-encrypt of an
@@ -599,15 +596,74 @@ func (s *Store) rewrapTenant(ctx context.Context, username string) error {
 		return fmt.Errorf("list secrets for rewrap: %w", err)
 	}
 	for _, m := range metas {
-		_, value, err := s.Get(ctx, username, m.Name)
-		if err != nil {
-			return fmt.Errorf("rewrap %s/%s: read: %w", username, m.Name, err)
-		}
-		if _, err := s.Set(ctx, username, m.Name, value, m.Delivery); err != nil {
-			return fmt.Errorf("rewrap %s/%s: write: %w", username, m.Name, err)
+		if err := s.rewrapOne(ctx, username, m.Name); err != nil {
+			return fmt.Errorf("rewrap %s/%s: %w", username, m.Name, err)
 		}
 	}
 	return nil
+}
+
+// rewrapMaxAttempts bounds rewrapOne's retry loop — generous for what
+// should be, in practice, at most one real collision (a tenant setting
+// a secret at the exact moment an admin rewraps their key).
+const rewrapMaxAttempts = 5
+
+// rewrapOne re-encrypts a single secret under the currently-resolved
+// KMS client, via a version-guarded conditional UPDATE rather than
+// Get-then-Set. A plain Get-then-Set is a read-modify-write race: if a
+// tenant calls SetSecret on the same (username, name) between rewrapOne's
+// read and write, the unconditional Set would silently overwrite the
+// tenant's new value with the old plaintext re-encrypted, AND bump the
+// version again — a silent rollback with no error anywhere (CodeRabbit
+// finding on #1631). The conditional UPDATE affects zero rows if the
+// version moved since the read; rewrapOne detects that and retries with
+// a fresh read instead of clobbering.
+//
+// Preserves the row's version and delivery on success — a rewrap isn't
+// a value change, so it shouldn't look like one (no version bump).
+func (s *Store) rewrapOne(ctx context.Context, username, name string) error {
+	for attempt := 0; attempt < rewrapMaxAttempts; attempt++ {
+		meta, value, err := s.Get(ctx, username, name)
+		if err != nil {
+			if errors.Is(err, ErrNotFound) {
+				return nil // deleted concurrently — nothing left to rewrap
+			}
+			return fmt.Errorf("read: %w", err)
+		}
+		nonce, ct, wrappedDEK, kekID, err := s.encryptForStorage(ctx, username, name, []byte(value))
+		if err != nil {
+			return fmt.Errorf("encrypt: %w", err)
+		}
+		ok, err := s.tryRewrapAtVersion(ctx, username, name, nonce, ct, wrappedDEK, kekID, meta.Version)
+		if err != nil {
+			return fmt.Errorf("write: %w", err)
+		}
+		if ok {
+			return nil
+		}
+		// meta.Version no longer matches the row — something else
+		// wrote (or deleted) it since the read above. Retry with a
+		// fresh Get rather than overwrite whatever that write did.
+	}
+	return fmt.Errorf("gave up after %d attempts: concurrent writes to %s/%s kept racing the rewrap", rewrapMaxAttempts, username, name)
+}
+
+// tryRewrapAtVersion attempts the single conditional UPDATE rewrapOne
+// needs, split out so it's testable without needing to actually win a
+// race: a test can set up a row at version N, advance it to N+1 via an
+// ordinary Set, and then assert that a rewrap attempt still targeting
+// version N affects zero rows and leaves the N+1 row untouched.
+func (s *Store) tryRewrapAtVersion(ctx context.Context, username, name string, nonce, ct, wrappedDEK []byte, kekID string, expectedVersion int32) (bool, error) {
+	const q = `
+		UPDATE secrets
+		SET nonce = $1, ciphertext = $2, wrapped_dek = $3, kek_id = $4, updated_at = NOW()
+		WHERE username = $5 AND name = $6 AND version = $7
+	`
+	tag, err := s.pool.Exec(ctx, q, nonce, ct, wrappedDEK, kekID, username, name, expectedVersion)
+	if err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() == 1, nil
 }
 
 // Get reads a single secret's decrypted plaintext value. Returns

--- a/internal/secrets/store.go
+++ b/internal/secrets/store.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	corecrypto "github.com/footprintai/containarium/pkg/core/secrets"
@@ -105,11 +106,42 @@ type Store struct {
 	// on, a legacy row hitting Get is a strong "you
 	// missed a migration" signal that should page.
 	requireEnvelope bool
+
+	// #1630 — per-tenant KEK override. tenantKMSFactory is nil unless
+	// the daemon's KMS backend is "gcp" (LoadTenantKMSFactory); a nil
+	// factory means SetTenantKMSKey refuses rather than silently
+	// no-op-ing.
+	//
+	// tenantKEK maps username -> the GCP key resource name that
+	// username's NEW writes should wrap under (in-memory cache of the
+	// tenant_kms_keys table, loaded once at construction and kept in
+	// sync by SetTenantKMSKey/ClearTenantKMSKey).
+	//
+	// kekClients caches built KMSClient instances by key resource
+	// name — shared between the encrypt path (resolveEncryptKMS,
+	// keyed by tenantKEK) and the decrypt path (resolveDecryptKMS,
+	// keyed by parsing the ROW's own kek_id). Decrypt being resolved
+	// per-row rather than per-"current override" is what makes a
+	// partially-completed SetTenantKMSKey/ClearTenantKMSKey safe: a
+	// row still carrying its old kek_id keeps decrypting correctly
+	// even while other rows for the same tenant have already moved to
+	// the new key.
+	tenantKMSFactory TenantKMSFactory
+	tenantKEKMu      sync.RWMutex
+	tenantKEK        map[string]string
+	kekClientsMu     sync.RWMutex
+	kekClients       map[string]corecrypto.KMSClient
 }
 
 // ErrNotFound is returned by Get / Delete when the (username, name)
 // tuple has no row.
 var ErrNotFound = errors.New("secrets: not found")
+
+// ErrTenantKMSNotSupported is returned by SetTenantKMSKey when the
+// daemon has no tenantKMSFactory configured (#1630) — i.e.
+// CONTAINARIUM_KMS_BACKEND isn't "gcp". Callers map this to a
+// caller-facing precondition failure, not an internal-error catch-all.
+var ErrTenantKMSNotSupported = errors.New("secrets: per-tenant KMS keys require CONTAINARIUM_KMS_BACKEND=gcp")
 
 // Option configures a Store at construction time. Phase 4.1 uses
 // this to bolt on the KMS client without breaking the existing
@@ -146,6 +178,17 @@ func WithRequireEnvelope(require bool) Option {
 	}
 }
 
+// WithTenantKMSFactory enables per-tenant KEKs (#1630). Pass the result
+// of secrets.LoadTenantKMSFactory() — nil is a no-op, equivalent to
+// omitting this option, matching WithKMS's convention.
+func WithTenantKMSFactory(f TenantKMSFactory) Option {
+	return func(s *Store) {
+		if f != nil {
+			s.tenantKMSFactory = f
+		}
+	}
+}
+
 // NewStore opens the secrets store. Creates the `secrets` table on
 // first run and applies any column migrations; idempotent on every
 // subsequent call.
@@ -162,12 +205,20 @@ func NewStore(ctx context.Context, pool *pgxpool.Pool, cipher *corecrypto.Cipher
 	if cipher == nil {
 		return nil, errors.New("secrets: cipher is nil")
 	}
-	s := &Store{pool: pool, cipher: cipher}
+	s := &Store{
+		pool:       pool,
+		cipher:     cipher,
+		tenantKEK:  map[string]string{},
+		kekClients: map[string]corecrypto.KMSClient{},
+	}
 	for _, opt := range opts {
 		opt(s)
 	}
 	if err := s.initSchema(ctx); err != nil {
 		return nil, fmt.Errorf("init schema: %w", err)
+	}
+	if err := s.loadTenantKEKCache(ctx); err != nil {
+		return nil, fmt.Errorf("load tenant kms key overrides: %w", err)
 	}
 	return s, nil
 }
@@ -203,6 +254,18 @@ func (s *Store) initSchema(ctx context.Context) error {
 
 		CREATE INDEX IF NOT EXISTS idx_secrets_username
 			ON secrets(username);
+
+		-- #1630 — per-tenant KEK overrides. One row per tenant that has
+		-- opted into its own key; absence means the tenant is on the
+		-- shared KEK. No soft-delete: clearing the override is a hard
+		-- DELETE, matching org_encryption_settings-style tables — the
+		-- audit log carries the durable history, not this row.
+		CREATE TABLE IF NOT EXISTS tenant_kms_keys (
+			username          TEXT PRIMARY KEY,
+			kek_resource_name TEXT NOT NULL,
+			created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		);
 	`
 	_, err := s.pool.Exec(ctx, schema)
 	return err
@@ -295,7 +358,13 @@ func (s *Store) Set(ctx context.Context, username, name, value, delivery string)
 // wrapped DEK is safe to hand back — it's encrypted under the
 // KEK.
 func (s *Store) encryptForStorage(ctx context.Context, username, name string, plaintext []byte) (nonce, ct, wrappedDEK []byte, kekID string, err error) {
-	if s.kms == nil {
+	// #1630 — username's own KEK override if it has one, else the
+	// shared/default s.kms (nil = legacy mode).
+	kms, err := s.resolveEncryptKMS(username)
+	if err != nil {
+		return nil, nil, nil, "", fmt.Errorf("resolve kms for %s: %w", username, err)
+	}
+	if kms == nil {
 		// Legacy mode: master-key encrypt directly.
 		nonce, ct, err = s.cipher.Encrypt(username, name, plaintext)
 		if err != nil {
@@ -320,7 +389,7 @@ func (s *Store) encryptForStorage(ctx context.Context, username, name string, pl
 		return nil, nil, nil, "", fmt.Errorf("encrypt (envelope): %w", err)
 	}
 
-	wrappedDEK, kekID, err = s.kms.Wrap(ctx, dek)
+	wrappedDEK, kekID, err = kms.Wrap(ctx, dek)
 	if err != nil {
 		return nil, nil, nil, "", fmt.Errorf("KMS wrap: %w", err)
 	}
@@ -345,11 +414,16 @@ func (s *Store) decryptFromStorage(ctx context.Context, username, name string, n
 		}
 		return s.cipher.Decrypt(username, name, nonce, ct)
 	}
-	// Envelope row.
-	if s.kms == nil {
+	// Envelope row. #1630 — resolved from the ROW's own kek_id, not
+	// from any "current tenant override" state; see resolveDecryptKMS.
+	kms, err := s.resolveDecryptKMS(kekID)
+	if err != nil {
+		return nil, fmt.Errorf("resolve kms for kek_id %q: %w", kekID, err)
+	}
+	if kms == nil {
 		return nil, fmt.Errorf("secret %s/%s is envelope-encoded (kek_id=%q) but Store has no KMSClient configured", username, name, kekID)
 	}
-	dek, err := s.kms.Unwrap(ctx, wrappedDEK, kekID)
+	dek, err := kms.Unwrap(ctx, wrappedDEK, kekID)
 	if err != nil {
 		return nil, fmt.Errorf("KMS unwrap: %w", err)
 	}
@@ -359,6 +433,181 @@ func (s *Store) decryptFromStorage(ctx context.Context, username, name string, n
 		return nil, fmt.Errorf("build DEK cipher: %w", err)
 	}
 	return dekCipher.Decrypt(username, name, nonce, ct)
+}
+
+// resolveEncryptKMS picks the KMSClient a NEW Set for username should
+// wrap under: username's per-tenant override if one is set (#1630),
+// otherwise the shared/default s.kms (nil = legacy mode, unchanged
+// behavior for every daemon that hasn't configured per-tenant keys).
+func (s *Store) resolveEncryptKMS(username string) (corecrypto.KMSClient, error) {
+	if s.tenantKMSFactory == nil {
+		return s.kms, nil
+	}
+	s.tenantKEKMu.RLock()
+	keyName, ok := s.tenantKEK[username]
+	s.tenantKEKMu.RUnlock()
+	if !ok {
+		return s.kms, nil
+	}
+	return s.kekClient(keyName)
+}
+
+// resolveDecryptKMS picks the KMSClient that can unwrap a row whose
+// kek_id is kekID. GCP rows are routed by the KEY NAME parsed out of
+// kek_id, not by any "current tenant override" — every row decrypts
+// under whatever key it actually says it's under, independent of
+// whether SetTenantKMSKey/ClearTenantKMSKey has since moved that
+// tenant's override elsewhere (or is still mid-rewrap). This is what
+// makes a partially-completed rewrap safe: nothing here needs to know
+// "am I done migrating this tenant yet."
+//
+// Non-GCP kek_ids (inproc/vault/aws) fall back to s.kms unchanged —
+// per-tenant keys aren't implemented for those backends (#1630 scope).
+func (s *Store) resolveDecryptKMS(kekID string) (corecrypto.KMSClient, error) {
+	if s.tenantKMSFactory != nil {
+		if keyName, ok := strings.CutPrefix(kekID, corecrypto.GCPKEKPrefix); ok {
+			return s.kekClient(keyName)
+		}
+	}
+	return s.kms, nil
+}
+
+// kekClient returns a cached KMSClient for keyResourceName, building
+// one via tenantKMSFactory on first use. Shared by both the encrypt
+// path (resolveEncryptKMS) and the decrypt path (resolveDecryptKMS) —
+// a key that happens to be both "the shared default" and reached via
+// this cache just means one harmless redundant client alongside s.kms,
+// not an inconsistency.
+func (s *Store) kekClient(keyResourceName string) (corecrypto.KMSClient, error) {
+	s.kekClientsMu.RLock()
+	c, ok := s.kekClients[keyResourceName]
+	s.kekClientsMu.RUnlock()
+	if ok {
+		return c, nil
+	}
+
+	s.kekClientsMu.Lock()
+	defer s.kekClientsMu.Unlock()
+	if c, ok := s.kekClients[keyResourceName]; ok { // re-check post-lock
+		return c, nil
+	}
+	built, err := s.tenantKMSFactory(keyResourceName)
+	if err != nil {
+		return nil, err
+	}
+	s.kekClients[keyResourceName] = built
+	return built, nil
+}
+
+// loadTenantKEKCache populates tenantKEK from the tenant_kms_keys
+// table once at Store construction, so resolveEncryptKMS is a pure
+// in-memory lookup rather than a DB round-trip on every Set.
+func (s *Store) loadTenantKEKCache(ctx context.Context) error {
+	rows, err := s.pool.Query(ctx, `SELECT username, kek_resource_name FROM tenant_kms_keys`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var username, keyName string
+		if err := rows.Scan(&username, &keyName); err != nil {
+			return err
+		}
+		s.tenantKEK[username] = keyName
+	}
+	return rows.Err()
+}
+
+// SetTenantKMSKey sets username's per-tenant KEK to keyResourceName
+// and re-wraps every secret username currently owns under it (#1630).
+// Empty keyResourceName is equivalent to ClearTenantKMSKey.
+//
+// Requires the daemon's KMS backend to be "gcp" (WithTenantKMSFactory
+// configured) — returns an error otherwise rather than silently
+// no-op-ing what looks like a security-relevant change.
+//
+// The override is persisted and cached BEFORE the rewrap loop runs, so
+// this is resumable: a retry after a partial failure only re-wraps
+// rows still under their old key (each Get/Set pair is independently
+// correct regardless of how many prior rows already moved — see
+// resolveDecryptKMS).
+func (s *Store) SetTenantKMSKey(ctx context.Context, username, keyResourceName string) error {
+	username = strings.TrimSpace(username)
+	if username == "" {
+		return errors.New("secrets: username is required")
+	}
+	keyResourceName = strings.TrimSpace(keyResourceName)
+	if keyResourceName == "" {
+		return s.ClearTenantKMSKey(ctx, username)
+	}
+	if s.tenantKMSFactory == nil {
+		return ErrTenantKMSNotSupported
+	}
+	if _, err := s.kekClient(keyResourceName); err != nil {
+		return fmt.Errorf("build tenant kms client: %w", err)
+	}
+
+	const q = `
+		INSERT INTO tenant_kms_keys (username, kek_resource_name)
+		VALUES ($1, $2)
+		ON CONFLICT (username) DO UPDATE SET
+			kek_resource_name = EXCLUDED.kek_resource_name,
+			updated_at        = NOW();
+	`
+	if _, err := s.pool.Exec(ctx, q, username, keyResourceName); err != nil {
+		return fmt.Errorf("persist tenant kms key: %w", err)
+	}
+	s.tenantKEKMu.Lock()
+	s.tenantKEK[username] = keyResourceName
+	s.tenantKEKMu.Unlock()
+
+	return s.rewrapTenant(ctx, username)
+}
+
+// ClearTenantKMSKey reverts username to the shared/default KEK,
+// re-wrapping every secret they currently own back under it. Idempotent
+// — clearing a tenant with no override just re-wraps (a no-op-shaped
+// rewrap, since every row is already on the shared key) and succeeds.
+func (s *Store) ClearTenantKMSKey(ctx context.Context, username string) error {
+	username = strings.TrimSpace(username)
+	if username == "" {
+		return errors.New("secrets: username is required")
+	}
+	if _, err := s.pool.Exec(ctx, `DELETE FROM tenant_kms_keys WHERE username = $1`, username); err != nil {
+		return fmt.Errorf("clear tenant kms key: %w", err)
+	}
+	s.tenantKEKMu.Lock()
+	delete(s.tenantKEK, username)
+	s.tenantKEKMu.Unlock()
+
+	return s.rewrapTenant(ctx, username)
+}
+
+// rewrapTenant re-encrypts every secret username owns under whatever
+// resolveEncryptKMS currently resolves for username — i.e., the
+// override SetTenantKMSKey/ClearTenantKMSKey just committed. Reuses
+// Get (decrypts via each row's own kek_id) + Set (re-encrypts via the
+// current resolver) rather than any bespoke SQL, so it inherits both
+// functions' existing tests and correctness.
+//
+// Not optimized to skip rows already on the target key — tenants carry
+// a handful of secrets, not thousands, so a harmless re-encrypt of an
+// already-correct row is an acceptable simplicity tradeoff here.
+func (s *Store) rewrapTenant(ctx context.Context, username string) error {
+	metas, err := s.List(ctx, username)
+	if err != nil {
+		return fmt.Errorf("list secrets for rewrap: %w", err)
+	}
+	for _, m := range metas {
+		_, value, err := s.Get(ctx, username, m.Name)
+		if err != nil {
+			return fmt.Errorf("rewrap %s/%s: read: %w", username, m.Name, err)
+		}
+		if _, err := s.Set(ctx, username, m.Name, value, m.Delivery); err != nil {
+			return fmt.Errorf("rewrap %s/%s: write: %w", username, m.Name, err)
+		}
+	}
+	return nil
 }
 
 // Get reads a single secret's decrypted plaintext value. Returns

--- a/internal/secrets/store.go
+++ b/internal/secrets/store.go
@@ -608,6 +608,13 @@ func (s *Store) rewrapTenant(ctx context.Context, username string) error {
 // a secret at the exact moment an admin rewraps their key).
 const rewrapMaxAttempts = 5
 
+// rewrapOneTestHook, when non-nil, is invoked by rewrapOne once per
+// attempt, right after its read and before its conditional write —
+// tests use it to deterministically force a version mismatch on a
+// chosen attempt, so the retry branch is directly testable instead of
+// depending on real goroutine timing. Always nil outside tests.
+var rewrapOneTestHook func(username, name string, attempt int)
+
 // rewrapOne re-encrypts a single secret under the currently-resolved
 // KMS client, via a version-guarded conditional UPDATE rather than
 // Get-then-Set. A plain Get-then-Set is a read-modify-write race: if a
@@ -629,6 +636,14 @@ func (s *Store) rewrapOne(ctx context.Context, username, name string) error {
 				return nil // deleted concurrently — nothing left to rewrap
 			}
 			return fmt.Errorf("read: %w", err)
+		}
+		// Test-only seam: lets tests deterministically inject a
+		// concurrent write between this read and the conditional
+		// write below, so the retry branch is directly exercisable
+		// instead of relying on real goroutine timing. Nil (and this
+		// call a no-op) in production.
+		if rewrapOneTestHook != nil {
+			rewrapOneTestHook(username, name, attempt)
 		}
 		nonce, ct, wrappedDEK, kekID, err := s.encryptForStorage(ctx, username, name, []byte(value))
 		if err != nil {

--- a/internal/secrets/tenant_kms_integration_test.go
+++ b/internal/secrets/tenant_kms_integration_test.go
@@ -450,11 +450,17 @@ func TestTryRewrapAtVersion_StaleVersionIsNoOp(t *testing.T) {
 	}
 }
 
-// TestRewrapOne_RetriesOnceTheRaceClears proves the other half: once
-// there's no more contention, rewrapOne's retry loop succeeds and
-// produces a correctly re-encrypted row under the NEW key — not stuck
-// forever just because a single stale attempt was rejected once.
-func TestRewrapOne_RetriesOnceTheRaceClears(t *testing.T) {
+// TestRewrapOne_HappyPathConvergesWithoutVersionBump proves the
+// uncontended case: with no concurrent writer, rewrapOne's first
+// attempt succeeds and produces a correctly re-encrypted row under the
+// NEW key, and — since a rewrap isn't a value change — without bumping
+// version. (This does NOT exercise the retry branch itself: that would
+// need a seam to force a version change between rewrapOne's read and
+// its conditional write, which doesn't exist and isn't worth adding
+// for this. TestTryRewrapAtVersion_StaleVersionIsNoOp covers the
+// mechanism the retry loop depends on — that a stale write is rejected,
+// not silently applied — directly.)
+func TestRewrapOne_HappyPathConvergesWithoutVersionBump(t *testing.T) {
 	fk := &fakeMultiKeyGCPKMS{t: t}
 	srv := httptest.NewServer(http.HandlerFunc(fk.handle))
 	defer srv.Close()

--- a/internal/secrets/tenant_kms_integration_test.go
+++ b/internal/secrets/tenant_kms_integration_test.go
@@ -454,12 +454,8 @@ func TestTryRewrapAtVersion_StaleVersionIsNoOp(t *testing.T) {
 // uncontended case: with no concurrent writer, rewrapOne's first
 // attempt succeeds and produces a correctly re-encrypted row under the
 // NEW key, and — since a rewrap isn't a value change — without bumping
-// version. (This does NOT exercise the retry branch itself: that would
-// need a seam to force a version change between rewrapOne's read and
-// its conditional write, which doesn't exist and isn't worth adding
-// for this. TestTryRewrapAtVersion_StaleVersionIsNoOp covers the
-// mechanism the retry loop depends on — that a stale write is rejected,
-// not silently applied — directly.)
+// version. TestRewrapOne_RetriesPastAStaleFirstAttempt below is the
+// companion that actually exercises the retry branch.
 func TestRewrapOne_HappyPathConvergesWithoutVersionBump(t *testing.T) {
 	fk := &fakeMultiKeyGCPKMS{t: t}
 	srv := httptest.NewServer(http.HandlerFunc(fk.handle))
@@ -504,5 +500,88 @@ func TestRewrapOne_HappyPathConvergesWithoutVersionBump(t *testing.T) {
 	}
 	if kekID != corecrypto.GCPKEKPrefix+tenantKey {
 		t.Fatalf("kek_id = %q, want %q", kekID, corecrypto.GCPKEKPrefix+tenantKey)
+	}
+}
+
+// TestRewrapOne_RetriesPastAStaleFirstAttempt is the direct regression
+// test CodeRabbit asked for on #1631: it forces rewrapOne's FIRST
+// attempt to lose the race (via rewrapOneTestHook, which fires a real
+// concurrent Set between rewrapOne's read and its conditional write)
+// and asserts it correctly retries rather than giving up or clobbering
+// the concurrent writer's value. TestTryRewrapAtVersion_StaleVersionIsNoOp
+// proves the primitive a stale write is rejected; this test proves
+// rewrapOne's loop actually notices that and reads again — a bug that
+// silently accepted the rejection (e.g. returned nil on ok==false
+// instead of retrying) would pass every other test in this file but
+// fail this one, since the tenant's secret would be left un-rewrapped.
+func TestRewrapOne_RetriesPastAStaleFirstAttempt(t *testing.T) {
+	fk := &fakeMultiKeyGCPKMS{t: t}
+	srv := httptest.NewServer(http.HandlerFunc(fk.handle))
+	defer srv.Close()
+
+	factory := newFakeTenantKMSFactory(t, srv)
+	store, pool := newIntegrationStore(t, factory)
+	ctx := context.Background()
+	const user, name = "tenant-kms-user-race3", "API_KEY"
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, "DELETE FROM secrets WHERE username = $1", user)
+		_, _ = pool.Exec(ctx, "DELETE FROM tenant_kms_keys WHERE username = $1", user)
+	})
+	_, _ = pool.Exec(ctx, "DELETE FROM secrets WHERE username = $1", user)
+	_, _ = pool.Exec(ctx, "DELETE FROM tenant_kms_keys WHERE username = $1", user)
+
+	if _, err := store.Set(ctx, user, name, "before-race", ""); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	raced := false
+	var raceAttempts []int
+	rewrapOneTestHook = func(hookUser, hookName string, attempt int) {
+		if hookUser != user || hookName != name {
+			return
+		}
+		raceAttempts = append(raceAttempts, attempt)
+		if raced {
+			return // only race the very first attempt
+		}
+		raced = true
+		// A real concurrent write, landing after rewrapOne's read
+		// (which just happened) and before its conditional write
+		// (about to happen) — bumps the row to version 2 with a
+		// genuinely different value.
+		if _, err := store.Set(ctx, user, name, "raced-in-value", ""); err != nil {
+			t.Fatalf("concurrent Set inside hook: %v", err)
+		}
+	}
+	t.Cleanup(func() { rewrapOneTestHook = nil })
+
+	tenantKey := "projects/p/locations/l/keyRings/r/cryptoKeys/" + user
+	if err := store.SetTenantKMSKey(ctx, user, tenantKey); err != nil {
+		t.Fatalf("SetTenantKMSKey: %v", err)
+	}
+
+	if len(raceAttempts) < 2 {
+		t.Fatalf("expected rewrapOne to make at least 2 attempts (one rejected, one that succeeded); hook fired for attempts %v", raceAttempts)
+	}
+
+	meta, value, err := store.Get(ctx, user, name)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if value != "raced-in-value" {
+		t.Fatalf("value = %q, want %q — the retry must have picked up the concurrent writer's value, not the stale one", value, "raced-in-value")
+	}
+	if meta.Version != 2 {
+		t.Fatalf("version = %d, want 2 — the concurrent Set's version, unchanged by the eventual successful rewrap", meta.Version)
+	}
+
+	var kekID string
+	if err := pool.QueryRow(ctx,
+		`SELECT kek_id FROM secrets WHERE username = $1 AND name = $2`, user, name,
+	).Scan(&kekID); err != nil {
+		t.Fatalf("query kek_id: %v", err)
+	}
+	if kekID != corecrypto.GCPKEKPrefix+tenantKey {
+		t.Fatalf("kek_id = %q, want %q — the secret must still end up under the tenant's new key despite the race", kekID, corecrypto.GCPKEKPrefix+tenantKey)
 	}
 }

--- a/internal/secrets/tenant_kms_integration_test.go
+++ b/internal/secrets/tenant_kms_integration_test.go
@@ -1,0 +1,393 @@
+package secrets
+
+import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	corecrypto "github.com/footprintai/containarium/pkg/core/secrets"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Integration-style test against a real Postgres, same convention as
+// TestSecretsStore_Roundtrip (t.Skip in CI, runnable locally with
+// CONTAINARIUM_TEST_DSN set). Exercises SetTenantKMSKey /
+// ClearTenantKMSKey / rewrapTenant end to end — the parts of #1630 that
+// need real SQL (List/Get/Set + the tenant_kms_keys table), which the
+// pure-dispatch tests in tenant_kms_test.go don't reach.
+//
+// The KMS side is a local fake Cloud KMS server (httptest), not real
+// GCP — same reasoning kms_gcp_test.go uses. It derives a genuinely
+// distinct AES key PER key-resource-name (sha256 of the path), so it
+// actually enforces "the wrong key can't decrypt this ciphertext,"
+// which is the property this test needs to prove.
+type fakeMultiKeyGCPKMS struct{ t *testing.T }
+
+func (f *fakeMultiKeyGCPKMS) aeadFor(keyResourceName string) cipher.AEAD {
+	sum := sha256.Sum256([]byte(keyResourceName))
+	block, err := aes.NewCipher(sum[:])
+	if err != nil {
+		f.t.Fatalf("aes.NewCipher: %v", err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		f.t.Fatalf("cipher.NewGCM: %v", err)
+	}
+	return aead
+}
+
+func (f *fakeMultiKeyGCPKMS) handle(w http.ResponseWriter, r *http.Request) {
+	// Path shape: /v1/<key-resource-name>:encrypt|:decrypt
+	path := strings.TrimPrefix(r.URL.Path, "/v1/")
+	op := "encrypt"
+	keyResourceName := path
+	if idx := strings.LastIndex(path, ":"); idx >= 0 {
+		keyResourceName, op = path[:idx], path[idx+1:]
+	}
+	aead := f.aeadFor(keyResourceName)
+
+	switch op {
+	case "encrypt":
+		var body struct {
+			Plaintext string `json:"plaintext"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		pt, err := base64.StdEncoding.DecodeString(body.Plaintext)
+		if err != nil {
+			http.Error(w, "bad plaintext", http.StatusBadRequest)
+			return
+		}
+		nonce := make([]byte, aead.NonceSize())
+		_, _ = io.ReadFull(rand.Reader, nonce)
+		ct := aead.Seal(nonce, nonce, pt, nil)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"ciphertext": base64.StdEncoding.EncodeToString(ct),
+		})
+	case "decrypt":
+		var body struct {
+			Ciphertext string `json:"ciphertext"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		blob, err := base64.StdEncoding.DecodeString(body.Ciphertext)
+		if err != nil || len(blob) < aead.NonceSize() {
+			http.Error(w, `{"error":{"message":"bad ciphertext"}}`, http.StatusBadRequest)
+			return
+		}
+		nonce, ct := blob[:aead.NonceSize()], blob[aead.NonceSize():]
+		pt, err := aead.Open(nil, nonce, ct, nil)
+		if err != nil {
+			// This is the load-bearing failure mode this test exists to
+			// check: decrypting under the WRONG key's derived AEAD.
+			http.Error(w, `{"error":{"message":"decryption failed"}}`, http.StatusForbidden)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"plaintext": base64.StdEncoding.EncodeToString(pt),
+		})
+	default:
+		http.Error(w, "unknown op", http.StatusNotFound)
+	}
+}
+
+func newFakeTenantKMSFactory(t *testing.T, srv *httptest.Server) TenantKMSFactory {
+	t.Helper()
+	return func(keyResourceName string) (corecrypto.KMSClient, error) {
+		return corecrypto.NewGCPKMS(corecrypto.GCPConfig{
+			KeyName:  keyResourceName,
+			Token:    "test-token",
+			Endpoint: srv.URL,
+		})
+	}
+}
+
+func newIntegrationStore(t *testing.T, tenantFactory TenantKMSFactory) (*Store, *pgxpool.Pool) {
+	t.Helper()
+	dsn := os.Getenv("CONTAINARIUM_TEST_DSN")
+	if dsn == "" {
+		t.Skip("set CONTAINARIUM_TEST_DSN to run this against Postgres (the store-integration lane does)")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect Postgres: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	key := make([]byte, corecrypto.MasterKeySize)
+	for i := range key {
+		key[i] = byte(i + 1)
+	}
+	cipher, err := corecrypto.NewCipher(key)
+	if err != nil {
+		t.Fatalf("NewCipher: %v", err)
+	}
+
+	// The shared/default KMS is a fixed key on the SAME fake server —
+	// exercises the "shared vs per-tenant" boundary for real, not just
+	// "per-tenant vs nothing."
+	fakeGCPServerURL := ""
+	if tenantFactory != nil {
+		// tenantFactory closes over srv.URL already; reuse it for the
+		// shared client too by asking the factory to build one under a
+		// fixed "shared" key name.
+		shared, err := tenantFactory("projects/p/locations/l/keyRings/r/cryptoKeys/shared")
+		if err != nil {
+			t.Fatalf("build shared kms client: %v", err)
+		}
+		store, err := NewStore(ctx, pool, cipher, WithKMS(shared), WithTenantKMSFactory(tenantFactory))
+		if err != nil {
+			t.Fatalf("NewStore: %v", err)
+		}
+		return store, pool
+	}
+	_ = fakeGCPServerURL
+	store, err := NewStore(ctx, pool, cipher)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	return store, pool
+}
+
+func TestSetTenantKMSKey_RewrapsExistingSecretsUnderTheNewKey(t *testing.T) {
+	fk := &fakeMultiKeyGCPKMS{t: t}
+	srv := httptest.NewServer(http.HandlerFunc(fk.handle))
+	defer srv.Close()
+
+	store, pool := newIntegrationStore(t, newFakeTenantKMSFactory(t, srv))
+	ctx := context.Background()
+	const user = "tenant-kms-user-a"
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, "DELETE FROM secrets WHERE username = $1", user)
+		_, _ = pool.Exec(ctx, "DELETE FROM tenant_kms_keys WHERE username = $1", user)
+	})
+	_, _ = pool.Exec(ctx, "DELETE FROM secrets WHERE username = $1", user)
+	_, _ = pool.Exec(ctx, "DELETE FROM tenant_kms_keys WHERE username = $1", user)
+
+	// Write under the shared key first.
+	if _, err := store.Set(ctx, user, "DATABASE_URL", "postgres://before", ""); err != nil {
+		t.Fatalf("Set (shared key): %v", err)
+	}
+
+	tenantKey := "projects/p/locations/l/keyRings/r/cryptoKeys/" + user
+	if err := store.SetTenantKMSKey(ctx, user, tenantKey); err != nil {
+		t.Fatalf("SetTenantKMSKey: %v", err)
+	}
+
+	// The pre-existing secret must still decrypt correctly — proves the
+	// rewrap actually ran, not just that the override was recorded.
+	_, value, err := store.Get(ctx, user, "DATABASE_URL")
+	if err != nil {
+		t.Fatalf("Get after SetTenantKMSKey: %v", err)
+	}
+	if value != "postgres://before" {
+		t.Fatalf("value after rewrap = %q, want %q", value, "postgres://before")
+	}
+
+	// A NEW secret set after the override must land under the tenant
+	// key, not the shared one — check via the raw row's kek_id.
+	if _, err := store.Set(ctx, user, "NEW_SECRET", "after-override", ""); err != nil {
+		t.Fatalf("Set (post-override): %v", err)
+	}
+	var kekID string
+	if err := pool.QueryRow(ctx,
+		`SELECT kek_id FROM secrets WHERE username = $1 AND name = $2`, user, "NEW_SECRET",
+	).Scan(&kekID); err != nil {
+		t.Fatalf("query kek_id: %v", err)
+	}
+	if kekID != corecrypto.GCPKEKPrefix+tenantKey {
+		t.Fatalf("kek_id = %q, want %q (the tenant's own key)", kekID, corecrypto.GCPKEKPrefix+tenantKey)
+	}
+}
+
+func TestSetTenantKMSKey_IsolatesFromOtherTenants(t *testing.T) {
+	// The load-bearing security property: tenant A's key cannot
+	// decrypt tenant B's secret, by construction (wrong AEAD key on
+	// the fake server), not merely by authz.
+	fk := &fakeMultiKeyGCPKMS{t: t}
+	srv := httptest.NewServer(http.HandlerFunc(fk.handle))
+	defer srv.Close()
+
+	factory := newFakeTenantKMSFactory(t, srv)
+	store, pool := newIntegrationStore(t, factory)
+	ctx := context.Background()
+	const userA, userB = "tenant-kms-user-a2", "tenant-kms-user-b2"
+	t.Cleanup(func() {
+		for _, u := range []string{userA, userB} {
+			_, _ = pool.Exec(ctx, "DELETE FROM secrets WHERE username = $1", u)
+			_, _ = pool.Exec(ctx, "DELETE FROM tenant_kms_keys WHERE username = $1", u)
+		}
+	})
+	for _, u := range []string{userA, userB} {
+		_, _ = pool.Exec(ctx, "DELETE FROM secrets WHERE username = $1", u)
+		_, _ = pool.Exec(ctx, "DELETE FROM tenant_kms_keys WHERE username = $1", u)
+	}
+
+	keyA := "projects/p/locations/l/keyRings/r/cryptoKeys/" + userA
+	keyB := "projects/p/locations/l/keyRings/r/cryptoKeys/" + userB
+	if err := store.SetTenantKMSKey(ctx, userA, keyA); err != nil {
+		t.Fatalf("SetTenantKMSKey A: %v", err)
+	}
+	if err := store.SetTenantKMSKey(ctx, userB, keyB); err != nil {
+		t.Fatalf("SetTenantKMSKey B: %v", err)
+	}
+	if _, err := store.Set(ctx, userA, "SECRET", "a-only", ""); err != nil {
+		t.Fatalf("Set A: %v", err)
+	}
+
+	// A's client (already resolved via A's override) reads A's secret fine.
+	if _, value, err := store.Get(ctx, userA, "SECRET"); err != nil || value != "a-only" {
+		t.Fatalf("Get A: value=%q err=%v", value, err)
+	}
+
+	// Simulate "B's key applied to A's ciphertext" directly against the
+	// fake server, the way an attacker (or a bug) reaching for the
+	// wrong key would: fetch A's raw envelope row, then try to Unwrap
+	// its wrapped_dek using B's KMSClient instead of A's.
+	var wrappedDEK []byte
+	if err := pool.QueryRow(ctx,
+		`SELECT wrapped_dek FROM secrets WHERE username = $1 AND name = $2`, userA, "SECRET",
+	).Scan(&wrappedDEK); err != nil {
+		t.Fatalf("query wrapped_dek: %v", err)
+	}
+	bClient, err := factory(keyB)
+	if err != nil {
+		t.Fatalf("build B's client: %v", err)
+	}
+	if _, err := bClient.Unwrap(ctx, wrappedDEK, corecrypto.GCPKEKPrefix+keyA); err == nil {
+		t.Fatal("tenant B's key must NOT be able to unwrap tenant A's DEK, but it succeeded")
+	}
+}
+
+func TestClearTenantKMSKey_RewrapsBackToSharedAndIsIdempotent(t *testing.T) {
+	fk := &fakeMultiKeyGCPKMS{t: t}
+	srv := httptest.NewServer(http.HandlerFunc(fk.handle))
+	defer srv.Close()
+
+	store, pool := newIntegrationStore(t, newFakeTenantKMSFactory(t, srv))
+	ctx := context.Background()
+	const user = "tenant-kms-user-c"
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, "DELETE FROM secrets WHERE username = $1", user)
+		_, _ = pool.Exec(ctx, "DELETE FROM tenant_kms_keys WHERE username = $1", user)
+	})
+	_, _ = pool.Exec(ctx, "DELETE FROM secrets WHERE username = $1", user)
+	_, _ = pool.Exec(ctx, "DELETE FROM tenant_kms_keys WHERE username = $1", user)
+
+	tenantKey := "projects/p/locations/l/keyRings/r/cryptoKeys/" + user
+	if err := store.SetTenantKMSKey(ctx, user, tenantKey); err != nil {
+		t.Fatalf("SetTenantKMSKey: %v", err)
+	}
+	if _, err := store.Set(ctx, user, "API_KEY", "under-tenant-key", ""); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	if err := store.ClearTenantKMSKey(ctx, user); err != nil {
+		t.Fatalf("ClearTenantKMSKey: %v", err)
+	}
+	// Idempotent — clearing an already-cleared tenant must not error.
+	if err := store.ClearTenantKMSKey(ctx, user); err != nil {
+		t.Fatalf("second ClearTenantKMSKey: %v", err)
+	}
+
+	_, value, err := store.Get(ctx, user, "API_KEY")
+	if err != nil {
+		t.Fatalf("Get after clear: %v", err)
+	}
+	if value != "under-tenant-key" {
+		t.Fatalf("value after clear-rewrap = %q, want %q", value, "under-tenant-key")
+	}
+
+	var kekID string
+	if err := pool.QueryRow(ctx,
+		`SELECT kek_id FROM secrets WHERE username = $1 AND name = $2`, user, "API_KEY",
+	).Scan(&kekID); err != nil {
+		t.Fatalf("query kek_id: %v", err)
+	}
+	wantSharedKekID := corecrypto.GCPKEKPrefix + "projects/p/locations/l/keyRings/r/cryptoKeys/shared"
+	if kekID != wantSharedKekID {
+		t.Fatalf("kek_id after clear = %q, want the shared key %q", kekID, wantSharedKekID)
+	}
+
+	var stillOverridden int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM tenant_kms_keys WHERE username = $1`, user,
+	).Scan(&stillOverridden); err != nil {
+		t.Fatalf("query tenant_kms_keys: %v", err)
+	}
+	if stillOverridden != 0 {
+		t.Fatal("tenant_kms_keys row should be gone after clear")
+	}
+}
+
+func TestSetTenantKMSKey_RejectsWhenNoTenantFactoryConfigured(t *testing.T) {
+	store, pool := newIntegrationStore(t, nil)
+	_ = pool
+	if err := store.SetTenantKMSKey(context.Background(), "someone", "projects/p/locations/l/keyRings/r/cryptoKeys/k"); err == nil {
+		t.Fatal("expected an error when the daemon has no per-tenant KMS factory configured")
+	}
+}
+
+func TestLoadTenantKEKCache_SurvivesRestart(t *testing.T) {
+	fk := &fakeMultiKeyGCPKMS{t: t}
+	srv := httptest.NewServer(http.HandlerFunc(fk.handle))
+	defer srv.Close()
+	factory := newFakeTenantKMSFactory(t, srv)
+
+	store, pool := newIntegrationStore(t, factory)
+	ctx := context.Background()
+	const user = "tenant-kms-user-restart"
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, "DELETE FROM secrets WHERE username = $1", user)
+		_, _ = pool.Exec(ctx, "DELETE FROM tenant_kms_keys WHERE username = $1", user)
+	})
+	_, _ = pool.Exec(ctx, "DELETE FROM secrets WHERE username = $1", user)
+	_, _ = pool.Exec(ctx, "DELETE FROM tenant_kms_keys WHERE username = $1", user)
+
+	tenantKey := "projects/p/locations/l/keyRings/r/cryptoKeys/" + user
+	if err := store.SetTenantKMSKey(ctx, user, tenantKey); err != nil {
+		t.Fatalf("SetTenantKMSKey: %v", err)
+	}
+
+	// Simulate a daemon restart: build a brand-new *Store against the
+	// same pool. Its in-memory tenantKEK cache must be re-populated
+	// from tenant_kms_keys, not start empty.
+	key := make([]byte, corecrypto.MasterKeySize)
+	for i := range key {
+		key[i] = byte(i + 1)
+	}
+	cph, err := corecrypto.NewCipher(key)
+	if err != nil {
+		t.Fatalf("NewCipher: %v", err)
+	}
+	shared, err := factory("projects/p/locations/l/keyRings/r/cryptoKeys/shared")
+	if err != nil {
+		t.Fatalf("build shared client: %v", err)
+	}
+	restarted, err := NewStore(ctx, pool, cph, WithKMS(shared), WithTenantKMSFactory(factory))
+	if err != nil {
+		t.Fatalf("NewStore (restart): %v", err)
+	}
+
+	if _, err := restarted.Set(ctx, user, "POST_RESTART", "value", ""); err != nil {
+		t.Fatalf("Set after restart: %v", err)
+	}
+	var kekID string
+	if err := pool.QueryRow(ctx,
+		`SELECT kek_id FROM secrets WHERE username = $1 AND name = $2`, user, "POST_RESTART",
+	).Scan(&kekID); err != nil {
+		t.Fatalf("query kek_id: %v", err)
+	}
+	if kekID != corecrypto.GCPKEKPrefix+tenantKey {
+		t.Fatalf("kek_id after restart = %q, want %q — the tenant override did not survive the restart", kekID, corecrypto.GCPKEKPrefix+tenantKey)
+	}
+}

--- a/internal/secrets/tenant_kms_integration_test.go
+++ b/internal/secrets/tenant_kms_integration_test.go
@@ -391,3 +391,112 @@ func TestLoadTenantKEKCache_SurvivesRestart(t *testing.T) {
 		t.Fatalf("kek_id after restart = %q, want %q — the tenant override did not survive the restart", kekID, corecrypto.GCPKEKPrefix+tenantKey)
 	}
 }
+
+// TestTryRewrapAtVersion_StaleVersionIsNoOp is the deterministic
+// regression test for the CodeRabbit finding on #1631: a rewrap attempt
+// targeting a version that's no longer current must affect zero rows
+// and must NOT touch the row that a concurrent write already produced.
+func TestTryRewrapAtVersion_StaleVersionIsNoOp(t *testing.T) {
+	fk := &fakeMultiKeyGCPKMS{t: t}
+	srv := httptest.NewServer(http.HandlerFunc(fk.handle))
+	defer srv.Close()
+
+	store, pool := newIntegrationStore(t, newFakeTenantKMSFactory(t, srv))
+	ctx := context.Background()
+	const user, name = "tenant-kms-user-race", "API_KEY"
+	t.Cleanup(func() { _, _ = pool.Exec(ctx, "DELETE FROM secrets WHERE username = $1", user) })
+	_, _ = pool.Exec(ctx, "DELETE FROM secrets WHERE username = $1", user)
+
+	meta1, err := store.Set(ctx, user, name, "v1", "")
+	if err != nil {
+		t.Fatalf("initial Set: %v", err)
+	}
+	if meta1.Version != 1 {
+		t.Fatalf("meta1.Version = %d, want 1", meta1.Version)
+	}
+
+	// Simulate rewrapOne having read version 1, then — before it can
+	// write — a real concurrent SetSecret lands, advancing the row to
+	// version 2 with a genuinely new value.
+	if _, err := store.Set(ctx, user, name, "v2-from-concurrent-writer", ""); err != nil {
+		t.Fatalf("concurrent Set: %v", err)
+	}
+
+	// Now attempt the stale rewrap write — as if rewrapOne's read had
+	// happened before the concurrent Set above. It must be rejected
+	// (0 rows affected), not silently applied over the newer value.
+	staleNonce, staleCT, staleWrapped, staleKekID, err := store.encryptForStorage(ctx, user, name, []byte("v1"))
+	if err != nil {
+		t.Fatalf("encryptForStorage: %v", err)
+	}
+	ok, err := store.tryRewrapAtVersion(ctx, user, name, staleNonce, staleCT, staleWrapped, staleKekID, meta1.Version)
+	if err != nil {
+		t.Fatalf("tryRewrapAtVersion: %v", err)
+	}
+	if ok {
+		t.Fatal("tryRewrapAtVersion succeeded against a stale version — it should have been rejected")
+	}
+
+	// The row must still hold the concurrent writer's value, untouched.
+	meta2, value, err := store.Get(ctx, user, name)
+	if err != nil {
+		t.Fatalf("Get after stale attempt: %v", err)
+	}
+	if value != "v2-from-concurrent-writer" {
+		t.Fatalf("value = %q, want the concurrent writer's value — a stale rewrap silently overwrote it", value)
+	}
+	if meta2.Version != 2 {
+		t.Fatalf("version = %d, want 2 — untouched by the rejected rewrap attempt", meta2.Version)
+	}
+}
+
+// TestRewrapOne_RetriesOnceTheRaceClears proves the other half: once
+// there's no more contention, rewrapOne's retry loop succeeds and
+// produces a correctly re-encrypted row under the NEW key — not stuck
+// forever just because a single stale attempt was rejected once.
+func TestRewrapOne_RetriesOnceTheRaceClears(t *testing.T) {
+	fk := &fakeMultiKeyGCPKMS{t: t}
+	srv := httptest.NewServer(http.HandlerFunc(fk.handle))
+	defer srv.Close()
+
+	factory := newFakeTenantKMSFactory(t, srv)
+	store, pool := newIntegrationStore(t, factory)
+	ctx := context.Background()
+	const user, name = "tenant-kms-user-race2", "API_KEY"
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, "DELETE FROM secrets WHERE username = $1", user)
+		_, _ = pool.Exec(ctx, "DELETE FROM tenant_kms_keys WHERE username = $1", user)
+	})
+	_, _ = pool.Exec(ctx, "DELETE FROM secrets WHERE username = $1", user)
+	_, _ = pool.Exec(ctx, "DELETE FROM tenant_kms_keys WHERE username = $1", user)
+
+	if _, err := store.Set(ctx, user, name, "steady-value", ""); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	tenantKey := "projects/p/locations/l/keyRings/r/cryptoKeys/" + user
+	if err := store.SetTenantKMSKey(ctx, user, tenantKey); err != nil {
+		t.Fatalf("SetTenantKMSKey: %v", err)
+	}
+
+	meta, value, err := store.Get(ctx, user, name)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if value != "steady-value" {
+		t.Fatalf("value = %q, want steady-value", value)
+	}
+	if meta.Version != 1 {
+		t.Fatalf("version = %d, want 1 — a successful rewrap must not bump version (it's not a value change)", meta.Version)
+	}
+
+	var kekID string
+	if err := pool.QueryRow(ctx,
+		`SELECT kek_id FROM secrets WHERE username = $1 AND name = $2`, user, name,
+	).Scan(&kekID); err != nil {
+		t.Fatalf("query kek_id: %v", err)
+	}
+	if kekID != corecrypto.GCPKEKPrefix+tenantKey {
+		t.Fatalf("kek_id = %q, want %q", kekID, corecrypto.GCPKEKPrefix+tenantKey)
+	}
+}

--- a/internal/secrets/tenant_kms_test.go
+++ b/internal/secrets/tenant_kms_test.go
@@ -1,0 +1,238 @@
+package secrets
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/footprintai/containarium/internal/safecast"
+	corecrypto "github.com/footprintai/containarium/pkg/core/secrets"
+)
+
+// #1630 — per-tenant KEK dispatch. These tests avoid Postgres entirely
+// (same discipline as envelope_dispatch_test.go): they construct a
+// *Store literal directly and exercise resolveEncryptKMS /
+// resolveDecryptKMS / kekClient, which are pure in-memory + factory
+// logic. SetTenantKMSKey / ClearTenantKMSKey / rewrapTenant need a real
+// Postgres (they call List/Get/Set) — those live in
+// tenant_kms_integration_test.go, gated on CONTAINARIUM_TEST_DSN like
+// the rest of the Postgres-backed suite.
+
+// fakeTenantKMS is a KMSClient double whose kek_id is settable per
+// instance, so tests can prove "this exact client" was chosen rather
+// than merely "a client was chosen." Wrap/Unwrap are otherwise
+// pass-through (XOR with a per-instance byte) — enough to prove a
+// value only round-trips through the SAME instance, catching a
+// resolver that returns the wrong client for decrypt.
+type fakeTenantKMS struct {
+	kekID   string
+	tweak   byte
+	wrapErr error
+}
+
+func (f *fakeTenantKMS) Wrap(_ context.Context, dek []byte) ([]byte, string, error) {
+	if f.wrapErr != nil {
+		return nil, "", f.wrapErr
+	}
+	out := make([]byte, len(dek))
+	for i, b := range dek {
+		out[i] = b ^ f.tweak
+	}
+	return out, f.kekID, nil
+}
+
+func (f *fakeTenantKMS) Unwrap(_ context.Context, wrapped []byte, kekID string) ([]byte, error) {
+	if kekID != f.kekID {
+		return nil, errors.New("fakeTenantKMS: kek_id mismatch — wrong client selected")
+	}
+	out := make([]byte, len(wrapped))
+	for i, b := range wrapped {
+		out[i] = b ^ f.tweak
+	}
+	return out, nil
+}
+
+func newFakeFactory(t *testing.T, built map[string]int) TenantKMSFactory {
+	t.Helper()
+	return func(keyResourceName string) (corecrypto.KMSClient, error) {
+		if keyResourceName == "bad-key" {
+			return nil, errors.New("fake: malformed key")
+		}
+		built[keyResourceName]++
+		// Deterministic per-key tweak byte so different keys are
+		// distinguishable but the same key always builds an
+		// equivalent (thought not necessarily identical, since the
+		// cache should prevent rebuilding) client.
+		return &fakeTenantKMS{kekID: corecrypto.GCPKEKPrefix + keyResourceName, tweak: safecast.U8(len(keyResourceName))}, nil
+	}
+}
+
+func TestResolveEncryptKMS_NoFactory_UsesSharedDefault(t *testing.T) {
+	shared := &fakeTenantKMS{kekID: "shared"}
+	s := &Store{kms: shared}
+	got, err := s.resolveEncryptKMS("alice")
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if got != shared {
+		t.Fatal("expected the shared client when no tenant factory is configured")
+	}
+}
+
+func TestResolveEncryptKMS_NoOverride_UsesSharedDefault(t *testing.T) {
+	shared := &fakeTenantKMS{kekID: "shared"}
+	built := map[string]int{}
+	s := &Store{
+		kms:              shared,
+		tenantKMSFactory: newFakeFactory(t, built),
+		tenantKEK:        map[string]string{},
+		kekClients:       map[string]corecrypto.KMSClient{},
+	}
+	got, err := s.resolveEncryptKMS("alice")
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if got != shared {
+		t.Fatal("alice has no override — must resolve to the shared client")
+	}
+	if len(built) != 0 {
+		t.Fatal("must not build a tenant client when there's no override to serve")
+	}
+}
+
+func TestResolveEncryptKMS_WithOverride_BuildsAndCachesTenantClient(t *testing.T) {
+	shared := &fakeTenantKMS{kekID: "shared"}
+	built := map[string]int{}
+	s := &Store{
+		kms:              shared,
+		tenantKMSFactory: newFakeFactory(t, built),
+		tenantKEK:        map[string]string{"alice": "tenant-key-a"},
+		kekClients:       map[string]corecrypto.KMSClient{},
+	}
+	got, err := s.resolveEncryptKMS("alice")
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if got == shared {
+		t.Fatal("alice has an override — must NOT resolve to the shared client")
+	}
+	if built["tenant-key-a"] != 1 {
+		t.Fatalf("expected the factory called once for tenant-key-a; got %d", built["tenant-key-a"])
+	}
+
+	// Bob has no override and must be unaffected by alice's.
+	bobClient, err := s.resolveEncryptKMS("bob")
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if bobClient != shared {
+		t.Fatal("bob has no override — must resolve to the shared client, independent of alice's")
+	}
+
+	// A second resolve for alice must reuse the cached client, not
+	// rebuild it.
+	again, err := s.resolveEncryptKMS("alice")
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if again != got {
+		t.Fatal("expected the SAME cached client instance on a second resolve")
+	}
+	if built["tenant-key-a"] != 1 {
+		t.Fatalf("expected the factory still called exactly once; got %d calls", built["tenant-key-a"])
+	}
+}
+
+func TestResolveEncryptKMS_FactoryErrorPropagates(t *testing.T) {
+	built := map[string]int{}
+	s := &Store{
+		tenantKMSFactory: newFakeFactory(t, built),
+		tenantKEK:        map[string]string{"alice": "bad-key"},
+		kekClients:       map[string]corecrypto.KMSClient{},
+	}
+	if _, err := s.resolveEncryptKMS("alice"); err == nil {
+		t.Fatal("expected the factory's error to propagate")
+	}
+}
+
+func TestResolveDecryptKMS_GCPRowRoutesByKeyNameNotByCurrentOverride(t *testing.T) {
+	// The load-bearing property from the design doc: decrypt is
+	// resolved from the ROW's own kek_id, never from "whatever the
+	// tenant's override currently is." Simulate the exact scenario
+	// that would break a naive "resolve by current override" design:
+	// alice's override has already moved to key B, but a row still
+	// carries key A's kek_id — it must still decrypt correctly.
+	built := map[string]int{}
+	s := &Store{
+		kms:              &fakeTenantKMS{kekID: "shared"},
+		tenantKMSFactory: newFakeFactory(t, built),
+		tenantKEK:        map[string]string{"alice": "key-b"}, // current override says B
+		kekClients:       map[string]corecrypto.KMSClient{},
+	}
+
+	// Row was wrapped under key A (kek_id = "gcp:key-a") — resolve
+	// must build/return A's client, not B's, regardless of alice's
+	// current override.
+	client, err := s.resolveDecryptKMS(corecrypto.GCPKEKPrefix + "key-a")
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	fk, ok := client.(*fakeTenantKMS)
+	if !ok || fk.kekID != corecrypto.GCPKEKPrefix+"key-a" {
+		t.Fatalf("resolved client kek_id = %v; want %s", client, corecrypto.GCPKEKPrefix+"key-a")
+	}
+}
+
+func TestResolveDecryptKMS_NonGCPKekIDFallsBackToShared(t *testing.T) {
+	shared := &fakeTenantKMS{kekID: "inproc:master"}
+	built := map[string]int{}
+	s := &Store{
+		kms:              shared,
+		tenantKMSFactory: newFakeFactory(t, built),
+		kekClients:       map[string]corecrypto.KMSClient{},
+	}
+	got, err := s.resolveDecryptKMS("inproc:master")
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if got != shared {
+		t.Fatal("a non-gcp-prefixed kek_id must fall back to the shared client")
+	}
+	if len(built) != 0 {
+		t.Fatal("must not consult the tenant factory for a non-gcp row")
+	}
+}
+
+func TestResolveDecryptKMS_NoFactoryConfigured_AlwaysSharedClient(t *testing.T) {
+	shared := &fakeTenantKMS{kekID: "gcp:whatever"}
+	s := &Store{kms: shared}
+	got, err := s.resolveDecryptKMS("gcp:some-other-key")
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if got != shared {
+		t.Fatal("with no tenant factory configured, every row must resolve to the shared client (today's behavior, unchanged)")
+	}
+}
+
+func TestKEKClient_CachesAcrossCallsForTheSameKey(t *testing.T) {
+	built := map[string]int{}
+	s := &Store{
+		tenantKMSFactory: newFakeFactory(t, built),
+		kekClients:       map[string]corecrypto.KMSClient{},
+	}
+	a, err := s.kekClient("key-x")
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	b, err := s.kekClient("key-x")
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if a != b {
+		t.Fatal("expected the cached instance on the second call")
+	}
+	if built["key-x"] != 1 {
+		t.Fatalf("factory should be called exactly once; got %d", built["key-x"])
+	}
+}

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -835,6 +835,16 @@ func NewDualServer(config *DualServerConfig) (*DualServer, error) {
 							kms = nil
 							kdesc = "disabled (config error)"
 						}
+						// #1630 — per-tenant KEK factory, only non-nil
+						// when CONTAINARIUM_KMS_BACKEND=gcp. A config
+						// error here degrades the SAME way the shared
+						// client does: log and disable, don't fail the
+						// whole secrets store over it.
+						tenantKMSFactory, tkerr := secretsstore.LoadTenantKMSFactory()
+						if tkerr != nil {
+							log.Printf("Warning: per-tenant KMS factory config error: %v. SetTenantKMSKey will be unavailable.", tkerr)
+							tenantKMSFactory = nil
+						}
 						// Phase 4.1 Phase-E — master-key retirement
 						// gate. CONTAINARIUM_REQUIRE_ENVELOPE=true
 						// means every decrypt must go through KMS;
@@ -858,6 +868,9 @@ func NewDualServer(config *DualServerConfig) (*DualServer, error) {
 							}
 							if requireEnvelope {
 								opts = append(opts, secretsstore.WithRequireEnvelope(true))
+							}
+							if tenantKMSFactory != nil {
+								opts = append(opts, secretsstore.WithTenantKMSFactory(tenantKMSFactory))
 							}
 							if store, serr := secretsstore.NewStore(context.Background(), secretsPool, cipher, opts...); serr != nil {
 								log.Printf("Warning: Failed to init secrets store: %v. Secrets disabled.", serr)

--- a/internal/server/secrets_kms_key_test.go
+++ b/internal/server/secrets_kms_key_test.go
@@ -33,8 +33,17 @@ func kmsKeyTestCtx(username, roles, scopes string) context.Context {
 	return metadata.NewIncomingContext(context.Background(), metadata.Pairs(pairs...))
 }
 
+// These three denial tests use an UNCONFIGURED server (nil secretsStore,
+// on purpose): the auth checks run BEFORE the store/argument checks, so
+// an unauthenticated or under-privileged caller is denied without ever
+// touching Postgres — and without an unauthenticated caller being able
+// to learn whether this daemon even has a secrets store configured.
+// (CodeRabbit finding on #1631: the first version of this handler
+// checked the store first, which both leaked that distinction and
+// forced every authz test onto CONTAINARIUM_TEST_DSN.)
+
 func TestSetTenantKMSKey_NoAuthContext(t *testing.T) {
-	s := &ContainerServer{secretsStore: mustTestSecretsStore(t)}
+	s := &ContainerServer{}
 	_, err := s.SetTenantKMSKey(context.Background(),
 		&pb.SetTenantKMSKeyRequest{Username: "alice", KekResourceName: "k"})
 	if status.Code(err) != codes.Unauthenticated {
@@ -43,7 +52,7 @@ func TestSetTenantKMSKey_NoAuthContext(t *testing.T) {
 }
 
 func TestSetTenantKMSKey_NonAdminDenied(t *testing.T) {
-	s := &ContainerServer{secretsStore: mustTestSecretsStore(t)}
+	s := &ContainerServer{}
 	ctx := kmsKeyTestCtx("alice", "member", "secrets:write")
 	_, err := s.SetTenantKMSKey(ctx, &pb.SetTenantKMSKeyRequest{Username: "alice", KekResourceName: "k"})
 	if status.Code(err) != codes.PermissionDenied {
@@ -56,7 +65,7 @@ func TestSetTenantKMSKey_AdminWithoutExplicitScopeDenied(t *testing.T) {
 	// token must NOT be enough, even for changing its own tenant's
 	// key — this is a privileged operation with no self-access
 	// exception (see the handler's doc comment).
-	s := &ContainerServer{secretsStore: mustTestSecretsStore(t)}
+	s := &ContainerServer{}
 	ctx := kmsKeyTestCtx("cloud-daemon", "admin", "")
 	_, err := s.SetTenantKMSKey(ctx, &pb.SetTenantKMSKeyRequest{Username: "cloud-daemon", KekResourceName: "k"})
 	if status.Code(err) != codes.PermissionDenied {

--- a/internal/server/secrets_kms_key_test.go
+++ b/internal/server/secrets_kms_key_test.go
@@ -1,0 +1,133 @@
+package server
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/internal/secrets"
+	corecrypto "github.com/footprintai/containarium/pkg/core/secrets"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// #1630 — SetTenantKMSKey's authz is deliberately NOT
+// AuthorizeSecretTenant's self-access-exempt shape: admin role +
+// explicit secrets:write scope are required unconditionally, even when
+// the caller's own subject equals the requested username. These tests
+// pin that directly, mirroring internal/auth/secrets_authz_test.go's
+// context-construction convention (metadata.NewIncomingContext with the
+// same MD keys) since SetTenantKMSKey doesn't route through
+// AuthorizeSecretTenant at all.
+
+func kmsKeyTestCtx(username, roles, scopes string) context.Context {
+	pairs := []string{auth.MDKeyUsername, username, auth.MDKeyRoles, roles}
+	if scopes != "" {
+		pairs = append(pairs, auth.MDKeyScopes, scopes)
+	}
+	return metadata.NewIncomingContext(context.Background(), metadata.Pairs(pairs...))
+}
+
+func TestSetTenantKMSKey_NoAuthContext(t *testing.T) {
+	s := &ContainerServer{secretsStore: mustTestSecretsStore(t)}
+	_, err := s.SetTenantKMSKey(context.Background(),
+		&pb.SetTenantKMSKeyRequest{Username: "alice", KekResourceName: "k"})
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("code = %v, want Unauthenticated", status.Code(err))
+	}
+}
+
+func TestSetTenantKMSKey_NonAdminDenied(t *testing.T) {
+	s := &ContainerServer{secretsStore: mustTestSecretsStore(t)}
+	ctx := kmsKeyTestCtx("alice", "member", "secrets:write")
+	_, err := s.SetTenantKMSKey(ctx, &pb.SetTenantKMSKeyRequest{Username: "alice", KekResourceName: "k"})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("code = %v, want PermissionDenied", status.Code(err))
+	}
+}
+
+func TestSetTenantKMSKey_AdminWithoutExplicitScopeDenied(t *testing.T) {
+	// The composition this RPC exists to avoid: an unscoped admin
+	// token must NOT be enough, even for changing its own tenant's
+	// key — this is a privileged operation with no self-access
+	// exception (see the handler's doc comment).
+	s := &ContainerServer{secretsStore: mustTestSecretsStore(t)}
+	ctx := kmsKeyTestCtx("cloud-daemon", "admin", "")
+	_, err := s.SetTenantKMSKey(ctx, &pb.SetTenantKMSKeyRequest{Username: "cloud-daemon", KekResourceName: "k"})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("code = %v, want PermissionDenied", status.Code(err))
+	}
+}
+
+func TestSetTenantKMSKey_AdminWithExplicitScopeAllowed(t *testing.T) {
+	s := &ContainerServer{secretsStore: mustTestSecretsStore(t)}
+	ctx := kmsKeyTestCtx("cloud-daemon", "admin", "secrets:write")
+
+	// No tenant factory wired on this store (no CONTAINARIUM_KMS_BACKEND=gcp
+	// in this test process) — the authz gate must be satisfied and the
+	// request must reach the store, which then reports the real
+	// FailedPrecondition rather than PermissionDenied.
+	_, err := s.SetTenantKMSKey(ctx, &pb.SetTenantKMSKeyRequest{
+		Username: "authz-ok-user", KekResourceName: "projects/p/locations/l/keyRings/r/cryptoKeys/k",
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("code = %v, want FailedPrecondition (authz passed, store correctly refused — no gcp backend configured)", status.Code(err))
+	}
+}
+
+func TestSetTenantKMSKey_StoreNotConfigured(t *testing.T) {
+	s := &ContainerServer{} // secretsStore left nil — --standalone daemon
+	ctx := kmsKeyTestCtx("cloud-daemon", "admin", "secrets:write")
+	_, err := s.SetTenantKMSKey(ctx, &pb.SetTenantKMSKeyRequest{Username: "alice", KekResourceName: "k"})
+	if status.Code(err) != codes.Unavailable {
+		t.Fatalf("code = %v, want Unavailable", status.Code(err))
+	}
+}
+
+func TestSetTenantKMSKey_RequiresUsername(t *testing.T) {
+	s := &ContainerServer{secretsStore: mustTestSecretsStore(t)}
+	ctx := kmsKeyTestCtx("cloud-daemon", "admin", "secrets:write")
+	_, err := s.SetTenantKMSKey(ctx, &pb.SetTenantKMSKeyRequest{Username: "", KekResourceName: "k"})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("code = %v, want InvalidArgument", status.Code(err))
+	}
+}
+
+// mustTestSecretsStore returns a real Store against CONTAINARIUM_TEST_DSN,
+// skipping the test if it isn't set — same convention as
+// internal/secrets' own Postgres-gated tests. secrets.Store is a
+// concrete struct (correctly — the RPCs are the interface boundary),
+// so there's no lighter-weight fake to construct here; every test in
+// this file needs a real Store to get past the server's nil-store
+// check regardless of which code path it's actually exercising.
+func mustTestSecretsStore(t *testing.T) *secrets.Store {
+	t.Helper()
+	dsn := os.Getenv("CONTAINARIUM_TEST_DSN")
+	if dsn == "" {
+		t.Skip("set CONTAINARIUM_TEST_DSN to run this against Postgres")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect Postgres: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	key := make([]byte, corecrypto.MasterKeySize)
+	for i := range key {
+		key[i] = byte(i + 1)
+	}
+	cph, err := corecrypto.NewCipher(key)
+	if err != nil {
+		t.Fatalf("NewCipher: %v", err)
+	}
+	store, err := secrets.NewStore(ctx, pool, cph)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	return store
+}

--- a/internal/server/secrets_server.go
+++ b/internal/server/secrets_server.go
@@ -179,6 +179,58 @@ func (s *ContainerServer) RefreshSecrets(ctx context.Context, req *pb.RefreshSec
 	}, nil
 }
 
+// SetTenantKMSKey sets or clears a tenant's per-tenant KEK for secrets
+// envelope encryption, re-wrapping their existing secrets (#1630).
+//
+// Unlike every other RPC in this file, this does NOT use
+// AuthorizeSecretTenant's self-access exception: admin role + the
+// secrets:write scope granted EXPLICITLY on the token are required
+// unconditionally, even when the caller's own subject happens to equal
+// req.Username. Changing which key encrypts a tenant's secrets is a
+// privileged operation performed on a tenant's behalf in this
+// platform's actual usage (the cloud control plane, not the tenant
+// itself) — see SetTenantKMSKeyRequest's proto comment.
+func (s *ContainerServer) SetTenantKMSKey(ctx context.Context, req *pb.SetTenantKMSKeyRequest) (*pb.SetTenantKMSKeyResponse, error) {
+	if s.secretsStore == nil {
+		return nil, status.Error(codes.Unavailable, "secrets store not configured on this daemon")
+	}
+	if req.Username == "" {
+		return nil, status.Error(codes.InvalidArgument, "username is required")
+	}
+	_, roles, ok := auth.SubjectFromGRPCContext(ctx)
+	if !ok {
+		return nil, status.Error(codes.Unauthenticated, "no authenticated subject in request context")
+	}
+	if !auth.HasRole(roles, auth.RoleAdmin) {
+		return nil, status.Error(codes.PermissionDenied, "SetTenantKMSKey requires the admin role")
+	}
+	scopes, _ := auth.ScopesFromGRPCContext(ctx)
+	if !auth.HasExplicitScope(scopes, auth.ScopeSecretsWrite) {
+		return nil, status.Error(codes.PermissionDenied,
+			"SetTenantKMSKey requires the "+auth.ScopeSecretsWrite+
+				" scope to be granted explicitly on this token; the admin role alone does not imply it "+
+				"(re-mint with `containarium token generate --scopes "+auth.ScopeSecretsWrite+" ...`)")
+	}
+
+	if err := s.secretsStore.SetTenantKMSKey(ctx, req.Username, req.KekResourceName); err != nil {
+		return nil, mapSecretError(err)
+	}
+
+	hasTenantKey := req.KekResourceName != ""
+	msg := fmt.Sprintf("tenant %s reverted to the shared KEK", req.Username)
+	if hasTenantKey {
+		msg = fmt.Sprintf("tenant %s now on its own KMS key", req.Username)
+	}
+	// Audit. Never log the key resource name's full path isn't
+	// sensitive (GCP resource names aren't secrets), but keep the log
+	// line's shape consistent with the other secrets RPCs regardless.
+	log.Printf("[secrets] set-tenant-kms-key %s has_tenant_key=%v", req.Username, hasTenantKey)
+	return &pb.SetTenantKMSKeyResponse{
+		Message:      msg,
+		HasTenantKey: hasTenantKey,
+	}, nil
+}
+
 // stampSecretsOnLXC reads every secret owned by `username`,
 // decrypts, and `incus config set environment.<NAME>=<value>`s
 // each one onto `<username>-container`. Used by RefreshSecrets
@@ -323,10 +375,13 @@ func (s *ContainerServer) stampSecretsOnLXC(ctx context.Context, username string
 }
 
 // mapSecretError maps store errors to gRPC status codes. Centralized
-// so the five RPC methods stay short.
+// so the RPC methods in this file stay short.
 func mapSecretError(err error) error {
 	if errors.Is(err, secrets.ErrNotFound) {
 		return status.Error(codes.NotFound, "secret not found")
+	}
+	if errors.Is(err, secrets.ErrTenantKMSNotSupported) {
+		return status.Error(codes.FailedPrecondition, err.Error())
 	}
 	// pkg/core/secrets validation errors carry the right message for
 	// the caller — surface as InvalidArgument.

--- a/internal/server/secrets_server.go
+++ b/internal/server/secrets_server.go
@@ -191,12 +191,10 @@ func (s *ContainerServer) RefreshSecrets(ctx context.Context, req *pb.RefreshSec
 // platform's actual usage (the cloud control plane, not the tenant
 // itself) — see SetTenantKMSKeyRequest's proto comment.
 func (s *ContainerServer) SetTenantKMSKey(ctx context.Context, req *pb.SetTenantKMSKeyRequest) (*pb.SetTenantKMSKeyResponse, error) {
-	if s.secretsStore == nil {
-		return nil, status.Error(codes.Unavailable, "secrets store not configured on this daemon")
-	}
-	if req.Username == "" {
-		return nil, status.Error(codes.InvalidArgument, "username is required")
-	}
+	// Auth runs FIRST, before the store/argument checks below — an
+	// unauthenticated or under-privileged caller must not be able to
+	// learn whether this daemon even has a secrets store configured,
+	// or probe argument validation (CodeRabbit finding on #1631).
 	_, roles, ok := auth.SubjectFromGRPCContext(ctx)
 	if !ok {
 		return nil, status.Error(codes.Unauthenticated, "no authenticated subject in request context")
@@ -210,6 +208,13 @@ func (s *ContainerServer) SetTenantKMSKey(ctx context.Context, req *pb.SetTenant
 			"SetTenantKMSKey requires the "+auth.ScopeSecretsWrite+
 				" scope to be granted explicitly on this token; the admin role alone does not imply it "+
 				"(re-mint with `containarium token generate --scopes "+auth.ScopeSecretsWrite+" ...`)")
+	}
+
+	if s.secretsStore == nil {
+		return nil, status.Error(codes.Unavailable, "secrets store not configured on this daemon")
+	}
+	if req.Username == "" {
+		return nil, status.Error(codes.InvalidArgument, "username is required")
 	}
 
 	if err := s.secretsStore.SetTenantKMSKey(ctx, req.Username, req.KekResourceName); err != nil {

--- a/pkg/core/secrets/kms_gcp.go
+++ b/pkg/core/secrets/kms_gcp.go
@@ -104,11 +104,14 @@ type GCPKMS struct {
 	cachedAt  time.Time
 }
 
-// gcpKEKPrefix labels a kek_id as "wrap was done by GCP
+// GCPKEKPrefix labels a kek_id as "wrap was done by GCP
 // Cloud KMS." Future readers (an operator who migrated
 // from GCP to Vault, for instance) refuse rows that don't
-// match their backend's prefix.
-const gcpKEKPrefix = "gcp:"
+// match their backend's prefix. Exported so callers outside this
+// package (internal/secrets.Store's per-tenant KEK dispatch, #1630)
+// can parse a kek_id's key resource name back out without duplicating
+// the literal.
+const GCPKEKPrefix = "gcp:"
 
 // gcpDefaultEndpoint is the public Cloud KMS endpoint.
 // Override via GCPConfig.Endpoint for private endpoints
@@ -150,7 +153,7 @@ func NewGCPKMS(cfg GCPConfig) (*GCPKMS, error) {
 	// Rows wrapped under different keys (or different
 	// projects) get distinct kek_ids; cross-deployment
 	// confusion is structurally impossible.
-	kekID := gcpKEKPrefix + cfg.KeyName
+	kekID := GCPKEKPrefix + cfg.KeyName
 	return &GCPKMS{
 		cfg:    cfg,
 		client: &http.Client{Timeout: cfg.Timeout},
@@ -192,8 +195,8 @@ func (g *GCPKMS) Wrap(ctx context.Context, plaintextDEK []byte) ([]byte, string,
 // rather than spending a Cloud KMS call on a guaranteed
 // mismatch.
 func (g *GCPKMS) Unwrap(ctx context.Context, wrappedDEK []byte, kekID string) ([]byte, error) {
-	if !strings.HasPrefix(kekID, gcpKEKPrefix) {
-		return nil, fmt.Errorf("GCPKMS: refusing to unwrap row whose kek_id=%q (no %q prefix)", kekID, gcpKEKPrefix)
+	if !strings.HasPrefix(kekID, GCPKEKPrefix) {
+		return nil, fmt.Errorf("GCPKMS: refusing to unwrap row whose kek_id=%q (no %q prefix)", kekID, GCPKEKPrefix)
 	}
 	body := map[string]string{
 		"ciphertext": string(wrappedDEK),

--- a/pkg/pb/containarium/v1/secrets.pb.go
+++ b/pkg/pb/containarium/v1/secrets.pb.go
@@ -768,6 +768,133 @@ func (x *RefreshSecretsResponse) GetStamped() int32 {
 	return 0
 }
 
+// SetTenantKMSKeyRequest sets or clears a tenant's per-tenant KEK for
+// secrets envelope encryption. This is a privileged, admin-only
+// operation performed ON BEHALF OF a tenant — unlike SetSecret/GetSecret,
+// it always requires the admin role and an explicitly granted
+// secrets:write scope, even when the caller's own subject equals
+// username, because changing which key encrypts a tenant's secrets is
+// not something a tenant does to itself in the platform's actual usage.
+type SetTenantKMSKeyRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Username (tenant) whose KEK to set or clear.
+	Username string `protobuf:"bytes,1,opt,name=username,proto3" json:"username,omitempty"`
+	// GCP Cloud KMS CryptoKey resource name
+	// (projects/P/locations/L/keyRings/R/cryptoKeys/K) that this tenant's
+	// secrets will be wrapped under going forward. The daemon re-wraps
+	// every existing secret the tenant owns under this key.
+	//
+	// Empty clears the override: existing secrets are re-wrapped back
+	// under the daemon's shared KEK (CONTAINARIUM_GCP_KMS_KEY_NAME)
+	// before the tenant's own key can be invalidated by whoever manages
+	// it upstream.
+	//
+	// Requires CONTAINARIUM_KMS_BACKEND=gcp — per-tenant keys are not
+	// yet supported for the vault/aws/inproc backends.
+	KekResourceName string `protobuf:"bytes,2,opt,name=kek_resource_name,json=kekResourceName,proto3" json:"kek_resource_name,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *SetTenantKMSKeyRequest) Reset() {
+	*x = SetTenantKMSKeyRequest{}
+	mi := &file_containarium_v1_secrets_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetTenantKMSKeyRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetTenantKMSKeyRequest) ProtoMessage() {}
+
+func (x *SetTenantKMSKeyRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_secrets_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetTenantKMSKeyRequest.ProtoReflect.Descriptor instead.
+func (*SetTenantKMSKeyRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_secrets_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *SetTenantKMSKeyRequest) GetUsername() string {
+	if x != nil {
+		return x.Username
+	}
+	return ""
+}
+
+func (x *SetTenantKMSKeyRequest) GetKekResourceName() string {
+	if x != nil {
+		return x.KekResourceName
+	}
+	return ""
+}
+
+type SetTenantKMSKeyResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Operator-facing summary, including how many secrets were re-wrapped.
+	Message string `protobuf:"bytes,1,opt,name=message,proto3" json:"message,omitempty"`
+	// True if the tenant now has a per-tenant key (kek_resource_name was
+	// non-empty in the request); false if cleared back to the shared KEK.
+	HasTenantKey  bool `protobuf:"varint,2,opt,name=has_tenant_key,json=hasTenantKey,proto3" json:"has_tenant_key,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetTenantKMSKeyResponse) Reset() {
+	*x = SetTenantKMSKeyResponse{}
+	mi := &file_containarium_v1_secrets_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetTenantKMSKeyResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetTenantKMSKeyResponse) ProtoMessage() {}
+
+func (x *SetTenantKMSKeyResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_secrets_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetTenantKMSKeyResponse.ProtoReflect.Descriptor instead.
+func (*SetTenantKMSKeyResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_secrets_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *SetTenantKMSKeyResponse) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+func (x *SetTenantKMSKeyResponse) GetHasTenantKey() bool {
+	if x != nil {
+		return x.HasTenantKey
+	}
+	return false
+}
+
 var File_containarium_v1_secrets_proto protoreflect.FileDescriptor
 
 const file_containarium_v1_secrets_proto_rawDesc = "" +
@@ -811,7 +938,13 @@ const file_containarium_v1_secrets_proto_rawDesc = "" +
 	"\busername\x18\x01 \x01(\tR\busername\"L\n" +
 	"\x16RefreshSecretsResponse\x12\x18\n" +
 	"\amessage\x18\x01 \x01(\tR\amessage\x12\x18\n" +
-	"\astamped\x18\x02 \x01(\x05R\astamped*\x81\x01\n" +
+	"\astamped\x18\x02 \x01(\x05R\astamped\"`\n" +
+	"\x16SetTenantKMSKeyRequest\x12\x1a\n" +
+	"\busername\x18\x01 \x01(\tR\busername\x12*\n" +
+	"\x11kek_resource_name\x18\x02 \x01(\tR\x0fkekResourceName\"Y\n" +
+	"\x17SetTenantKMSKeyResponse\x12\x18\n" +
+	"\amessage\x18\x01 \x01(\tR\amessage\x12$\n" +
+	"\x0ehas_tenant_key\x18\x02 \x01(\bR\fhasTenantKey*\x81\x01\n" +
 	"\x0eSecretDelivery\x12\x1f\n" +
 	"\x1bSECRET_DELIVERY_UNSPECIFIED\x10\x00\x12\x17\n" +
 	"\x13SECRET_DELIVERY_ENV\x10\x01\x12\x18\n" +
@@ -831,20 +964,22 @@ func file_containarium_v1_secrets_proto_rawDescGZIP() []byte {
 }
 
 var file_containarium_v1_secrets_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_containarium_v1_secrets_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
+var file_containarium_v1_secrets_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
 var file_containarium_v1_secrets_proto_goTypes = []any{
-	(SecretDelivery)(0),            // 0: containarium.v1.SecretDelivery
-	(*SecretMetadata)(nil),         // 1: containarium.v1.SecretMetadata
-	(*SetSecretRequest)(nil),       // 2: containarium.v1.SetSecretRequest
-	(*SetSecretResponse)(nil),      // 3: containarium.v1.SetSecretResponse
-	(*GetSecretRequest)(nil),       // 4: containarium.v1.GetSecretRequest
-	(*GetSecretResponse)(nil),      // 5: containarium.v1.GetSecretResponse
-	(*ListSecretsRequest)(nil),     // 6: containarium.v1.ListSecretsRequest
-	(*ListSecretsResponse)(nil),    // 7: containarium.v1.ListSecretsResponse
-	(*DeleteSecretRequest)(nil),    // 8: containarium.v1.DeleteSecretRequest
-	(*DeleteSecretResponse)(nil),   // 9: containarium.v1.DeleteSecretResponse
-	(*RefreshSecretsRequest)(nil),  // 10: containarium.v1.RefreshSecretsRequest
-	(*RefreshSecretsResponse)(nil), // 11: containarium.v1.RefreshSecretsResponse
+	(SecretDelivery)(0),             // 0: containarium.v1.SecretDelivery
+	(*SecretMetadata)(nil),          // 1: containarium.v1.SecretMetadata
+	(*SetSecretRequest)(nil),        // 2: containarium.v1.SetSecretRequest
+	(*SetSecretResponse)(nil),       // 3: containarium.v1.SetSecretResponse
+	(*GetSecretRequest)(nil),        // 4: containarium.v1.GetSecretRequest
+	(*GetSecretResponse)(nil),       // 5: containarium.v1.GetSecretResponse
+	(*ListSecretsRequest)(nil),      // 6: containarium.v1.ListSecretsRequest
+	(*ListSecretsResponse)(nil),     // 7: containarium.v1.ListSecretsResponse
+	(*DeleteSecretRequest)(nil),     // 8: containarium.v1.DeleteSecretRequest
+	(*DeleteSecretResponse)(nil),    // 9: containarium.v1.DeleteSecretResponse
+	(*RefreshSecretsRequest)(nil),   // 10: containarium.v1.RefreshSecretsRequest
+	(*RefreshSecretsResponse)(nil),  // 11: containarium.v1.RefreshSecretsResponse
+	(*SetTenantKMSKeyRequest)(nil),  // 12: containarium.v1.SetTenantKMSKeyRequest
+	(*SetTenantKMSKeyResponse)(nil), // 13: containarium.v1.SetTenantKMSKeyResponse
 }
 var file_containarium_v1_secrets_proto_depIdxs = []int32{
 	0, // 0: containarium.v1.SecretMetadata.delivery_mode:type_name -> containarium.v1.SecretDelivery
@@ -870,7 +1005,7 @@ func file_containarium_v1_secrets_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_v1_secrets_proto_rawDesc), len(file_containarium_v1_secrets_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   11,
+			NumMessages:   13,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/pb/containarium/v1/service.pb.go
+++ b/pkg/pb/containarium/v1/service.pb.go
@@ -26,7 +26,7 @@ var File_containarium_v1_service_proto protoreflect.FileDescriptor
 
 const file_containarium_v1_service_proto_rawDesc = "" +
 	"\n" +
-	"\x1dcontainarium/v1/service.proto\x12\x0fcontainarium.v1\x1a\x1fcontainarium/v1/container.proto\x1a\x1ccontainarium/v1/config.proto\x1a\x19containarium/v1/app.proto\x1a\x1dcontainarium/v1/network.proto\x1a\x1bcontainarium/v1/alert.proto\x1a\x1dcontainarium/v1/secrets.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto2ҫ\x01\n" +
+	"\x1dcontainarium/v1/service.proto\x12\x0fcontainarium.v1\x1a\x1fcontainarium/v1/container.proto\x1a\x1ccontainarium/v1/config.proto\x1a\x19containarium/v1/app.proto\x1a\x1dcontainarium/v1/network.proto\x1a\x1bcontainarium/v1/alert.proto\x1a\x1dcontainarium/v1/secrets.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto2\x90\xaf\x01\n" +
 	"\x10ContainerService\x12\xae\x02\n" +
 	"\x0fCreateContainer\x12'.containarium.v1.CreateContainerRequest\x1a(.containarium.v1.CreateContainerResponse\"\xc7\x01\x92A\xaa\x01\n" +
 	"\n" +
@@ -163,7 +163,9 @@ const file_containarium_v1_service_proto_rawDesc = "" +
 	"\fDeleteSecret\x12$.containarium.v1.DeleteSecretRequest\x1a%.containarium.v1.DeleteSecretResponse\"\xdf\x01\x92A\xb6\x01\n" +
 	"\aSecrets\x12\x16Delete a tenant secret\x1a\x92\x01Removes the secret from Postgres. Does NOT cascade to env-var stamps on running containers — call RefreshSecrets to re-stamp without restarting.\x82\xd3\xe4\x93\x02\x1f*\x1d/v1/secrets/{username}/{name}\x12\x90\x03\n" +
 	"\x0eRefreshSecrets\x12&.containarium.v1.RefreshSecretsRequest\x1a'.containarium.v1.RefreshSecretsResponse\"\xac\x02\x92A\xff\x01\n" +
-	"\aSecrets\x12(Re-stamp tenant secrets into the LXC env\x1a\xc9\x01Reads all of the tenant's secrets from the DB, decrypts, and updates the LXC's environment.<NAME> config keys to match. Running processes keep their old env (POSIX); new execs see the refreshed values.\x82\xd3\xe4\x93\x02#:\x01*\"\x1e/v1/secrets/{username}/refreshB\xa4\x04\x92A\xd5\x03\x12\xc4\x02\n" +
+	"\aSecrets\x12(Re-stamp tenant secrets into the LXC env\x1a\xc9\x01Reads all of the tenant's secrets from the DB, decrypts, and updates the LXC's environment.<NAME> config keys to match. Running processes keep their old env (POSIX); new execs see the refreshed values.\x82\xd3\xe4\x93\x02#:\x01*\"\x1e/v1/secrets/{username}/refresh\x12\xbb\x03\n" +
+	"\x0fSetTenantKMSKey\x12'.containarium.v1.SetTenantKMSKeyRequest\x1a(.containarium.v1.SetTenantKMSKeyResponse\"\xd4\x02\x92A\xa7\x02\n" +
+	"\aSecrets\x12*Set or clear a tenant's per-tenant KMS key\x1a\xef\x01Re-wraps the tenant's existing secrets under the given GCP KMS CryptoKey (or back to the shared KEK if kek_resource_name is empty). Requires CONTAINARIUM_KMS_BACKEND=gcp. Admin role + explicit secrets:write scope required, unconditionally.\x82\xd3\xe4\x93\x02#:\x01*\"\x1e/v1/secrets/{username}/kms-keyB\xa4\x04\x92A\xd5\x03\x12\xc4\x02\n" +
 	"\x10Containarium API\x12\xa0\x01Container management API for LXC-based development environments. Provides both gRPC and REST interfaces for managing containers, SSH keys, and system resources.\";\n" +
 	"\fContainarium\x12+https://github.com/footprintai/containarium*K\n" +
 	"\n" +
@@ -236,67 +238,69 @@ var file_containarium_v1_service_proto_goTypes = []any{
 	(*ListSecretsRequest)(nil),                // 58: containarium.v1.ListSecretsRequest
 	(*DeleteSecretRequest)(nil),               // 59: containarium.v1.DeleteSecretRequest
 	(*RefreshSecretsRequest)(nil),             // 60: containarium.v1.RefreshSecretsRequest
-	(*CreateContainerResponse)(nil),           // 61: containarium.v1.CreateContainerResponse
-	(*ListContainersResponse)(nil),            // 62: containarium.v1.ListContainersResponse
-	(*GetContainerResponse)(nil),              // 63: containarium.v1.GetContainerResponse
-	(*DebugContainerResponse)(nil),            // 64: containarium.v1.DebugContainerResponse
-	(*DeleteContainerResponse)(nil),           // 65: containarium.v1.DeleteContainerResponse
-	(*StartContainerResponse)(nil),            // 66: containarium.v1.StartContainerResponse
-	(*StopContainerResponse)(nil),             // 67: containarium.v1.StopContainerResponse
-	(*ResizeContainerResponse)(nil),           // 68: containarium.v1.ResizeContainerResponse
-	(*MoveContainerResponse)(nil),             // 69: containarium.v1.MoveContainerResponse
-	(*CreateContainerSnapshotResponse)(nil),   // 70: containarium.v1.CreateContainerSnapshotResponse
-	(*ListContainerSnapshotsResponse)(nil),    // 71: containarium.v1.ListContainerSnapshotsResponse
-	(*DeleteContainerSnapshotResponse)(nil),   // 72: containarium.v1.DeleteContainerSnapshotResponse
-	(*RollbackContainerSnapshotResponse)(nil), // 73: containarium.v1.RollbackContainerSnapshotResponse
-	(*DeleteTenantStorageResponse)(nil),       // 74: containarium.v1.DeleteTenantStorageResponse
-	(*RewrapContainerResponse)(nil),           // 75: containarium.v1.RewrapContainerResponse
-	(*PrepareEncryptedMigrationResponse)(nil), // 76: containarium.v1.PrepareEncryptedMigrationResponse
-	(*AdoptMigratedContainerResponse)(nil),    // 77: containarium.v1.AdoptMigratedContainerResponse
-	(*ToggleMonitoringResponse)(nil),          // 78: containarium.v1.ToggleMonitoringResponse
-	(*ToggleAutoSleepResponse)(nil),           // 79: containarium.v1.ToggleAutoSleepResponse
-	(*SetContainerTTLResponse)(nil),           // 80: containarium.v1.SetContainerTTLResponse
-	(*SetContainerDeletePolicyResponse)(nil),  // 81: containarium.v1.SetContainerDeletePolicyResponse
-	(*SetContainerAttributionResponse)(nil),   // 82: containarium.v1.SetContainerAttributionResponse
-	(*AddSSHKeyResponse)(nil),                 // 83: containarium.v1.AddSSHKeyResponse
-	(*RemoveSSHKeyResponse)(nil),              // 84: containarium.v1.RemoveSSHKeyResponse
-	(*AddCollaboratorResponse)(nil),           // 85: containarium.v1.AddCollaboratorResponse
-	(*RemoveCollaboratorResponse)(nil),        // 86: containarium.v1.RemoveCollaboratorResponse
-	(*ListCollaboratorsResponse)(nil),         // 87: containarium.v1.ListCollaboratorsResponse
-	(*GetMetricsResponse)(nil),                // 88: containarium.v1.GetMetricsResponse
-	(*CleanupDiskResponse)(nil),               // 89: containarium.v1.CleanupDiskResponse
-	(*InstallStackResponse)(nil),              // 90: containarium.v1.InstallStackResponse
-	(*ListStacksResponse)(nil),                // 91: containarium.v1.ListStacksResponse
-	(*GetSystemInfoResponse)(nil),             // 92: containarium.v1.GetSystemInfoResponse
-	(*ListBackendsResponse)(nil),              // 93: containarium.v1.ListBackendsResponse
-	(*AdvertiseCapacityResponse)(nil),         // 94: containarium.v1.AdvertiseCapacityResponse
-	(*WithdrawCapacityResponse)(nil),          // 95: containarium.v1.WithdrawCapacityResponse
-	(*GetCapacityHeadroomResponse)(nil),       // 96: containarium.v1.GetCapacityHeadroomResponse
-	(*ProfileBackendResponse)(nil),            // 97: containarium.v1.ProfileBackendResponse
-	(*GetCapabilityProfileResponse)(nil),      // 98: containarium.v1.GetCapabilityProfileResponse
-	(*GetSelfMeasurementResponse)(nil),        // 99: containarium.v1.GetSelfMeasurementResponse
-	(*GetLatestReleaseResponse)(nil),          // 100: containarium.v1.GetLatestReleaseResponse
-	(*ValidateGPUResponse)(nil),               // 101: containarium.v1.ValidateGPUResponse
-	(*TriggerUpgradeResponse)(nil),            // 102: containarium.v1.TriggerUpgradeResponse
-	(*GetUpgradeStatusResponse)(nil),          // 103: containarium.v1.GetUpgradeStatusResponse
-	(*GetMonitoringInfoResponse)(nil),         // 104: containarium.v1.GetMonitoringInfoResponse
-	(*SetMetricsExportResponse)(nil),          // 105: containarium.v1.SetMetricsExportResponse
-	(*GetMetricsExportResponse)(nil),          // 106: containarium.v1.GetMetricsExportResponse
-	(*CreateAlertRuleResponse)(nil),           // 107: containarium.v1.CreateAlertRuleResponse
-	(*ListAlertRulesResponse)(nil),            // 108: containarium.v1.ListAlertRulesResponse
-	(*GetAlertRuleResponse)(nil),              // 109: containarium.v1.GetAlertRuleResponse
-	(*UpdateAlertRuleResponse)(nil),           // 110: containarium.v1.UpdateAlertRuleResponse
-	(*DeleteAlertRuleResponse)(nil),           // 111: containarium.v1.DeleteAlertRuleResponse
-	(*GetAlertingInfoResponse)(nil),           // 112: containarium.v1.GetAlertingInfoResponse
-	(*ListDefaultAlertRulesResponse)(nil),     // 113: containarium.v1.ListDefaultAlertRulesResponse
-	(*UpdateAlertingConfigResponse)(nil),      // 114: containarium.v1.UpdateAlertingConfigResponse
-	(*TestWebhookResponse)(nil),               // 115: containarium.v1.TestWebhookResponse
-	(*ListWebhookDeliveriesResponse)(nil),     // 116: containarium.v1.ListWebhookDeliveriesResponse
-	(*SetSecretResponse)(nil),                 // 117: containarium.v1.SetSecretResponse
-	(*GetSecretResponse)(nil),                 // 118: containarium.v1.GetSecretResponse
-	(*ListSecretsResponse)(nil),               // 119: containarium.v1.ListSecretsResponse
-	(*DeleteSecretResponse)(nil),              // 120: containarium.v1.DeleteSecretResponse
-	(*RefreshSecretsResponse)(nil),            // 121: containarium.v1.RefreshSecretsResponse
+	(*SetTenantKMSKeyRequest)(nil),            // 61: containarium.v1.SetTenantKMSKeyRequest
+	(*CreateContainerResponse)(nil),           // 62: containarium.v1.CreateContainerResponse
+	(*ListContainersResponse)(nil),            // 63: containarium.v1.ListContainersResponse
+	(*GetContainerResponse)(nil),              // 64: containarium.v1.GetContainerResponse
+	(*DebugContainerResponse)(nil),            // 65: containarium.v1.DebugContainerResponse
+	(*DeleteContainerResponse)(nil),           // 66: containarium.v1.DeleteContainerResponse
+	(*StartContainerResponse)(nil),            // 67: containarium.v1.StartContainerResponse
+	(*StopContainerResponse)(nil),             // 68: containarium.v1.StopContainerResponse
+	(*ResizeContainerResponse)(nil),           // 69: containarium.v1.ResizeContainerResponse
+	(*MoveContainerResponse)(nil),             // 70: containarium.v1.MoveContainerResponse
+	(*CreateContainerSnapshotResponse)(nil),   // 71: containarium.v1.CreateContainerSnapshotResponse
+	(*ListContainerSnapshotsResponse)(nil),    // 72: containarium.v1.ListContainerSnapshotsResponse
+	(*DeleteContainerSnapshotResponse)(nil),   // 73: containarium.v1.DeleteContainerSnapshotResponse
+	(*RollbackContainerSnapshotResponse)(nil), // 74: containarium.v1.RollbackContainerSnapshotResponse
+	(*DeleteTenantStorageResponse)(nil),       // 75: containarium.v1.DeleteTenantStorageResponse
+	(*RewrapContainerResponse)(nil),           // 76: containarium.v1.RewrapContainerResponse
+	(*PrepareEncryptedMigrationResponse)(nil), // 77: containarium.v1.PrepareEncryptedMigrationResponse
+	(*AdoptMigratedContainerResponse)(nil),    // 78: containarium.v1.AdoptMigratedContainerResponse
+	(*ToggleMonitoringResponse)(nil),          // 79: containarium.v1.ToggleMonitoringResponse
+	(*ToggleAutoSleepResponse)(nil),           // 80: containarium.v1.ToggleAutoSleepResponse
+	(*SetContainerTTLResponse)(nil),           // 81: containarium.v1.SetContainerTTLResponse
+	(*SetContainerDeletePolicyResponse)(nil),  // 82: containarium.v1.SetContainerDeletePolicyResponse
+	(*SetContainerAttributionResponse)(nil),   // 83: containarium.v1.SetContainerAttributionResponse
+	(*AddSSHKeyResponse)(nil),                 // 84: containarium.v1.AddSSHKeyResponse
+	(*RemoveSSHKeyResponse)(nil),              // 85: containarium.v1.RemoveSSHKeyResponse
+	(*AddCollaboratorResponse)(nil),           // 86: containarium.v1.AddCollaboratorResponse
+	(*RemoveCollaboratorResponse)(nil),        // 87: containarium.v1.RemoveCollaboratorResponse
+	(*ListCollaboratorsResponse)(nil),         // 88: containarium.v1.ListCollaboratorsResponse
+	(*GetMetricsResponse)(nil),                // 89: containarium.v1.GetMetricsResponse
+	(*CleanupDiskResponse)(nil),               // 90: containarium.v1.CleanupDiskResponse
+	(*InstallStackResponse)(nil),              // 91: containarium.v1.InstallStackResponse
+	(*ListStacksResponse)(nil),                // 92: containarium.v1.ListStacksResponse
+	(*GetSystemInfoResponse)(nil),             // 93: containarium.v1.GetSystemInfoResponse
+	(*ListBackendsResponse)(nil),              // 94: containarium.v1.ListBackendsResponse
+	(*AdvertiseCapacityResponse)(nil),         // 95: containarium.v1.AdvertiseCapacityResponse
+	(*WithdrawCapacityResponse)(nil),          // 96: containarium.v1.WithdrawCapacityResponse
+	(*GetCapacityHeadroomResponse)(nil),       // 97: containarium.v1.GetCapacityHeadroomResponse
+	(*ProfileBackendResponse)(nil),            // 98: containarium.v1.ProfileBackendResponse
+	(*GetCapabilityProfileResponse)(nil),      // 99: containarium.v1.GetCapabilityProfileResponse
+	(*GetSelfMeasurementResponse)(nil),        // 100: containarium.v1.GetSelfMeasurementResponse
+	(*GetLatestReleaseResponse)(nil),          // 101: containarium.v1.GetLatestReleaseResponse
+	(*ValidateGPUResponse)(nil),               // 102: containarium.v1.ValidateGPUResponse
+	(*TriggerUpgradeResponse)(nil),            // 103: containarium.v1.TriggerUpgradeResponse
+	(*GetUpgradeStatusResponse)(nil),          // 104: containarium.v1.GetUpgradeStatusResponse
+	(*GetMonitoringInfoResponse)(nil),         // 105: containarium.v1.GetMonitoringInfoResponse
+	(*SetMetricsExportResponse)(nil),          // 106: containarium.v1.SetMetricsExportResponse
+	(*GetMetricsExportResponse)(nil),          // 107: containarium.v1.GetMetricsExportResponse
+	(*CreateAlertRuleResponse)(nil),           // 108: containarium.v1.CreateAlertRuleResponse
+	(*ListAlertRulesResponse)(nil),            // 109: containarium.v1.ListAlertRulesResponse
+	(*GetAlertRuleResponse)(nil),              // 110: containarium.v1.GetAlertRuleResponse
+	(*UpdateAlertRuleResponse)(nil),           // 111: containarium.v1.UpdateAlertRuleResponse
+	(*DeleteAlertRuleResponse)(nil),           // 112: containarium.v1.DeleteAlertRuleResponse
+	(*GetAlertingInfoResponse)(nil),           // 113: containarium.v1.GetAlertingInfoResponse
+	(*ListDefaultAlertRulesResponse)(nil),     // 114: containarium.v1.ListDefaultAlertRulesResponse
+	(*UpdateAlertingConfigResponse)(nil),      // 115: containarium.v1.UpdateAlertingConfigResponse
+	(*TestWebhookResponse)(nil),               // 116: containarium.v1.TestWebhookResponse
+	(*ListWebhookDeliveriesResponse)(nil),     // 117: containarium.v1.ListWebhookDeliveriesResponse
+	(*SetSecretResponse)(nil),                 // 118: containarium.v1.SetSecretResponse
+	(*GetSecretResponse)(nil),                 // 119: containarium.v1.GetSecretResponse
+	(*ListSecretsResponse)(nil),               // 120: containarium.v1.ListSecretsResponse
+	(*DeleteSecretResponse)(nil),              // 121: containarium.v1.DeleteSecretResponse
+	(*RefreshSecretsResponse)(nil),            // 122: containarium.v1.RefreshSecretsResponse
+	(*SetTenantKMSKeyResponse)(nil),           // 123: containarium.v1.SetTenantKMSKeyResponse
 }
 var file_containarium_v1_service_proto_depIdxs = []int32{
 	0,   // 0: containarium.v1.ContainerService.CreateContainer:input_type -> containarium.v1.CreateContainerRequest
@@ -360,69 +364,71 @@ var file_containarium_v1_service_proto_depIdxs = []int32{
 	58,  // 58: containarium.v1.ContainerService.ListSecrets:input_type -> containarium.v1.ListSecretsRequest
 	59,  // 59: containarium.v1.ContainerService.DeleteSecret:input_type -> containarium.v1.DeleteSecretRequest
 	60,  // 60: containarium.v1.ContainerService.RefreshSecrets:input_type -> containarium.v1.RefreshSecretsRequest
-	61,  // 61: containarium.v1.ContainerService.CreateContainer:output_type -> containarium.v1.CreateContainerResponse
-	62,  // 62: containarium.v1.ContainerService.ListContainers:output_type -> containarium.v1.ListContainersResponse
-	63,  // 63: containarium.v1.ContainerService.GetContainer:output_type -> containarium.v1.GetContainerResponse
-	64,  // 64: containarium.v1.ContainerService.DebugContainer:output_type -> containarium.v1.DebugContainerResponse
-	65,  // 65: containarium.v1.ContainerService.DeleteContainer:output_type -> containarium.v1.DeleteContainerResponse
-	66,  // 66: containarium.v1.ContainerService.StartContainer:output_type -> containarium.v1.StartContainerResponse
-	67,  // 67: containarium.v1.ContainerService.StopContainer:output_type -> containarium.v1.StopContainerResponse
-	68,  // 68: containarium.v1.ContainerService.ResizeContainer:output_type -> containarium.v1.ResizeContainerResponse
-	69,  // 69: containarium.v1.ContainerService.MoveContainer:output_type -> containarium.v1.MoveContainerResponse
-	70,  // 70: containarium.v1.ContainerService.CreateContainerSnapshot:output_type -> containarium.v1.CreateContainerSnapshotResponse
-	71,  // 71: containarium.v1.ContainerService.ListContainerSnapshots:output_type -> containarium.v1.ListContainerSnapshotsResponse
-	72,  // 72: containarium.v1.ContainerService.DeleteContainerSnapshot:output_type -> containarium.v1.DeleteContainerSnapshotResponse
-	73,  // 73: containarium.v1.ContainerService.RollbackContainerSnapshot:output_type -> containarium.v1.RollbackContainerSnapshotResponse
-	74,  // 74: containarium.v1.ContainerService.DeleteTenantStorage:output_type -> containarium.v1.DeleteTenantStorageResponse
-	75,  // 75: containarium.v1.ContainerService.RewrapContainer:output_type -> containarium.v1.RewrapContainerResponse
-	76,  // 76: containarium.v1.ContainerService.PrepareEncryptedMigration:output_type -> containarium.v1.PrepareEncryptedMigrationResponse
-	77,  // 77: containarium.v1.ContainerService.AdoptMigratedContainer:output_type -> containarium.v1.AdoptMigratedContainerResponse
-	78,  // 78: containarium.v1.ContainerService.ToggleMonitoring:output_type -> containarium.v1.ToggleMonitoringResponse
-	79,  // 79: containarium.v1.ContainerService.ToggleAutoSleep:output_type -> containarium.v1.ToggleAutoSleepResponse
-	80,  // 80: containarium.v1.ContainerService.SetContainerTTL:output_type -> containarium.v1.SetContainerTTLResponse
-	81,  // 81: containarium.v1.ContainerService.SetContainerDeletePolicy:output_type -> containarium.v1.SetContainerDeletePolicyResponse
-	82,  // 82: containarium.v1.ContainerService.SetContainerAttribution:output_type -> containarium.v1.SetContainerAttributionResponse
-	83,  // 83: containarium.v1.ContainerService.AddSSHKey:output_type -> containarium.v1.AddSSHKeyResponse
-	84,  // 84: containarium.v1.ContainerService.RemoveSSHKey:output_type -> containarium.v1.RemoveSSHKeyResponse
-	85,  // 85: containarium.v1.ContainerService.AddCollaborator:output_type -> containarium.v1.AddCollaboratorResponse
-	86,  // 86: containarium.v1.ContainerService.RemoveCollaborator:output_type -> containarium.v1.RemoveCollaboratorResponse
-	87,  // 87: containarium.v1.ContainerService.ListCollaborators:output_type -> containarium.v1.ListCollaboratorsResponse
-	88,  // 88: containarium.v1.ContainerService.GetMetrics:output_type -> containarium.v1.GetMetricsResponse
-	89,  // 89: containarium.v1.ContainerService.CleanupDisk:output_type -> containarium.v1.CleanupDiskResponse
-	90,  // 90: containarium.v1.ContainerService.InstallStack:output_type -> containarium.v1.InstallStackResponse
-	91,  // 91: containarium.v1.ContainerService.ListStacks:output_type -> containarium.v1.ListStacksResponse
-	92,  // 92: containarium.v1.ContainerService.GetSystemInfo:output_type -> containarium.v1.GetSystemInfoResponse
-	93,  // 93: containarium.v1.ContainerService.ListBackends:output_type -> containarium.v1.ListBackendsResponse
-	94,  // 94: containarium.v1.ContainerService.AdvertiseCapacity:output_type -> containarium.v1.AdvertiseCapacityResponse
-	95,  // 95: containarium.v1.ContainerService.WithdrawCapacity:output_type -> containarium.v1.WithdrawCapacityResponse
-	96,  // 96: containarium.v1.ContainerService.GetCapacityHeadroom:output_type -> containarium.v1.GetCapacityHeadroomResponse
-	97,  // 97: containarium.v1.ContainerService.ProfileBackend:output_type -> containarium.v1.ProfileBackendResponse
-	98,  // 98: containarium.v1.ContainerService.GetCapabilityProfile:output_type -> containarium.v1.GetCapabilityProfileResponse
-	99,  // 99: containarium.v1.ContainerService.GetSelfMeasurement:output_type -> containarium.v1.GetSelfMeasurementResponse
-	100, // 100: containarium.v1.ContainerService.GetLatestRelease:output_type -> containarium.v1.GetLatestReleaseResponse
-	101, // 101: containarium.v1.ContainerService.ValidateGPU:output_type -> containarium.v1.ValidateGPUResponse
-	102, // 102: containarium.v1.ContainerService.TriggerUpgrade:output_type -> containarium.v1.TriggerUpgradeResponse
-	103, // 103: containarium.v1.ContainerService.GetUpgradeStatus:output_type -> containarium.v1.GetUpgradeStatusResponse
-	104, // 104: containarium.v1.ContainerService.GetMonitoringInfo:output_type -> containarium.v1.GetMonitoringInfoResponse
-	105, // 105: containarium.v1.ContainerService.SetMetricsExport:output_type -> containarium.v1.SetMetricsExportResponse
-	106, // 106: containarium.v1.ContainerService.GetMetricsExport:output_type -> containarium.v1.GetMetricsExportResponse
-	107, // 107: containarium.v1.ContainerService.CreateAlertRule:output_type -> containarium.v1.CreateAlertRuleResponse
-	108, // 108: containarium.v1.ContainerService.ListAlertRules:output_type -> containarium.v1.ListAlertRulesResponse
-	109, // 109: containarium.v1.ContainerService.GetAlertRule:output_type -> containarium.v1.GetAlertRuleResponse
-	110, // 110: containarium.v1.ContainerService.UpdateAlertRule:output_type -> containarium.v1.UpdateAlertRuleResponse
-	111, // 111: containarium.v1.ContainerService.DeleteAlertRule:output_type -> containarium.v1.DeleteAlertRuleResponse
-	112, // 112: containarium.v1.ContainerService.GetAlertingInfo:output_type -> containarium.v1.GetAlertingInfoResponse
-	113, // 113: containarium.v1.ContainerService.ListDefaultAlertRules:output_type -> containarium.v1.ListDefaultAlertRulesResponse
-	114, // 114: containarium.v1.ContainerService.UpdateAlertingConfig:output_type -> containarium.v1.UpdateAlertingConfigResponse
-	115, // 115: containarium.v1.ContainerService.TestWebhook:output_type -> containarium.v1.TestWebhookResponse
-	116, // 116: containarium.v1.ContainerService.ListWebhookDeliveries:output_type -> containarium.v1.ListWebhookDeliveriesResponse
-	117, // 117: containarium.v1.ContainerService.SetSecret:output_type -> containarium.v1.SetSecretResponse
-	118, // 118: containarium.v1.ContainerService.GetSecret:output_type -> containarium.v1.GetSecretResponse
-	119, // 119: containarium.v1.ContainerService.ListSecrets:output_type -> containarium.v1.ListSecretsResponse
-	120, // 120: containarium.v1.ContainerService.DeleteSecret:output_type -> containarium.v1.DeleteSecretResponse
-	121, // 121: containarium.v1.ContainerService.RefreshSecrets:output_type -> containarium.v1.RefreshSecretsResponse
-	61,  // [61:122] is the sub-list for method output_type
-	0,   // [0:61] is the sub-list for method input_type
+	61,  // 61: containarium.v1.ContainerService.SetTenantKMSKey:input_type -> containarium.v1.SetTenantKMSKeyRequest
+	62,  // 62: containarium.v1.ContainerService.CreateContainer:output_type -> containarium.v1.CreateContainerResponse
+	63,  // 63: containarium.v1.ContainerService.ListContainers:output_type -> containarium.v1.ListContainersResponse
+	64,  // 64: containarium.v1.ContainerService.GetContainer:output_type -> containarium.v1.GetContainerResponse
+	65,  // 65: containarium.v1.ContainerService.DebugContainer:output_type -> containarium.v1.DebugContainerResponse
+	66,  // 66: containarium.v1.ContainerService.DeleteContainer:output_type -> containarium.v1.DeleteContainerResponse
+	67,  // 67: containarium.v1.ContainerService.StartContainer:output_type -> containarium.v1.StartContainerResponse
+	68,  // 68: containarium.v1.ContainerService.StopContainer:output_type -> containarium.v1.StopContainerResponse
+	69,  // 69: containarium.v1.ContainerService.ResizeContainer:output_type -> containarium.v1.ResizeContainerResponse
+	70,  // 70: containarium.v1.ContainerService.MoveContainer:output_type -> containarium.v1.MoveContainerResponse
+	71,  // 71: containarium.v1.ContainerService.CreateContainerSnapshot:output_type -> containarium.v1.CreateContainerSnapshotResponse
+	72,  // 72: containarium.v1.ContainerService.ListContainerSnapshots:output_type -> containarium.v1.ListContainerSnapshotsResponse
+	73,  // 73: containarium.v1.ContainerService.DeleteContainerSnapshot:output_type -> containarium.v1.DeleteContainerSnapshotResponse
+	74,  // 74: containarium.v1.ContainerService.RollbackContainerSnapshot:output_type -> containarium.v1.RollbackContainerSnapshotResponse
+	75,  // 75: containarium.v1.ContainerService.DeleteTenantStorage:output_type -> containarium.v1.DeleteTenantStorageResponse
+	76,  // 76: containarium.v1.ContainerService.RewrapContainer:output_type -> containarium.v1.RewrapContainerResponse
+	77,  // 77: containarium.v1.ContainerService.PrepareEncryptedMigration:output_type -> containarium.v1.PrepareEncryptedMigrationResponse
+	78,  // 78: containarium.v1.ContainerService.AdoptMigratedContainer:output_type -> containarium.v1.AdoptMigratedContainerResponse
+	79,  // 79: containarium.v1.ContainerService.ToggleMonitoring:output_type -> containarium.v1.ToggleMonitoringResponse
+	80,  // 80: containarium.v1.ContainerService.ToggleAutoSleep:output_type -> containarium.v1.ToggleAutoSleepResponse
+	81,  // 81: containarium.v1.ContainerService.SetContainerTTL:output_type -> containarium.v1.SetContainerTTLResponse
+	82,  // 82: containarium.v1.ContainerService.SetContainerDeletePolicy:output_type -> containarium.v1.SetContainerDeletePolicyResponse
+	83,  // 83: containarium.v1.ContainerService.SetContainerAttribution:output_type -> containarium.v1.SetContainerAttributionResponse
+	84,  // 84: containarium.v1.ContainerService.AddSSHKey:output_type -> containarium.v1.AddSSHKeyResponse
+	85,  // 85: containarium.v1.ContainerService.RemoveSSHKey:output_type -> containarium.v1.RemoveSSHKeyResponse
+	86,  // 86: containarium.v1.ContainerService.AddCollaborator:output_type -> containarium.v1.AddCollaboratorResponse
+	87,  // 87: containarium.v1.ContainerService.RemoveCollaborator:output_type -> containarium.v1.RemoveCollaboratorResponse
+	88,  // 88: containarium.v1.ContainerService.ListCollaborators:output_type -> containarium.v1.ListCollaboratorsResponse
+	89,  // 89: containarium.v1.ContainerService.GetMetrics:output_type -> containarium.v1.GetMetricsResponse
+	90,  // 90: containarium.v1.ContainerService.CleanupDisk:output_type -> containarium.v1.CleanupDiskResponse
+	91,  // 91: containarium.v1.ContainerService.InstallStack:output_type -> containarium.v1.InstallStackResponse
+	92,  // 92: containarium.v1.ContainerService.ListStacks:output_type -> containarium.v1.ListStacksResponse
+	93,  // 93: containarium.v1.ContainerService.GetSystemInfo:output_type -> containarium.v1.GetSystemInfoResponse
+	94,  // 94: containarium.v1.ContainerService.ListBackends:output_type -> containarium.v1.ListBackendsResponse
+	95,  // 95: containarium.v1.ContainerService.AdvertiseCapacity:output_type -> containarium.v1.AdvertiseCapacityResponse
+	96,  // 96: containarium.v1.ContainerService.WithdrawCapacity:output_type -> containarium.v1.WithdrawCapacityResponse
+	97,  // 97: containarium.v1.ContainerService.GetCapacityHeadroom:output_type -> containarium.v1.GetCapacityHeadroomResponse
+	98,  // 98: containarium.v1.ContainerService.ProfileBackend:output_type -> containarium.v1.ProfileBackendResponse
+	99,  // 99: containarium.v1.ContainerService.GetCapabilityProfile:output_type -> containarium.v1.GetCapabilityProfileResponse
+	100, // 100: containarium.v1.ContainerService.GetSelfMeasurement:output_type -> containarium.v1.GetSelfMeasurementResponse
+	101, // 101: containarium.v1.ContainerService.GetLatestRelease:output_type -> containarium.v1.GetLatestReleaseResponse
+	102, // 102: containarium.v1.ContainerService.ValidateGPU:output_type -> containarium.v1.ValidateGPUResponse
+	103, // 103: containarium.v1.ContainerService.TriggerUpgrade:output_type -> containarium.v1.TriggerUpgradeResponse
+	104, // 104: containarium.v1.ContainerService.GetUpgradeStatus:output_type -> containarium.v1.GetUpgradeStatusResponse
+	105, // 105: containarium.v1.ContainerService.GetMonitoringInfo:output_type -> containarium.v1.GetMonitoringInfoResponse
+	106, // 106: containarium.v1.ContainerService.SetMetricsExport:output_type -> containarium.v1.SetMetricsExportResponse
+	107, // 107: containarium.v1.ContainerService.GetMetricsExport:output_type -> containarium.v1.GetMetricsExportResponse
+	108, // 108: containarium.v1.ContainerService.CreateAlertRule:output_type -> containarium.v1.CreateAlertRuleResponse
+	109, // 109: containarium.v1.ContainerService.ListAlertRules:output_type -> containarium.v1.ListAlertRulesResponse
+	110, // 110: containarium.v1.ContainerService.GetAlertRule:output_type -> containarium.v1.GetAlertRuleResponse
+	111, // 111: containarium.v1.ContainerService.UpdateAlertRule:output_type -> containarium.v1.UpdateAlertRuleResponse
+	112, // 112: containarium.v1.ContainerService.DeleteAlertRule:output_type -> containarium.v1.DeleteAlertRuleResponse
+	113, // 113: containarium.v1.ContainerService.GetAlertingInfo:output_type -> containarium.v1.GetAlertingInfoResponse
+	114, // 114: containarium.v1.ContainerService.ListDefaultAlertRules:output_type -> containarium.v1.ListDefaultAlertRulesResponse
+	115, // 115: containarium.v1.ContainerService.UpdateAlertingConfig:output_type -> containarium.v1.UpdateAlertingConfigResponse
+	116, // 116: containarium.v1.ContainerService.TestWebhook:output_type -> containarium.v1.TestWebhookResponse
+	117, // 117: containarium.v1.ContainerService.ListWebhookDeliveries:output_type -> containarium.v1.ListWebhookDeliveriesResponse
+	118, // 118: containarium.v1.ContainerService.SetSecret:output_type -> containarium.v1.SetSecretResponse
+	119, // 119: containarium.v1.ContainerService.GetSecret:output_type -> containarium.v1.GetSecretResponse
+	120, // 120: containarium.v1.ContainerService.ListSecrets:output_type -> containarium.v1.ListSecretsResponse
+	121, // 121: containarium.v1.ContainerService.DeleteSecret:output_type -> containarium.v1.DeleteSecretResponse
+	122, // 122: containarium.v1.ContainerService.RefreshSecrets:output_type -> containarium.v1.RefreshSecretsResponse
+	123, // 123: containarium.v1.ContainerService.SetTenantKMSKey:output_type -> containarium.v1.SetTenantKMSKeyResponse
+	62,  // [62:124] is the sub-list for method output_type
+	0,   // [0:62] is the sub-list for method input_type
 	0,   // [0:0] is the sub-list for extension type_name
 	0,   // [0:0] is the sub-list for extension extendee
 	0,   // [0:0] is the sub-list for field type_name

--- a/pkg/pb/containarium/v1/service.pb.gw.go
+++ b/pkg/pb/containarium/v1/service.pb.gw.go
@@ -2359,6 +2359,51 @@ func local_request_ContainerService_RefreshSecrets_0(ctx context.Context, marsha
 	return msg, metadata, err
 }
 
+func request_ContainerService_SetTenantKMSKey_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq SetTenantKMSKeyRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	val, ok := pathParams["username"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "username")
+	}
+	protoReq.Username, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "username", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.SetTenantKMSKey(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ContainerService_SetTenantKMSKey_0(ctx context.Context, marshaler runtime.Marshaler, server ContainerServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq SetTenantKMSKeyRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	val, ok := pathParams["username"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "username")
+	}
+	protoReq.Username, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "username", err)
+	}
+	msg, err := server.SetTenantKMSKey(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterContainerServiceHandlerServer registers the http handlers for service ContainerService to "mux".
 // UnaryRPC     :call ContainerServiceServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -3605,6 +3650,26 @@ func RegisterContainerServiceHandlerServer(ctx context.Context, mux *runtime.Ser
 		}
 		forward_ContainerService_RefreshSecrets_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_ContainerService_SetTenantKMSKey_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.ContainerService/SetTenantKMSKey", runtime.WithHTTPPathPattern("/v1/secrets/{username}/kms-key"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ContainerService_SetTenantKMSKey_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_SetTenantKMSKey_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 
 	return nil
 }
@@ -4699,6 +4764,23 @@ func RegisterContainerServiceHandlerClient(ctx context.Context, mux *runtime.Ser
 		}
 		forward_ContainerService_RefreshSecrets_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_ContainerService_SetTenantKMSKey_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.ContainerService/SetTenantKMSKey", runtime.WithHTTPPathPattern("/v1/secrets/{username}/kms-key"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ContainerService_SetTenantKMSKey_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_SetTenantKMSKey_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
@@ -4765,6 +4847,7 @@ var (
 	pattern_ContainerService_ListSecrets_0               = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "secrets", "username"}, ""))
 	pattern_ContainerService_DeleteSecret_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "secrets", "username", "name"}, ""))
 	pattern_ContainerService_RefreshSecrets_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "secrets", "username", "refresh"}, ""))
+	pattern_ContainerService_SetTenantKMSKey_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "secrets", "username", "kms-key"}, ""))
 )
 
 var (
@@ -4830,4 +4913,5 @@ var (
 	forward_ContainerService_ListSecrets_0               = runtime.ForwardResponseMessage
 	forward_ContainerService_DeleteSecret_0              = runtime.ForwardResponseMessage
 	forward_ContainerService_RefreshSecrets_0            = runtime.ForwardResponseMessage
+	forward_ContainerService_SetTenantKMSKey_0           = runtime.ForwardResponseMessage
 )

--- a/pkg/pb/containarium/v1/service_grpc.pb.go
+++ b/pkg/pb/containarium/v1/service_grpc.pb.go
@@ -80,6 +80,7 @@ const (
 	ContainerService_ListSecrets_FullMethodName               = "/containarium.v1.ContainerService/ListSecrets"
 	ContainerService_DeleteSecret_FullMethodName              = "/containarium.v1.ContainerService/DeleteSecret"
 	ContainerService_RefreshSecrets_FullMethodName            = "/containarium.v1.ContainerService/RefreshSecrets"
+	ContainerService_SetTenantKMSKey_FullMethodName           = "/containarium.v1.ContainerService/SetTenantKMSKey"
 )
 
 // ContainerServiceClient is the client API for ContainerService service.
@@ -377,6 +378,13 @@ type ContainerServiceClient interface {
 	// useful after rotation when the next exec'd process should see
 	// the new value without a full container restart.
 	RefreshSecrets(ctx context.Context, in *RefreshSecretsRequest, opts ...grpc.CallOption) (*RefreshSecretsResponse, error)
+	// SetTenantKMSKey sets or clears a tenant's per-tenant KMS key for
+	// secrets envelope encryption, re-wrapping the tenant's existing
+	// secrets under the new key (or back to the shared KEK on clear).
+	// Admin role + explicit secrets:write scope required unconditionally
+	// — see SetTenantKMSKeyRequest's comment for why this RPC doesn't get
+	// the self-access exception the other secrets RPCs have.
+	SetTenantKMSKey(ctx context.Context, in *SetTenantKMSKeyRequest, opts ...grpc.CallOption) (*SetTenantKMSKeyResponse, error)
 }
 
 type containerServiceClient struct {
@@ -997,6 +1005,16 @@ func (c *containerServiceClient) RefreshSecrets(ctx context.Context, in *Refresh
 	return out, nil
 }
 
+func (c *containerServiceClient) SetTenantKMSKey(ctx context.Context, in *SetTenantKMSKeyRequest, opts ...grpc.CallOption) (*SetTenantKMSKeyResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SetTenantKMSKeyResponse)
+	err := c.cc.Invoke(ctx, ContainerService_SetTenantKMSKey_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ContainerServiceServer is the server API for ContainerService service.
 // All implementations must embed UnimplementedContainerServiceServer
 // for forward compatibility.
@@ -1292,6 +1310,13 @@ type ContainerServiceServer interface {
 	// useful after rotation when the next exec'd process should see
 	// the new value without a full container restart.
 	RefreshSecrets(context.Context, *RefreshSecretsRequest) (*RefreshSecretsResponse, error)
+	// SetTenantKMSKey sets or clears a tenant's per-tenant KMS key for
+	// secrets envelope encryption, re-wrapping the tenant's existing
+	// secrets under the new key (or back to the shared KEK on clear).
+	// Admin role + explicit secrets:write scope required unconditionally
+	// — see SetTenantKMSKeyRequest's comment for why this RPC doesn't get
+	// the self-access exception the other secrets RPCs have.
+	SetTenantKMSKey(context.Context, *SetTenantKMSKeyRequest) (*SetTenantKMSKeyResponse, error)
 	mustEmbedUnimplementedContainerServiceServer()
 }
 
@@ -1484,6 +1509,9 @@ func (UnimplementedContainerServiceServer) DeleteSecret(context.Context, *Delete
 }
 func (UnimplementedContainerServiceServer) RefreshSecrets(context.Context, *RefreshSecretsRequest) (*RefreshSecretsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RefreshSecrets not implemented")
+}
+func (UnimplementedContainerServiceServer) SetTenantKMSKey(context.Context, *SetTenantKMSKeyRequest) (*SetTenantKMSKeyResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method SetTenantKMSKey not implemented")
 }
 func (UnimplementedContainerServiceServer) mustEmbedUnimplementedContainerServiceServer() {}
 func (UnimplementedContainerServiceServer) testEmbeddedByValue()                          {}
@@ -2604,6 +2632,24 @@ func _ContainerService_RefreshSecrets_Handler(srv interface{}, ctx context.Conte
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ContainerService_SetTenantKMSKey_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SetTenantKMSKeyRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ContainerServiceServer).SetTenantKMSKey(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ContainerService_SetTenantKMSKey_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ContainerServiceServer).SetTenantKMSKey(ctx, req.(*SetTenantKMSKeyRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // ContainerService_ServiceDesc is the grpc.ServiceDesc for ContainerService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -2854,6 +2900,10 @@ var ContainerService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "RefreshSecrets",
 			Handler:    _ContainerService_RefreshSecrets_Handler,
+		},
+		{
+			MethodName: "SetTenantKMSKey",
+			Handler:    _ContainerService_SetTenantKMSKey_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/proto/containarium/v1/secrets.proto
+++ b/proto/containarium/v1/secrets.proto
@@ -168,3 +168,38 @@ message RefreshSecretsResponse {
   // secrets owned by the tenant at refresh time).
   int32 stamped = 2;
 }
+
+// SetTenantKMSKeyRequest sets or clears a tenant's per-tenant KEK for
+// secrets envelope encryption. This is a privileged, admin-only
+// operation performed ON BEHALF OF a tenant — unlike SetSecret/GetSecret,
+// it always requires the admin role and an explicitly granted
+// secrets:write scope, even when the caller's own subject equals
+// username, because changing which key encrypts a tenant's secrets is
+// not something a tenant does to itself in the platform's actual usage.
+message SetTenantKMSKeyRequest {
+  // Username (tenant) whose KEK to set or clear.
+  string username = 1;
+
+  // GCP Cloud KMS CryptoKey resource name
+  // (projects/P/locations/L/keyRings/R/cryptoKeys/K) that this tenant's
+  // secrets will be wrapped under going forward. The daemon re-wraps
+  // every existing secret the tenant owns under this key.
+  //
+  // Empty clears the override: existing secrets are re-wrapped back
+  // under the daemon's shared KEK (CONTAINARIUM_GCP_KMS_KEY_NAME)
+  // before the tenant's own key can be invalidated by whoever manages
+  // it upstream.
+  //
+  // Requires CONTAINARIUM_KMS_BACKEND=gcp — per-tenant keys are not
+  // yet supported for the vault/aws/inproc backends.
+  string kek_resource_name = 2;
+}
+
+message SetTenantKMSKeyResponse {
+  // Operator-facing summary, including how many secrets were re-wrapped.
+  string message = 1;
+
+  // True if the tenant now has a per-tenant key (kek_resource_name was
+  // non-empty in the request); false if cleared back to the shared KEK.
+  bool has_tenant_key = 2;
+}

--- a/proto/containarium/v1/service.proto
+++ b/proto/containarium/v1/service.proto
@@ -983,4 +983,22 @@ service ContainerService {
       tags: "Secrets";
     };
   }
+
+  // SetTenantKMSKey sets or clears a tenant's per-tenant KMS key for
+  // secrets envelope encryption, re-wrapping the tenant's existing
+  // secrets under the new key (or back to the shared KEK on clear).
+  // Admin role + explicit secrets:write scope required unconditionally
+  // — see SetTenantKMSKeyRequest's comment for why this RPC doesn't get
+  // the self-access exception the other secrets RPCs have.
+  rpc SetTenantKMSKey(SetTenantKMSKeyRequest) returns (SetTenantKMSKeyResponse) {
+    option (google.api.http) = {
+      post: "/v1/secrets/{username}/kms-key"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Set or clear a tenant's per-tenant KMS key";
+      description: "Re-wraps the tenant's existing secrets under the given GCP KMS CryptoKey (or back to the shared KEK if kek_resource_name is empty). Requires CONTAINARIUM_KMS_BACKEND=gcp. Admin role + explicit secrets:write scope required, unconditionally.";
+      tags: "Secrets";
+    };
+  }
 }


### PR DESCRIPTION
## Summary

Closes #1630: an admin-scoped RPC lets an operator set (or clear) a
per-tenant GCP KMS key for secrets envelope encryption, re-wrapping the
tenant's existing secrets under it. Today every tenant shares one KEK;
this adds the missing plumbing to opt a specific tenant onto its own key
without touching anyone else.

Proto-first per this repo's CLAUDE.md: new `SetTenantKMSKey` RPC in
`secrets.proto`/`service.proto`, regenerated (`buf generate`), server
handler, both `internal/client` transports, and a CLI pair:
`containarium secrets set-kms-key` / `clear-kms-key`.

**Why this PR is larger than a typical change**: proto + generated code
+ server + both client transports + CLI is one coherent contract-first
unit per this repo's own convention (a boundary can't ship half-wired).
Roughly half the diff is generated code (`pkg/pb/...`, swagger.json) and
tests; non-generated source is ~565 lines across proto + store + server
+ client + CLI.

## Design

- **Decrypt is resolved per-row, not per-"current override."**
  `resolveDecryptKMS` parses the key resource name out of each row's own
  `kek_id` (via the newly-exported `corecrypto.GCPKEKPrefix`) and builds/
  caches a client for THAT key — never from "whatever the tenant's
  override currently is." This is what makes `SetTenantKMSKey`/
  `ClearTenantKMSKey` safe to interrupt mid-rewrap: a row still on its
  old key keeps decrypting correctly no matter how far the rewrap has
  gotten, and a retry just continues (each `Get`/`Set` pair is
  independently correct).
- **Encrypt is resolved per-username** from a new `tenant_kms_keys`
  table (one row per tenant with an override), cached in memory and
  reloaded at daemon restart (`loadTenantKEKCache`).
- **`SetTenantKMSKey`/`ClearTenantKMSKey` reuse existing `List`/`Get`/
  `Set`** rather than bespoke SQL for the rewrap loop — inherits those
  functions' existing correctness and tests, at the cost of not skipping
  already-correct rows (acceptable: tenants carry a handful of secrets,
  not thousands).
- **Authz is deliberately NOT `AuthorizeSecretTenant`'s self-access-exempt
  shape.** Every other secrets RPC lets a caller act on its own tenant
  without the admin+explicit-scope requirement. This RPC requires admin
  role + `secrets:write` granted *explicitly* unconditionally, even when
  the caller's subject equals the target username — changing which key
  encrypts a tenant's secrets is a privileged operation done on a
  tenant's behalf (the platform-managed-key story), not something a
  tenant does to itself.
- **Scoped to the `gcp` KMS backend only.** `LoadTenantKMSFactory`
  returns `(nil, nil)` for vault/aws/inproc/none — matches the actual
  ask; those backends can follow later if needed.

## Test evidence

- `internal/secrets/tenant_kms_test.go` — pure in-memory dispatch
  (`resolveEncryptKMS`/`resolveDecryptKMS`/`kekClient`), no Postgres, no
  network. Mutation-verified: reverting `resolveEncryptKMS` to ignore the
  override makes `TestSetTenantKMSKey_RewrapsExistingSecretsUnderTheNewKey`
  fail for the right reason (confirmed locally, then restored).
- `internal/secrets/tenant_kms_integration_test.go` — real Postgres
  (`CONTAINARIUM_TEST_DSN`-gated, same convention as
  `TestSecretsStore_Roundtrip`) + a local fake multi-key Cloud KMS server
  with genuinely per-key-derived AES keys (not a single shared fake key —
  it actually enforces "wrong key can't decrypt"). Covers rewrap, clear,
  restart-survival of the cache, and the load-bearing isolation property:
  tenant B's key cannot unwrap tenant A's DEK.
- `internal/server/secrets_kms_key_test.go` — the authz gate, direct
  method calls against a real store. Mutation-verified: disabling the
  admin+scope check makes both denial tests fail with the wrong code
  (confirmed locally, then restored).
- `internal/client/http_secrets_test.go` — grpc-gateway camelCase decode
  (`hasTenantKey`), mutation-verified against the same class of bug
  `TestListSecretsDecodesGatewayCamelCase` (#1219) already guards.
- `internal/secrets/kms_factory_test.go` — `LoadTenantKMSFactory` against
  a local fake KMS endpoint (`httptest`), not real GCP; proves the built
  client is scoped to the key passed to the factory, not the daemon's
  shared key.

All Postgres-gated tests were actually run (not just written) against a
local Postgres instance during development, not merely compiled.

Locally: `go build ./...`, `go vet ./...`, `gofmt -l` (clean),
`golangci-lint run` on every touched package (0 issues), full
`go test ./...` (two unrelated pre-existing failures in
`test/integration` — `TestStorageQuotaEnforcement`/`TestStoragePersistence`
require a live remote server + downloaded certs; confirmed they fail
identically on `main` with this branch's changes stashed out).

CI run pending on the pushed branch — will confirm green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added admin controls to assign or clear tenant-specific Google Cloud KMS keys.
  - Existing tenant secrets are automatically re-encrypted when keys change or are removed.
  - Added HTTP, gRPC, and command-line support with status reporting.
  - Tenant-specific encryption settings persist across service restarts.
  - Supported for deployments using the Google Cloud KMS backend.

- **Security**
  - Operations require administrator access and the `secrets:write` permission.
  - Tenant encryption keys remain isolated from other tenants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->