### PR TITLE
docs: PRD + architecture design for continuous threat detection

### DIFF
--- a/docs/architecture/continuous-threat-detection.md
+++ b/docs/architecture/continuous-threat-detection.md
@@ -1,0 +1,284 @@
+# Design: Continuous threat detection (security sentry)
+
+**Date:** 2026-08-31
+**Status:** proposed
+**Stack:** protobuf/gRPC (grpc-gateway) + existing daemon; Go 1.24 (no new deployable, no new language)
+**PRD:** `docs/product/continuous-threat-detection.md` — stories #1639 #1640 #1641 #1642 #1643
+
+## Problem
+
+The daemon already collects the signals that reveal abuse and tenant-fence
+probing — eBPF per-flow records and typed deny events — but nothing
+correlates or delivers them: deny events terminate in the audit log
+(`internal/server/network_policy_enforcer.go`), flow records feed only the
+traffic view, and no continuous loop evaluates either. This design adds a
+rule-based detection engine inside the daemon that turns those streams
+into typed, deduped, tamper-evident **security findings** delivered to the
+event bus, the audit chain, a webhook, and a CLI. Detection-only: no
+automated response in this phase.
+
+## Design
+
+One new Go package, `internal/threatdetect/`, wired into the existing
+daemon. No new process, container, or language.
+
+```mermaid
+flowchart LR
+  subgraph eBPF["existing eBPF layer (internal/netbpf)"]
+    FR["FlowRecord poll (15s)"]
+    DE["DenyEvent perf ring"]
+  end
+  subgraph enforcer["network_policy_enforcer.go"]
+    HOOKS["SetFlowHook / SetDenyHook (new fan-out)"]
+    IPT["IP→tenant cache (existing)"]
+  end
+  subgraph td["internal/threatdetect (new)"]
+    ENG["Engine\n(rule registry + dedupe)"]
+    R1["rule: bad-destination"]
+    R2["rule: cross-tenant flow"]
+    R3["rule: deny-burst"]
+    ST["FindingStore (Postgres)"]
+    NT["Notifier (direct webhook POST)"]
+  end
+  SINKS1["events.Bus → SubscribeEvents"]
+  SINKS2["audit log (hash chain)"]
+  SINKS3["alert.DeliveryStore (webhook record)"]
+  CLI["containarium security findings / sentry status\n(ThreatDetectionService, gRPC + gateway)"]
+
+  FR --> HOOKS --> ENG
+  DE --> HOOKS
+  IPT -. "tenant lookup" .-> ENG
+  ENG --> R1 & R2 & R3
+  R1 & R2 & R3 --> ST
+  ST --> NT --> SINKS3
+  ST --> SINKS1
+  ST --> SINKS2
+  ST --> CLI
+```
+
+### Components
+
+1. **Engine** (`internal/threatdetect/engine.go`) — receives flow batches
+   and deny events via two hooks registered on the network-policy
+   enforcer (same pattern as `Scanner.SetScanResultHook` →
+   `auto_quarantine.go`, the one existing detect→act template). Fans each
+   input to every registered `Rule`; a rule returns zero or more
+   `RawFinding`s. The engine owns dedupe: an open finding is keyed by
+   `(rule, tenant, subject)`; a repeat increments `count` and bumps
+   `last_seen` instead of creating a new finding or re-alerting.
+   Requires the eBPF object loaded but **not** `..._ENFORCE` — it works
+   in observation mode. When eBPF is absent, `GetSentryStatus` reports
+   `UNAVAILABLE` with the reason; it never silently reports "no
+   findings". Enable flag: `CONTAINARIUM_THREAT_SENTRY=1` (off by
+   default, consistent with the platform's opt-in convention; the fleet
+   rollout note lives in the PRD).
+
+2. **Rules** — one file each, all implementing:
+
+   ```go
+   type Rule interface {
+       ID() pb.ThreatRuleId
+       OnFlows(ctx RuleContext, flows []netbpf.FlowRecord) []RawFinding
+       OnDeny(ctx RuleContext, ev netbpf.DenyEvent) []RawFinding
+       Sweep(ctx RuleContext, now time.Time) []RawFinding // time-window rules
+   }
+   ```
+
+   `RuleContext` exposes the enforcer's existing IP→tenant cache (already
+   refreshed by the 10s reconcile loop) and the rule's stored config —
+   rules never talk to Incus or the DB themselves, which keeps them
+   pure and table-testable.
+
+   - **bad-destination** (`rule_baddest.go`, #1641): matches flow dst IP
+     against a merged matcher = embedded baseline list (`go:embed`ed
+     versioned YAML, mining pools first) + operator additions persisted
+     via `DaemonConfigStore`. Exact IPs in a map, CIDRs in a binary
+     LPM trie. HIGH severity; subject = destination.
+   - **cross-tenant flow** (`rule_crosstenant.go`, #1642): both src and
+     dst IP resolve to containers with *different* tenant ids on this
+     backend ⇒ CRITICAL. This is the continuous form of the one-shot
+     `cmd/isolation-sentry` check.
+   - **deny-burst** (`rule_denyburst.go`, #1642): per-tenant sliding
+     window over deny events; ≥ N (default 20) within M minutes
+     (default 5) ⇒ MEDIUM "fence probing". Window swept via `Sweep()`
+     on a 30s tick. N and M operator-tunable via rule config.
+
+3. **FindingStore** (`internal/threatdetect/store.go`) — Postgres table
+   (schema below), created via the same `initSchema` idiom as
+   `alert.DeliveryStore`. On every insert/update it (a) emits
+   `EVENT_TYPE_SECURITY_FINDING` on the singleton `events.Bus`, and
+   (b) writes an audit entry (category `security.finding`) through the
+   existing audit logger, so findings ride the tamper-evident hash chain
+   with zero new chain code. Without Postgres the store degrades to a
+   bounded in-memory ring: events and audit entries still flow, CLI
+   listing works for the current process lifetime, and `sentry status`
+   reports `DEGRADED (no persistence)`.
+
+4. **Notifier** (`internal/threatdetect/notifier.go`) — for MEDIUM+
+   findings, POSTs the finding JSON **directly** to the configured
+   webhook (`alert_webhook_url` + HMAC via `alert_webhook_secret`, both
+   already persisted in `DaemonConfigStore`) and records every attempt in
+   the existing `alert.DeliveryStore`. Deliberately bypasses the
+   vmalert/alertmanager pipeline: that path requires the
+   VictoriaMetrics core container and is metrics-shaped; a direct POST
+   works on any backend, including minimal BYOC hosts. Bounded queue +
+   retry with backoff; a dead webhook drops deliveries (recorded as
+   failed) and never blocks the engine — delivery is downstream of
+   persistence.
+
+5. **API + CLI** — new `proto/containarium/v1/threatdetection.proto`
+   (contract below), implemented in
+   `internal/server/threatdetect_server.go`; cobra verbs in
+   `internal/cmd/` calling the generated client (CLI-first); MCP tools
+   in `internal/mcp/tools.go` as thin wrappers over the same client
+   functions.
+
+6. **Cloud shim (cloud repo, separate work)** — P0 is pass-through only:
+   the shim forwards `ListFindings`/`GetSentryStatus` per backend, as it
+   does for other OSS surfaces. Findings deliberately carry no
+   cloud-org mapping in OSS; the shim maps tenant→org exactly as it does
+   for containers. Aggregation UI is P1.
+
+### Data flow (happy path and failure paths)
+
+Flow poll (15s) → enforcer flow hook → engine → rules → new/updated
+finding in store → {event bus, audit chain} synchronously, webhook
+asynchronously → operator triages via `containarium security findings`.
+Worst-case detection latency = 15s poll + one evaluation pass ≪ the 60s
+budget in #1640; deny-burst adds ≤ 30s sweep granularity.
+
+Failure paths: rule panic is recovered per-rule and surfaces in
+`sentry status` (one broken rule never kills the engine or the
+enforcer); Postgres down ⇒ degraded in-memory mode (above); webhook down
+⇒ failed deliveries recorded, findings unaffected; eBPF not loaded ⇒
+engine refuses to start and status says why.
+
+### Data model
+
+```sql
+CREATE TABLE IF NOT EXISTS security_findings (
+  id           BIGSERIAL PRIMARY KEY,
+  rule         TEXT        NOT NULL,           -- pb.ThreatRuleId name
+  severity     TEXT        NOT NULL,           -- pb.ThreatSeverity name
+  tenant_id    TEXT        NOT NULL,
+  container    TEXT        NOT NULL DEFAULT '',
+  subject      TEXT        NOT NULL,           -- dedupe scope: dst IP / peer tenant / ''
+  state        TEXT        NOT NULL DEFAULT 'open',  -- open | resolved
+  count        BIGINT      NOT NULL DEFAULT 1,
+  evidence     JSONB       NOT NULL,           -- marshaled typed Go struct, capped (last 10 flows / deny counts)
+  first_seen   TIMESTAMPTZ NOT NULL,
+  last_seen    TIMESTAMPTZ NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS security_findings_open_dedupe
+  ON security_findings (rule, tenant_id, subject) WHERE state = 'open';
+```
+
+`evidence` is written by marshaling a named Go struct
+(`threatdetect.Evidence`), never an ad-hoc map — the JSONB column is a
+storage encoding, not a typing escape hatch.
+
+## Language choices
+
+| Component | Language | Why this one | Type gate in CI |
+|-----------|----------|--------------|-----------------|
+| `internal/threatdetect/` engine, rules, store, notifier | Go | Lives inside the existing Go daemon; consumes in-process eBPF structs; latency-sensitive hot path | `go build` + `go vet` (existing lanes) |
+| proto contract + generated clients | protobuf → Go (+ TS/OpenAPI via existing `buf generate`) | Repo convention: one contract, three consumers | `make proto` drift = dirty tree in CI |
+| CLI verbs + MCP wrappers | Go | CLI-first convention; wraps generated client | same as daemon |
+
+No Python, no new TypeScript (no UI in MVP — the P1 cloud aggregation
+view will consume the generated OpenAPI client like every other webui
+surface).
+
+## Contracts
+
+**`proto/containarium/v1/threatdetection.proto`** (source of truth;
+`make proto` generates Go server/client, gateway REST shim, swagger):
+
+```proto
+enum ThreatSeverity { THREAT_SEVERITY_UNSPECIFIED = 0; THREAT_SEVERITY_LOW = 1;
+                      THREAT_SEVERITY_MEDIUM = 2; THREAT_SEVERITY_HIGH = 3;
+                      THREAT_SEVERITY_CRITICAL = 4; }
+enum ThreatRuleId   { THREAT_RULE_ID_UNSPECIFIED = 0; THREAT_RULE_ID_BAD_DESTINATION = 1;
+                      THREAT_RULE_ID_CROSS_TENANT_FLOW = 2; THREAT_RULE_ID_DENY_BURST = 3; }
+
+service ThreatDetectionService {
+  rpc ListFindings(ListFindingsRequest) returns (ListFindingsResponse);          // GET  /v1/security/findings
+  rpc ResolveFinding(ResolveFindingRequest) returns (ResolveFindingResponse);    // POST /v1/security/findings/{id}/resolve
+  rpc GetSentryStatus(GetSentryStatusRequest) returns (GetSentryStatusResponse); // GET  /v1/security/sentry/status
+  rpc ListBadDestinations(...) returns (...);                                    // GET  /v1/security/bad-destinations
+  rpc AddBadDestination(...) returns (...);                                      // POST /v1/security/bad-destinations
+  rpc RemoveBadDestination(...) returns (...);                                   // DELETE /v1/security/bad-destinations/{cidr}
+  rpc UpdateThreatRuleConfig(...) returns (...);                                 // PATCH /v1/security/threat-rules/{rule}
+}
+```
+
+`Finding` message mirrors the table; filters on `ListFindingsRequest`:
+severity (enum, not string), tenant, since, state. `ListFindings` is
+tenant-scoped by the existing RBAC interceptor; admin sees all.
+
+**`events.proto`** — new enum value `EVENT_TYPE_SECURITY_FINDING = 50`
+(next free range, 50-59 reserved for security) + `SecurityFindingEvent`
+payload message carrying the `Finding`; emitted via a new
+`Emitter.EmitSecurityFinding(*pb.Finding)` alongside the existing typed
+emitters.
+
+**Internal Go boundaries** — enforcer→engine hooks are typed
+(`func([]netbpf.FlowRecord)`, `func(netbpf.DenyEvent)`); webhook payload
+is a named struct with an HMAC-signed body (same signing scheme the
+alert relay uses).
+
+## Test strategy
+
+| Component | Unit (table-driven) | Contract / integration | Real vs mocked |
+|-----------|--------------------|------------------------|----------------|
+| Engine + dedupe | `engine_test.go`: synthetic flow/deny sequences → expected finding set; dedupe cases (repeat ⇒ count++, no dup row, no re-alert); rule-panic isolation; disabled/no-eBPF ⇒ status UNAVAILABLE | wire-up test: enforcer hook fan-out fires engine on a fake flow batch | eBPF mocked (structs are plain Go); clock injected |
+| bad-destination rule | exact-IP hit, CIDR hit, miss, operator-added entry, list reload | replay of the mining-incident flow shape (persistent TLS 5-tuple to a listed pool) ⇒ HIGH finding — the #1641 acceptance test | matcher real; list fixture pinned |
+| cross-tenant rule | same-tenant flow ⇒ none; cross-tenant ⇒ CRITICAL; unknown IP ⇒ none (never guess) | e2e: two-org peers on one backend probe each other (reuses `cmd/isolation-sentry` scaffolding) ⇒ finding — the #1642 acceptance test | tenant cache faked in unit, real in e2e |
+| deny-burst rule | N-1 denies ⇒ none; N ⇒ MEDIUM; window expiry resets; tunable N/M | covered by the same two-org e2e (denies accumulate when enforcement is on) | injected clock |
+| FindingStore | upsert/dedupe SQL, state transitions, evidence cap | real Postgres in a container (existing integration lane); **audit-chain test: write findings, `VerifyChainSinceID` passes** — the #1639 acceptance test; restart ⇒ findings persist | real DB; degraded-mode path unit-tested with nil pool |
+| Notifier | severity threshold, HMAC signature, retry/backoff, dead-webhook never blocks | httptest server asserting payload + `DeliveryStore` row recorded | real local HTTP server |
+| Proto/API | — | generated-client round-trip for every RPC (gRPC and gateway REST); enum filters rejected as strings | generated clients only, never hand-rolled |
+| CLI | flag→request mapping table | `security findings` / `sentry status` against a daemon fixture | generated client |
+
+Type gate: `go vet` + `go build` + proto-drift check (regenerated tree
+must be clean) in the existing required CI lanes.
+
+## Deviations from the default stack
+
+None. No new language, no new deployable, no new datastore. One
+deliberate internal deviation: the Notifier bypasses the existing
+vmalert/alertmanager pipeline (documented above — that path requires the
+VictoriaMetrics core container; direct POST works on minimal backends).
+It still reuses the same webhook URL/secret config and delivery-record
+store, so operators configure alerting once.
+
+## Rejected alternatives
+
+- **Adopt an IDS (Falco/Tetragon/Suricata) per backend.** Real detection
+  depth, but a heavy per-host dependency (kernel module/eBPF programs we
+  don't own, rulesets to operate) for an MVP whose three rules need only
+  data we already collect. Reconsider at P2 with measured precision data.
+- **Express rules as vmalert alerts over exported metrics.** The alert
+  stack exists, but exported metrics deliberately carry **no tenant
+  labels** (golden-test invariant in the GCM exporter), the
+  VictoriaMetrics container isn't guaranteed on BYOC hosts, and per-flow
+  matching (dst IP against a list) isn't a metrics query. Wrong substrate.
+- **A separate detection daemon/sidecar.** Cleaner failure isolation, but
+  it would need its own access to the eBPF maps, the tenant cache, the
+  audit chain, and the DB — four new contracts to keep in sync, versus
+  two in-process hooks. Not justified at this scale; the per-rule panic
+  isolation buys most of the safety.
+- **Generic anomaly scoring from day one** (reusing
+  `internal/modelgateway/anomaly.go`). Good prior art, but unfalsifiable
+  precision before a baseline exists; PRD defers it to P2 deliberately.
+
+## At 10x
+
+10x containers per host: flow volume scales with flows, not containers —
+the LRU is already 65536 entries; the engine is O(flows) per batch with
+O(1) matcher lookups, headroom is fine. 10x backends: findings stay
+per-backend; the cloud aggregation layer (P1) inherits the shim's
+existing fan-out. The piece that would actually change: dedupe state
+and deny-burst windows are in-memory per daemon — a daemon restart
+reopens a still-live finding as new. Acceptable now (dedupe re-converges
+in one window); at much larger scale, move window state into the store.

--- a/docs/product/continuous-threat-detection.md
+++ b/docs/product/continuous-threat-detection.md
@@ -1,0 +1,226 @@
+# PRD: Continuous threat detection (background security sentry)
+
+**Date:** 2026-08-31
+**Status:** accepted — P0 stories filed as #1639 #1640 #1641 #1642 #1643
+**Owner:** devops@footprint-ai.com
+
+## Problem
+
+Nothing on the platform continuously watches for abuse or cross-tenant
+attack attempts. Every incident to date was detected by someone else, by
+luck, or not at all:
+
+- **Cryptomining abuse (cloud#815, 2026-07-11).** An abusive signup
+  created 12 containers in 19 minutes from a 2-minute-old account and ran
+  miners at ~260% CPU with a persistent TLS connection to a known mining
+  pool. **Google Cloud SCC detected it, not us** — the alert arrived
+  after the mining window had already ended. Repeated events risk GCP
+  **project suspension**, which would take down every tenant on that
+  provider. On BYOC hosts there is no external detector at all: the same
+  attack there is invisible.
+- **Cross-org isolation breach (cloud#780, 2026-07-07).** Two containers
+  in different orgs on the same backend could reach each other. The
+  condition had existed in production indefinitely; it was found only
+  when the one-shot CI isolation sentry was armed for the first time.
+  Nothing verifies the tenant fence between CI runs, and nothing would
+  notice a tenant *probing* it.
+- **Signals already exist but terminate in a log nobody watches.** The
+  eBPF network-policy layer emits per-flow records (5-tuple,
+  bytes/packets, 15s poll → `TrafficService`) and typed deny events
+  (policy / virtual-patch / signature-match). Deny events go to the
+  audit log and stdout only — no alert, no event-bus fan-out, no
+  thresholding (`internal/server/network_policy_enforcer.go:414`).
+- **Cost of the gap:** incident response starts from an external abuse
+  notification (reputational + suspension risk), the operator burns
+  hours reconstructing timelines from raw logs, and the multi-tenant
+  isolation story — the product's core promise — is verified only at CI
+  time, not continuously.
+
+**Why now:** the substrate shipped over the last two quarters (eBPF
+Phase A #315, flow accounting #627, deny-event plumbing #660/#661,
+webhook alert path, event bus). The remaining work is correlation and
+delivery, not new data collection — and free-tier signup means
+cloud#815-class abuse recurs until detected automatically.
+
+## Target user
+
+The **platform operator / on-call engineer** running a Containarium
+fleet (our cloud, or an OSS self-hoster). Job-to-be-done: *know within
+minutes — not from a third party — when a tenant is abusing the platform
+or testing the tenant fence, with enough context to respond.*
+
+Tenants benefit indirectly (their co-residents are watched) but are not
+the MVP audience.
+
+## Success metrics
+
+| Metric | Baseline | Target |
+|--------|----------|--------|
+| Time-to-detect mining-class abuse (start of egress to known-bad destination → our own alert) | External-only: provider alert after the fact on GCP; **never** on BYOC | < 5 min, from our own alert, on every backend with eBPF enabled |
+| Cross-tenant reachability / fence-probing detection | One-shot CI sentry only; probes between runs invisible | Continuous: cross-tenant flow or deny-burst alerts within 5 min |
+| Alert precision (on-call trusts the channel) | Unknown — instrument first | After 4 weeks tuning: < 3 false-positive alerts/week fleet-wide |
+
+## MVP scope — the core journey
+
+> A tenant workload opens a connection to a known mining pool (or starts
+> probing sibling containers). Within one detection cycle the daemon
+> raises a **security finding**, records it in the tamper-evident audit
+> log, emits it on the event bus, and delivers it to the operator's
+> configured webhook. The operator runs
+> `containarium security findings` to see what fired, on which backend,
+> for which tenant, with the triggering flows attached — and responds
+> using existing primitives.
+
+Detection-only in the MVP: the sentry **observes and alerts, it does not
+act**. (Automated response is P1 — precision must be measured before
+anything is allowed to freeze or quarantine on its own.)
+
+The engine lives in the OSS daemon (CLI-first; cloud wraps it), runs as
+a background loop over signals already collected — eBPF flow records and
+deny events — and evaluates a small, fixed, explainable rule set. No ML
+in the MVP.
+
+### P0 stories
+
+**Story 1: Security finding as a first-class platform event** (#1639)**.**
+As an operator, I want detections recorded as typed security findings so
+that they are queryable, streamable, and tamper-evident — not log lines.
+**Acceptance criteria:**
+- [ ] A `SECURITY_FINDING` event type exists in `events.proto` with rule
+      id, severity, tenant/container ref, backend, and evidence
+      (triggering flow 5-tuples / deny counts); delivered via
+      `EventService.SubscribeEvents`.
+- [ ] Every finding also lands in the audit log inside the existing hash
+      chain, and `VerifyChainSinceID` still passes over a window
+      containing findings.
+- [ ] Findings persist across daemon restart.
+**Priority:** P0
+
+**Story 2: Background detection loop in the daemon** (#1640)**.**
+As an operator, I want a detection engine that continuously evaluates
+rules over the eBPF flow and deny-event streams so that detection is not
+tied to a scan schedule or a CI run.
+**Acceptance criteria:**
+- [ ] Engine subscribes to flow records and deny events in-process; end
+      of a detection cycle ≤ 60s after the triggering flow is polled.
+- [ ] Runs in observation mode: requires the eBPF object loaded but NOT
+      `CONTAINARIUM_NETWORK_POLICY_ENFORCE` — detection works on a fleet
+      that hasn't turned on enforcement yet.
+- [ ] A rule firing repeatedly for the same tenant+rule dedupes into one
+      open finding with an updated count, not an alert storm.
+- [ ] Engine on/off state and per-rule status visible via
+      `containarium security sentry status` (CLI verb; MCP tool wraps
+      the same client function).
+**Priority:** P0
+
+**Story 3: Known-bad destination rule (catches cloud#815)** (#1641)**.**
+As an operator, I want an alert when any tenant egresses to a known
+mining pool or known-bad destination so that coin-mining abuse is
+detected in minutes instead of via a provider abuse notice.
+**Acceptance criteria:**
+- [ ] Ships with a static, versioned bad-destination list (mining pools
+      first) matched against flow destination IPs; list is
+      operator-extendable via CLI without a daemon rebuild.
+- [ ] A flow to a listed destination raises a HIGH finding naming the
+      tenant container and destination within one detection cycle.
+- [ ] Replaying the cloud#815 flow pattern in a test environment
+      produces the finding.
+**Priority:** P0
+
+**Story 4: Fence-probe rules (catches cloud#780-class conditions)** (#1642)**.**
+As an operator, I want an alert when cross-tenant east-west traffic
+occurs, or when one tenant accumulates a burst of policy denies, so that
+both a *breached* fence and a *probed* fence are visible.
+**Acceptance criteria:**
+- [ ] A flow whose source and destination resolve to containers in
+      different tenants on the same backend raises a CRITICAL finding —
+      the continuous version of the one-shot isolation sentry.
+- [ ] ≥ N deny events (default 20) for one tenant within M minutes
+      (default 5) raises a MEDIUM "fence probing" finding; N and M are
+      operator-tunable.
+- [ ] Both rules verified by an e2e test that creates two-org peers and
+      probes across them (reusing `cmd/isolation-sentry` scaffolding).
+**Priority:** P0
+
+**Story 5: Delivery and triage surface** (#1643)**.**
+As an on-call engineer, I want findings pushed to my webhook and
+listable from the CLI so that I learn about an incident from my own
+platform first and can triage without SSH-ing into backends.
+**Acceptance criteria:**
+- [ ] MEDIUM+ findings deliver to the existing webhook path with
+      recorded delivery status; a dead webhook never blocks detection.
+- [ ] `containarium security findings [--severity --tenant --since]`
+      lists findings with evidence; works against a remote server.
+- [ ] Cloud: findings from all connected backends are visible through
+      the shim (aggregation UI is P1; pass-through visibility is P0).
+**Priority:** P0
+
+### Rollout prerequisite (not a story)
+
+Detection requires the eBPF object loaded
+(`CONTAINARIUM_NETWORK_POLICY_BPF_OBJECT`), which is off by default and
+not enabled fleet-wide today. MVP ships with a rollout note: enable
+observation mode per backend, measure overhead (Phase A was
+hardware-validated), then arm the sentry. Backends without eBPF report
+"sentry unavailable" honestly rather than silently detecting nothing —
+the cloud#780 lesson is that silent non-verification reads as safety.
+
+## Later phases
+
+- **P1 — Automated response ladder.** Org-freeze primitive
+  (cloud#815 follow-up; reversible, unlike today's soft-delete) and
+  auto-quarantine wiring for CRITICAL network findings, reusing the
+  existing ClamAV→deny-rule hook template
+  (`internal/server/auto_quarantine.go`). Gated on 4 weeks of measured
+  precision.
+- **P1 — Control-plane abuse rules (cloud repo).** Container-create
+  velocity on young accounts (12 creates in 19 min from a 2-minute-old
+  org was the cloud#815 tell) — CP-side signal the daemon can't see.
+- **P1 — Cloud fleet aggregation view.** One pane across backends,
+  including BYOC (findings ride the sentinel tunnel; BYOC hosts export
+  no metrics by design, so the event path is the transport).
+- **P2 — Anomaly scoring.** Reuse the model-gateway anomaly engine
+  (EWMA windows, novelty sets, composite score) for "unusual for this
+  tenant" detection beyond fixed rules.
+- **P2 — Process-level signals.** CPU-pattern + known-miner-binary
+  checks inside boxes; today's flow-level view can't see a miner using
+  an unlisted pool.
+
+## Out of scope
+
+- **Full IDS integration (Falco/Tetragon/Suricata).** Heavy operational
+  dependency per backend; the Tier-2 signature engine is already
+  documented as evadable, and rule-based flow detection must prove
+  signal quality first. Revisit at P2 with data.
+- **Any auto-response in the MVP** — a false positive that freezes a
+  paying tenant costs more than a late alert; precision is unmeasured.
+- **Attacker source-IP traceability** — real gap, separately tracked as
+  a cloud#815 follow-up; different plumbing (proxy-protocol/XFF), not
+  this engine.
+- **DDoS / volumetric protection** — different problem class and
+  mitigations; nothing here should imply we detect or absorb it.
+- **Tenant-facing security dashboard** — operator-first; exposing
+  findings to tenants raises its own questions (what does a tenant get
+  to see about a co-resident probing them?).
+
+## Open questions & assumptions
+
+1. **eBPF observation-mode fleet rollout** — assumed acceptable overhead
+   (Phase A hardware-validated). Validate: enable on one low-stakes
+   backend, compare host CPU before/after.
+2. **BYOC coverage in MVP** — assumed P0 detects locally on any backend
+   with eBPF, but cross-backend *visibility* through the cloud shim may
+   lag for BYOC. Decide during design whether the tunnel event path is
+   MVP or P1.
+3. **Bad-destination list sourcing** — MVP assumes a static in-repo list
+   is enough to catch commodity miners. Validate against the cloud#815
+   IOCs; a refreshing threat feed is a later decision.
+4. **Alert destination** — the webhook path exists but where it points
+   (Slack? pager?) is operator config; no evidence yet on preferred
+   channel.
+5. **IPv6** — flow accounting is IPv4-only today; assumed acceptable for
+   MVP (tenant egress is effectively v4 in current deployments). Confirm
+   before GA claims.
+6. **Precision baseline is unknown by definition** — the metric plan is
+   instrument-first: run 4 weeks in observe-only, count would-have-paged
+   alerts, then set thresholds.


### PR DESCRIPTION
Adds the accepted PRD and the proposed architecture design for the continuous threat detection MVP (background security sentry).

- `docs/product/continuous-threat-detection.md` — problem/evidence, success metrics, 5 P0 stories: #1639 #1640 #1641 #1642 #1643
- `docs/architecture/continuous-threat-detection.md` — `internal/threatdetect/` engine + 3 rules, `ThreatDetectionService` proto contract, `EVENT_TYPE_SECURITY_FINDING`, findings on the audit hash chain, direct webhook delivery, per-component test strategy

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added architecture documentation for an opt-in continuous threat-detection capability.
  * Documented detection rules for known-bad destinations, cross-tenant traffic, and bursts of denied activity.
  * Defined finding severity, deduplication, persistence, audit events, webhooks, and degraded-mode behavior.
  * Added product guidance covering observation-only rollout, CLI and webhook triage, configuration, operational prerequisites, and future enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->