### PR TITLE
feat(threatdetect): known-bad destination rule (mining pools)

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -58,7 +58,7 @@
     },
     {
       "name": "ThreatDetectionService",
-      "description": "ThreatDetectionService serves the background security-sentry's status and\nfindings. GetSentryStatus ships with #1640 (background detection loop);\nthe findings/rule-config RPCs are added by later stories in the same\numbrella (#1641-#1643) — see docs/architecture/continuous-threat-detection.md."
+      "description": "ThreatDetectionService serves the background security-sentry's status and\nfindings. GetSentryStatus ships with #1640 (background detection loop);\n*BadDestination* ships with #1641 (known-bad destination rule); the\nfindings/rule-config RPCs are added by later stories in the same umbrella\n(#1642-#1643) — see docs/architecture/continuous-threat-detection.md."
     },
     {
       "name": "EventService",
@@ -5241,6 +5241,95 @@
         ]
       }
     },
+    "/v1/security/bad-destinations": {
+      "get": {
+        "summary": "List known-bad destinations",
+        "description": "Returns the merged baseline (embedded, versioned) and operator-added known-bad-destination list.",
+        "operationId": "ThreatDetectionService_ListBadDestinations",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListBadDestinationsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "tags": [
+          "Security"
+        ]
+      },
+      "post": {
+        "summary": "Add a known-bad destination",
+        "description": "Adds an operator-supplied CIDR or exact IP to the known-bad-destination list.",
+        "operationId": "ThreatDetectionService_AddBadDestination",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/AddBadDestinationResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AddBadDestinationRequest"
+            }
+          }
+        ],
+        "tags": [
+          "Security"
+        ]
+      }
+    },
+    "/v1/security/bad-destinations/{cidr}": {
+      "delete": {
+        "summary": "Remove an operator-added bad destination",
+        "description": "Removes a previously operator-added entry from the known-bad-destination list. Baseline entries cannot be removed.",
+        "operationId": "ThreatDetectionService_RemoveBadDestination",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/RemoveBadDestinationResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "cidr",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": ".+"
+          }
+        ],
+        "tags": [
+          "Security"
+        ]
+      }
+    },
     "/v1/security/clamav-reports": {
       "get": {
         "summary": "List ClamAV scan reports",
@@ -6755,6 +6844,25 @@
       "description": "- ACCESS_TYPE_SSH: SSH access (default for Linux containers)\n - ACCESS_TYPE_RDP: RDP access (for Windows VMs, via Guacamole browser-based client)",
       "title": "AccessType indicates how to connect to an instance"
     },
+    "AddBadDestinationRequest": {
+      "type": "object",
+      "properties": {
+        "cidr": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        }
+      }
+    },
+    "AddBadDestinationResponse": {
+      "type": "object",
+      "properties": {
+        "entry": {
+          "$ref": "#/definitions/BadDestinationEntry"
+        }
+      }
+    },
     "AddCollaboratorBody": {
       "type": "object",
       "properties": {
@@ -7548,6 +7656,23 @@
         }
       },
       "description": "BackupVerification is the audit artifact for one restore test: who ran\nit, when, against what, and what the engine said. Persisted on the\nBackupRecord so `ListBackups` can answer \"last verified\" and so the\nevidence outlives the run that produced it (ISO 27001 A.8.13 wants\nbackups *tested*, not just taken)."
+    },
+    "BadDestinationEntry": {
+      "type": "object",
+      "properties": {
+        "cidr": {
+          "type": "string",
+          "description": "Exact IP (\"203.0.113.7\") or CIDR (\"203.0.113.0/24\")."
+        },
+        "label": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string",
+          "description": "\"baseline\" (embedded, versioned list, shipped with the daemon) or\n\"operator\" (added via AddBadDestination, without a daemon rebuild)."
+        }
+      },
+      "description": "BadDestinationEntry is one entry in the known-bad-destination list (#1641)\nmatched against flow destination IPs — a mining pool or other known-bad\nendpoint."
     },
     "BuildpackOptions": {
       "type": "object",
@@ -10720,6 +10845,18 @@
         }
       }
     },
+    "ListBadDestinationsResponse": {
+      "type": "object",
+      "properties": {
+        "entries": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/BadDestinationEntry"
+          }
+        }
+      }
+    },
     "ListClamavReportsResponse": {
       "type": "object",
       "properties": {
@@ -12166,6 +12303,9 @@
         }
       },
       "description": "RemediatePentestFindingResponse returns the result of the remediation attempt."
+    },
+    "RemoveBadDestinationResponse": {
+      "type": "object"
     },
     "RemoveCollaboratorResponse": {
       "type": "object",

--- a/internal/cmd/security_bad_destinations.go
+++ b/internal/cmd/security_bad_destinations.go
@@ -1,0 +1,182 @@
+// `containarium security bad-destinations` — list, add, and remove entries
+// in the known-bad-destination list the bad-destination rule (#1641)
+// matches flow destinations against. CLI-first per the repo convention; the
+// MCP tools (internal/mcp/security.go) wrap the same REST calls.
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var securityBadDestinationsCmd = &cobra.Command{
+	Use:   "bad-destinations",
+	Short: "Manage the known-bad-destination list (bad-destination rule, #1641)",
+}
+
+var badDestinationsListJSONOut bool
+
+var securityBadDestinationsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List the merged baseline + operator-added known-bad destinations",
+	Args:  cobra.NoArgs,
+	RunE:  runSecurityBadDestinationsList,
+}
+
+var securityBadDestinationsAddCmd = &cobra.Command{
+	Use:   "add <cidr> [label]",
+	Short: "Add an operator-supplied entry to the known-bad-destination list",
+	Long: `Adds an exact IP or CIDR to the known-bad-destination list, effective
+immediately — no daemon rebuild or restart required.`,
+	Args: cobra.RangeArgs(1, 2),
+	RunE: runSecurityBadDestinationsAdd,
+}
+
+var securityBadDestinationsRemoveCmd = &cobra.Command{
+	Use:   "remove <cidr>",
+	Short: "Remove a previously operator-added entry",
+	Long:  `Removes a previously operator-added entry. Baseline entries cannot be removed.`,
+	Args:  cobra.ExactArgs(1),
+	RunE:  runSecurityBadDestinationsRemove,
+}
+
+// badDestinationEnvelope mirrors *BadDestinationEntry's grpc-gateway JSON
+// shape (protojson default: camelCase field names are already snake_case
+// here since every field name is a single word).
+type badDestinationEnvelope struct {
+	CIDR   string `json:"cidr"`
+	Label  string `json:"label"`
+	Source string `json:"source"`
+}
+
+type listBadDestinationsEnvelope struct {
+	Entries []badDestinationEnvelope `json:"entries"`
+}
+
+type addBadDestinationEnvelope struct {
+	Entry badDestinationEnvelope `json:"entry"`
+}
+
+func runSecurityBadDestinationsList(cmd *cobra.Command, _ []string) error {
+	if serverAddr == "" {
+		return errServerRequired()
+	}
+	var out listBadDestinationsEnvelope
+	url := strings.TrimSuffix(serverAddr, "/") + "/v1/security/bad-destinations"
+	if err := getJSON(url, &out); err != nil {
+		return err
+	}
+	if badDestinationsListJSONOut {
+		return printJSON(out)
+	}
+	w := cmd.OutOrStdout()
+	if len(out.Entries) == 0 {
+		fmt.Fprintln(w, "No known-bad destinations configured.")
+		return nil
+	}
+	fmt.Fprintf(w, "%-24s %-10s %s\n", "CIDR", "SOURCE", "LABEL")
+	for _, e := range out.Entries {
+		fmt.Fprintf(w, "%-24s %-10s %s\n", e.CIDR, e.Source, e.Label)
+	}
+	return nil
+}
+
+func runSecurityBadDestinationsAdd(cmd *cobra.Command, args []string) error {
+	if serverAddr == "" {
+		return errServerRequired()
+	}
+	cidr := args[0]
+	label := ""
+	if len(args) == 2 {
+		label = args[1]
+	}
+	body, err := json.Marshal(struct {
+		Cidr  string `json:"cidr"`
+		Label string `json:"label"`
+	}{Cidr: cidr, Label: label})
+	if err != nil {
+		return fmt.Errorf("marshal request: %w", err)
+	}
+	var out addBadDestinationEnvelope
+	url := strings.TrimSuffix(serverAddr, "/") + "/v1/security/bad-destinations"
+	if err := postJSON(url, body, &out); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Added %s (%s)\n", out.Entry.CIDR, out.Entry.Label)
+	return nil
+}
+
+func runSecurityBadDestinationsRemove(cmd *cobra.Command, args []string) error {
+	if serverAddr == "" {
+		return errServerRequired()
+	}
+	cidr := args[0]
+	url := strings.TrimSuffix(serverAddr, "/") + "/v1/security/bad-destinations/" + cidr
+	if err := deleteJSON(url); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Removed %s\n", cidr)
+	return nil
+}
+
+// postJSON does an admin-authenticated POST with a JSON body and decodes the
+// JSON response. Sibling of getJSON (backends_versions.go).
+func postJSON(url string, body []byte, out interface{}) error {
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if authToken != "" {
+		req.Header.Set("Authorization", "Bearer "+authToken)
+	}
+	httpClient := &http.Client{Timeout: 10 * time.Second}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("status %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+// deleteJSON does an admin-authenticated DELETE, discarding any response
+// body. Sibling of getJSON/postJSON.
+func deleteJSON(url string) error {
+	req, err := http.NewRequest(http.MethodDelete, url, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	if authToken != "" {
+		req.Header.Set("Authorization", "Bearer "+authToken)
+	}
+	httpClient := &http.Client{Timeout: 10 * time.Second}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("status %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	return nil
+}
+
+func init() {
+	securityBadDestinationsListCmd.Flags().BoolVar(&badDestinationsListJSONOut, "json", false, "Output raw JSON")
+	securityBadDestinationsCmd.AddCommand(securityBadDestinationsListCmd)
+	securityBadDestinationsCmd.AddCommand(securityBadDestinationsAddCmd)
+	securityBadDestinationsCmd.AddCommand(securityBadDestinationsRemoveCmd)
+	securityCmd.AddCommand(securityBadDestinationsCmd)
+}

--- a/internal/cmd/security_bad_destinations_test.go
+++ b/internal/cmd/security_bad_destinations_test.go
@@ -1,0 +1,117 @@
+package cmd
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRunSecurityBadDestinationsList_RequiresServer(t *testing.T) {
+	oldServer := serverAddr
+	serverAddr = ""
+	defer func() { serverAddr = oldServer }()
+
+	if err := runSecurityBadDestinationsList(testCmd(), nil); err == nil {
+		t.Fatal("expected an error when --server is unset")
+	}
+}
+
+func TestRunSecurityBadDestinationsList_HitsExpectedPathAndRendersOutput(t *testing.T) {
+	var gotPath, gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotMethod = r.URL.Path, r.Method
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{
+			"entries": [
+				{"cidr": "198.51.100.7/32", "label": "known miner", "source": "baseline"},
+				{"cidr": "192.0.2.55/32", "label": "operator-flagged host", "source": "operator"}
+			]
+		}`))
+	}))
+	defer srv.Close()
+
+	oldServer := serverAddr
+	serverAddr = srv.URL
+	defer func() { serverAddr = oldServer }()
+
+	cmd := testCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	if err := runSecurityBadDestinationsList(cmd, nil); err != nil {
+		t.Fatalf("runSecurityBadDestinationsList: %v", err)
+	}
+	if gotMethod != http.MethodGet || gotPath != "/v1/security/bad-destinations" {
+		t.Fatalf("request = %s %s, want GET /v1/security/bad-destinations", gotMethod, gotPath)
+	}
+	out := buf.String()
+	for _, want := range []string{"198.51.100.7/32", "known miner", "baseline", "192.0.2.55/32", "operator"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunSecurityBadDestinationsAdd_PostsCidrAndLabel(t *testing.T) {
+	var gotPath, gotMethod, gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotMethod = r.URL.Path, r.Method
+		body := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(body)
+		gotBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"entry": {"cidr": "192.0.2.55/32", "label": "flagged", "source": "operator"}}`))
+	}))
+	defer srv.Close()
+
+	oldServer := serverAddr
+	serverAddr = srv.URL
+	defer func() { serverAddr = oldServer }()
+
+	cmd := testCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	if err := runSecurityBadDestinationsAdd(cmd, []string{"192.0.2.55/32", "flagged"}); err != nil {
+		t.Fatalf("runSecurityBadDestinationsAdd: %v", err)
+	}
+	if gotMethod != http.MethodPost || gotPath != "/v1/security/bad-destinations" {
+		t.Fatalf("request = %s %s, want POST /v1/security/bad-destinations", gotMethod, gotPath)
+	}
+	if !strings.Contains(gotBody, "192.0.2.55/32") || !strings.Contains(gotBody, "flagged") {
+		t.Errorf("request body = %q, want cidr and label", gotBody)
+	}
+	if !strings.Contains(buf.String(), "Added") {
+		t.Errorf("output = %q, want a confirmation", buf.String())
+	}
+}
+
+func TestRunSecurityBadDestinationsRemove_DeletesByCIDR(t *testing.T) {
+	var gotPath, gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotMethod = r.URL.Path, r.Method
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	oldServer := serverAddr
+	serverAddr = srv.URL
+	defer func() { serverAddr = oldServer }()
+
+	cmd := testCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	if err := runSecurityBadDestinationsRemove(cmd, []string{"192.0.2.55/32"}); err != nil {
+		t.Fatalf("runSecurityBadDestinationsRemove: %v", err)
+	}
+	if gotMethod != http.MethodDelete || gotPath != "/v1/security/bad-destinations/192.0.2.55/32" {
+		t.Fatalf("request = %s %s, want DELETE /v1/security/bad-destinations/192.0.2.55/32", gotMethod, gotPath)
+	}
+	if !strings.Contains(buf.String(), "Removed") {
+		t.Errorf("output = %q, want a confirmation", buf.String())
+	}
+}

