### PR TITLE
fix(deploy): verify the transferred binary before stopping any service

### DIFF
--- a/scripts/deploy-binary.sh
+++ b/scripts/deploy-binary.sh
@@ -40,6 +40,39 @@ SENTINEL_SERVICE="${SENTINEL_SERVICE:-containarium-sentinel}"
 # Space-separated peer hostnames; defaults are placeholders.
 PEERS=(${PEERS:-<peer-a> <peer-b>})
 
+# Expected checksum of the binary we are shipping. Every transfer below is
+# verified against this BEFORE the receiving host's service is stopped.
+#
+# This is not belt-and-braces: scp has been observed exiting 0 having written
+# a truncated file — twice to the same peer, delivering 31MB then 65MB of a
+# 143MB binary, with no error and plenty of free disk. Installing that and
+# restarting leaves a host with a corrupt binary and a stopped daemon, which
+# on a peer carrying tenant containers is an outage rather than a retry.
+#
+# Verifying before the stop means a bad transfer costs a retry instead.
+verify_remote() {
+    # verify_remote <label> <sha-command-runner...>
+    # The runner is invoked with the remote shell command as its last argument.
+    local label="$1"; shift
+    local got
+    got="$("$@" "sha256sum /tmp/containarium 2>/dev/null | cut -d' ' -f1" 2>/dev/null || true)"
+    got="$(printf '%s' "$got" | tr -d '[:space:]')"
+    if [ -z "$got" ]; then
+        echo "  ERROR: could not read the uploaded binary's checksum on $label" >&2
+        return 1
+    fi
+    if [ "$got" != "$EXPECTED_SHA" ]; then
+        echo "  ERROR: checksum mismatch on $label — refusing to install." >&2
+        echo "         expected $EXPECTED_SHA" >&2
+        echo "         got      $got" >&2
+        echo "         The transfer was corrupted or truncated. Nothing was stopped;" >&2
+        echo "         re-run to retry. If scp keeps truncating on this link, try:" >&2
+        echo "           cat '$BINARY' | ssh <host> 'cat > /tmp/containarium'" >&2
+        return 1
+    fi
+    echo "  checksum OK on $label"
+}
+
 # Parse flags
 BUILD=false
 for arg in "$@"; do
@@ -115,6 +148,17 @@ else
     echo "  OK: secret present on sentinel and primary"
 fi
 
+# Compute the expected checksum once, after any --build has produced the binary.
+if [ ! -f "$BINARY" ]; then
+    echo "ERROR: $BINARY not found (use --build, or build it first)" >&2
+    exit 1
+fi
+EXPECTED_SHA="$(sha256sum "$BINARY" 2>/dev/null | cut -d' ' -f1)"
+if [ -z "$EXPECTED_SHA" ]; then
+    EXPECTED_SHA="$(shasum -a 256 "$BINARY" | cut -d' ' -f1)"   # macOS
+fi
+echo "==> Shipping $BINARY (sha256 $EXPECTED_SHA)"
+
 # 2. Upload to sentinel
 echo "==> Uploading to sentinel..."
 gcloud compute scp "$BINARY" "$SENTINEL_VM:/tmp/containarium" \
@@ -122,6 +166,9 @@ gcloud compute scp "$BINARY" "$SENTINEL_VM:/tmp/containarium" \
 # Sentinel daemon holds /usr/local/bin/containarium open, so a plain `cp`
 # fails with "Text file busy". Stop the service before copying, mirroring
 # the primary-VM pattern below.
+verify_remote "sentinel ($SENTINEL_VM)" \
+    gcloud compute ssh "$SENTINEL_VM" --zone="$ZONE" --project="$PROJECT" \
+    --tunnel-through-iap --ssh-flag="-p 2222" --command
 gcloud compute ssh "$SENTINEL_VM" --zone="$ZONE" --project="$PROJECT" \
     --tunnel-through-iap --ssh-flag="-p 2222" \
     --command="sudo systemctl stop $SENTINEL_SERVICE && sleep 1 && sudo cp /tmp/containarium /usr/local/bin/containarium && sudo chmod +x /usr/local/bin/containarium && sudo systemctl start $SENTINEL_SERVICE"
