### PR TITLE
fix(secrets): ClearTenantKMSKey no longer rewraps existing secrets (#1637)

### DIFF
--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -119,9 +119,15 @@ Use 'secrets clear-kms-key' to revert username to the shared KEK.`,
 
 var secretsClearKMSKeyCmd = &cobra.Command{
 	Use:   "clear-kms-key <username>",
-	Short: "Revert a tenant to the shared KMS key (admin only)",
-	Long: `Reverts username from its own per-tenant KMS key back to the
-daemon's shared KEK, re-wrapping every secret they currently own.
+	Short: "Stop using a tenant's per-tenant KMS key (admin only)",
+	Long: `Stops routing username's NEW secrets to their per-tenant KMS key —
+future writes fall back to the daemon's shared KEK. This does NOT
+touch any secret username already owns: each existing row stays
+wrapped under whatever key it was already wrapped under. If that key
+is later destroyed (the cloud control plane does this right after
+calling this command, as the cryptographic-shred half of per-org CMEK
+disable), those pre-existing secrets become permanently unreadable —
+this is not a reversible "revert," it's the last step before a shred.
 Idempotent — clearing a tenant with no override still succeeds.
 
 Same authz requirement as 'secrets set-kms-key': admin role + the

--- a/internal/secrets/store.go
+++ b/internal/secrets/store.go
@@ -564,10 +564,17 @@ func (s *Store) SetTenantKMSKey(ctx context.Context, username, keyResourceName s
 	return s.rewrapTenant(ctx, username)
 }
 
-// ClearTenantKMSKey reverts username to the shared/default KEK,
-// re-wrapping every secret they currently own back under it. Idempotent
-// — clearing a tenant with no override just re-wraps (a no-op-shaped
-// rewrap, since every row is already on the shared key) and succeeds.
+// ClearTenantKMSKey stops routing username's NEW secret writes to their
+// dedicated KMS key — it does NOT touch any existing secret. This is the
+// cryptographic-shred half of per-org CMEK disable
+// (FootprintAI/Containarium-cloud#1386, #1387): the caller (the cloud
+// control plane) destroys the underlying GCP key right after this call
+// returns, and every row still carrying that key's kek_id becomes
+// permanently unreadable — resolveDecryptKMS resolves strictly from each
+// row's own persisted kek_id, never from this override, so leaving old
+// rows alone here is exactly what makes that destroy a real shred rather
+// than a no-op. Idempotent: clearing a tenant with no override is just a
+// delete of zero rows, still succeeds.
 func (s *Store) ClearTenantKMSKey(ctx context.Context, username string) error {
 	username = strings.TrimSpace(username)
 	if username == "" {
@@ -580,12 +587,16 @@ func (s *Store) ClearTenantKMSKey(ctx context.Context, username string) error {
 	delete(s.tenantKEK, username)
 	s.tenantKEKMu.Unlock()
 
-	return s.rewrapTenant(ctx, username)
+	return nil
 }
 
 // rewrapTenant re-encrypts every secret username owns under whatever
 // resolveEncryptKMS currently resolves for username — i.e., the
-// override SetTenantKMSKey/ClearTenantKMSKey just committed.
+// dedicated key SetTenantKMSKey just committed. Only SetTenantKMSKey
+// calls this (migrating live secrets onto a NEW key they're keeping);
+// ClearTenantKMSKey does NOT — see its doc comment for why leaving old
+// rows alone is what makes per-org CMEK disable a real cryptographic
+// shred instead of a silent preserve-under-a-different-key.
 //
 // Not optimized to skip rows already on the target key — tenants carry
 // a handful of secrets, not thousands, so a harmless re-encrypt of an

--- a/internal/secrets/tenant_kms_integration_test.go
+++ b/internal/secrets/tenant_kms_integration_test.go
@@ -268,7 +268,16 @@ func TestSetTenantKMSKey_IsolatesFromOtherTenants(t *testing.T) {
 	}
 }
 
-func TestClearTenantKMSKey_RewrapsBackToSharedAndIsIdempotent(t *testing.T) {
+// TestClearTenantKMSKey_LeavesExistingRowsOnTheirOwnKeyAndIsIdempotent pins
+// the cryptographic-shred contract (Containarium-cloud's per-org-CMEK
+// disclosure-gap design correction, FootprintAI/Containarium#1637):
+// disabling per-org CMEK must NOT rewrap a tenant's existing secrets back
+// to the shared KEK. Clear only stops routing NEW writes to the tenant's
+// dedicated key — existing rows keep the kek_id they were already wrapped
+// under, so once the cloud side destroys that GCP key, those rows become
+// permanently unreadable. Rewrapping them to the shared key here would
+// silently preserve access to pre-disable values, defeating the shred.
+func TestClearTenantKMSKey_LeavesExistingRowsOnTheirOwnKeyAndIsIdempotent(t *testing.T) {
 	fk := &fakeMultiKeyGCPKMS{t: t}
 	srv := httptest.NewServer(http.HandlerFunc(fk.handle))
 	defer srv.Close()
@@ -284,11 +293,27 @@ func TestClearTenantKMSKey_RewrapsBackToSharedAndIsIdempotent(t *testing.T) {
 	_, _ = pool.Exec(ctx, "DELETE FROM tenant_kms_keys WHERE username = $1", user)
 
 	tenantKey := "projects/p/locations/l/keyRings/r/cryptoKeys/" + user
+	wantTenantKekID := corecrypto.GCPKEKPrefix + tenantKey
 	if err := store.SetTenantKMSKey(ctx, user, tenantKey); err != nil {
 		t.Fatalf("SetTenantKMSKey: %v", err)
 	}
 	if _, err := store.Set(ctx, user, "API_KEY", "under-tenant-key", ""); err != nil {
 		t.Fatalf("Set: %v", err)
+	}
+
+	kekIDOf := func(name string) string {
+		t.Helper()
+		var kekID string
+		if err := pool.QueryRow(ctx,
+			`SELECT kek_id FROM secrets WHERE username = $1 AND name = $2`, user, name,
+		).Scan(&kekID); err != nil {
+			t.Fatalf("query kek_id for %s: %v", name, err)
+		}
+		return kekID
+	}
+
+	if got := kekIDOf("API_KEY"); got != wantTenantKekID {
+		t.Fatalf("kek_id before clear = %q, want the tenant key %q", got, wantTenantKekID)
 	}
 
 	if err := store.ClearTenantKMSKey(ctx, user); err != nil {
@@ -299,23 +324,19 @@ func TestClearTenantKMSKey_RewrapsBackToSharedAndIsIdempotent(t *testing.T) {
 		t.Fatalf("second ClearTenantKMSKey: %v", err)
 	}
 
+	// The pre-clear secret must still decrypt correctly RIGHT NOW — the
+	// tenant's dedicated GCP key is still alive in this test (only the
+	// cloud side ever calls GCP KMS destroy). But its kek_id must be
+	// UNCHANGED, not moved to the shared key: that's the whole point.
 	_, value, err := store.Get(ctx, user, "API_KEY")
 	if err != nil {
 		t.Fatalf("Get after clear: %v", err)
 	}
 	if value != "under-tenant-key" {
-		t.Fatalf("value after clear-rewrap = %q, want %q", value, "under-tenant-key")
+		t.Fatalf("value after clear = %q, want %q", value, "under-tenant-key")
 	}
-
-	var kekID string
-	if err := pool.QueryRow(ctx,
-		`SELECT kek_id FROM secrets WHERE username = $1 AND name = $2`, user, "API_KEY",
-	).Scan(&kekID); err != nil {
-		t.Fatalf("query kek_id: %v", err)
-	}
-	wantSharedKekID := corecrypto.GCPKEKPrefix + "projects/p/locations/l/keyRings/r/cryptoKeys/shared"
-	if kekID != wantSharedKekID {
-		t.Fatalf("kek_id after clear = %q, want the shared key %q", kekID, wantSharedKekID)
+	if got := kekIDOf("API_KEY"); got != wantTenantKekID {
+		t.Fatalf("kek_id after clear = %q, want UNCHANGED tenant key %q (clear must not rewrap)", got, wantTenantKekID)
 	}
 
 	var stillOverridden int
@@ -326,6 +347,17 @@ func TestClearTenantKMSKey_RewrapsBackToSharedAndIsIdempotent(t *testing.T) {
 	}
 	if stillOverridden != 0 {
 		t.Fatal("tenant_kms_keys row should be gone after clear")
+	}
+
+	// A NEW write after clear must route to the shared key — the
+	// override is gone, so this is the shared fallback, unrelated to the
+	// pre-clear row above.
+	if _, err := store.Set(ctx, user, "NEW_AFTER_CLEAR", "new-value", ""); err != nil {
+		t.Fatalf("Set after clear: %v", err)
+	}
+	wantSharedKekID := corecrypto.GCPKEKPrefix + "projects/p/locations/l/keyRings/r/cryptoKeys/shared"
+	if got := kekIDOf("NEW_AFTER_CLEAR"); got != wantSharedKekID {
+		t.Fatalf("kek_id of a write after clear = %q, want the shared key %q", got, wantSharedKekID)
 	}
 }
 

--- a/internal/server/secrets_server.go
+++ b/internal/server/secrets_server.go
@@ -222,7 +222,7 @@ func (s *ContainerServer) SetTenantKMSKey(ctx context.Context, req *pb.SetTenant
 	}
 
 	hasTenantKey := req.KekResourceName != ""
-	msg := fmt.Sprintf("tenant %s reverted to the shared KEK", req.Username)
+	msg := fmt.Sprintf("tenant %s's KMS key override cleared; new secrets use the shared KEK, existing ones keep their current key", req.Username)
 	if hasTenantKey {
 		msg = fmt.Sprintf("tenant %s now on its own KMS key", req.Username)
 	}


### PR DESCRIPTION
Closes #1637

## Summary
- `ClearTenantKMSKey` no longer calls `rewrapTenant`. It only deletes the tenant's `tenant_kms_keys` override row (routing NEW writes to the shared KEK); every existing secret row keeps whatever `kek_id` it was already wrapped under.
- This is a correction, not a new feature: the cloud repo's per-org-CMEK disclosure-gap design review found the old rewrap-on-clear behavior silently defeated the "revoke destroys your key material" claim. `Encryption.Disable` on the cloud side calls this RPC (with an empty resource name) and then destroys the org's real GCP KMS key right after — under the old behavior every secret had already moved off that key by the time it was destroyed, so nothing was actually shredded. Now, once the cloud side's destroy completes, every row still carrying that key's `kek_id` becomes permanently unreadable — `resolveDecryptKMS` resolves strictly per-row, never from the tenant's current override, which is what makes leaving old rows alone here safe.
- `SetTenantKMSKey`'s rewrap-on-SET path (enabling/rotating onto a NEW key the org is keeping) is untouched — this only removes the rewrap from the *clear* path.
- Corrected the CLI help text (`secrets clear-kms-key --help`) and the RPC's audit/response message, both of which described the old rewrap-and-preserve behavior.

## Test evidence
- `internal/secrets/tenant_kms_integration_test.go`: replaced `TestClearTenantKMSKey_RewrapsBackToSharedAndIsIdempotent` with `TestClearTenantKMSKey_LeavesExistingRowsOnTheirOwnKeyAndIsIdempotent` — asserts a pre-existing secret's `kek_id` is UNCHANGED after clear (not moved to shared), the override row is gone, a NEW write after clear correctly routes to the shared key, and clear stays idempotent. Mutation-verified: restoring the old `rewrapTenant` call makes the new test fail for the right reason (`kek_id` shows shared instead of the tenant key).
- Full `internal/secrets`, `internal/server`, `internal/cmd`, `internal/client` suites green with `-race` against real Postgres (`CONTAINARIUM_TEST_DSN`).
- `go build ./...`, `go vet ./...`, `golangci-lint run` on the touched packages — clean.

## Notes for reviewers
- Cross-repo: this is required for FootprintAI/Containarium-cloud#1386/#1387 to actually deliver the "revoke = cryptographic shred" claim in `docs/architecture/per-org-cmek-disclosure-gap.md` (cloud repo). The cloud-side code needs no changes — its clear-then-destroy ordering was already correct, only its rationale comments referenced the old rewrap behavior (fixed there separately).
- No proto/wire-shape change — `SetTenantKMSKeyRequest`/`Response` are unchanged; this is a pure store-layer behavior fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Clearing a tenant KMS key now affects only newly written secrets.
  - Existing secrets remain encrypted with their current keys and remain readable while those keys exist.
  - New secrets use the shared encryption key after clearing.
  - Repeated key-clearing operations are now safely idempotent.
  - Updated messaging clarifies that destroying retained keys can make existing secrets permanently unreadable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->