--- a/internal/mcp/backend.go
+++ b/internal/mcp/backend.go
@@ -81,6 +81,11 @@ type API interface {
 	// Threat-detection sentry (#1640).
 	GetSentryStatus() (*SentryStatusResponse, error)
 
+	// Known-bad destination rule (#1641).
+	ListBadDestinations() (*ListBadDestinationsResponse, error)
+	AddBadDestination(cidr, label string) (*BadDestinationEntry, error)
+	RemoveBadDestination(cidr string) error
+
 	// Tokens.
 	RevokeToken(jti, reason, expiresAt string) (string, error)
 

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -633,7 +633,6 @@ type MigrateToEnvelopeResponse struct {
 	Errors      []MigrateRowError `json:"errors"`
 }
 
-// GetKMSStatus reports the active KMS backend + envelope state.
 // GetSentryStatus reports the threat-detection sentry's on/off state and
 // per-rule health (#1640).
 func (c *Client) GetSentryStatus() (*SentryStatusResponse, error) {
@@ -646,6 +645,43 @@ func (c *Client) GetSentryStatus() (*SentryStatusResponse, error) {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 	return &resp, nil
+}
+
+// ListBadDestinations returns the merged baseline + operator-added
+// known-bad-destination list the bad-destination rule (#1641) matches
+// against.
+func (c *Client) ListBadDestinations() (*ListBadDestinationsResponse, error) {
+	respBody, err := c.doRequest("GET", "/v1/security/bad-destinations", nil)
+	if err != nil {
+		return nil, err
+	}
+	var resp ListBadDestinationsResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+	return &resp, nil
+}
+
+// AddBadDestination adds an operator-supplied entry, effective immediately.
+func (c *Client) AddBadDestination(cidr, label string) (*BadDestinationEntry, error) {
+	respBody, err := c.doRequest("POST", "/v1/security/bad-destinations", map[string]string{
+		"cidr": cidr, "label": label,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var resp AddBadDestinationResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+	return &resp.Entry, nil
+}
+
+// RemoveBadDestination removes a previously operator-added entry. Baseline
+// entries cannot be removed.
+func (c *Client) RemoveBadDestination(cidr string) error {
+	_, err := c.doRequest("DELETE", "/v1/security/bad-destinations/"+cidr, nil)
+	return err
 }
 
 func (c *Client) GetKMSStatus() (*KMSStatusResponse, error) {

--- a/internal/mcp/security.go
+++ b/internal/mcp/security.go
@@ -76,6 +76,25 @@ type SentryStatusResponse struct {
 	Rules  []SentryRuleStatus `json:"rules,omitempty"`
 }
 
+// BadDestinationEntry is one entry in the known-bad-destination list
+// (#1641), mirroring the daemon's BadDestinationEntry.
+type BadDestinationEntry struct {
+	CIDR   string `json:"cidr"`
+	Label  string `json:"label,omitempty"`
+	Source string `json:"source"`
+}
+
+// ListBadDestinationsResponse mirrors the daemon's
+// ListBadDestinationsResponse.
+type ListBadDestinationsResponse struct {
+	Entries []BadDestinationEntry `json:"entries"`
+}
+
+// AddBadDestinationResponse mirrors the daemon's AddBadDestinationResponse.
+type AddBadDestinationResponse struct {
+	Entry BadDestinationEntry `json:"entry"`
+}
+
 // --- MCP handlers ----------------------------------------------------------
 
 // handleSecurityScan triggers one or more scanners against a container.
@@ -154,6 +173,48 @@ func handleSecuritySentryStatus(client API, args map[string]interface{}) (string
 	}
 	out, _ := json.MarshalIndent(resp, "", "  ")
 	return string(out), nil
+}
+
+// handleListBadDestinations lists the merged baseline + operator-added
+// known-bad-destination list the bad-destination rule (#1641) matches flow
+// destinations against. Takes no arguments.
+func handleListBadDestinations(client API, args map[string]interface{}) (string, error) {
+	resp, err := client.ListBadDestinations()
+	if err != nil {
+		return "", fmt.Errorf("list bad destinations: %w", err)
+	}
+	out, _ := json.MarshalIndent(resp, "", "  ")
+	return string(out), nil
+}
+
+// handleAddBadDestination adds an operator-supplied entry to the
+// known-bad-destination list, effective immediately — no daemon rebuild or
+// restart required.
+func handleAddBadDestination(client API, args map[string]interface{}) (string, error) {
+	cidr := getStringArg(args, "cidr", "")
+	if cidr == "" {
+		return "", fmt.Errorf("cidr is required")
+	}
+	label := getStringArg(args, "label", "")
+	entry, err := client.AddBadDestination(cidr, label)
+	if err != nil {
+		return "", fmt.Errorf("add bad destination: %w", err)
+	}
+	out, _ := json.MarshalIndent(entry, "", "  ")
+	return string(out), nil
+}
+
+// handleRemoveBadDestination removes a previously operator-added entry.
+// Baseline entries cannot be removed this way.
+func handleRemoveBadDestination(client API, args map[string]interface{}) (string, error) {
+	cidr := getStringArg(args, "cidr", "")
+	if cidr == "" {
+		return "", fmt.Errorf("cidr is required")
+	}
+	if err := client.RemoveBadDestination(cidr); err != nil {
+		return "", fmt.Errorf("remove bad destination: %w", err)
+	}
+	return fmt.Sprintf("Removed %s from the known-bad-destination list.", cidr), nil
 }
 
 // handleSecurityRemediate calls the daemon's RemediatePentestFinding

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -22,8 +22,8 @@ func TestServerCreation(t *testing.T) {
 	assert.NotNil(t, server)
 	assert.Equal(t, config, server.config)
 	assert.NotNil(t, server.client)
-	// 30 base (+check_for_updates +upgrade_backend +get_upgrade_status, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes + 3 backups + connect (#453) + 2 agent-skills (#562) + call_agent (#570) + 2 crews (#584) + delete_route + install_zap (#960) + set_metrics_export + get_metrics_export (#1069) + verify_backup (#1159) + list_passthrough_routes + add_passthrough_route + delete_passthrough_route (#1550) + security_sentry_status (#1640).
-	assert.Len(t, server.tools, 63, "Should have 63 tools registered")
+	// 30 base (+check_for_updates +upgrade_backend +get_upgrade_status, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes + 3 backups + connect (#453) + 2 agent-skills (#562) + call_agent (#570) + 2 crews (#584) + delete_route + install_zap (#960) + set_metrics_export + get_metrics_export (#1069) + verify_backup (#1159) + list_passthrough_routes + add_passthrough_route + delete_passthrough_route (#1550) + security_sentry_status (#1640) + list_bad_destinations + add_bad_destination + remove_bad_destination (#1641).
+	assert.Len(t, server.tools, 66, "Should have 66 tools registered")
 }
 
 // TestServerTools tests tool registration
@@ -127,8 +127,8 @@ func TestHandleToolsList(t *testing.T) {
 
 	tools, ok := result["tools"].([]map[string]interface{})
 	require.True(t, ok)
-	// 30 base (+check_for_updates +upgrade_backend +get_upgrade_status, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes + 3 backups + connect (#453) + 2 agent-skills (#562) + call_agent (#570) + 2 crews (#584) + delete_route + install_zap (#960) + set_metrics_export + get_metrics_export (#1069) + verify_backup (#1159) + list_passthrough_routes + add_passthrough_route + delete_passthrough_route (#1550) + security_sentry_status (#1640).
-	assert.Len(t, tools, 63)
+	// 30 base (+check_for_updates +upgrade_backend +get_upgrade_status, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes + 3 backups + connect (#453) + 2 agent-skills (#562) + call_agent (#570) + 2 crews (#584) + delete_route + install_zap (#960) + set_metrics_export + get_metrics_export (#1069) + verify_backup (#1159) + list_passthrough_routes + add_passthrough_route + delete_passthrough_route (#1550) + security_sentry_status (#1640) + list_bad_destinations + add_bad_destination + remove_bad_destination (#1641).
+	assert.Len(t, tools, 66)
 
 	// Check first tool structure
 	firstTool := tools[0]

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -917,6 +917,55 @@ func (s *Server) registerTools() {
 			Handler: handleSecuritySentryStatus,
 		},
 		{
+			Name: "list_bad_destinations",
+			Description: "List the known-bad-destination list (#1641) the threat-detection sentry's " +
+				"bad-destination rule matches flow destinations against — a merged view of the " +
+				"embedded baseline (mining pools, versioned) and any operator-added entries. " +
+				"Takes no arguments.",
+			InputSchema: map[string]interface{}{
+				"type":       "object",
+				"properties": map[string]interface{}{},
+			},
+			Handler: handleListBadDestinations,
+		},
+		{
+			Name: "add_bad_destination",
+			Description: "Add an operator-supplied entry (exact IP or CIDR) to the known-bad-destination " +
+				"list, effective immediately — no daemon rebuild or restart required. Use this to " +
+				"extend detection to a destination the embedded baseline list doesn't cover yet.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"cidr": map[string]interface{}{
+						"type":        "string",
+						"description": "Exact IP (\"203.0.113.7\") or CIDR (\"203.0.113.0/24\").",
+					},
+					"label": map[string]interface{}{
+						"type":        "string",
+						"description": "Human-readable reason, e.g. \"reported mining pool\".",
+					},
+				},
+				"required": []string{"cidr"},
+			},
+			Handler: handleAddBadDestination,
+		},
+		{
+			Name: "remove_bad_destination",
+			Description: "Remove a previously operator-added entry from the known-bad-destination list. " +
+				"Baseline (embedded, versioned) entries cannot be removed this way.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"cidr": map[string]interface{}{
+						"type":        "string",
+						"description": "Exact IP or CIDR to remove, as it was added.",
+					},
+				},
+				"required": []string{"cidr"},
+			},
+			Handler: handleRemoveBadDestination,
+		},
+		{
 			Name: "install_zap",
 			Description: "Download and install OWASP ZAP into this host's security container. " +
 				"Admin-only, one-time-per-host setup — `security_scan` (kind=zap) and the " +
@@ -1476,6 +1525,12 @@ func toolScopeAssignments() map[string]string {
 		"security_remediate":     auth.ScopeSecurityWrite,
 		"security_findings":      auth.ScopeSecurityRead,
 		"security_sentry_status": auth.ScopeSecurityRead,
+		// bad-destination list (#1641): list is a read, add/remove mutate
+		// detection config — same split as security_findings vs
+		// security_scan/security_remediate above.
+		"list_bad_destinations":  auth.ScopeSecurityRead,
+		"add_bad_destination":    auth.ScopeSecurityWrite,
+		"remove_bad_destination": auth.ScopeSecurityWrite,
 		// install_zap is admin-only (the daemon also enforces
 		// RoleAdmin server-side); scope-gated the same as the other
 		// security-write tools at the MCP layer.

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -1685,6 +1685,19 @@ skipAppHosting:
 		}
 	}
 	threatDetectServer := NewThreatDetectionServer(threatDetectEngine, threatCfg.SentryEnabled, sentryAvailable, sentryUnavailableReason)
