### PR TITLE
feat(gateway): report the daemon version on /health

### DIFF
--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -24,6 +24,7 @@ import (
 	"github.com/footprintai/containarium/internal/releases"
 	"github.com/footprintai/containarium/internal/security"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"github.com/footprintai/containarium/pkg/version"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/rs/cors"
 	"google.golang.org/grpc"
@@ -719,11 +720,7 @@ func (gs *GatewayServer) Start(ctx context.Context) error {
 	httpMux.HandleFunc("/internal/alert-relay", gs.handleAlertRelay)
 
 	// Health check endpoint (no auth required)
-	httpMux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"status":"healthy"}`))
-	})
+	httpMux.HandleFunc("/health", healthHandler)
 
 	mountInternalProxies(httpMux, gs)
 
@@ -888,4 +885,30 @@ func getAllowedOrigins() []string {
 		"http://localhost:8080",
 		"http://localhost",
 	}
+}
+
+// healthResponse is the /health payload. A named struct rather than an inline
+// literal so the shape is one reviewable thing — this endpoint is
+// unauthenticated, so what it carries is a deliberate decision.
+type healthResponse struct {
+	Status string `json:"status"`
+	// Version answers "what is this box running" without shell access (#1647).
+	// Previously the only way to tell was SSH plus `containarium version`,
+	// which made fleet audits, drift detection, and confirming a fix landed
+	// all require per-host credentials.
+	//
+	// Deliberately just the version: git commit and build time would narrow an
+	// anonymous caller's CVE search without helping the operational question.
+	Version string `json:"version"`
+}
+
+// healthHandler serves the unauthenticated liveness endpoint. Split out of the
+// mux wiring so it can be tested directly.
+func healthHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(healthResponse{
+		Status:  "healthy",
+		Version: version.GetVersion(),
+	})
 }

--- a/internal/gateway/health_version_test.go
+++ b/internal/gateway/health_version_test.go
@@ -1,0 +1,88 @@
+package gateway
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/footprintai/containarium/pkg/version"
+)
+
+// #1647: a running host exposed no version anywhere. /health answered
+// {"status":"healthy"} and nothing else; /version, /healthz and /metrics all
+// 404'd; and `containarium backends versions` sat behind auth that returned
+// 401 even from the primary itself. The only way to learn what a box was
+// running was SSH plus `containarium version`.
+//
+// That made routine work harder than it should be: a fleet audit needed shell
+// access to every machine, two production primaries silently diverged for
+// weeks, and several filed bugs had to record "app version: unconfirmed"
+// because the host could not be asked.
+//
+// /health is the natural home — it is already unauthenticated, already
+// scraped, and already reached by anything doing liveness checks, so putting
+// the version there makes every existing health check a version check too.
+
+func TestHealthEndpoint_ReportsVersion(t *testing.T) {
+	rec := httptest.NewRecorder()
+	healthHandler(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+
+	var got healthResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("response is not valid JSON: %v (body: %s)", err, rec.Body.String())
+	}
+
+	if got.Version == "" {
+		t.Error("version is empty — the whole point of #1647 is that a host can be asked " +
+			"what it runs without shell access")
+	}
+	if got.Version != version.GetVersion() {
+		t.Errorf("version = %q, want %q (the binary's own version)", got.Version, version.GetVersion())
+	}
+}
+
+// The existing contract must not change: anything already parsing this
+// endpoint keys off "status", and a liveness probe that starts failing
+// because we added a field would be a bad trade for observability.
+func TestHealthEndpoint_StatusFieldUnchanged(t *testing.T) {
+	rec := httptest.NewRecorder()
+	healthHandler(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+
+	var raw map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	if raw["status"] != "healthy" {
+		t.Errorf(`status = %v, want "healthy" — existing consumers key off this`, raw["status"])
+	}
+}
+
+// Guard against leaking more than intended. Version answers "what is this box
+// running"; commit hash and build time narrow an attacker's CVE search without
+// helping the operational question, so they stay out until someone decides
+// otherwise deliberately.
+func TestHealthEndpoint_ExposesOnlyStatusAndVersion(t *testing.T) {
+	rec := httptest.NewRecorder()
+	healthHandler(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+
+	var raw map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+
+	allowed := map[string]bool{"status": true, "version": true}
+	for k := range raw {
+		if !allowed[k] {
+			t.Errorf("unexpected field %q in /health — this endpoint is unauthenticated; "+
+				"adding build detail here widens what an anonymous caller learns", k)
+		}
+	}
+}


### PR DESCRIPTION
Closes #1647

## The problem

A running host could not be asked what it was running:

| Probe | Before |
|---|---|
| `GET /health` | `{"status":"healthy"}` — no version |
| `GET /version` | 404 |
| `GET /healthz` | 404 |
| `GET /metrics` | 404 |
| `containarium backends versions` | `401` — even from the primary itself |

SSH plus `containarium version` was the only route.

That taxed ordinary work in ways that showed up repeatedly this week: a fleet audit needed shell access to every machine; two production primaries silently ran different Caddy builds until someone went looking; two BYOC peers **remain of unknown version** because their host credentials aren't available; and several bugs filed this week record *"app version: unconfirmed"* — which makes them harder to close with confidence later.

## What changed

`/health` now returns the daemon version:

```json
{"status":"healthy","version":"0.70.0"}
```

`/health` is the natural home — already unauthenticated, already scraped, already hit by anything doing liveness checks. Putting the version there makes **every existing health check a version check**, with no new route and no new auth surface.

The payload is a named `healthResponse` struct rather than an inline literal, per the repo's typing convention and because an unauthenticated endpoint's contents deserve to be one reviewable thing.

## Deliberately just status + version

Git commit and build time would narrow an anonymous caller's CVE search without answering the operational question. `TestHealthEndpoint_ExposesOnlyStatusAndVersion` pins that, so widening it has to be a **decision** rather than a drift.

## Test evidence

| Criterion | Test |
|---|---|
| Version present and matches the binary | `TestHealthEndpoint_ReportsVersion` |
| `"status":"healthy"` unchanged | `TestHealthEndpoint_StatusFieldUnchanged` |
| No extra fields leak | `TestHealthEndpoint_ExposesOnlyStatusAndVersion` |

Full `internal/gateway` package green. **Mutation-verified**: blanking the version field fails `TestHealthEndpoint_ReportsVersion` with its intended message, so the test genuinely bites.

The second test exists because a liveness probe breaking in exchange for observability would be a bad trade — existing consumers key off `status`, and that contract is unchanged.

## Review notes

- The handler is extracted from the mux closure into `healthHandler` so it can be tested directly; the wiring is otherwise unchanged.
- Alternatives considered and not taken: a dedicated `/version` route (a new unauthenticated surface for no extra benefit), and fixing `backends versions`' auth (worth doing separately, but it doesn't help anyone without credentials — which was the actual blocker).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The health endpoint now reports the running daemon’s version alongside its healthy status.
  * Responses use JSON with a consistent content type and include only the status and version fields.

* **Bug Fixes**
  * Preserved the existing healthy status response while adding version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->