### PR TITLE
ci(dependabot): group the k8s.io and OpenTelemetry module families

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,35 @@ updates:
     labels:
       - "dependencies"
       - "security"
+    groups:
+      # The k8s.io modules are released as a set and are NOT independently
+      # upgradable. Bumping one alone can leave a sibling behind at a version
+      # whose generated code references symbols the other no longer exports,
+      # e.g. k8s.io/apimachinery v0.37.0 against k8s.io/api v0.36.4:
+      #
+      #   k8s.io/api@v0.36.4/extensions/v1beta1/zz_generated.validations.go:128:33:
+      #     undefined: validate.EachSliceVal
+      #
+      # That failed build, unit, kind e2e, golangci-lint and govulncheck on a
+      # single-module PR. One grouped PR moves the set together instead.
+      #
+      # controller-runtime and structured-merge-diff track the same Kubernetes
+      # release line, so they belong in the group. sigs.k8s.io/agent-sandbox is
+      # deliberately NOT here: it versions independently (v1.x while k8s.io is
+      # v0.3x) and its bumps require a paired change to the controller version
+      # pinned in scripts/k8s-e2e.sh, which is easier to review on its own.
+      kubernetes:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/controller-runtime"
+          - "sigs.k8s.io/structured-merge-diff/*"
+      # The OpenTelemetry modules share a release train, and a split bump
+      # leaves instrumentation packages straddling two contrib releases
+      # (otelgrpc v0.70.0 alongside otelhttp v0.71.0). Harmless so far, but
+      # they are meant to move together.
+      opentelemetry:
+        patterns:
+          - "go.opentelemetry.io/*"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Follow-up to the dependency-PR batch — this is the process fix for what made that batch painful.

## The problem

Dependabot opens one PR per module, but these families are **released as a set**. Split, they're individually broken.

Concretely, from this week: bumping `k8s.io/apimachinery` to v0.37.0 alone left `k8s.io/api` at v0.36.4, whose generated code calls a symbol that doesn't exist across that boundary:

```
k8s.io/api@v0.36.4/extensions/v1beta1/zz_generated.validations.go:128:33:
  undefined: validate.EachSliceVal
```

That failed **build, unit, kind e2e, golangci-lint and govulncheck** on #1622.

The instructive part is the sibling PR. #1626 (`client-go`) was **green** — but only because minimal version selection happened to drag `api` and `apimachinery` up along with it. Merging it first silently resolved a PR that was red for the mirror-image reason. That's luck, not a process, and it cuts the other way just as easily: a green single-module PR can leave the tree in a state the next one breaks.

## What this changes

| Group | Modules | Rationale |
|---|---|---|
| `kubernetes` | 9 — `k8s.io/*`, `controller-runtime`, `structured-merge-diff/*` | Version-locked release set |
| `opentelemetry` | 11 — `go.opentelemetry.io/*` | Shared release train; a split bump left `otelgrpc` v0.70.0 straddling `otelhttp` v0.71.0 |

**`sigs.k8s.io/agent-sandbox` is deliberately left ungrouped.** It versions independently (v1.x while `k8s.io` is v0.3x), and its bumps require a paired change to the controller version pinned in `scripts/k8s-e2e.sh` — #1632 was exactly that. Grouping it would bury a change that needs its own review.

## Secondary benefit: much less merge churn

Every gomod PR edits `go.mod`/`go.sum`, so under strict branch protection **each merge conflicts every other open one**. Ten dependency PRs meant ten update-CI-merge cycles plus three manual conflict resolutions and two supersede-and-reopen rounds. Grouping collapses that.

## Verification

Patterns simulated against the current `go.mod` rather than assumed:

```
kubernetes (9):    k8s.io/{api,apiextensions-apiserver,apimachinery,client-go,
                   klog/v2,kube-openapi,utils},
                   sigs.k8s.io/{controller-runtime,structured-merge-diff/v6}
opentelemetry (11): go.opentelemetry.io/{otel,otel/*,contrib/*,auto/sdk,proto/otlp}
ungrouped:          sigs.k8s.io/{agent-sandbox,json,randfill,yaml}
agent-sandbox correctly excluded: True
```

`yaml.safe_load` parses the file cleanly. Config-only — no code, no build impact. The real proof is next Monday's run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Grouped Kubernetes-related Go module updates together.
  * Grouped OpenTelemetry module updates together for more streamlined update proposals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->