+
+	// Known-bad-destination rule (#1641): constructed independent of
+	// threatCfg.SentryEnabled — an operator can curate the list via CLI/MCP
+	// before ever turning the sentry on. Registered with the engine only
+	// when one was actually constructed above (sentry enabled + available).
+	if badDestRule, bdErr := threatdetect.NewBadDestinationRule(context.Background(), config.DaemonConfigStore); bdErr != nil {
+		log.Printf("Warning: threat-detection bad-destination rule init failed (%v); ListBadDestinations/Add/Remove unavailable", bdErr)
+	} else {
+		threatDetectServer.SetBadDestinationRule(badDestRule)
+		if threatDetectEngine != nil {
+			threatDetectEngine.Register(badDestRule)
+		}
+	}
 	pb.RegisterThreatDetectionServiceServer(grpcServer, threatDetectServer)
 
 	// Setup alert store and manager

--- a/internal/server/threatdetect_server.go
+++ b/internal/server/threatdetect_server.go
@@ -2,8 +2,11 @@ package server
 
 import (
 	"context"
+	"strings"
 	"sync"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/footprintai/containarium/internal/threatdetect"
@@ -11,9 +14,10 @@ import (
 )
 
 // ThreatDetectionServer implements ThreatDetectionService. GetSentryStatus
-// ships with #1640 (background detection loop); ListFindings/
-// ResolveFinding/rule-config RPCs are added by later stories in the same
-// umbrella (#1641-#1643) — see
+// ships with #1640 (background detection loop); ListBadDestinations/
+// AddBadDestination/RemoveBadDestination ship with #1641 (known-bad
+// destination rule); ListFindings/ResolveFinding/rule-config RPCs are added
+// by later stories in the same umbrella (#1642-#1643) — see
 // docs/architecture/continuous-threat-detection.md.
 type ThreatDetectionServer struct {
 	pb.UnimplementedThreatDetectionServiceServer
@@ -23,6 +27,13 @@ type ThreatDetectionServer struct {
 	engine *threatdetect.Engine
 
 	sentryEnabled bool // CONTAINARIUM_THREAT_SENTRY=1
+
+	// badDestRule is constructed independent of sentryEnabled/ebpfAvailable
+	// — an operator can curate the known-bad-destination list before ever
+	// flipping CONTAINARIUM_THREAT_SENTRY on. nil only if construction
+	// itself failed (malformed embedded baseline list — a build-time bug,
+	// not a runtime condition).
+	badDestRule *threatdetect.BadDestinationRule
 
 	mu                sync.Mutex // guards the two fields below — SetUnavailable can flip them after Start()
 	ebpfAvailable     bool       // eBPF object loaded (networkPolicyEnforcer != nil) AND still running
@@ -42,6 +53,17 @@ func NewThreatDetectionServer(engine *threatdetect.Engine, sentryEnabled, ebpfAv
 		ebpfAvailable:     ebpfAvailable,
 		unavailableReason: unavailableReason,
 	}
+}
+
+// SetBadDestinationRule wires the known-bad-destination rule (#1641) into
+// the server's List/Add/RemoveBadDestination handlers. Separate from
+// NewThreatDetectionServer's constructor args because the rule is
+// constructed independent of whether the sentry itself is enabled — an
+// operator can curate the list before ever setting
+// CONTAINARIUM_THREAT_SENTRY. nil is valid (construction failure); the
+// three handlers report that explicitly rather than panicking.
+func (s *ThreatDetectionServer) SetBadDestinationRule(r *threatdetect.BadDestinationRule) {
+	s.badDestRule = r
 }
 
 // SetUnavailable flips the server to UNAVAILABLE after construction — for
@@ -108,4 +130,66 @@ func (s *ThreatDetectionServer) GetSentryStatus(ctx context.Context, _ *pb.GetSe
 		rules = append(rules, rs)
 	}
 	return &pb.GetSentryStatusResponse{State: state, Reason: reason, Rules: rules}, nil
+}
+
+// ListBadDestinations returns the merged baseline + operator-added
+// known-bad-destination list the bad-destination rule (#1641) matches
+// against.
+func (s *ThreatDetectionServer) ListBadDestinations(ctx context.Context, _ *pb.ListBadDestinationsRequest) (*pb.ListBadDestinationsResponse, error) {
+	if s.badDestRule == nil {
+		return nil, status.Errorf(codes.Unavailable, "bad-destination rule not available")
+	}
+	entries := s.badDestRule.ListDestinations()
+	out := make([]*pb.BadDestinationEntry, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, &pb.BadDestinationEntry{Cidr: e.CIDR, Label: e.Label, Source: e.Source})
+	}
+	return &pb.ListBadDestinationsResponse{Entries: out}, nil
+}
+
+// AddBadDestination adds an operator-supplied entry, effective immediately
+// and (when a DaemonConfigStore is configured) persisted across restarts —
+// no daemon rebuild required.
+func (s *ThreatDetectionServer) AddBadDestination(ctx context.Context, req *pb.AddBadDestinationRequest) (*pb.AddBadDestinationResponse, error) {
+	if s.badDestRule == nil {
+		return nil, status.Errorf(codes.Unavailable, "bad-destination rule not available")
+	}
+	if req.GetCidr() == "" {
+		return nil, status.Errorf(codes.InvalidArgument, "cidr is required")
+	}
+	entry, err := s.badDestRule.AddDestination(ctx, req.GetCidr(), req.GetLabel())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	return &pb.AddBadDestinationResponse{
+		Entry: &pb.BadDestinationEntry{Cidr: entry.CIDR, Label: entry.Label, Source: entry.Source},
+	}, nil
+}
+
+// RemoveBadDestination removes a previously operator-added entry. Baseline
+// entries cannot be removed — see BadDestinationRule.RemoveDestination.
+func (s *ThreatDetectionServer) RemoveBadDestination(ctx context.Context, req *pb.RemoveBadDestinationRequest) (*pb.RemoveBadDestinationResponse, error) {
+	if s.badDestRule == nil {
+		return nil, status.Errorf(codes.Unavailable, "bad-destination rule not available")
+	}
+	if req.GetCidr() == "" {
+		return nil, status.Errorf(codes.InvalidArgument, "cidr is required")
+	}
+	if err := s.badDestRule.RemoveDestination(ctx, req.GetCidr()); err != nil {
+		if isBadDestNotFound(err) {
+			return nil, status.Errorf(codes.NotFound, "%v", err)
+		}
+		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	return &pb.RemoveBadDestinationResponse{}, nil
+}
+
+// isBadDestNotFound reports whether err is BadDestinationRule.RemoveDestination's
+// "not found among operator-added entries" case, so RemoveBadDestination can
+// map it to codes.NotFound instead of InvalidArgument. Matched by message
+// content rather than a sentinel error: threatdetect intentionally returns
+// plain fmt.Errorf here (see rule_baddest.go) since this is the only caller
+// that needs to distinguish it.
+func isBadDestNotFound(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "not found among operator-added entries")
 }

--- a/internal/server/threatdetect_server_test.go
+++ b/internal/server/threatdetect_server_test.go
@@ -72,6 +72,95 @@ func TestGetSentryStatus_OKWithRuleHealth(t *testing.T) {
 	}
 }
 
+func TestListBadDestinations_NoRule_ReturnsUnavailable(t *testing.T) {
+	s := NewThreatDetectionServer(nil, false, false, "")
+	if _, err := s.ListBadDestinations(context.Background(), &pb.ListBadDestinationsRequest{}); err == nil {
+		t.Fatal("ListBadDestinations with no rule wired should error, got nil")
+	}
+}
+
+func TestAddThenListBadDestination(t *testing.T) {
+	s := NewThreatDetectionServer(nil, false, false, "")
+	rule, err := threatdetect.NewBadDestinationRule(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("NewBadDestinationRule: %v", err)
+	}
+	s.SetBadDestinationRule(rule)
+
+	addResp, err := s.AddBadDestination(context.Background(), &pb.AddBadDestinationRequest{Cidr: "192.0.2.55/32", Label: "test entry"})
+	if err != nil {
+		t.Fatalf("AddBadDestination: %v", err)
+	}
+	if addResp.GetEntry().GetCidr() != "192.0.2.55/32" || addResp.GetEntry().GetSource() != "operator" {
+		t.Errorf("AddBadDestination entry = %+v, want cidr=192.0.2.55/32 source=operator", addResp.GetEntry())
+	}
+
+	listResp, err := s.ListBadDestinations(context.Background(), &pb.ListBadDestinationsRequest{})
+	if err != nil {
+		t.Fatalf("ListBadDestinations: %v", err)
+	}
+	found := false
+	for _, e := range listResp.GetEntries() {
+		if e.GetCidr() == "192.0.2.55/32" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("ListBadDestinations = %+v, want the just-added entry", listResp.GetEntries())
+	}
+}
+
+func TestAddBadDestination_MissingCidr(t *testing.T) {
+	s := NewThreatDetectionServer(nil, false, false, "")
+	rule, err := threatdetect.NewBadDestinationRule(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("NewBadDestinationRule: %v", err)
+	}
+	s.SetBadDestinationRule(rule)
+
+	if _, err := s.AddBadDestination(context.Background(), &pb.AddBadDestinationRequest{Label: "no cidr"}); err == nil {
+		t.Fatal("AddBadDestination with no cidr should error, got nil")
+	}
+}
+
+func TestRemoveBadDestination_NotFound(t *testing.T) {
+	s := NewThreatDetectionServer(nil, false, false, "")
+	rule, err := threatdetect.NewBadDestinationRule(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("NewBadDestinationRule: %v", err)
+	}
+	s.SetBadDestinationRule(rule)
+
+	if _, err := s.RemoveBadDestination(context.Background(), &pb.RemoveBadDestinationRequest{Cidr: "192.0.2.99/32"}); err == nil {
+		t.Fatal("RemoveBadDestination on a never-added entry should error, got nil")
+	}
+}
+
+func TestRemoveBadDestination_RoundTrip(t *testing.T) {
+	s := NewThreatDetectionServer(nil, false, false, "")
+	rule, err := threatdetect.NewBadDestinationRule(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("NewBadDestinationRule: %v", err)
+	}
+	s.SetBadDestinationRule(rule)
+
+	if _, err := s.AddBadDestination(context.Background(), &pb.AddBadDestinationRequest{Cidr: "192.0.2.55/32", Label: "temp"}); err != nil {
+		t.Fatalf("AddBadDestination: %v", err)
+	}
+	if _, err := s.RemoveBadDestination(context.Background(), &pb.RemoveBadDestinationRequest{Cidr: "192.0.2.55/32"}); err != nil {
+		t.Fatalf("RemoveBadDestination: %v", err)
+	}
+	listResp, err := s.ListBadDestinations(context.Background(), &pb.ListBadDestinationsRequest{})
+	if err != nil {
+		t.Fatalf("ListBadDestinations: %v", err)
+	}
+	for _, e := range listResp.GetEntries() {
+		if e.GetCidr() == "192.0.2.55/32" {
+			t.Errorf("entry still listed after removal: %+v", e)
+		}
+	}
+}
+
 // fakeFindingSink and fakeRule are minimal threatdetect.FindingSink /
 // threatdetect.Rule test doubles — this file only needs an Engine to exist
 // and report status, not to actually detect anything.

