### PR TITLE
feat(threatdetect): fence-probe rules — cross-tenant flow + deny-burst

### DIFF
--- a/internal/config/threatdetect.go
+++ b/internal/config/threatdetect.go
@@ -1,10 +1,22 @@
 package config
 
+import "time"
+
 // EnvThreatSentry is the opt-in flag for the continuous threat-detection
 // background sentry (#1640) — off by default, consistent with the
 // platform's other opt-in security features (network-policy enforce,
 // signature scanning above).
 const EnvThreatSentry = "CONTAINARIUM_THREAT_SENTRY"
+
+// EnvThreatDenyBurstN and EnvThreatDenyBurstWindowMinutes tune the
+// deny-burst fence-probe rule (#1642): N deny events for one tenant within
+// M minutes raises a MEDIUM finding. Operator-tunable without a daemon
+// rebuild — set the env var and restart. Live tuning via an
+// UpdateThreatRuleConfig RPC without a restart is #1643's scope.
+const (
+	EnvThreatDenyBurstN             = "CONTAINARIUM_THREAT_DENY_BURST_N"
+	EnvThreatDenyBurstWindowMinutes = "CONTAINARIUM_THREAT_DENY_BURST_WINDOW_MINUTES"
+)
 
 // ThreatDetect is the typed view of the CONTAINARIUM_THREAT_* namespace.
 type ThreatDetect struct {
@@ -13,10 +25,20 @@ type ThreatDetect struct {
 	// but NOT enforce mode — detection runs in observation mode.
 	// (EnvThreatSentry)
 	SentryEnabled bool
+	// DenyBurstN and DenyBurstWindow are the deny-burst rule's threshold and
+	// sliding window. Zero/unset falls back to the rule's own defaults (see
+	// threatdetect.DefaultDenyBurstN/Window) — this struct only carries an
+	// override when the operator actually set one.
+	DenyBurstN      int
+	DenyBurstWindow time.Duration
 }
 
 // LoadThreatDetect reads the CONTAINARIUM_THREAT_* namespace once, using the
-// shared truthy convention (1/true/yes/on).
+// shared truthy convention (1/true/yes/on) for the enable flag.
 func LoadThreatDetect() ThreatDetect {
-	return ThreatDetect{SentryEnabled: getBool(EnvThreatSentry)}
+	return ThreatDetect{
+		SentryEnabled:   getBool(EnvThreatSentry),
+		DenyBurstN:      getInt(EnvThreatDenyBurstN, 0),
+		DenyBurstWindow: time.Duration(getInt(EnvThreatDenyBurstWindowMinutes, 0)) * time.Minute,
+	}
 }

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -1675,6 +1675,13 @@ skipAppHosting:
 		}
 		if sink != nil {
 			threatDetectEngine = threatdetect.NewEngine(sink, "", degraded, networkPolicyEnforcer.TenantForIP, nil)
+			// Fence-probe rules (#1642): a breached fence (cross-tenant
+			// flow) and a probed fence (deny-burst) are both continuous
+			// forms of checks that previously only ran one-shot or landed
+			// in the audit log with nothing watching. Zero-value N/window
+			// falls back to the rule's own defaults.
+			threatDetectEngine.Register(threatdetect.NewCrossTenantFlowRule())
+			threatDetectEngine.Register(threatdetect.NewDenyBurstRule(threatCfg.DenyBurstN, threatCfg.DenyBurstWindow))
 			networkPolicyEnforcer.SetFlowHook(threatDetectEngine.OnFlows)
 			networkPolicyEnforcer.SetDenyHook(threatDetectEngine.OnDeny)
 			if degraded {

--- a/internal/threatdetect/engine_test.go
+++ b/internal/threatdetect/engine_test.go
@@ -37,6 +37,14 @@ func (s *fakeSink) calls() []*Finding {
 	return append([]*Finding(nil), s.upserts...)
 }
 
+// reset clears recorded upserts, for a multi-phase test that reuses one
+// engine/sink across sequential scenarios.
+func (s *fakeSink) reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.upserts = nil
+}
+
 // testRule is a Rule test double whose behavior is supplied per-test via
 // closures, so each test stays a short table-driven case instead of a new
 // named type.

--- a/internal/threatdetect/fence_probe_e2e_test.go
+++ b/internal/threatdetect/fence_probe_e2e_test.go
@@ -1,0 +1,107 @@
+package threatdetect
+
+import (
+	"testing"
+	"time"
+
+	"github.com/footprintai/containarium/internal/netbpf"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// TestFenceProbe_TwoOrgPeers_CrossTenantFlowAndDenyBurst is the #1642
+// acceptance-criteria proof, driven through the real Engine (both rules
+// registered, exactly as internal/server/dual_server.go wires them) rather
+// than each rule in isolation.
+//
+// The issue and design doc ask for this reusing `cmd/isolation-sentry`'s
+// two-org peer scaffolding against a real backend. That command/scaffolding
+// does not exist in this repo (searched: no cmd/isolation-sentry directory,
+// no isolation-sentry references anywhere in the tree) — the design doc's
+// reference to it is stale. Flagged on the issue and in the PR as a gap:
+// the full two-org Incus/eBPF e2e needs new scaffolding built first, which
+// is out of scope for a single-package rules PR. This test is the
+// Engine-level fallback the coordinating story's directive calls for
+// instead, and should be superseded by a real e2e once that scaffolding
+// exists.
+func TestFenceProbe_TwoOrgPeers_CrossTenantFlowAndDenyBurst(t *testing.T) {
+	// "Two-org peers on one backend": org-a's container at 10.10.0.5,
+	// org-b's at 10.10.0.9, both resolvable via the enforcer's ip_tenant
+	// cache (faked here as RuleContext.TenantForIP would be in production).
+	tenants := map[string]string{
+		"10.10.0.5": "org-a",
+		"10.10.0.9": "org-b",
+	}
+	clock := time.Unix(2_000_000, 0)
+	now := func() time.Time { return clock }
+
+	sink := &fakeSink{}
+	engine := NewEngine(sink, "backend-1", false, fakeTenants(tenants), now)
+	engine.Register(NewCrossTenantFlowRule())
+	engine.Register(NewDenyBurstRule(20, 5*time.Minute)) // design doc defaults
+
+	t.Run("breached fence: org-a probes org-b directly, CRITICAL", func(t *testing.T) {
+		engine.OnFlows([]netbpf.FlowRecord{{
+			Saddr: beIP(10, 10, 0, 5), Daddr: beIP(10, 10, 0, 9),
+			Sport: 44000, Dport: 22, Proto: 6, Bytes: 512, Packets: 4,
+		}})
+
+		found := findUpsert(sink.calls(), pb.ThreatRuleId_THREAT_RULE_ID_CROSS_TENANT_FLOW)
+		if found == nil {
+			t.Fatal("no cross-tenant-flow finding upserted")
+		}
+		if found.Severity != pb.ThreatSeverity_THREAT_SEVERITY_CRITICAL {
+			t.Errorf("severity = %v, want CRITICAL", found.Severity)
+		}
+		if found.TenantID != "org-a" || found.Subject != "org-b" {
+			t.Errorf("tenant/subject = %s/%s, want org-a/org-b", found.TenantID, found.Subject)
+		}
+	})
+
+	t.Run("probed fence: org-b's container accumulates a deny burst against org-a, MEDIUM", func(t *testing.T) {
+		sink.reset()
+		// The network-policy enforcer would deny each of these (blocked
+		// cross-tenant attempts, e.g. under enforce mode); we drive the
+		// engine's OnDeny hook directly the same way the enforcer does.
+		for i := 0; i < 20; i++ {
+			engine.OnDeny(netbpf.DenyEvent{
+				Saddr: beIP(10, 10, 0, 9), Daddr: beIP(10, 10, 0, 5),
+				Dport: 22, Proto: 6, Reason: netbpf.DenyReasonPolicy,
+			})
+		}
+		// deny-burst is Sweep-driven (30s engine tick in production).
+		engine.Sweep(clock)
+
+		found := findUpsert(sink.calls(), pb.ThreatRuleId_THREAT_RULE_ID_DENY_BURST)
+		if found == nil {
+			t.Fatal("no deny-burst finding upserted")
+		}
+		if found.Severity != pb.ThreatSeverity_THREAT_SEVERITY_MEDIUM {
+			t.Errorf("severity = %v, want MEDIUM", found.Severity)
+		}
+		if found.TenantID != "org-b" {
+			t.Errorf("tenant = %s, want org-b (the probing side)", found.TenantID)
+		}
+	})
+
+	t.Run("below threshold: 19 denies alone never fire", func(t *testing.T) {
+		sink.reset()
+		fresh := NewEngine(sink, "backend-1", false, fakeTenants(tenants), now)
+		fresh.Register(NewDenyBurstRule(20, 5*time.Minute))
+		for i := 0; i < 19; i++ {
+			fresh.OnDeny(netbpf.DenyEvent{Saddr: beIP(10, 10, 0, 9), Daddr: beIP(10, 10, 0, 5)})
+		}
+		fresh.Sweep(clock)
+		if found := findUpsert(sink.calls(), pb.ThreatRuleId_THREAT_RULE_ID_DENY_BURST); found != nil {
+			t.Errorf("finding upserted below threshold: %+v", found)
+		}
+	})
+}
+
+func findUpsert(calls []*Finding, rule pb.ThreatRuleId) *Finding {
+	for _, f := range calls {
+		if f.Rule == rule {
+			return f
+		}
+	}
+	return nil
+}

--- a/internal/threatdetect/render.go
+++ b/internal/threatdetect/render.go
@@ -1,0 +1,53 @@
+package threatdetect
+
+import (
+	"math"
+
+	"github.com/footprintai/containarium/internal/netbpf"
+)
+
+// safeInt64 clamps a uint64 traffic counter (flow bytes/packets, deny
+// counts) to int64 range rather than letting a value above 2^63 wrap to a
+// negative evidence field (same guarded-clamp pattern as
+// internal/sentinel/metricsexport.go's safeInt64 — duplicated locally, not
+// exported, for the same reason protoName is above). Real flow counters are
+// nowhere near this; the clamp exists so a wrap would be impossible rather
+// than merely unlikely.
+func safeInt64(v uint64) int64 {
+	if v > math.MaxInt64 {
+		return math.MaxInt64
+	}
+	return int64(v)
+}
+
+// protoName renders an IP protocol number as the lowercase string used
+// throughout the evidence types (mirrors the equivalent unexported helper in
+// internal/server/network_policy_enforcer.go — duplicated here rather than
+// exported across the package boundary, since it's three lines and pulling
+// internal/server into internal/threatdetect would invert the dependency
+// direction the enforcer's SetFlowHook/SetDenyHook wiring already relies on).
+func protoName(proto uint8) string {
+	switch proto {
+	case 1:
+		return "icmp"
+	case 6:
+		return "tcp"
+	case 17:
+		return "udp"
+	default:
+		return ""
+	}
+}
+
+// denyReasonName renders a DenyEvent.Reason as the short label an operator
+// sees in a finding's evidence.
+func denyReasonName(reason uint8) string {
+	switch reason {
+	case netbpf.DenyReasonVirtualPatch:
+		return "virtual-patch"
+	case netbpf.DenyReasonSignature:
+		return "signature"
+	default:
+		return "policy"
+	}
+}

--- a/internal/threatdetect/rule_crosstenant.go
+++ b/internal/threatdetect/rule_crosstenant.go
@@ -1,0 +1,71 @@
+package threatdetect
+
+import (
+	"time"
+
+	"github.com/footprintai/containarium/internal/netbpf"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// CrossTenantFlowRule is the continuous form of the one-shot isolation
+// check: a flow whose source and destination resolve to containers in
+// different tenants on the same backend means the tenant fence has been
+// breached, not merely probed (see DenyBurstRule for probing). See
+// docs/architecture/continuous-threat-detection.md.
+type CrossTenantFlowRule struct{}
+
+// NewCrossTenantFlowRule builds the rule. Stateless — every flow is judged
+// independently, so there is nothing to construct.
+func NewCrossTenantFlowRule() *CrossTenantFlowRule { return &CrossTenantFlowRule{} }
+
+func (r *CrossTenantFlowRule) ID() pb.ThreatRuleId {
+	return pb.ThreatRuleId_THREAT_RULE_ID_CROSS_TENANT_FLOW
+}
+
+// OnFlows flags a flow only when BOTH endpoints resolve to a known tenant
+// and those tenants differ. An unresolved endpoint (traffic to/from
+// something outside this backend's tenant fleet — a peer backend, the
+// internet, the host itself) never raises a finding: guessing at an unknown
+// IP's tenant would turn ordinary egress into false positives.
+func (r *CrossTenantFlowRule) OnFlows(ctx RuleContext, flows []netbpf.FlowRecord) []RawFinding {
+	var out []RawFinding
+	for _, f := range flows {
+		srcTenant, srcOK := ctx.TenantForIP(f.Src())
+		if !srcOK {
+			continue
+		}
+		dstTenant, dstOK := ctx.TenantForIP(f.Dst())
+		if !dstOK || dstTenant == srcTenant {
+			continue
+		}
+		out = append(out, RawFinding{
+			Rule:     pb.ThreatRuleId_THREAT_RULE_ID_CROSS_TENANT_FLOW,
+			Severity: pb.ThreatSeverity_THREAT_SEVERITY_CRITICAL,
+			TenantID: srcTenant,
+			// Subject is the peer tenant id — see RawFinding's dedupe-scope
+			// doc. Two tenants probing each other from both sides dedupe
+			// into two distinct findings (one per direction), which is
+			// correct: each side's container is a separate thing to
+			// investigate.
+			Subject: dstTenant,
+			Evidence: Evidence{Flows: []FlowEvidence{{
+				SrcIP:    f.Src().String(),
+				DstIP:    f.Dst().String(),
+				SrcPort:  uint32(f.Sport),
+				DstPort:  uint32(f.Dport),
+				Protocol: protoName(f.Proto),
+				Bytes:    safeInt64(f.Bytes),
+				Packets:  safeInt64(f.Packets),
+			}}},
+		})
+	}
+	return out
+}
+
+// OnDeny: cross-tenant-flow is a flow-shaped rule; a policy deny means the
+// enforcer already stopped the packet, so it can't be the breach this rule
+// exists to catch (that's DenyBurstRule's signal instead).
+func (r *CrossTenantFlowRule) OnDeny(RuleContext, netbpf.DenyEvent) []RawFinding { return nil }
+
+// Sweep: no time-window state to evaluate.
+func (r *CrossTenantFlowRule) Sweep(RuleContext, time.Time) []RawFinding { return nil }

--- a/internal/threatdetect/rule_crosstenant_test.go
+++ b/internal/threatdetect/rule_crosstenant_test.go
@@ -1,0 +1,158 @@
+package threatdetect
+
+import (
+	"encoding/binary"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/footprintai/containarium/internal/netbpf"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// beIP encodes a dotted-quad as the network-byte-order uint32 FlowRecord and
+// DenyEvent carry on the wire (mirrors internal/netbpf's own test helpers).
+func beIP(a, b, c, d byte) uint32 {
+	return binary.NativeEndian.Uint32([]byte{a, b, c, d})
+}
+
+// fakeTenants is a RuleContext.TenantForIP double: a fixed IP->tenant map,
+// everything else unresolved. Both new rules must never guess at an
+// unrecognized IP, so "not in the map" is the interesting case to exercise,
+// not an edge case to skip.
+func fakeTenants(m map[string]string) func(netip.Addr) (string, bool) {
+	return func(ip netip.Addr) (string, bool) {
+		t, ok := m[ip.String()]
+		return t, ok
+	}
+}
+
+func TestCrossTenantFlowRule_ID(t *testing.T) {
+	r := NewCrossTenantFlowRule()
+	if r.ID() != pb.ThreatRuleId_THREAT_RULE_ID_CROSS_TENANT_FLOW {
+		t.Errorf("ID() = %v, want THREAT_RULE_ID_CROSS_TENANT_FLOW", r.ID())
+	}
+}
+
+func TestCrossTenantFlowRule_OnFlows(t *testing.T) {
+	tenants := fakeTenants(map[string]string{
+		"10.0.0.1": "alice",
+		"10.0.0.2": "alice",
+		"10.0.0.3": "bob",
+	})
+	ctx := RuleContext{TenantForIP: tenants}
+
+	tests := []struct {
+		name     string
+		flow     netbpf.FlowRecord
+		wantFire bool
+		wantSev  pb.ThreatSeverity
+		wantTID  string
+		wantSubj string
+	}{
+		{
+			name:     "same tenant both ends: no finding",
+			flow:     netbpf.FlowRecord{Saddr: beIP(10, 0, 0, 1), Daddr: beIP(10, 0, 0, 2)},
+			wantFire: false,
+		},
+		{
+			name:     "different tenants: CRITICAL finding attributed to src, subject is peer tenant",
+			flow:     netbpf.FlowRecord{Saddr: beIP(10, 0, 0, 1), Daddr: beIP(10, 0, 0, 3)},
+			wantFire: true,
+			wantSev:  pb.ThreatSeverity_THREAT_SEVERITY_CRITICAL,
+			wantTID:  "alice",
+			wantSubj: "bob",
+		},
+		{
+			name:     "unknown source: no finding, never guess",
+			flow:     netbpf.FlowRecord{Saddr: beIP(192, 168, 1, 1), Daddr: beIP(10, 0, 0, 3)},
+			wantFire: false,
+		},
+		{
+			name:     "unknown destination: no finding, never guess",
+			flow:     netbpf.FlowRecord{Saddr: beIP(10, 0, 0, 1), Daddr: beIP(192, 168, 1, 1)},
+			wantFire: false,
+		},
+		{
+			name:     "both unknown: no finding",
+			flow:     netbpf.FlowRecord{Saddr: beIP(192, 168, 1, 1), Daddr: beIP(192, 168, 1, 2)},
+			wantFire: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewCrossTenantFlowRule()
+			got := r.OnFlows(ctx, []netbpf.FlowRecord{tc.flow})
+			if !tc.wantFire {
+				if len(got) != 0 {
+					t.Fatalf("OnFlows = %+v, want no finding", got)
+				}
+				return
+			}
+			if len(got) != 1 {
+				t.Fatalf("OnFlows = %+v, want exactly 1 finding", got)
+			}
+			f := got[0]
+			if f.Severity != tc.wantSev {
+				t.Errorf("Severity = %v, want %v", f.Severity, tc.wantSev)
+			}
+			if f.TenantID != tc.wantTID {
+				t.Errorf("TenantID = %q, want %q", f.TenantID, tc.wantTID)
+			}
+			if f.Subject != tc.wantSubj {
+				t.Errorf("Subject = %q, want %q", f.Subject, tc.wantSubj)
+			}
+			if f.Rule != pb.ThreatRuleId_THREAT_RULE_ID_CROSS_TENANT_FLOW {
+				t.Errorf("Rule = %v, want THREAT_RULE_ID_CROSS_TENANT_FLOW", f.Rule)
+			}
+			if len(f.Evidence.Flows) != 1 {
+				t.Fatalf("Evidence.Flows = %+v, want exactly 1 flow", f.Evidence.Flows)
+			}
+		})
+	}
+}
+
+// Replays the cross-org fence-probe incident's flow shape: two containers on
+// the same backend, different tenants, exchanging a flow. This is the
+// #1642 acceptance-criteria replay for the cross-tenant rule (the continuous
+// form of the one-shot isolation check).
+func TestCrossTenantFlowRule_IncidentReplay(t *testing.T) {
+	tenants := fakeTenants(map[string]string{
+		"10.10.0.5": "org-a",
+		"10.10.0.9": "org-b",
+	})
+	ctx := RuleContext{TenantForIP: tenants}
+	r := NewCrossTenantFlowRule()
+
+	got := r.OnFlows(ctx, []netbpf.FlowRecord{{
+		Saddr: beIP(10, 10, 0, 5), Daddr: beIP(10, 10, 0, 9),
+		Sport: 51000, Dport: 8080, Proto: 6, Bytes: 4096, Packets: 12,
+	}})
+
+	if len(got) != 1 {
+		t.Fatalf("findings = %+v, want exactly 1", got)
+	}
+	f := got[0]
+	if f.Severity != pb.ThreatSeverity_THREAT_SEVERITY_CRITICAL {
+		t.Errorf("Severity = %v, want CRITICAL", f.Severity)
+	}
+	if f.TenantID != "org-a" || f.Subject != "org-b" {
+		t.Errorf("TenantID/Subject = %q/%q, want org-a/org-b", f.TenantID, f.Subject)
+	}
+	ev := f.Evidence.Flows[0]
+	if ev.SrcIP != "10.10.0.5" || ev.DstIP != "10.10.0.9" || ev.DstPort != 8080 || ev.Protocol != "tcp" {
+		t.Errorf("evidence = %+v, want the replayed 5-tuple", ev)
+	}
+}
+
+func TestCrossTenantFlowRule_OnDenyAndSweep_AreNoops(t *testing.T) {
+	r := NewCrossTenantFlowRule()
+	ctx := RuleContext{TenantForIP: fakeTenants(nil)}
+	if got := r.OnDeny(ctx, netbpf.DenyEvent{}); got != nil {
+		t.Errorf("OnDeny = %+v, want nil (flow-shaped rule)", got)
+	}
+	if got := r.Sweep(ctx, time.Time{}); got != nil {
+		t.Errorf("Sweep = %+v, want nil (no window state)", got)
+	}
+}

--- a/internal/threatdetect/rule_denyburst.go
+++ b/internal/threatdetect/rule_denyburst.go
@@ -1,0 +1,172 @@
+package threatdetect
+
+import (
+	"sync"
+	"time"
+
+	"github.com/footprintai/containarium/internal/netbpf"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// Default N/M for DenyBurstRule (design doc: "N default 20, M default 5
+// minutes"). Operator-tunable via CONTAINARIUM_THREAT_DENY_BURST_N /
+// CONTAINARIUM_THREAT_DENY_BURST_WINDOW_MINUTES (see internal/config) — no
+// daemon rebuild required, just a restart with the new env var. Live tuning
+// via an UpdateThreatRuleConfig RPC without a restart is #1643's scope.
+const (
+	DefaultDenyBurstN      = 20
+	DefaultDenyBurstWindow = 5 * time.Minute
+)
+
+// denyBurstRecord is one deny event's evidence, kept in a tenant's sliding
+// window until it ages out.
+type denyBurstRecord struct {
+	at     time.Time
+	dst    string
+	dport  uint32
+	proto  string
+	reason string
+}
+
+// DenyBurstRule fires a MEDIUM "fence probing" finding when one tenant
+// accumulates >= N deny events within an M-minute sliding window — the
+// signal that a tenant is testing the fence rather than having already
+// breached it (CrossTenantFlowRule catches an actual breach). Per the
+// engine's Rule.Sweep doc and the design doc's "deny-burst adds ≤ 30s sweep
+// granularity", this rule accumulates on OnDeny but only evaluates and
+// fires on Sweep — not on every OnDeny call — so a burst that never grows
+// past a stale window doesn't keep re-alerting on the mere passage of time,
+// and a quiet window doesn't emit anything between ticks.
+type DenyBurstRule struct {
+	n      int
+	window time.Duration
+
+	mu      sync.Mutex
+	records map[string][]denyBurstRecord // tenantID -> window records, oldest first
+	dirty   map[string]bool              // tenantID -> at least one OnDeny since the last Sweep
+}
+
+// NewDenyBurstRule builds the rule with N deny events within window
+// triggering a finding. n<=0 or window<=0 falls back to the design doc's
+// defaults rather than constructing a rule that can never fire (n=0) or
+// fires on every single deny (window=0).
+func NewDenyBurstRule(n int, window time.Duration) *DenyBurstRule {
+	if n <= 0 {
+		n = DefaultDenyBurstN
+	}
+	if window <= 0 {
+		window = DefaultDenyBurstWindow
+	}
+	return &DenyBurstRule{
+		n:       n,
+		window:  window,
+		records: make(map[string][]denyBurstRecord),
+		dirty:   make(map[string]bool),
+	}
+}
+
+func (r *DenyBurstRule) ID() pb.ThreatRuleId { return pb.ThreatRuleId_THREAT_RULE_ID_DENY_BURST }
+
+// OnFlows: deny-burst is a deny-shaped rule; flow records carry no denial
+// information.
+func (r *DenyBurstRule) OnFlows(RuleContext, []netbpf.FlowRecord) []RawFinding { return nil }
+
+// OnDeny records the event into the source tenant's window. Never fires
+// directly — see the type doc for why evaluation is deferred to Sweep. An
+// event whose source IP doesn't resolve to a known tenant is dropped: a
+// probe from an unrecognized IP has no tenant to attribute the burst to.
+func (r *DenyBurstRule) OnDeny(ctx RuleContext, ev netbpf.DenyEvent) []RawFinding {
+	tenantID, ok := ctx.TenantForIP(ev.Src())
+	if !ok {
+		return nil
+	}
+	now := ctx.Now()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.records[tenantID] = append(r.records[tenantID], denyBurstRecord{
+		at:     now,
+		dst:    ev.Dst().String(),
+		dport:  uint32(ev.Dport),
+		proto:  protoName(ev.Proto),
+		reason: denyReasonName(ev.Reason),
+	})
+	r.dirty[tenantID] = true
+	return nil
+}
+
+// Sweep prunes every tracked tenant's window to [now-window, now] and, for
+// a tenant with new denies since the last Sweep (dirty) whose pruned window
+// still holds >= n records, returns a MEDIUM finding. Window expiry — the
+// pruned count dropping below n with no new denies — naturally stops future
+// findings until fresh denies re-cross the threshold, without any separate
+// "reset" bookkeeping.
+func (r *DenyBurstRule) Sweep(_ RuleContext, now time.Time) []RawFinding {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var out []RawFinding
+	for tenantID, records := range r.records {
+		cutoff := now.Add(-r.window)
+		kept := records[:0]
+		for _, rec := range records {
+			if rec.at.After(cutoff) {
+				kept = append(kept, rec)
+			}
+		}
+		if len(kept) == 0 {
+			delete(r.records, tenantID)
+			delete(r.dirty, tenantID)
+			continue
+		}
+		r.records[tenantID] = kept
+
+		fire := r.dirty[tenantID] && len(kept) >= r.n
+		r.dirty[tenantID] = false
+		if !fire {
+			continue
+		}
+
+		out = append(out, RawFinding{
+			Rule:     pb.ThreatRuleId_THREAT_RULE_ID_DENY_BURST,
+			Severity: pb.ThreatSeverity_THREAT_SEVERITY_MEDIUM,
+			TenantID: tenantID,
+			// Subject "" — the dedupe scope is the whole tenant, not a
+			// single peer/destination (a probe typically fans out across
+			// many destinations).
+			Subject:  "",
+			Evidence: Evidence{Denies: denyEvidenceFromRecords(kept)},
+		})
+	}
+	return out
+}
+
+// denyEvidenceFromRecords aggregates window records into DenyEvidence rows
+// grouped by (dst, dport, proto, reason), most-recent group last — Capped()
+// (applied by the store on write) keeps only the most recent EvidenceCap
+// groups.
+func denyEvidenceFromRecords(records []denyBurstRecord) []DenyEvidence {
+	type key struct {
+		dst, proto, reason string
+		dport              uint32
+	}
+	order := make([]key, 0, len(records))
+	counts := make(map[key]int64, len(records))
+	for _, rec := range records {
+		k := key{dst: rec.dst, proto: rec.proto, reason: rec.reason, dport: rec.dport}
+		if _, seen := counts[k]; !seen {
+			order = append(order, k)
+		}
+		counts[k]++
+	}
+	out := make([]DenyEvidence, 0, len(order))
+	for _, k := range order {
+		out = append(out, DenyEvidence{
+			DstIP:    k.dst,
+			DstPort:  k.dport,
+			Protocol: k.proto,
+			Reason:   k.reason,
+			Count:    counts[k],
+		})
+	}
+	return out
+}

--- a/internal/threatdetect/rule_denyburst_test.go
+++ b/internal/threatdetect/rule_denyburst_test.go
@@ -1,0 +1,230 @@
+package threatdetect
+
+import (
+	"testing"
+	"time"
+
+	"github.com/footprintai/containarium/internal/netbpf"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+func denyburstCtx(now time.Time, tenants map[string]string) RuleContext {
+	return RuleContext{
+		TenantForIP: fakeTenants(tenants),
+		Now:         func() time.Time { return now },
+	}
+}
+
+func TestDenyBurstRule_ID(t *testing.T) {
+	r := NewDenyBurstRule(0, 0)
+	if r.ID() != pb.ThreatRuleId_THREAT_RULE_ID_DENY_BURST {
+		t.Errorf("ID() = %v, want THREAT_RULE_ID_DENY_BURST", r.ID())
+	}
+}
+
+func TestNewDenyBurstRule_DefaultsOnZeroValue(t *testing.T) {
+	r := NewDenyBurstRule(0, 0)
+	if r.n != DefaultDenyBurstN {
+		t.Errorf("n = %d, want default %d", r.n, DefaultDenyBurstN)
+	}
+	if r.window != DefaultDenyBurstWindow {
+		t.Errorf("window = %v, want default %v", r.window, DefaultDenyBurstWindow)
+	}
+}
+
+// OnDeny alone never fires — evaluation is deferred to Sweep (see the type
+// doc). This must hold even once the threshold is technically met.
+func TestDenyBurstRule_OnDeny_NeverFiresDirectly(t *testing.T) {
+	r := NewDenyBurstRule(1, time.Minute)
+	tenants := map[string]string{"10.0.0.1": "alice"}
+	base := time.Unix(1000, 0)
+
+	for i := 0; i < 5; i++ {
+		ev := netbpf.DenyEvent{Saddr: beIP(10, 0, 0, 1), Daddr: beIP(10, 0, 0, 2)}
+		if got := r.OnDeny(denyburstCtx(base, tenants), ev); got != nil {
+			t.Fatalf("OnDeny returned %+v, want nil (Sweep-driven, not signal-driven)", got)
+		}
+	}
+}
+
+// Unresolved source IP: dropped, never attributed to a guessed tenant.
+func TestDenyBurstRule_OnDeny_UnknownSourceDropped(t *testing.T) {
+	r := NewDenyBurstRule(1, time.Minute)
+	base := time.Unix(1000, 0)
+	ev := netbpf.DenyEvent{Saddr: beIP(192, 168, 1, 1), Daddr: beIP(10, 0, 0, 2)}
+	r.OnDeny(denyburstCtx(base, nil), ev)
+
+	got := r.Sweep(denyburstCtx(base, nil), base)
+	if len(got) != 0 {
+		t.Fatalf("Sweep = %+v, want none (unresolved source never recorded)", got)
+	}
+}
+
+// The design doc's own table: N-1 denies -> none, N -> MEDIUM.
+func TestDenyBurstRule_NMinusOneVsN(t *testing.T) {
+	const n = 5
+	tenants := map[string]string{"10.0.0.1": "alice"}
+	base := time.Unix(1000, 0)
+	r := NewDenyBurstRule(n, time.Minute)
+
+	fireEvents := func(count int) []RawFinding {
+		for i := 0; i < count; i++ {
+			ev := netbpf.DenyEvent{Saddr: beIP(10, 0, 0, 1), Daddr: beIP(10, 0, 0, 2), Dport: 1234, Proto: 6}
+			r.OnDeny(denyburstCtx(base, tenants), ev)
+		}
+		return r.Sweep(denyburstCtx(base, tenants), base)
+	}
+
+	if got := fireEvents(n - 1); len(got) != 0 {
+		t.Fatalf("after %d denies, Sweep = %+v, want none", n-1, got)
+	}
+	// One more deny crosses the threshold (total n).
+	ev := netbpf.DenyEvent{Saddr: beIP(10, 0, 0, 1), Daddr: beIP(10, 0, 0, 2), Dport: 1234, Proto: 6}
+	r.OnDeny(denyburstCtx(base, tenants), ev)
+	got := r.Sweep(denyburstCtx(base, tenants), base)
+	if len(got) != 1 {
+		t.Fatalf("after %d denies, Sweep = %+v, want exactly 1 MEDIUM finding", n, got)
+	}
+	f := got[0]
+	if f.Severity != pb.ThreatSeverity_THREAT_SEVERITY_MEDIUM {
+		t.Errorf("Severity = %v, want MEDIUM", f.Severity)
+	}
+	if f.TenantID != "alice" {
+		t.Errorf("TenantID = %q, want alice", f.TenantID)
+	}
+	if f.Subject != "" {
+		t.Errorf("Subject = %q, want empty (tenant-scoped, not destination-scoped)", f.Subject)
+	}
+}
+
+// Once fired, a Sweep with no new denies since must not keep re-firing —
+// the store already collapses repeats, but the rule itself shouldn't
+// manufacture a "repeat" out of nothing happening.
+func TestDenyBurstRule_NoNewDenies_DoesNotRefire(t *testing.T) {
+	const n = 3
+	tenants := map[string]string{"10.0.0.1": "alice"}
+	base := time.Unix(1000, 0)
+	r := NewDenyBurstRule(n, time.Minute)
+
+	for i := 0; i < n; i++ {
+		ev := netbpf.DenyEvent{Saddr: beIP(10, 0, 0, 1)}
+		r.OnDeny(denyburstCtx(base, tenants), ev)
+	}
+	first := r.Sweep(denyburstCtx(base, tenants), base)
+	if len(first) != 1 {
+		t.Fatalf("first Sweep = %+v, want 1 finding", first)
+	}
+
+	// No new OnDeny; Sweep again a few seconds later (still inside window).
+	second := r.Sweep(denyburstCtx(base, tenants), base.Add(5*time.Second))
+	if len(second) != 0 {
+		t.Fatalf("second Sweep (no new denies) = %+v, want none", second)
+	}
+}
+
+// Window expiry: once every record ages out, the count resets below n and
+// a fresh burst is required to fire again.
+func TestDenyBurstRule_WindowExpiryResets(t *testing.T) {
+	const n = 3
+	window := time.Minute
+	tenants := map[string]string{"10.0.0.1": "alice"}
+	base := time.Unix(1000, 0)
+	r := NewDenyBurstRule(n, window)
+
+	for i := 0; i < n; i++ {
+		r.OnDeny(denyburstCtx(base, tenants), netbpf.DenyEvent{Saddr: beIP(10, 0, 0, 1)})
+	}
+	if got := r.Sweep(denyburstCtx(base, tenants), base); len(got) != 1 {
+		t.Fatalf("initial burst Sweep = %+v, want 1 finding", got)
+	}
+
+	// Jump past the window with no new denies: old records should be
+	// pruned and the tenant's tracked state cleared.
+	afterExpiry := base.Add(window + time.Second)
+	if got := r.Sweep(denyburstCtx(afterExpiry, tenants), afterExpiry); len(got) != 0 {
+		t.Fatalf("Sweep after window expiry = %+v, want none", got)
+	}
+
+	// Fewer than n new denies after expiry: still no finding.
+	for i := 0; i < n-1; i++ {
+		r.OnDeny(denyburstCtx(afterExpiry, tenants), netbpf.DenyEvent{Saddr: beIP(10, 0, 0, 1)})
+	}
+	if got := r.Sweep(denyburstCtx(afterExpiry, tenants), afterExpiry); len(got) != 0 {
+		t.Fatalf("Sweep with %d fresh denies post-expiry = %+v, want none (need a fresh full burst)", n-1, got)
+	}
+
+	// One more closes the fresh burst back to n.
+	r.OnDeny(denyburstCtx(afterExpiry, tenants), netbpf.DenyEvent{Saddr: beIP(10, 0, 0, 1)})
+	if got := r.Sweep(denyburstCtx(afterExpiry, tenants), afterExpiry); len(got) != 1 {
+		t.Fatalf("Sweep after fresh burst re-crosses n = %+v, want 1 finding", got)
+	}
+}
+
+// N and M are both operator-tunable constructor parameters.
+func TestDenyBurstRule_TunableNAndM(t *testing.T) {
+	tenants := map[string]string{"10.0.0.1": "alice"}
+	base := time.Unix(1000, 0)
+
+	// A tight rule (n=1) fires on the very first deny.
+	tight := NewDenyBurstRule(1, time.Hour)
+	tight.OnDeny(denyburstCtx(base, tenants), netbpf.DenyEvent{Saddr: beIP(10, 0, 0, 1)})
+	if got := tight.Sweep(denyburstCtx(base, tenants), base); len(got) != 1 {
+		t.Fatalf("n=1 rule Sweep after 1 deny = %+v, want 1 finding", got)
+	}
+
+	// A short window (M) expires almost immediately.
+	short := NewDenyBurstRule(2, time.Second)
+	short.OnDeny(denyburstCtx(base, tenants), netbpf.DenyEvent{Saddr: beIP(10, 0, 0, 1)})
+	short.OnDeny(denyburstCtx(base, tenants), netbpf.DenyEvent{Saddr: beIP(10, 0, 0, 1)})
+	later := base.Add(2 * time.Second)
+	if got := short.Sweep(denyburstCtx(later, tenants), later); len(got) != 0 {
+		t.Fatalf("short-window rule Sweep after window elapsed = %+v, want none", got)
+	}
+}
+
+// Different tenants accumulate independent windows.
+func TestDenyBurstRule_DistinctTenantsDoNotCollide(t *testing.T) {
+	const n = 2
+	tenants := map[string]string{"10.0.0.1": "alice", "10.0.0.9": "bob"}
+	base := time.Unix(1000, 0)
+	r := NewDenyBurstRule(n, time.Minute)
+
+	r.OnDeny(denyburstCtx(base, tenants), netbpf.DenyEvent{Saddr: beIP(10, 0, 0, 1)})
+	r.OnDeny(denyburstCtx(base, tenants), netbpf.DenyEvent{Saddr: beIP(10, 0, 0, 1)})
+	// Bob only has 1 deny — below n.
+	r.OnDeny(denyburstCtx(base, tenants), netbpf.DenyEvent{Saddr: beIP(10, 0, 0, 9)})
+
+	got := r.Sweep(denyburstCtx(base, tenants), base)
+	if len(got) != 1 {
+		t.Fatalf("Sweep = %+v, want exactly 1 finding (alice only)", got)
+	}
+	if got[0].TenantID != "alice" {
+		t.Errorf("TenantID = %q, want alice", got[0].TenantID)
+	}
+}
+
+func TestDenyBurstRule_OnFlows_IsNoop(t *testing.T) {
+	r := NewDenyBurstRule(1, time.Minute)
+	if got := r.OnFlows(RuleContext{}, []netbpf.FlowRecord{{}}); got != nil {
+		t.Errorf("OnFlows = %+v, want nil (deny-shaped rule)", got)
+	}
+}
+
+func TestDenyEvidenceFromRecords_AggregatesByDestination(t *testing.T) {
+	base := time.Unix(1000, 0)
+	records := []denyBurstRecord{
+		{at: base, dst: "10.0.0.2", dport: 22, proto: "tcp", reason: "policy"},
+		{at: base, dst: "10.0.0.2", dport: 22, proto: "tcp", reason: "policy"},
+		{at: base, dst: "10.0.0.3", dport: 443, proto: "tcp", reason: "policy"},
+	}
+	got := denyEvidenceFromRecords(records)
+	if len(got) != 2 {
+		t.Fatalf("evidence = %+v, want 2 groups", got)
+	}
+	if got[0].DstIP != "10.0.0.2" || got[0].Count != 2 {
+		t.Errorf("first group = %+v, want 10.0.0.2 count=2", got[0])
+	}
+	if got[1].DstIP != "10.0.0.3" || got[1].Count != 1 {
+		t.Errorf("second group = %+v, want 10.0.0.3 count=1", got[1])
+	}
+}


### PR DESCRIPTION
Closes #1642

**Supersedes #1652.** Same squash-merge/stacked-PR artifact as #1640's and #1641's rebases (#1656, #1657): #1652's merge-base predates #1656's squash-merge of #1640, so it showed CONFLICTING against \`main\` despite identical content. Same diff, rebased cleanly onto current \`main\`.

## What changed

- `internal/threatdetect/rule_crosstenant.go` (new) — `CrossTenantFlowRule`: source and destination resolve to containers with different tenant ids ⇒ CRITICAL. Unknown IP (either side) ⇒ no finding, never guess.
- `internal/threatdetect/rule_denyburst.go` (new) — `DenyBurstRule`: `Sweep`-driven per-tenant sliding window over deny events, ≥N within M minutes ⇒ MEDIUM, N/M tunable via `CONTAINARIUM_THREAT_DENY_BURST_N`/`_WINDOW`.
- `internal/threatdetect/fence_probe_e2e_test.go` (new) — two-org-peer scenario through the real `Engine`.
- `internal/config/threatdetect.go` — `DenyBurstN`/`DenyBurstWindow` config.
- `internal/server/dual_server.go` — registers both rules.

## Flagged gap (unchanged from #1652)

`cmd/isolation-sentry` — the two-org Incus e2e scaffolding the design doc names — does not exist anywhere in this repo (confirmed by full-tree search). The `TestFenceProbe_TwoOrgPeers_*` Engine-level test (fake `RuleContext`/`FindingSink`, real `Engine`) is the fallback proof this PR ships with, not a substitute for real Incus-backed two-org e2e coverage. Worth a follow-up issue to build that scaffolding.

## Test evidence

Same tests as #1652 (all previously green on this exact diff): `TestCrossTenantFlowRule_*`, `TestDenyBurstRule_*`, `TestFenceProbe_TwoOrgPeers_*`. Re-verified locally after the rebase:
```
go build ./...    # clean
go vet ./...       # clean
gofmt -l .          # clean
go test ./internal/threatdetect/... ./internal/server/... ./internal/config/...   # ok
```
CI running on the pushed branch now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cross-tenant flow detection with critical-severity findings and tenant attribution.
  * Added configurable deny-burst detection using thresholds and time windows.
  * Findings now include aggregated evidence such as destinations, ports, protocols, and deny reasons.
  * Added support for rendering common network protocols and deny reasons.

* **Bug Fixes**
  * Large counter values are safely handled without overflow.

* **Tests**
  * Added comprehensive coverage for cross-tenant probing, deny bursts, thresholds, expiry, attribution, and evidence aggregation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->