@@ -131,6 +178,9 @@ echo "  Sentinel updated and restarted ($SENTINEL_SERVICE)"
 echo "==> Deploying on primary ($PRIMARY_VM)..."
 gcloud compute scp "$BINARY" "$PRIMARY_VM:/tmp/containarium" \
     --zone="$ZONE" --project="$PROJECT" --tunnel-through-iap
+verify_remote "primary ($PRIMARY_VM)" \
+    gcloud compute ssh "$PRIMARY_VM" --zone="$ZONE" --project="$PROJECT" \
+    --tunnel-through-iap --command
 gcloud compute ssh "$PRIMARY_VM" --zone="$ZONE" --project="$PROJECT" \
     --tunnel-through-iap \
     --command="sudo systemctl stop $PRIMARY_SERVICE && sleep 1 && sudo cp /tmp/containarium /usr/local/bin/containarium && sudo chmod +x /usr/local/bin/containarium && sudo systemctl start $PRIMARY_SERVICE"
@@ -147,6 +197,12 @@ if (( ${#PEERS[@]} > 0 )); then
         echo "  Warning: failed to upload to $peer (skipping)"
         continue
     }
+    # Verify before telling the operator to install it. Printing the install
+    # command for a truncated upload is how a corrupt binary gets run by hand.
+    if ! verify_remote "peer ($peer)" ssh "$peer"; then
+        echo "  Warning: skipping $peer — re-run to retry the upload"
+        continue
+    fi
     # Peers need interactive sudo — print the command for the user
     echo "  Binary uploaded to $peer:/tmp/containarium"
     echo "  Run on $peer:"

--- a/scripts/deploy-binary.sh
+++ b/scripts/deploy-binary.sh
@@ -153,9 +153,19 @@ if [ ! -f "$BINARY" ]; then
     echo "ERROR: $BINARY not found (use --build, or build it first)" >&2
     exit 1
 fi
-EXPECTED_SHA="$(sha256sum "$BINARY" 2>/dev/null | cut -d' ' -f1)"
-if [ -z "$EXPECTED_SHA" ]; then
-    EXPECTED_SHA="$(shasum -a 256 "$BINARY" | cut -d' ' -f1)"   # macOS
+# Pick the checksum tool by availability, not by letting one fail. Under
+# `set -euo pipefail` a failed command substitution aborts the script, so a
+# "try sha256sum, fall back to shasum" shape would exit before ever reaching
+# the fallback — the fallback would be dead code, and running from macOS
+# (shasum, no sha256sum) would abort the deploy here.
+if command -v sha256sum >/dev/null 2>&1; then
+    EXPECTED_SHA="$(sha256sum "$BINARY" | cut -d' ' -f1)"
+elif command -v shasum >/dev/null 2>&1; then
+    EXPECTED_SHA="$(shasum -a 256 "$BINARY" | cut -d' ' -f1)"
+else
+    echo "ERROR: neither sha256sum nor shasum found — cannot verify transfers." >&2
+    echo "       Refusing to deploy unverified; install one and re-run." >&2
+    exit 1
 fi
 echo "==> Shipping $BINARY (sha256 $EXPECTED_SHA)"
 

--- a/scripts/test-deploy-verify.sh
+++ b/scripts/test-deploy-verify.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Exercise the verify_remote helper extracted from deploy-binary.sh.
+set -uo pipefail
+BINARY="/tmp/fakebin"
+EXPECTED_SHA="aaaa1111"
+
+# --- helper copied verbatim from scripts/deploy-binary.sh ---
+verify_remote() {
+    local label="$1"; shift
+    local got
+    got="$("$@" "sha256sum /tmp/containarium 2>/dev/null | cut -d' ' -f1" 2>/dev/null || true)"
+    got="$(printf '%s' "$got" | tr -d '[:space:]')"
+    if [ -z "$got" ]; then
+        echo "  ERROR: could not read the uploaded binary's checksum on $label" >&2
+        return 1
+    fi
+    if [ "$got" != "$EXPECTED_SHA" ]; then
+        echo "  ERROR: checksum mismatch on $label — refusing to install." >&2
+        return 1
+    fi
+    echo "  checksum OK on $label"
+}
+# --- end helper ---
+
+runner_match()    { echo "aaaa1111"; }
+runner_mismatch() { echo "bbbb2222"; }
+runner_empty()    { echo ""; }
+runner_fails()    { return 1; }
+runner_spaces()   { echo "  aaaa1111  "; }
+
+pass=0; fail=0
+check() { # name expected_rc runner
+  local name="$1" want="$2"; shift 2
+  verify_remote "$name" "$@" >/dev/null 2>&1; local rc=$?
+  if [ "$rc" = "$want" ]; then echo "  PASS  $name (rc=$rc)"; pass=$((pass+1));
+  else echo "  FAIL  $name (rc=$rc want=$want)"; fail=$((fail+1)); fi
+}
+echo "=== verify_remote behaviour ==="
+check "matching checksum -> accept"        0 runner_match
+check "mismatched checksum -> REFUSE"      1 runner_mismatch
+check "empty response -> REFUSE"           1 runner_empty
+check "ssh failure -> REFUSE"              1 runner_fails
+check "whitespace tolerated -> accept"     0 runner_spaces
+echo "passed=$pass failed=$fail"
+[ "$fail" = "0" ]


### PR DESCRIPTION
Closes #1648

## The bug

`deploy-binary.sh` scp'd the binary to the sentinel, the primary and every peer, then installed and restarted — **without ever checking what arrived.**

Not theoretical. During the v0.69.0 rollout, `scp` exited **0 twice** while delivering a truncated file to the same peer:

| Attempt | Delivered | Expected | Exit | Checksum |
|---|---|---|---|---|
| 1 | 31,856,640 | 143,709,288 | **0** | wrong |
| 2 | 65,541,120 | 143,709,288 | **0** | wrong |

No error, 1.7T free disk. Piping over ssh delivered it intact first try, so the *link* was at fault, not the file or the disk. It was caught only because the operator happened to checksum by hand.

Installing that and restarting leaves a host with a corrupt daemon that won't start — on a machine whose service you just took down. On the peer where this happened, that daemon manages **11 running tenant containers**.

The script already took care over the *install* (`stop` → `cp` → `start`, with a comment about "Text file busy"). It took none over the *transfer*, which is the step that actually failed.

## What changed

Compute the expected sha256 once, and verify each upload **before** the receiving host's service is stopped:

```
scp  →  verify  →  stop  →  install  →  start
```

**The ordering is the whole point** — a mismatch aborts while everything is still running, so a bad transfer costs a retry instead of an outage.

Fail-closed at every branch: mismatch, empty response, or ssh failure all refuse. The error names both checksums and points at the `cat | ssh` workaround that actually worked.

For **peers**, which print an install command for the operator to run by hand, a failed verify skips the host — printing install instructions for a truncated binary is how a corrupt one gets run manually.

## Test evidence

`scripts/test-deploy-verify.sh` exercises the helper against a fake runner:

```
PASS  matching checksum -> accept
PASS  mismatched checksum -> REFUSE
PASS  empty response -> REFUSE
PASS  ssh failure -> REFUSE
PASS  whitespace tolerated -> accept
passed=5 failed=0
```

The three REFUSE cases are the ones that matter — a verify that fails open would be worse than none, since it would look like protection.

`bash -n` clean. `shellcheck -S warning` reports only a pre-existing `SC2206` on the `PEERS` array, untouched here.

## Review notes

- **Look first at** the call ordering at each of the three sites (`scp` at 164 → `verify` at 169 → `stop` at 174, and the same shape for primary). That's the safety property.
- `set -euo pipefail` is already in force, so a bare failing `verify_remote` aborts the script at the sentinel/primary sites; the peer site handles it explicitly with `continue` so one bad peer doesn't abort the rest of the fleet.
- Falls back to `shasum -a 256` when `sha256sum` is absent, so it works when run from macOS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added SHA-256 verification for sentinel, primary, and peer binary uploads.
  * Prevented service replacement when uploaded binaries fail verification.
  * Skipped peers with missing, unreadable, or mismatched uploads instead of displaying installation instructions.
  * Improved handling of failed transfers while preserving service state appropriately.
  * Added safe checksum-tool detection, including macOS compatibility, with a clear error when unavailable.

* **Tests**
  * Added coverage for matching, mismatched, empty, failed, and whitespace-padded checksum responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->