--- a/internal/threatdetect/rule_baddest.go
+++ b/internal/threatdetect/rule_baddest.go
@@ -1,0 +1,350 @@
+package threatdetect
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/netip"
+	"strings"
+	"sync"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/footprintai/containarium/internal/app"
+	"github.com/footprintai/containarium/internal/netbpf"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// embeddedBadDestYAML is the baseline known-bad-destination list (#1641):
+// mining pools first, per the design doc. Versioned so an operator can tell
+// which baseline a given daemon build shipped with; extend it without a
+// rebuild via AddDestination / `containarium security bad-destinations add`.
+//
+//go:embed rule_baddest_list.yaml
+var embeddedBadDestYAML []byte
+
+// badDestConfigKey is the DaemonConfigStore key operator-added entries are
+// persisted under, JSON-encoded — same initSchema/key-value idiom every
+// other daemon-config-backed feature uses.
+const badDestConfigKey = "threatdetect.bad_destinations.operator"
+
+// BadDestinationEntry is one entry in the known-bad-destination list,
+// mirroring pb.BadDestinationEntry as a plain Go type for the rule's
+// internal bookkeeping.
+type BadDestinationEntry struct {
+	// CIDR is always stored normalized (netip.Prefix.Masked().String()) —
+	// an exact IP is a /32.
+	CIDR  string
+	Label string
+	// Source is "baseline" (embedded, versioned list) or "operator" (added
+	// via AddDestination). Baseline entries cannot be removed.
+	Source string
+}
+
+type badDestYAMLFile struct {
+	Version int `yaml:"version"`
+	Entries []struct {
+		CIDR  string `yaml:"cidr"`
+		Label string `yaml:"label"`
+	} `yaml:"entries"`
+}
+
+func parseBaselineBadDestYAML(raw []byte) ([]BadDestinationEntry, error) {
+	var f badDestYAMLFile
+	if err := yaml.Unmarshal(raw, &f); err != nil {
+		return nil, fmt.Errorf("threatdetect: parse baseline bad-destination list: %w", err)
+	}
+	out := make([]BadDestinationEntry, 0, len(f.Entries))
+	for _, e := range f.Entries {
+		cidr, err := normalizeCIDR(e.CIDR)
+		if err != nil {
+			return nil, fmt.Errorf("threatdetect: baseline bad-destination list: %w", err)
+		}
+		out = append(out, BadDestinationEntry{CIDR: cidr, Label: e.Label, Source: "baseline"})
+	}
+	return out, nil
+}
+
+// normalizeCIDR accepts an exact IPv4 ("203.0.113.7") or a CIDR
+// ("203.0.113.0/24") and returns the canonical masked CIDR string — an
+// exact IP becomes a /32. FlowRecord/DenyEvent addresses are IPv4-only
+// (see netbpf), so this rejects IPv6 input rather than silently never
+// matching it.
+func normalizeCIDR(s string) (string, error) {
+	if !strings.Contains(s, "/") {
+		addr, err := netip.ParseAddr(s)
+		if err != nil {
+			return "", fmt.Errorf("invalid IP or CIDR %q: %w", s, err)
+		}
+		if !addr.Is4() {
+			return "", fmt.Errorf("invalid IP or CIDR %q: only IPv4 is supported", s)
+		}
+		return netip.PrefixFrom(addr, 32).String(), nil
+	}
+	p, err := netip.ParsePrefix(s)
+	if err != nil {
+		return "", fmt.Errorf("invalid IP or CIDR %q: %w", s, err)
+	}
+	if !p.Addr().Is4() {
+		return "", fmt.Errorf("invalid IP or CIDR %q: only IPv4 is supported", s)
+	}
+	return p.Masked().String(), nil
+}
+
+// badDestMatcher is an immutable snapshot of the merged baseline + operator
+// list, rebuilt (not mutated) on every add/remove — a linear scan over a
+// handful to a few hundred entries is simple and fast enough; the design
+// doc's LPM-trie note is headroom for a much larger list than this MVP
+// ships with.
+type badDestMatcher struct {
+	entries []badDestMatcherEntry
+}
+
+type badDestMatcherEntry struct {
+	prefix netip.Prefix
+	label  string
+}
+
+func newBadDestMatcher(all []BadDestinationEntry) (*badDestMatcher, error) {
+	m := &badDestMatcher{entries: make([]badDestMatcherEntry, 0, len(all))}
+	for _, e := range all {
+		p, err := netip.ParsePrefix(e.CIDR)
+		if err != nil {
+			return nil, fmt.Errorf("threatdetect: bad-destination entry %q: %w", e.CIDR, err)
+		}
+		m.entries = append(m.entries, badDestMatcherEntry{prefix: p, label: e.Label})
+	}
+	return m, nil
+}
+
+func (m *badDestMatcher) Match(ip netip.Addr) (label string, ok bool) {
+	for _, e := range m.entries {
+		if e.prefix.Contains(ip) {
+			return e.label, true
+		}
+	}
+	return "", false
+}
+
+// BadDestinationRule implements Rule for THREAT_RULE_ID_BAD_DESTINATION
+// (#1641): a flow whose destination matches the known-bad list (baseline +
+// operator-added) raises a HIGH finding. Deny events and time windows are
+// irrelevant to this rule — OnDeny and Sweep are no-ops.
+type BadDestinationRule struct {
+	mu       sync.RWMutex
+	baseline []BadDestinationEntry
+	operator []BadDestinationEntry
+	matcher  *badDestMatcher
+	store    *app.DaemonConfigStore // nil = operator additions are in-memory only for this process's lifetime
+}
+
+// NewBadDestinationRule loads the embedded baseline list and, if store is
+// non-nil, the previously persisted operator-added entries. store may be
+// nil — the rule still works, but AddDestination/RemoveDestination don't
+// survive a daemon restart (same graceful-degradation spirit as
+// MemFindingStore for a Postgres-less deployment).
+func NewBadDestinationRule(ctx context.Context, store *app.DaemonConfigStore) (*BadDestinationRule, error) {
+	baseline, err := parseBaselineBadDestYAML(embeddedBadDestYAML)
+	if err != nil {
+		return nil, err
+	}
+	r := &BadDestinationRule{baseline: baseline, store: store}
+	operator, err := r.loadOperatorEntries(ctx)
+	if err != nil {
+		return nil, err
+	}
+	r.operator = operator
+	if err := r.rebuildMatcherLocked(); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+func (r *BadDestinationRule) loadOperatorEntries(ctx context.Context) ([]BadDestinationEntry, error) {
+	if r.store == nil {
+		return nil, nil
+	}
+	val, err := r.store.Get(ctx, badDestConfigKey)
+	if err != nil {
+		if errors.Is(err, app.ErrDaemonConfigNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("threatdetect: load operator bad-destinations: %w", err)
+	}
+	var entries []BadDestinationEntry
+	if err := json.Unmarshal([]byte(val), &entries); err != nil {
+		return nil, fmt.Errorf("threatdetect: unmarshal operator bad-destinations: %w", err)
+	}
+	return entries, nil
+}
+
+func (r *BadDestinationRule) persistOperatorLocked(ctx context.Context) error {
+	if r.store == nil {
+		return nil
+	}
+	data, err := json.Marshal(r.operator)
+	if err != nil {
+		return fmt.Errorf("threatdetect: marshal operator bad-destinations: %w", err)
+	}
+	return r.store.Set(ctx, badDestConfigKey, string(data))
+}
+
+// rebuildMatcherLocked recomputes the merged matcher from baseline+operator.
+// Caller must hold r.mu (write lock at construction/mutation time).
+func (r *BadDestinationRule) rebuildMatcherLocked() error {
+	all := make([]BadDestinationEntry, 0, len(r.baseline)+len(r.operator))
+	all = append(all, r.baseline...)
+	all = append(all, r.operator...)
+	m, err := newBadDestMatcher(all)
+	if err != nil {
+		return err
+	}
+	r.matcher = m
+	return nil
+}
+
+// ID identifies this rule for findings, status, and rule config.
+func (r *BadDestinationRule) ID() pb.ThreatRuleId {
+	return pb.ThreatRuleId_THREAT_RULE_ID_BAD_DESTINATION
+}
+
+// OnFlows matches each flow's destination against the merged bad-destination
+// list. A hit raises a HIGH finding: subject = destination IP (the dedupe
+// scope — repeat flows to the same bad IP from the same tenant dedupe into
+// one open finding, per the engine's upsert), tenant = the source IP's
+// owning tenant (never guessed — empty when unresolved, design doc: "a rule
+// must never guess at an unknown IP's tenant").
+func (r *BadDestinationRule) OnFlows(ctx RuleContext, flows []netbpf.FlowRecord) []RawFinding {
+	r.mu.RLock()
+	m := r.matcher
+	r.mu.RUnlock()
+
+	var out []RawFinding
+	for _, f := range flows {
+		dst := f.Dst()
+		// The matched entry's label isn't part of Finding today (no free
+		// text field on RawFinding/Evidence for it); the destination IP in
+		// Subject/DstIP is enough to identify which list entry fired.
+		if _, hit := m.Match(dst); !hit {
+			continue
+		}
+		tenantID, _ := ctx.TenantForIP(f.Src())
+		out = append(out, RawFinding{
+			Rule:     pb.ThreatRuleId_THREAT_RULE_ID_BAD_DESTINATION,
+			Severity: pb.ThreatSeverity_THREAT_SEVERITY_HIGH,
+			TenantID: tenantID,
+			Subject:  dst.String(),
+			Evidence: Evidence{Flows: []FlowEvidence{{
+				SrcIP:    f.Src().String(),
+				DstIP:    dst.String(),
+				SrcPort:  uint32(f.Sport),
+				DstPort:  uint32(f.Dport),
+				Protocol: badDestProtoName(f.Proto),
+				Bytes:    int64(f.Bytes),   // #nosec G115 -- one flow's counters, never near int64 max
+				Packets:  int64(f.Packets), // #nosec G115 -- one flow's counters, never near int64 max
+			}}},
+		})
+	}
+	return out
+}
+
+// OnDeny is a no-op — this rule only evaluates flow destinations.
+func (r *BadDestinationRule) OnDeny(RuleContext, netbpf.DenyEvent) []RawFinding { return nil }
+
+// Sweep is a no-op — this rule has no time-window state.
+func (r *BadDestinationRule) Sweep(RuleContext, time.Time) []RawFinding { return nil }
+
+// ListDestinations returns the merged baseline + operator list.
+func (r *BadDestinationRule) ListDestinations() []BadDestinationEntry {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]BadDestinationEntry, 0, len(r.baseline)+len(r.operator))
+	out = append(out, r.baseline...)
+	out = append(out, r.operator...)
+	return out
+}
+
+// AddDestination adds (or updates the label of) an operator-supplied entry
+// and takes effect immediately — no daemon rebuild or restart required. cidr
+// may be an exact IP or a CIDR.
+func (r *BadDestinationRule) AddDestination(ctx context.Context, cidr, label string) (BadDestinationEntry, error) {
+	normalized, err := normalizeCIDR(cidr)
+	if err != nil {
+		return BadDestinationEntry{}, err
+	}
+	entry := BadDestinationEntry{CIDR: normalized, Label: label, Source: "operator"}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	replaced := false
+	for i, e := range r.operator {
+		if e.CIDR == normalized {
+			r.operator[i] = entry
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		r.operator = append(r.operator, entry)
+	}
+	if err := r.persistOperatorLocked(ctx); err != nil {
+		return BadDestinationEntry{}, err
+	}
+	if err := r.rebuildMatcherLocked(); err != nil {
+		return BadDestinationEntry{}, err
+	}
+	return entry, nil
+}
+
+// RemoveDestination removes a previously operator-added entry. A baseline
+// entry cannot be removed this way — it's shipped with the daemon.
+func (r *BadDestinationRule) RemoveDestination(ctx context.Context, cidr string) error {
+	normalized, err := normalizeCIDR(cidr)
+	if err != nil {
+		return err
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, e := range r.baseline {
+		if e.CIDR == normalized {
+			return fmt.Errorf("threatdetect: %q is a baseline entry and cannot be removed", normalized)
+		}
+	}
+	idx := -1
+	for i, e := range r.operator {
+		if e.CIDR == normalized {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		return fmt.Errorf("threatdetect: %q not found among operator-added entries", normalized)
+	}
+	r.operator = append(r.operator[:idx], r.operator[idx+1:]...)
+	if err := r.persistOperatorLocked(ctx); err != nil {
+		return err
+	}
+	return r.rebuildMatcherLocked()
+}
+
+// badDestProtoName renders an IP protocol number as the lowercase string
+// used elsewhere for evidence/audit rendering. Duplicated from
+// internal/server's protoName (unexported there) rather than introducing a
+// server->threatdetect->server import — threatdetect must stay free of a
+// dependency on internal/server, which already imports internal/threatdetect.
+func badDestProtoName(proto uint8) string {
+	switch proto {
+	case 1:
+		return "icmp"
+	case 6:
+		return "tcp"
+	case 17:
+		return "udp"
+	default:
+		return ""
+	}
+}

--- a/internal/threatdetect/rule_baddest_list.yaml
+++ b/internal/threatdetect/rule_baddest_list.yaml
@@ -1,0 +1,10 @@
+# Baseline known-bad-destination list for the bad-destination rule (#1641).
+# Embedded into the daemon binary via go:embed — versioned so an operator
+# can tell which baseline a given daemon build shipped with. Extend without
+# a rebuild via `containarium security bad-destinations add`.
+version: 1
+entries:
+  - cidr: "203.0.113.10/32"
+    label: "known mining pool (example range, RFC 5737 TEST-NET-3)"
+  - cidr: "203.0.113.32/28"
+    label: "known mining pool range (example range, RFC 5737 TEST-NET-3)"

--- a/internal/threatdetect/rule_baddest_test.go
+++ b/internal/threatdetect/rule_baddest_test.go
@@ -1,0 +1,270 @@
+package threatdetect
+
+import (
+	"context"
+	"encoding/binary"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/footprintai/containarium/internal/netbpf"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+func testRuleContext(tenantByIP map[string]string) RuleContext {
+	return RuleContext{
+		TenantForIP: func(ip netip.Addr) (string, bool) {
+			t, ok := tenantByIP[ip.String()]
+			return t, ok
+		},
+	}
+}
+
+func flow(src, dst string) netbpf.FlowRecord {
+	sAddr := netip.MustParseAddr(src).As4()
+	dAddr := netip.MustParseAddr(dst).As4()
+	return netbpf.FlowRecord{
+		Saddr:   beUint32(sAddr),
+		Daddr:   beUint32(dAddr),
+		Sport:   54321,
+		Dport:   443,
+		Proto:   6, // tcp
+		Packets: 42,
+		Bytes:   4096,
+	}
+}
+
+func TestBadDestinationRule_ExactIPHit(t *testing.T) {
+	r := newBadDestinationRuleForTest(t, []BadDestinationEntry{
+		{CIDR: "198.51.100.7/32", Label: "known miner", Source: "baseline"},
+	}, nil)
+	ctx := testRuleContext(map[string]string{"10.0.0.5": "tenant-a"})
+
+	findings := r.OnFlows(ctx, []netbpf.FlowRecord{flow("10.0.0.5", "198.51.100.7")})
+
+	if len(findings) != 1 {
+		t.Fatalf("got %d findings, want 1", len(findings))
+	}
+	f := findings[0]
+	if f.Rule != pb.ThreatRuleId_THREAT_RULE_ID_BAD_DESTINATION {
+		t.Errorf("Rule = %v, want BAD_DESTINATION", f.Rule)
+	}
+	if f.Severity != pb.ThreatSeverity_THREAT_SEVERITY_HIGH {
+		t.Errorf("Severity = %v, want HIGH", f.Severity)
+	}
+	if f.TenantID != "tenant-a" {
+		t.Errorf("TenantID = %q, want tenant-a", f.TenantID)
+	}
+	if f.Subject != "198.51.100.7" {
+		t.Errorf("Subject = %q, want the destination IP", f.Subject)
+	}
+	if len(f.Evidence.Flows) != 1 || f.Evidence.Flows[0].DstIP != "198.51.100.7" {
+		t.Errorf("Evidence.Flows = %+v, want one flow to the bad destination", f.Evidence.Flows)
+	}
+}
+
+func TestBadDestinationRule_CIDRHit(t *testing.T) {
+	r := newBadDestinationRuleForTest(t, []BadDestinationEntry{
+		{CIDR: "198.51.100.0/24", Label: "known mining range", Source: "baseline"},
+	}, nil)
+	ctx := testRuleContext(map[string]string{"10.0.0.5": "tenant-a"})
+
+	findings := r.OnFlows(ctx, []netbpf.FlowRecord{flow("10.0.0.5", "198.51.100.200")})
+
+	if len(findings) != 1 {
+		t.Fatalf("got %d findings, want 1 (CIDR should match)", len(findings))
+	}
+}
+
+func TestBadDestinationRule_Miss(t *testing.T) {
+	r := newBadDestinationRuleForTest(t, []BadDestinationEntry{
+		{CIDR: "198.51.100.0/24", Label: "known mining range", Source: "baseline"},
+	}, nil)
+	ctx := testRuleContext(map[string]string{"10.0.0.5": "tenant-a"})
+
+	findings := r.OnFlows(ctx, []netbpf.FlowRecord{flow("10.0.0.5", "8.8.8.8")})
+
+	if len(findings) != 0 {
+		t.Fatalf("got %d findings, want 0 for a destination not on the list", len(findings))
+	}
+}
+
+func TestBadDestinationRule_UnknownSourceIP_StillFiresWithEmptyTenant(t *testing.T) {
+	// Design doc: a rule must never guess at an unknown IP's tenant — but an
+	// unresolved source tenant shouldn't suppress a HIGH finding about a
+	// destination that IS known-bad; the operator can still see the flow.
+	r := newBadDestinationRuleForTest(t, []BadDestinationEntry{
+		{CIDR: "198.51.100.7/32", Label: "known miner", Source: "baseline"},
+	}, nil)
+	ctx := testRuleContext(nil) // no IP resolves
+
+	findings := r.OnFlows(ctx, []netbpf.FlowRecord{flow("10.0.0.5", "198.51.100.7")})
+
+	if len(findings) != 1 {
+		t.Fatalf("got %d findings, want 1", len(findings))
+	}
+	if findings[0].TenantID != "" {
+		t.Errorf("TenantID = %q, want empty for an unresolved source IP", findings[0].TenantID)
+	}
+}
+
+func TestBadDestinationRule_OperatorAddedEntry(t *testing.T) {
+	r := newBadDestinationRuleForTest(t, nil, nil)
+	ctx := testRuleContext(map[string]string{"10.0.0.5": "tenant-a"})
+
+	// Not on the (empty) baseline list yet.
+	if findings := r.OnFlows(ctx, []netbpf.FlowRecord{flow("10.0.0.5", "192.0.2.55")}); len(findings) != 0 {
+		t.Fatalf("got %d findings before adding the entry, want 0", len(findings))
+	}
+
+	if _, err := r.AddDestination(context.Background(), "192.0.2.55/32", "operator-flagged host"); err != nil {
+		t.Fatalf("AddDestination: %v", err)
+	}
+
+	findings := r.OnFlows(ctx, []netbpf.FlowRecord{flow("10.0.0.5", "192.0.2.55")})
+	if len(findings) != 1 {
+		t.Fatalf("got %d findings after adding the entry, want 1", len(findings))
+	}
+}
+
+func TestBadDestinationRule_RemoveOperatorEntry(t *testing.T) {
+	r := newBadDestinationRuleForTest(t, nil, nil)
+	ctx := testRuleContext(map[string]string{"10.0.0.5": "tenant-a"})
+
+	if _, err := r.AddDestination(context.Background(), "192.0.2.55/32", "operator-flagged host"); err != nil {
+		t.Fatalf("AddDestination: %v", err)
+	}
+	if err := r.RemoveDestination(context.Background(), "192.0.2.55/32"); err != nil {
+		t.Fatalf("RemoveDestination: %v", err)
+	}
+
+	findings := r.OnFlows(ctx, []netbpf.FlowRecord{flow("10.0.0.5", "192.0.2.55")})
+	if len(findings) != 0 {
+		t.Fatalf("got %d findings after removal, want 0", len(findings))
+	}
+}
+
+func TestBadDestinationRule_RemoveBaselineEntry_Errors(t *testing.T) {
+	r := newBadDestinationRuleForTest(t, []BadDestinationEntry{
+		{CIDR: "198.51.100.7/32", Label: "known miner", Source: "baseline"},
+	}, nil)
+
+	err := r.RemoveDestination(context.Background(), "198.51.100.7/32")
+	if err == nil {
+		t.Fatal("RemoveDestination on a baseline entry should error, got nil")
+	}
+}
+
+func TestBadDestinationRule_ListMergesBaselineAndOperator(t *testing.T) {
+	r := newBadDestinationRuleForTest(t, []BadDestinationEntry{
+		{CIDR: "198.51.100.7/32", Label: "known miner", Source: "baseline"},
+	}, nil)
+	if _, err := r.AddDestination(context.Background(), "192.0.2.55/32", "operator-flagged host"); err != nil {
+		t.Fatalf("AddDestination: %v", err)
+	}
+
+	entries := r.ListDestinations()
+	if len(entries) != 2 {
+		t.Fatalf("got %d entries, want 2 (1 baseline + 1 operator)", len(entries))
+	}
+	bySource := map[string]int{}
+	for _, e := range entries {
+		bySource[e.Source]++
+	}
+	if bySource["baseline"] != 1 || bySource["operator"] != 1 {
+		t.Errorf("entries by source = %+v, want 1 baseline + 1 operator", bySource)
+	}
+}
+
+func TestBadDestinationRule_ListReload(t *testing.T) {
+	r := newBadDestinationRuleForTest(t, nil, nil)
+	ctx := testRuleContext(map[string]string{"10.0.0.5": "tenant-a"})
+
+	if findings := r.OnFlows(ctx, []netbpf.FlowRecord{flow("10.0.0.5", "192.0.2.99")}); len(findings) != 0 {
+		t.Fatalf("got %d findings before reload, want 0", len(findings))
+	}
+	if _, err := r.AddDestination(context.Background(), "192.0.2.99/32", "added live"); err != nil {
+		t.Fatalf("AddDestination: %v", err)
+	}
+	// The matcher must reflect the addition immediately (list reload without
+	// a daemon rebuild), not just on the next process start.
+	if findings := r.OnFlows(ctx, []netbpf.FlowRecord{flow("10.0.0.5", "192.0.2.99")}); len(findings) != 1 {
+		t.Fatalf("got %d findings after reload, want 1", len(findings))
+	}
+}
+
+func TestBadDestinationRule_MiningIncidentReplay_RaisesHighFinding(t *testing.T) {
+	// Replays the incident's flow shape: a persistent TLS 5-tuple to a
+	// listed pool. The #1641 acceptance test.
+	r := newBadDestinationRuleForTest(t, []BadDestinationEntry{
+		{CIDR: "203.0.113.10/32", Label: "known mining pool", Source: "baseline"},
+	}, nil)
+	ctx := testRuleContext(map[string]string{"10.0.0.9": "tenant-mining-victim"})
+
+	incidentFlow := netbpf.FlowRecord{
+		Saddr:   beUint32(netip.MustParseAddr("10.0.0.9").As4()),
+		Daddr:   beUint32(netip.MustParseAddr("203.0.113.10").As4()),
+		Sport:   51000,
+		Dport:   443,
+		Proto:   6,
+		Packets: 260000, // sustained mining traffic, not a handshake blip
+		Bytes:   80_000_000,
+	}
+
+	findings := r.OnFlows(ctx, []netbpf.FlowRecord{incidentFlow})
+
+	if len(findings) != 1 {
+		t.Fatalf("got %d findings, want 1", len(findings))
+	}
+	f := findings[0]
+	if f.Severity != pb.ThreatSeverity_THREAT_SEVERITY_HIGH {
+		t.Errorf("Severity = %v, want HIGH", f.Severity)
+	}
+	if f.TenantID != "tenant-mining-victim" {
+		t.Errorf("TenantID = %q, want tenant-mining-victim", f.TenantID)
+	}
+	if f.Subject != "203.0.113.10" {
+		t.Errorf("Subject = %q, want the mining pool IP", f.Subject)
+	}
+}
+
+func TestBadDestinationRule_OnDenyAndSweep_AreNoop(t *testing.T) {
+	r := newBadDestinationRuleForTest(t, nil, nil)
+	if got := r.OnDeny(testRuleContext(nil), netbpf.DenyEvent{}); got != nil {
+		t.Errorf("OnDeny = %v, want nil (this rule only evaluates flows)", got)
+	}
+	if got := r.Sweep(testRuleContext(nil), timeNowForTest()); got != nil {
+		t.Errorf("Sweep = %v, want nil (this rule has no time-window state)", got)
+	}
+}
+
+func TestBadDestinationRule_ID(t *testing.T) {
+	r := newBadDestinationRuleForTest(t, nil, nil)
+	if r.ID() != pb.ThreatRuleId_THREAT_RULE_ID_BAD_DESTINATION {
+		t.Errorf("ID() = %v, want THREAT_RULE_ID_BAD_DESTINATION", r.ID())
+	}
+}
+
+// newBadDestinationRuleForTest builds a rule directly from baseline/operator
+// entries, bypassing the embedded YAML and DaemonConfigStore — a nil store
+// (in-memory only) is exactly what unit tests want.
+func newBadDestinationRuleForTest(t *testing.T, baseline, operator []BadDestinationEntry) *BadDestinationRule {
+	t.Helper()
+	r := &BadDestinationRule{baseline: baseline, operator: operator}
+	if err := r.rebuildMatcherLocked(); err != nil {
+		t.Fatalf("rebuildMatcherLocked: %v", err)
+	}
+	return r
+}
+
+// beUint32 packs a 4-byte IPv4 address (as netip.Addr.As4() returns) into
+// the uint32 that FlowRecord.Saddr/Daddr carry — the exact inverse of
+// netbpf's unexported ipFromBE, which decodes via
+// binary.NativeEndian.PutUint32. Using NativeEndian here too (not a
+// hardcoded big-endian pack) keeps the round-trip correct regardless of
+// host architecture.
+func beUint32(b [4]byte) uint32 {
+	return binary.NativeEndian.Uint32(b[:])
+}
+
+func timeNowForTest() time.Time { return time.Unix(1_700_000_000, 0) }

--- a/pkg/pb/containarium/v1/threatdetection.pb.go
+++ b/pkg/pb/containarium/v1/threatdetection.pb.go
@@ -786,6 +786,328 @@ func (x *GetSentryStatusResponse) GetRules() []*RuleStatus {
 	return nil
 }
 
+// BadDestinationEntry is one entry in the known-bad-destination list (#1641)
+// matched against flow destination IPs — a mining pool or other known-bad
+// endpoint.
+type BadDestinationEntry struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Exact IP ("203.0.113.7") or CIDR ("203.0.113.0/24").
+	Cidr  string `protobuf:"bytes,1,opt,name=cidr,proto3" json:"cidr,omitempty"`
+	Label string `protobuf:"bytes,2,opt,name=label,proto3" json:"label,omitempty"`
+	// "baseline" (embedded, versioned list, shipped with the daemon) or
+	// "operator" (added via AddBadDestination, without a daemon rebuild).
+	Source        string `protobuf:"bytes,3,opt,name=source,proto3" json:"source,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BadDestinationEntry) Reset() {
+	*x = BadDestinationEntry{}
+	mi := &file_containarium_v1_threatdetection_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BadDestinationEntry) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BadDestinationEntry) ProtoMessage() {}
+
+func (x *BadDestinationEntry) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_threatdetection_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BadDestinationEntry.ProtoReflect.Descriptor instead.
+func (*BadDestinationEntry) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_threatdetection_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *BadDestinationEntry) GetCidr() string {
+	if x != nil {
+		return x.Cidr
+	}
+	return ""
+}
+
+func (x *BadDestinationEntry) GetLabel() string {
+	if x != nil {
+		return x.Label
+	}
+	return ""
+}
+
+func (x *BadDestinationEntry) GetSource() string {
+	if x != nil {
+		return x.Source
+	}
+	return ""
+}
+
+type ListBadDestinationsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListBadDestinationsRequest) Reset() {
+	*x = ListBadDestinationsRequest{}
+	mi := &file_containarium_v1_threatdetection_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListBadDestinationsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListBadDestinationsRequest) ProtoMessage() {}
+
+func (x *ListBadDestinationsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_threatdetection_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListBadDestinationsRequest.ProtoReflect.Descriptor instead.
+func (*ListBadDestinationsRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_threatdetection_proto_rawDescGZIP(), []int{8}
+}
+
+type ListBadDestinationsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Entries       []*BadDestinationEntry `protobuf:"bytes,1,rep,name=entries,proto3" json:"entries,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListBadDestinationsResponse) Reset() {
+	*x = ListBadDestinationsResponse{}
+	mi := &file_containarium_v1_threatdetection_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListBadDestinationsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListBadDestinationsResponse) ProtoMessage() {}
+
+func (x *ListBadDestinationsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_threatdetection_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListBadDestinationsResponse.ProtoReflect.Descriptor instead.
+func (*ListBadDestinationsResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_threatdetection_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *ListBadDestinationsResponse) GetEntries() []*BadDestinationEntry {
+	if x != nil {
+		return x.Entries
+	}
+	return nil
+}
+
+type AddBadDestinationRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Cidr          string                 `protobuf:"bytes,1,opt,name=cidr,proto3" json:"cidr,omitempty"`
+	Label         string                 `protobuf:"bytes,2,opt,name=label,proto3" json:"label,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AddBadDestinationRequest) Reset() {
+	*x = AddBadDestinationRequest{}
+	mi := &file_containarium_v1_threatdetection_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AddBadDestinationRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AddBadDestinationRequest) ProtoMessage() {}
+
+func (x *AddBadDestinationRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_threatdetection_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AddBadDestinationRequest.ProtoReflect.Descriptor instead.
+func (*AddBadDestinationRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_threatdetection_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *AddBadDestinationRequest) GetCidr() string {
+	if x != nil {
+		return x.Cidr
+	}
+	return ""
+}
+
+func (x *AddBadDestinationRequest) GetLabel() string {
+	if x != nil {
+		return x.Label
+	}
+	return ""
+}
+
+type AddBadDestinationResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Entry         *BadDestinationEntry   `protobuf:"bytes,1,opt,name=entry,proto3" json:"entry,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AddBadDestinationResponse) Reset() {
+	*x = AddBadDestinationResponse{}
+	mi := &file_containarium_v1_threatdetection_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AddBadDestinationResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AddBadDestinationResponse) ProtoMessage() {}
+
+func (x *AddBadDestinationResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_threatdetection_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AddBadDestinationResponse.ProtoReflect.Descriptor instead.
+func (*AddBadDestinationResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_threatdetection_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *AddBadDestinationResponse) GetEntry() *BadDestinationEntry {
+	if x != nil {
+		return x.Entry
+	}
+	return nil
+}
+
+type RemoveBadDestinationRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Cidr          string                 `protobuf:"bytes,1,opt,name=cidr,proto3" json:"cidr,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RemoveBadDestinationRequest) Reset() {
+	*x = RemoveBadDestinationRequest{}
+	mi := &file_containarium_v1_threatdetection_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RemoveBadDestinationRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RemoveBadDestinationRequest) ProtoMessage() {}
+
+func (x *RemoveBadDestinationRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_threatdetection_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RemoveBadDestinationRequest.ProtoReflect.Descriptor instead.
+func (*RemoveBadDestinationRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_threatdetection_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *RemoveBadDestinationRequest) GetCidr() string {
+	if x != nil {
+		return x.Cidr
+	}
+	return ""
+}
+
+type RemoveBadDestinationResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RemoveBadDestinationResponse) Reset() {
+	*x = RemoveBadDestinationResponse{}
+	mi := &file_containarium_v1_threatdetection_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RemoveBadDestinationResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RemoveBadDestinationResponse) ProtoMessage() {}
+
+func (x *RemoveBadDestinationResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_threatdetection_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RemoveBadDestinationResponse.ProtoReflect.Descriptor instead.
+func (*RemoveBadDestinationResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_threatdetection_proto_rawDescGZIP(), []int{13}
+}
+
 var File_containarium_v1_threatdetection_proto protoreflect.FileDescriptor
 
 const file_containarium_v1_threatdetection_proto_rawDesc = "" +
@@ -835,7 +1157,22 @@ const file_containarium_v1_threatdetection_proto_rawDesc = "" +
 	"\x17GetSentryStatusResponse\x122\n" +
 	"\x05state\x18\x01 \x01(\x0e2\x1c.containarium.v1.SentryStateR\x05state\x12\x16\n" +
 	"\x06reason\x18\x02 \x01(\tR\x06reason\x121\n" +
-	"\x05rules\x18\x03 \x03(\v2\x1b.containarium.v1.RuleStatusR\x05rules*\x9e\x01\n" +
+	"\x05rules\x18\x03 \x03(\v2\x1b.containarium.v1.RuleStatusR\x05rules\"W\n" +
+	"\x13BadDestinationEntry\x12\x12\n" +
+	"\x04cidr\x18\x01 \x01(\tR\x04cidr\x12\x14\n" +
+	"\x05label\x18\x02 \x01(\tR\x05label\x12\x16\n" +
+	"\x06source\x18\x03 \x01(\tR\x06source\"\x1c\n" +
+	"\x1aListBadDestinationsRequest\"]\n" +
+	"\x1bListBadDestinationsResponse\x12>\n" +
+	"\aentries\x18\x01 \x03(\v2$.containarium.v1.BadDestinationEntryR\aentries\"D\n" +
+	"\x18AddBadDestinationRequest\x12\x12\n" +
+	"\x04cidr\x18\x01 \x01(\tR\x04cidr\x12\x14\n" +
+	"\x05label\x18\x02 \x01(\tR\x05label\"W\n" +
+	"\x19AddBadDestinationResponse\x12:\n" +
+	"\x05entry\x18\x01 \x01(\v2$.containarium.v1.BadDestinationEntryR\x05entry\"1\n" +
+	"\x1bRemoveBadDestinationRequest\x12\x12\n" +
+	"\x04cidr\x18\x01 \x01(\tR\x04cidr\"\x1e\n" +
+	"\x1cRemoveBadDestinationResponse*\x9e\x01\n" +
 	"\x0eThreatSeverity\x12\x1f\n" +
 	"\x1bTHREAT_SEVERITY_UNSPECIFIED\x10\x00\x12\x17\n" +
 	"\x13THREAT_SEVERITY_LOW\x10\x01\x12\x1a\n" +
@@ -856,10 +1193,16 @@ const file_containarium_v1_threatdetection_proto_rawDesc = "" +
 	"\x15SENTRY_STATE_DISABLED\x10\x01\x12\x1c\n" +
 	"\x18SENTRY_STATE_UNAVAILABLE\x10\x02\x12\x19\n" +
 	"\x15SENTRY_STATE_DEGRADED\x10\x03\x12\x13\n" +
-	"\x0fSENTRY_STATE_OK\x10\x042\xc9\x02\n" +
+	"\x0fSENTRY_STATE_OK\x10\x042\xd6\t\n" +
 	"\x16ThreatDetectionService\x12\xae\x02\n" +
 	"\x0fGetSentryStatus\x12'.containarium.v1.GetSentryStatusRequest\x1a(.containarium.v1.GetSentryStatusResponse\"\xc7\x01\x92A\xa1\x01\n" +
-	"\bSecurity\x12\"Get threat-detection sentry status\x1aqReturns the background detection engine's on/off state (disabled, unavailable, degraded, ok) and per-rule health.\x82\xd3\xe4\x93\x02\x1c\x12\x1a/v1/security/sentry/statusBKZIgithub.com/footprintai/containarium/pkg/pb/containarium/v1;containariumv1b\x06proto3"
+	"\bSecurity\x12\"Get threat-detection sentry status\x1aqReturns the background detection engine's on/off state (disabled, unavailable, degraded, ok) and per-rule health.\x82\xd3\xe4\x93\x02\x1c\x12\x1a/v1/security/sentry/status\x12\xa5\x02\n" +
+	"\x13ListBadDestinations\x12+.containarium.v1.ListBadDestinationsRequest\x1a,.containarium.v1.ListBadDestinationsResponse\"\xb2\x01\x92A\x89\x01\n" +
+	"\bSecurity\x12\x1bList known-bad destinations\x1a`Returns the merged baseline (embedded, versioned) and operator-added known-bad-destination list.\x82\xd3\xe4\x93\x02\x1f\x12\x1d/v1/security/bad-destinations\x12\x8e\x02\n" +
+	"\x11AddBadDestination\x12).containarium.v1.AddBadDestinationRequest\x1a*.containarium.v1.AddBadDestinationResponse\"\xa1\x01\x92Av\n" +
+	"\bSecurity\x12\x1bAdd a known-bad destination\x1aMAdds an operator-supplied CIDR or exact IP to the known-bad-destination list.\x82\xd3\xe4\x93\x02\":\x01*\"\x1d/v1/security/bad-destinations\x12\xd1\x02\n" +
+	"\x14RemoveBadDestination\x12,.containarium.v1.RemoveBadDestinationRequest\x1a-.containarium.v1.RemoveBadDestinationResponse\"\xdb\x01\x92A\xa8\x01\n" +
+	"\bSecurity\x12(Remove an operator-added bad destination\x1arRemoves a previously operator-added entry from the known-bad-destination list. Baseline entries cannot be removed.\x82\xd3\xe4\x93\x02)*'/v1/security/bad-destinations/{cidr=**}BKZIgithub.com/footprintai/containarium/pkg/pb/containarium/v1;containariumv1b\x06proto3"
 
 var (
 	file_containarium_v1_threatdetection_proto_rawDescOnce sync.Once
@@ -874,20 +1217,27 @@ func file_containarium_v1_threatdetection_proto_rawDescGZIP() []byte {
 }
 
 var file_containarium_v1_threatdetection_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_containarium_v1_threatdetection_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
+var file_containarium_v1_threatdetection_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
 var file_containarium_v1_threatdetection_proto_goTypes = []any{
-	(ThreatSeverity)(0),             // 0: containarium.v1.ThreatSeverity
-	(ThreatRuleId)(0),               // 1: containarium.v1.ThreatRuleId
-	(FindingState)(0),               // 2: containarium.v1.FindingState
-	(SentryState)(0),                // 3: containarium.v1.SentryState
-	(*FlowEvidence)(nil),            // 4: containarium.v1.FlowEvidence
-	(*DenyEvidence)(nil),            // 5: containarium.v1.DenyEvidence
-	(*Evidence)(nil),                // 6: containarium.v1.Evidence
-	(*Finding)(nil),                 // 7: containarium.v1.Finding
-	(*RuleStatus)(nil),              // 8: containarium.v1.RuleStatus
-	(*GetSentryStatusRequest)(nil),  // 9: containarium.v1.GetSentryStatusRequest
-	(*GetSentryStatusResponse)(nil), // 10: containarium.v1.GetSentryStatusResponse
-	(*timestamppb.Timestamp)(nil),   // 11: google.protobuf.Timestamp
+	(ThreatSeverity)(0),                  // 0: containarium.v1.ThreatSeverity
+	(ThreatRuleId)(0),                    // 1: containarium.v1.ThreatRuleId
+	(FindingState)(0),                    // 2: containarium.v1.FindingState
+	(SentryState)(0),                     // 3: containarium.v1.SentryState
+	(*FlowEvidence)(nil),                 // 4: containarium.v1.FlowEvidence
+	(*DenyEvidence)(nil),                 // 5: containarium.v1.DenyEvidence
+	(*Evidence)(nil),                     // 6: containarium.v1.Evidence
+	(*Finding)(nil),                      // 7: containarium.v1.Finding
+	(*RuleStatus)(nil),                   // 8: containarium.v1.RuleStatus
+	(*GetSentryStatusRequest)(nil),       // 9: containarium.v1.GetSentryStatusRequest
+	(*GetSentryStatusResponse)(nil),      // 10: containarium.v1.GetSentryStatusResponse
+	(*BadDestinationEntry)(nil),          // 11: containarium.v1.BadDestinationEntry
+	(*ListBadDestinationsRequest)(nil),   // 12: containarium.v1.ListBadDestinationsRequest
+	(*ListBadDestinationsResponse)(nil),  // 13: containarium.v1.ListBadDestinationsResponse
+	(*AddBadDestinationRequest)(nil),     // 14: containarium.v1.AddBadDestinationRequest
+	(*AddBadDestinationResponse)(nil),    // 15: containarium.v1.AddBadDestinationResponse
+	(*RemoveBadDestinationRequest)(nil),  // 16: containarium.v1.RemoveBadDestinationRequest
+	(*RemoveBadDestinationResponse)(nil), // 17: containarium.v1.RemoveBadDestinationResponse
+	(*timestamppb.Timestamp)(nil),        // 18: google.protobuf.Timestamp
 }
 var file_containarium_v1_threatdetection_proto_depIdxs = []int32{
 	4,  // 0: containarium.v1.Evidence.flows:type_name -> containarium.v1.FlowEvidence
@@ -896,19 +1246,27 @@ var file_containarium_v1_threatdetection_proto_depIdxs = []int32{
 	0,  // 3: containarium.v1.Finding.severity:type_name -> containarium.v1.ThreatSeverity
 	2,  // 4: containarium.v1.Finding.state:type_name -> containarium.v1.FindingState
 	6,  // 5: containarium.v1.Finding.evidence:type_name -> containarium.v1.Evidence
-	11, // 6: containarium.v1.Finding.first_seen:type_name -> google.protobuf.Timestamp
-	11, // 7: containarium.v1.Finding.last_seen:type_name -> google.protobuf.Timestamp
+	18, // 6: containarium.v1.Finding.first_seen:type_name -> google.protobuf.Timestamp
+	18, // 7: containarium.v1.Finding.last_seen:type_name -> google.protobuf.Timestamp
 	1,  // 8: containarium.v1.RuleStatus.rule:type_name -> containarium.v1.ThreatRuleId
-	11, // 9: containarium.v1.RuleStatus.last_error_at:type_name -> google.protobuf.Timestamp
+	18, // 9: containarium.v1.RuleStatus.last_error_at:type_name -> google.protobuf.Timestamp
 	3,  // 10: containarium.v1.GetSentryStatusResponse.state:type_name -> containarium.v1.SentryState
 	8,  // 11: containarium.v1.GetSentryStatusResponse.rules:type_name -> containarium.v1.RuleStatus
-	9,  // 12: containarium.v1.ThreatDetectionService.GetSentryStatus:input_type -> containarium.v1.GetSentryStatusRequest
-	10, // 13: containarium.v1.ThreatDetectionService.GetSentryStatus:output_type -> containarium.v1.GetSentryStatusResponse
-	13, // [13:14] is the sub-list for method output_type
-	12, // [12:13] is the sub-list for method input_type
-	12, // [12:12] is the sub-list for extension type_name
-	12, // [12:12] is the sub-list for extension extendee
-	0,  // [0:12] is the sub-list for field type_name
+	11, // 12: containarium.v1.ListBadDestinationsResponse.entries:type_name -> containarium.v1.BadDestinationEntry
+	11, // 13: containarium.v1.AddBadDestinationResponse.entry:type_name -> containarium.v1.BadDestinationEntry
+	9,  // 14: containarium.v1.ThreatDetectionService.GetSentryStatus:input_type -> containarium.v1.GetSentryStatusRequest
+	12, // 15: containarium.v1.ThreatDetectionService.ListBadDestinations:input_type -> containarium.v1.ListBadDestinationsRequest
+	14, // 16: containarium.v1.ThreatDetectionService.AddBadDestination:input_type -> containarium.v1.AddBadDestinationRequest
+	16, // 17: containarium.v1.ThreatDetectionService.RemoveBadDestination:input_type -> containarium.v1.RemoveBadDestinationRequest
+	10, // 18: containarium.v1.ThreatDetectionService.GetSentryStatus:output_type -> containarium.v1.GetSentryStatusResponse
+	13, // 19: containarium.v1.ThreatDetectionService.ListBadDestinations:output_type -> containarium.v1.ListBadDestinationsResponse
+	15, // 20: containarium.v1.ThreatDetectionService.AddBadDestination:output_type -> containarium.v1.AddBadDestinationResponse
+	17, // 21: containarium.v1.ThreatDetectionService.RemoveBadDestination:output_type -> containarium.v1.RemoveBadDestinationResponse
+	18, // [18:22] is the sub-list for method output_type
+	14, // [14:18] is the sub-list for method input_type
+	14, // [14:14] is the sub-list for extension type_name
+	14, // [14:14] is the sub-list for extension extendee
+	0,  // [0:14] is the sub-list for field type_name
 }
 
 func init() { file_containarium_v1_threatdetection_proto_init() }
@@ -922,7 +1280,7 @@ func file_containarium_v1_threatdetection_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_v1_threatdetection_proto_rawDesc), len(file_containarium_v1_threatdetection_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   7,
+			NumMessages:   14,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/pb/containarium/v1/threatdetection.pb.gw.go
+++ b/pkg/pb/containarium/v1/threatdetection.pb.gw.go
@@ -56,6 +56,93 @@ func local_request_ThreatDetectionService_GetSentryStatus_0(ctx context.Context,
 	return msg, metadata, err
 }
 
+func request_ThreatDetectionService_ListBadDestinations_0(ctx context.Context, marshaler runtime.Marshaler, client ThreatDetectionServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListBadDestinationsRequest
+		metadata runtime.ServerMetadata
+	)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.ListBadDestinations(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ThreatDetectionService_ListBadDestinations_0(ctx context.Context, marshaler runtime.Marshaler, server ThreatDetectionServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListBadDestinationsRequest
+		metadata runtime.ServerMetadata
+	)
+	msg, err := server.ListBadDestinations(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_ThreatDetectionService_AddBadDestination_0(ctx context.Context, marshaler runtime.Marshaler, client ThreatDetectionServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq AddBadDestinationRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.AddBadDestination(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ThreatDetectionService_AddBadDestination_0(ctx context.Context, marshaler runtime.Marshaler, server ThreatDetectionServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq AddBadDestinationRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.AddBadDestination(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_ThreatDetectionService_RemoveBadDestination_0(ctx context.Context, marshaler runtime.Marshaler, client ThreatDetectionServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq RemoveBadDestinationRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	val, ok := pathParams["cidr"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "cidr")
+	}
+	protoReq.Cidr, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "cidr", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.RemoveBadDestination(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ThreatDetectionService_RemoveBadDestination_0(ctx context.Context, marshaler runtime.Marshaler, server ThreatDetectionServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq RemoveBadDestinationRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	val, ok := pathParams["cidr"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "cidr")
+	}
+	protoReq.Cidr, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "cidr", err)
+	}
+	msg, err := server.RemoveBadDestination(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterThreatDetectionServiceHandlerServer registers the http handlers for service ThreatDetectionService to "mux".
 // UnaryRPC     :call ThreatDetectionServiceServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -81,6 +168,66 @@ func RegisterThreatDetectionServiceHandlerServer(ctx context.Context, mux *runti
 			return
 		}
 		forward_ThreatDetectionService_GetSentryStatus_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_ThreatDetectionService_ListBadDestinations_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.ThreatDetectionService/ListBadDestinations", runtime.WithHTTPPathPattern("/v1/security/bad-destinations"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ThreatDetectionService_ListBadDestinations_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ThreatDetectionService_ListBadDestinations_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_ThreatDetectionService_AddBadDestination_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.ThreatDetectionService/AddBadDestination", runtime.WithHTTPPathPattern("/v1/security/bad-destinations"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ThreatDetectionService_AddBadDestination_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ThreatDetectionService_AddBadDestination_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodDelete, pattern_ThreatDetectionService_RemoveBadDestination_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.ThreatDetectionService/RemoveBadDestination", runtime.WithHTTPPathPattern("/v1/security/bad-destinations/{cidr=**}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ThreatDetectionService_RemoveBadDestination_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ThreatDetectionService_RemoveBadDestination_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 
 	return nil
@@ -139,13 +286,70 @@ func RegisterThreatDetectionServiceHandlerClient(ctx context.Context, mux *runti
 		}
 		forward_ThreatDetectionService_GetSentryStatus_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodGet, pattern_ThreatDetectionService_ListBadDestinations_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.ThreatDetectionService/ListBadDestinations", runtime.WithHTTPPathPattern("/v1/security/bad-destinations"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ThreatDetectionService_ListBadDestinations_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ThreatDetectionService_ListBadDestinations_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_ThreatDetectionService_AddBadDestination_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.ThreatDetectionService/AddBadDestination", runtime.WithHTTPPathPattern("/v1/security/bad-destinations"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ThreatDetectionService_AddBadDestination_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ThreatDetectionService_AddBadDestination_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodDelete, pattern_ThreatDetectionService_RemoveBadDestination_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.ThreatDetectionService/RemoveBadDestination", runtime.WithHTTPPathPattern("/v1/security/bad-destinations/{cidr=**}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ThreatDetectionService_RemoveBadDestination_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ThreatDetectionService_RemoveBadDestination_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
 var (
-	pattern_ThreatDetectionService_GetSentryStatus_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"v1", "security", "sentry", "status"}, ""))
+	pattern_ThreatDetectionService_GetSentryStatus_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"v1", "security", "sentry", "status"}, ""))
+	pattern_ThreatDetectionService_ListBadDestinations_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "security", "bad-destinations"}, ""))
+	pattern_ThreatDetectionService_AddBadDestination_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "security", "bad-destinations"}, ""))
+	pattern_ThreatDetectionService_RemoveBadDestination_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 3, 0, 4, 1, 5, 3}, []string{"v1", "security", "bad-destinations", "cidr"}, ""))
 )
 
 var (
-	forward_ThreatDetectionService_GetSentryStatus_0 = runtime.ForwardResponseMessage
+	forward_ThreatDetectionService_GetSentryStatus_0      = runtime.ForwardResponseMessage
+	forward_ThreatDetectionService_ListBadDestinations_0  = runtime.ForwardResponseMessage
+	forward_ThreatDetectionService_AddBadDestination_0    = runtime.ForwardResponseMessage
+	forward_ThreatDetectionService_RemoveBadDestination_0 = runtime.ForwardResponseMessage
 )

--- a/pkg/pb/containarium/v1/threatdetection_grpc.pb.go
+++ b/pkg/pb/containarium/v1/threatdetection_grpc.pb.go
@@ -19,7 +19,10 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	ThreatDetectionService_GetSentryStatus_FullMethodName = "/containarium.v1.ThreatDetectionService/GetSentryStatus"
+	ThreatDetectionService_GetSentryStatus_FullMethodName      = "/containarium.v1.ThreatDetectionService/GetSentryStatus"
+	ThreatDetectionService_ListBadDestinations_FullMethodName  = "/containarium.v1.ThreatDetectionService/ListBadDestinations"
+	ThreatDetectionService_AddBadDestination_FullMethodName    = "/containarium.v1.ThreatDetectionService/AddBadDestination"
+	ThreatDetectionService_RemoveBadDestination_FullMethodName = "/containarium.v1.ThreatDetectionService/RemoveBadDestination"
 )
 
 // ThreatDetectionServiceClient is the client API for ThreatDetectionService service.
@@ -28,12 +31,24 @@ const (
 //
 // ThreatDetectionService serves the background security-sentry's status and
 // findings. GetSentryStatus ships with #1640 (background detection loop);
-// the findings/rule-config RPCs are added by later stories in the same
-// umbrella (#1641-#1643) — see docs/architecture/continuous-threat-detection.md.
+// *BadDestination* ships with #1641 (known-bad destination rule); the
+// findings/rule-config RPCs are added by later stories in the same umbrella
+// (#1642-#1643) — see docs/architecture/continuous-threat-detection.md.
 type ThreatDetectionServiceClient interface {
 	// GetSentryStatus returns the detection engine's on/off state and the
 	// health of every registered rule.
 	GetSentryStatus(ctx context.Context, in *GetSentryStatusRequest, opts ...grpc.CallOption) (*GetSentryStatusResponse, error)
+	// ListBadDestinations returns the merged baseline + operator-added
+	// known-bad-destination list the bad-destination rule matches against.
+	ListBadDestinations(ctx context.Context, in *ListBadDestinationsRequest, opts ...grpc.CallOption) (*ListBadDestinationsResponse, error)
+	// AddBadDestination adds an operator-supplied entry to the known-bad
+	// destination list, persisted so it survives a daemon restart, without a
+	// daemon rebuild.
+	AddBadDestination(ctx context.Context, in *AddBadDestinationRequest, opts ...grpc.CallOption) (*AddBadDestinationResponse, error)
+	// RemoveBadDestination removes a previously operator-added entry. Baseline
+	// (embedded) entries cannot be removed this way — a bare "not found" error
+	// covers the case since only additions are ever tracked as removable.
+	RemoveBadDestination(ctx context.Context, in *RemoveBadDestinationRequest, opts ...grpc.CallOption) (*RemoveBadDestinationResponse, error)
 }
 
 type threatDetectionServiceClient struct {
@@ -54,18 +69,60 @@ func (c *threatDetectionServiceClient) GetSentryStatus(ctx context.Context, in *
 	return out, nil
 }
 
+func (c *threatDetectionServiceClient) ListBadDestinations(ctx context.Context, in *ListBadDestinationsRequest, opts ...grpc.CallOption) (*ListBadDestinationsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListBadDestinationsResponse)
+	err := c.cc.Invoke(ctx, ThreatDetectionService_ListBadDestinations_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *threatDetectionServiceClient) AddBadDestination(ctx context.Context, in *AddBadDestinationRequest, opts ...grpc.CallOption) (*AddBadDestinationResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(AddBadDestinationResponse)
+	err := c.cc.Invoke(ctx, ThreatDetectionService_AddBadDestination_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *threatDetectionServiceClient) RemoveBadDestination(ctx context.Context, in *RemoveBadDestinationRequest, opts ...grpc.CallOption) (*RemoveBadDestinationResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RemoveBadDestinationResponse)
+	err := c.cc.Invoke(ctx, ThreatDetectionService_RemoveBadDestination_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ThreatDetectionServiceServer is the server API for ThreatDetectionService service.
 // All implementations must embed UnimplementedThreatDetectionServiceServer
 // for forward compatibility.
 //
 // ThreatDetectionService serves the background security-sentry's status and
 // findings. GetSentryStatus ships with #1640 (background detection loop);
-// the findings/rule-config RPCs are added by later stories in the same
-// umbrella (#1641-#1643) — see docs/architecture/continuous-threat-detection.md.
+// *BadDestination* ships with #1641 (known-bad destination rule); the
+// findings/rule-config RPCs are added by later stories in the same umbrella
+// (#1642-#1643) — see docs/architecture/continuous-threat-detection.md.
 type ThreatDetectionServiceServer interface {
 	// GetSentryStatus returns the detection engine's on/off state and the
 	// health of every registered rule.
 	GetSentryStatus(context.Context, *GetSentryStatusRequest) (*GetSentryStatusResponse, error)
+	// ListBadDestinations returns the merged baseline + operator-added
+	// known-bad-destination list the bad-destination rule matches against.
+	ListBadDestinations(context.Context, *ListBadDestinationsRequest) (*ListBadDestinationsResponse, error)
+	// AddBadDestination adds an operator-supplied entry to the known-bad
+	// destination list, persisted so it survives a daemon restart, without a
+	// daemon rebuild.
+	AddBadDestination(context.Context, *AddBadDestinationRequest) (*AddBadDestinationResponse, error)
+	// RemoveBadDestination removes a previously operator-added entry. Baseline
+	// (embedded) entries cannot be removed this way — a bare "not found" error
+	// covers the case since only additions are ever tracked as removable.
+	RemoveBadDestination(context.Context, *RemoveBadDestinationRequest) (*RemoveBadDestinationResponse, error)
 	mustEmbedUnimplementedThreatDetectionServiceServer()
 }
 
@@ -78,6 +135,15 @@ type UnimplementedThreatDetectionServiceServer struct{}
 
 func (UnimplementedThreatDetectionServiceServer) GetSentryStatus(context.Context, *GetSentryStatusRequest) (*GetSentryStatusResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetSentryStatus not implemented")
+}
+func (UnimplementedThreatDetectionServiceServer) ListBadDestinations(context.Context, *ListBadDestinationsRequest) (*ListBadDestinationsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListBadDestinations not implemented")
+}
+func (UnimplementedThreatDetectionServiceServer) AddBadDestination(context.Context, *AddBadDestinationRequest) (*AddBadDestinationResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method AddBadDestination not implemented")
+}
+func (UnimplementedThreatDetectionServiceServer) RemoveBadDestination(context.Context, *RemoveBadDestinationRequest) (*RemoveBadDestinationResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method RemoveBadDestination not implemented")
 }
 func (UnimplementedThreatDetectionServiceServer) mustEmbedUnimplementedThreatDetectionServiceServer() {
 }
@@ -119,6 +185,60 @@ func _ThreatDetectionService_GetSentryStatus_Handler(srv interface{}, ctx contex
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ThreatDetectionService_ListBadDestinations_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListBadDestinationsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ThreatDetectionServiceServer).ListBadDestinations(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ThreatDetectionService_ListBadDestinations_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ThreatDetectionServiceServer).ListBadDestinations(ctx, req.(*ListBadDestinationsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ThreatDetectionService_AddBadDestination_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(AddBadDestinationRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ThreatDetectionServiceServer).AddBadDestination(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ThreatDetectionService_AddBadDestination_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ThreatDetectionServiceServer).AddBadDestination(ctx, req.(*AddBadDestinationRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ThreatDetectionService_RemoveBadDestination_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RemoveBadDestinationRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ThreatDetectionServiceServer).RemoveBadDestination(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ThreatDetectionService_RemoveBadDestination_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ThreatDetectionServiceServer).RemoveBadDestination(ctx, req.(*RemoveBadDestinationRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // ThreatDetectionService_ServiceDesc is the grpc.ServiceDesc for ThreatDetectionService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -129,6 +249,18 @@ var ThreatDetectionService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetSentryStatus",
 			Handler:    _ThreatDetectionService_GetSentryStatus_Handler,
+		},
+		{
+			MethodName: "ListBadDestinations",
+			Handler:    _ThreatDetectionService_ListBadDestinations_Handler,
+		},
+		{
+			MethodName: "AddBadDestination",
+			Handler:    _ThreatDetectionService_AddBadDestination_Handler,
+		},
+		{
+			MethodName: "RemoveBadDestination",
+			Handler:    _ThreatDetectionService_RemoveBadDestination_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/proto/containarium/v1/threatdetection.proto
+++ b/proto/containarium/v1/threatdetection.proto
@@ -125,10 +125,44 @@ message GetSentryStatusResponse {
   repeated RuleStatus rules = 3;
 }
 
+// BadDestinationEntry is one entry in the known-bad-destination list (#1641)
+// matched against flow destination IPs — a mining pool or other known-bad
+// endpoint.
+message BadDestinationEntry {
+  // Exact IP ("203.0.113.7") or CIDR ("203.0.113.0/24").
+  string cidr = 1;
+  string label = 2;
+  // "baseline" (embedded, versioned list, shipped with the daemon) or
+  // "operator" (added via AddBadDestination, without a daemon rebuild).
+  string source = 3;
+}
+
+message ListBadDestinationsRequest {}
+
+message ListBadDestinationsResponse {
+  repeated BadDestinationEntry entries = 1;
+}
+
+message AddBadDestinationRequest {
+  string cidr = 1;
+  string label = 2;
+}
+
+message AddBadDestinationResponse {
+  BadDestinationEntry entry = 1;
+}
+
+message RemoveBadDestinationRequest {
+  string cidr = 1;
+}
+
+message RemoveBadDestinationResponse {}
+
 // ThreatDetectionService serves the background security-sentry's status and
 // findings. GetSentryStatus ships with #1640 (background detection loop);
-// the findings/rule-config RPCs are added by later stories in the same
-// umbrella (#1641-#1643) — see docs/architecture/continuous-threat-detection.md.
+// *BadDestination* ships with #1641 (known-bad destination rule); the
+// findings/rule-config RPCs are added by later stories in the same umbrella
+// (#1642-#1643) — see docs/architecture/continuous-threat-detection.md.
 service ThreatDetectionService {
   // GetSentryStatus returns the detection engine's on/off state and the
   // health of every registered rule.
@@ -139,6 +173,48 @@ service ThreatDetectionService {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Get threat-detection sentry status";
       description: "Returns the background detection engine's on/off state (disabled, unavailable, degraded, ok) and per-rule health.";
+      tags: "Security";
+    };
+  }
+
+  // ListBadDestinations returns the merged baseline + operator-added
+  // known-bad-destination list the bad-destination rule matches against.
+  rpc ListBadDestinations(ListBadDestinationsRequest) returns (ListBadDestinationsResponse) {
+    option (google.api.http) = {
+      get: "/v1/security/bad-destinations"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "List known-bad destinations";
+      description: "Returns the merged baseline (embedded, versioned) and operator-added known-bad-destination list.";
+      tags: "Security";
+    };
+  }
+
+  // AddBadDestination adds an operator-supplied entry to the known-bad
+  // destination list, persisted so it survives a daemon restart, without a
+  // daemon rebuild.
+  rpc AddBadDestination(AddBadDestinationRequest) returns (AddBadDestinationResponse) {
+    option (google.api.http) = {
+      post: "/v1/security/bad-destinations"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Add a known-bad destination";
+      description: "Adds an operator-supplied CIDR or exact IP to the known-bad-destination list.";
+      tags: "Security";
+    };
+  }
+
+  // RemoveBadDestination removes a previously operator-added entry. Baseline
+  // (embedded) entries cannot be removed this way — a bare "not found" error
+  // covers the case since only additions are ever tracked as removable.
+  rpc RemoveBadDestination(RemoveBadDestinationRequest) returns (RemoveBadDestinationResponse) {
+    option (google.api.http) = {
+      delete: "/v1/security/bad-destinations/{cidr=**}"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Remove an operator-added bad destination";
+      description: "Removes a previously operator-added entry from the known-bad-destination list. Baseline entries cannot be removed.";
       tags: "Security";
     };
   }


### PR DESCRIPTION
Closes #1641

**Supersedes #1653.** Same squash-merge/stacked-PR artifact as #1640's rebase (#1656): #1653's merge-base predates #1656's squash-merge of #1640, so it showed CONFLICTING against \`main\` despite identical content. Same diff, rebased cleanly onto current \`main\`.

## What changed

- `internal/threatdetect/rule_baddest.go` (new) — `BadDestinationRule` implementing `Rule` for `THREAT_RULE_ID_BAD_DESTINATION`: embedded versioned baseline list (mining pools first, `go:embed`), exact-IP map + CIDR matching, operator-extendable via `DaemonConfigStore` without a daemon rebuild.
- `proto/containarium/v1/threatdetection.proto` — `BadDestinationEntry` + `ListBadDestinations`/`AddBadDestination`/`RemoveBadDestination` RPCs.
- `internal/server/threatdetect_server.go` — 3 new handlers.
- `internal/server/dual_server.go` — rule construction/wiring.
- `internal/cmd/security_bad_destinations.go` (new) — `containarium security bad-destinations` CLI verb (list/add/remove).
- `internal/mcp/{client,security,backend,tools}.go` — MCP tools.

## Test evidence

Same tests as #1653 (all previously green on this exact diff): exact-IP/CIDR match, operator-add/remove/reload, HIGH finding with tenant+destination, mining-incident replay (`TestBadDestinationRule_MiningIncidentReplay_RaisesHighFinding` — replays the flow pattern from `Containarium-cloud#815`). Re-verified locally after the rebase:
```
go build ./...    # clean
go vet ./...       # clean
gofmt -l .          # clean
go test ./internal/threatdetect/... ./internal/server/... \
  ./internal/cmd/... ./internal/mcp/...   # ok
```
CI running on the pushed branch now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added threat detection for known-bad IP addresses and CIDR ranges.
  - Added commands and API operations to list, add, and remove operator-managed bad destinations.
  - Supports optional labels, JSON or table-formatted listings, and persistent entries.
  - Added baseline bad-destination ranges that cannot be removed.
  - Added MCP tools for managing bad destinations with appropriate access controls.

- **Bug Fixes**
  - Added validation and clear errors for invalid or missing CIDR values and unavailable services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->