### PR TITLE
feat(threatdetect): webhook delivery + findings triage CLI/MCP surface

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -58,7 +58,7 @@
     },
     {
       "name": "ThreatDetectionService",
-      "description": "ThreatDetectionService serves the background security-sentry's status and\nfindings. GetSentryStatus ships with #1640 (background detection loop);\n*BadDestination* ships with #1641 (known-bad destination rule); the\nfindings/rule-config RPCs are added by later stories in the same umbrella\n(#1642-#1643) — see docs/architecture/continuous-threat-detection.md."
+      "description": "ThreatDetectionService serves the background security-sentry's status and\nfindings. GetSentryStatus ships with #1640 (background detection loop);\n*BadDestination* ships with #1641 (known-bad destination rule);\nListFindings/ResolveFinding ship with #1643 (findings delivery + triage);\nrule-config RPCs remain unimplemented — see\ndocs/architecture/continuous-threat-detection.md."
     },
     {
       "name": "EventService",
@@ -5453,6 +5453,115 @@
             }
           }
         },
+        "tags": [
+          "Security"
+        ]
+      }
+    },
+    "/v1/security/findings": {
+      "get": {
+        "summary": "List security findings",
+        "description": "Lists security findings with optional severity/tenant/since/state filters, most recently seen first. Non-admin callers only see their own tenant.",
+        "operationId": "ThreatDetectionService_ListFindings",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListFindingsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "severity",
+            "description": "Exact match. THREAT_SEVERITY_UNSPECIFIED (default) matches any severity.",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "THREAT_SEVERITY_UNSPECIFIED",
+              "THREAT_SEVERITY_LOW",
+              "THREAT_SEVERITY_MEDIUM",
+              "THREAT_SEVERITY_HIGH",
+              "THREAT_SEVERITY_CRITICAL"
+            ],
+            "default": "THREAT_SEVERITY_UNSPECIFIED"
+          },
+          {
+            "name": "tenantId",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "since",
+            "description": "Only findings last seen at or after this time. Unset matches everything.",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "state",
+            "description": "Exact match. FINDING_STATE_UNSPECIFIED (default) matches any state.",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "FINDING_STATE_UNSPECIFIED",
+              "FINDING_STATE_OPEN",
+              "FINDING_STATE_RESOLVED"
+            ],
+            "default": "FINDING_STATE_UNSPECIFIED"
+          },
+          {
+            "name": "limit",
+            "description": "\u003c= 0 or \u003e 200 is treated as the server default (50).",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "tags": [
+          "Security"
+        ]
+      }
+    },
+    "/v1/security/findings/{id}/resolve": {
+      "post": {
+        "summary": "Resolve a security finding",
+        "description": "Marks an open finding as resolved. Fails with FAILED_PRECONDITION if it's already resolved, NOT_FOUND if it doesn't exist.",
+        "operationId": "ThreatDetectionService_ResolveFinding",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ResolveFindingResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "format": "int64"
+          }
+        ],
         "tags": [
           "Security"
         ]
@@ -10984,6 +11093,18 @@
       },
       "title": "ListDefaultAlertRulesResponse returns the built-in default alert rules"
     },
+    "ListFindingsResponse": {
+      "type": "object",
+      "properties": {
+        "findings": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/Finding"
+          }
+        }
+      }
+    },
     "ListNetworkPoliciesResponse": {
       "type": "object",
       "properties": {
@@ -12459,6 +12580,14 @@
         }
       },
       "title": "ResizeContainerResponse is the response from resizing a container"
+    },
+    "ResolveFindingResponse": {
+      "type": "object",
+      "properties": {
+        "finding": {
+          "$ref": "#/definitions/Finding"
+        }
+      }
     },
     "ResourceLimits": {
       "type": "object",

--- a/internal/cmd/security_findings.go
+++ b/internal/cmd/security_findings.go
@@ -1,0 +1,180 @@
+// `containarium security findings` — list and resolve security findings
+// raised by the threat-detection sentry (#1643). CLI-first per the repo
+// convention; the MCP tools (internal/mcp/security.go) wrap the same REST
+// calls.
+package cmd
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// securitySentryFindingsCmd IS the list command (per the #1643 acceptance
+// criterion's literal syntax: `containarium security findings [--severity
+// --tenant --since]`), with `resolve` as its only child action — cobra
+// dispatches to a subcommand when the first arg matches one, and falls back
+// to the parent's own RunE (list) otherwise.
+var securitySentryFindingsCmd = &cobra.Command{
+	Use:   "findings",
+	Short: "List and resolve security findings raised by the threat-detection sentry",
+	Long: `Lists security findings raised by the background threat-detection sentry
+(#1640-#1642), with evidence. Non-admin callers only see their own tenant.`,
+	Args: cobra.NoArgs,
+	RunE: runSecurityFindingsList,
+}
+
+var (
+	findingsSeverity string
+	findingsTenant   string
+	findingsSince    string
+	findingsState    string
+	findingsLimit    int
+	findingsJSONOut  bool
+)
+
+// securitySentryFindingsListCmd is an explicit `list` alias for the parent
+// command's default action — some operators expect every noun to have a
+// spelled-out verb (matches `security bad-destinations list`'s sibling
+// shape); both run the identical RunE.
+var securitySentryFindingsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List security findings, most recently seen first (same as `findings` with no subcommand)",
+	Args:  cobra.NoArgs,
+	RunE:  runSecurityFindingsList,
+}
+
+var securitySentryFindingsResolveCmd = &cobra.Command{
+	Use:   "resolve <id>",
+	Short: "Mark an open finding as resolved",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runSecurityFindingsResolve,
+}
+
+// findingEnvelope mirrors *Finding's grpc-gateway JSON shape (protojson
+// default: camelCase, enums as their string names, int64 as a JSON string).
+type findingEnvelope struct {
+	ID        string             `json:"id"`
+	Rule      string             `json:"rule"`
+	Severity  string             `json:"severity"`
+	TenantID  string             `json:"tenantId"`
+	Container string             `json:"container"`
+	BackendID string             `json:"backendId"`
+	Subject   string             `json:"subject"`
+	State     string             `json:"state"`
+	Count     string             `json:"count"`
+	Evidence  findingEvidenceEnv `json:"evidence"`
+	FirstSeen string             `json:"firstSeen"`
+	LastSeen  string             `json:"lastSeen"`
+}
+
+type findingEvidenceEnv struct {
+	Flows  []map[string]interface{} `json:"flows"`
+	Denies []map[string]interface{} `json:"denies"`
+}
+
+type listFindingsEnvelope struct {
+	Findings []findingEnvelope `json:"findings"`
+}
+
+type resolveFindingEnvelope struct {
+	Finding findingEnvelope `json:"finding"`
+}
+
+func runSecurityFindingsList(cmd *cobra.Command, _ []string) error {
+	if serverAddr == "" {
+		return errServerRequired()
+	}
+	q := url.Values{}
+	if findingsSeverity != "" {
+		q.Set("severity", "THREAT_SEVERITY_"+strings.ToUpper(findingsSeverity))
+	}
+	if findingsTenant != "" {
+		q.Set("tenant_id", findingsTenant)
+	}
+	if findingsSince != "" {
+		q.Set("since", findingsSince)
+	}
+	if findingsState != "" {
+		q.Set("state", "FINDING_STATE_"+strings.ToUpper(findingsState))
+	}
+	if findingsLimit > 0 {
+		q.Set("limit", strconv.Itoa(findingsLimit))
+	}
+	base := strings.TrimSuffix(serverAddr, "/") + "/v1/security/findings"
+	reqURL := base
+	if enc := q.Encode(); enc != "" {
+		reqURL = base + "?" + enc
+	}
+	var out listFindingsEnvelope
+	if err := getJSON(reqURL, &out); err != nil {
+		return err
+	}
+	if findingsJSONOut {
+		return printJSON(out)
+	}
+	w := cmd.OutOrStdout()
+	if len(out.Findings) == 0 {
+		fmt.Fprintln(w, "No findings.")
+		return nil
+	}
+	fmt.Fprintf(w, "%-6s %-28s %-10s %-8s %-14s %-6s %-10s %s\n",
+		"ID", "RULE", "SEVERITY", "STATE", "TENANT", "COUNT", "LAST SEEN", "SUBJECT")
+	for _, f := range out.Findings {
+		fmt.Fprintf(w, "%-6s %-28s %-10s %-8s %-14s %-6s %-10s %s\n",
+			f.ID,
+			strings.TrimPrefix(f.Rule, "THREAT_RULE_ID_"),
+			strings.TrimPrefix(f.Severity, "THREAT_SEVERITY_"),
+			strings.TrimPrefix(f.State, "FINDING_STATE_"),
+			f.TenantID,
+			f.Count,
+			f.LastSeen,
+			f.Subject,
+		)
+	}
+	return nil
+}
+
+func runSecurityFindingsResolve(cmd *cobra.Command, args []string) error {
+	if serverAddr == "" {
+		return errServerRequired()
+	}
+	id := args[0]
+	if _, err := strconv.ParseInt(id, 10, 64); err != nil {
+		return fmt.Errorf("invalid finding id %q: %w", id, err)
+	}
+	url := strings.TrimSuffix(serverAddr, "/") + "/v1/security/findings/" + id + "/resolve"
+	var out resolveFindingEnvelope
+	if err := postJSON(url, []byte("{}"), &out); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Resolved finding %s (%s)\n", out.Finding.ID,
+		strings.TrimPrefix(out.Finding.State, "FINDING_STATE_"))
+	return nil
+}
+
+// addFindingsListFlags registers the --severity/--tenant/--since/--state/
+// --limit/--json flag set. Called for both securitySentryFindingsCmd (the
+// AC's literal `security findings [--severity ...]` syntax) and
+// securitySentryFindingsListCmd (the explicit `list` alias) — both bind the same
+// package-level vars, which is safe since only one RunE executes per
+// invocation.
+func addFindingsListFlags(c *cobra.Command) {
+	c.Flags().StringVar(&findingsSeverity, "severity", "", "Filter by severity: low, medium, high, critical")
+	c.Flags().StringVar(&findingsTenant, "tenant", "", "Filter by tenant id (admin only; non-admins always see their own tenant)")
+	c.Flags().StringVar(&findingsSince, "since", "", "Only findings last seen at or after this RFC3339 timestamp")
+	c.Flags().StringVar(&findingsState, "state", "", "Filter by state: open, resolved")
+	c.Flags().IntVar(&findingsLimit, "limit", 0, "Max findings to return (default 50, cap 200)")
+	c.Flags().BoolVar(&findingsJSONOut, "json", false, "Output raw JSON")
+}
+
+func init() {
+	addFindingsListFlags(securitySentryFindingsCmd)
+	addFindingsListFlags(securitySentryFindingsListCmd)
+	securitySentryFindingsCmd.AddCommand(securitySentryFindingsListCmd)
+	securitySentryFindingsCmd.AddCommand(securitySentryFindingsResolveCmd)
+	securityCmd.AddCommand(securitySentryFindingsCmd)
+}

--- a/internal/cmd/security_findings_test.go
+++ b/internal/cmd/security_findings_test.go
@@ -1,0 +1,143 @@
+package cmd
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRunSecurityFindingsList_RequiresServer(t *testing.T) {
+	oldServer := serverAddr
+	serverAddr = ""
+	defer func() { serverAddr = oldServer }()
+
+	if err := runSecurityFindingsList(testCmd(), nil); err == nil {
+		t.Fatal("expected an error when --server is unset")
+	}
+}
+
+func TestRunSecurityFindingsList_HitsExpectedPathAndRendersOutput(t *testing.T) {
+	var gotPath, gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotMethod = r.URL.Path, r.Method
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{
+			"findings": [
+				{"id": "7", "rule": "THREAT_RULE_ID_BAD_DESTINATION", "severity": "THREAT_SEVERITY_HIGH",
+				 "tenantId": "alice", "state": "FINDING_STATE_OPEN", "count": "3",
+				 "lastSeen": "2026-08-31T10:00:00Z", "subject": "203.0.113.9"}
+			]
+		}`))
+	}))
+	defer srv.Close()
+
+	oldServer := serverAddr
+	serverAddr = srv.URL
+	defer func() { serverAddr = oldServer }()
+
+	oldSeverity, oldTenant, oldSince, oldState, oldLimit := findingsSeverity, findingsTenant, findingsSince, findingsState, findingsLimit
+	findingsSeverity, findingsTenant = "", ""
+	findingsSince, findingsState = "", ""
+	findingsLimit = 0
+	defer func() {
+		findingsSeverity, findingsTenant, findingsSince, findingsState, findingsLimit = oldSeverity, oldTenant, oldSince, oldState, oldLimit
+	}()
+
+	cmd := testCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	if err := runSecurityFindingsList(cmd, nil); err != nil {
+		t.Fatalf("runSecurityFindingsList: %v", err)
+	}
+	if gotMethod != http.MethodGet || gotPath != "/v1/security/findings" {
+		t.Fatalf("request = %s %s, want GET /v1/security/findings", gotMethod, gotPath)
+	}
+	out := buf.String()
+	for _, want := range []string{"BAD_DESTINATION", "HIGH", "OPEN", "alice", "203.0.113.9"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunSecurityFindingsList_EncodesFilters(t *testing.T) {
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"findings": []}`))
+	}))
+	defer srv.Close()
+
+	oldServer := serverAddr
+	serverAddr = srv.URL
+	defer func() { serverAddr = oldServer }()
+
+	oldSeverity, oldTenant, oldSince, oldState, oldLimit := findingsSeverity, findingsTenant, findingsSince, findingsState, findingsLimit
+	findingsSeverity = "high"
+	findingsTenant = "bob"
+	findingsSince = "2026-08-01T00:00:00Z"
+	findingsState = "open"
+	findingsLimit = 25
+	defer func() {
+		findingsSeverity, findingsTenant, findingsSince, findingsState, findingsLimit = oldSeverity, oldTenant, oldSince, oldState, oldLimit
+	}()
+
+	cmd := testCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	if err := runSecurityFindingsList(cmd, nil); err != nil {
+		t.Fatalf("runSecurityFindingsList: %v", err)
+	}
+
+	for _, want := range []string{
+		"severity=THREAT_SEVERITY_HIGH",
+		"tenant_id=bob",
+		"state=FINDING_STATE_OPEN",
+		"limit=25",
+	} {
+		if !strings.Contains(gotQuery, want) {
+			t.Errorf("query = %q, want it to contain %q", gotQuery, want)
+		}
+	}
+}
+
+func TestRunSecurityFindingsResolve_PostsToResolvePath(t *testing.T) {
+	var gotPath, gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotMethod = r.URL.Path, r.Method
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"finding": {"id": "7", "state": "FINDING_STATE_RESOLVED"}}`))
+	}))
+	defer srv.Close()
+
+	oldServer := serverAddr
+	serverAddr = srv.URL
+	defer func() { serverAddr = oldServer }()
+
+	cmd := testCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	if err := runSecurityFindingsResolve(cmd, []string{"7"}); err != nil {
+		t.Fatalf("runSecurityFindingsResolve: %v", err)
+	}
+	if gotMethod != http.MethodPost || gotPath != "/v1/security/findings/7/resolve" {
+		t.Fatalf("request = %s %s, want POST /v1/security/findings/7/resolve", gotMethod, gotPath)
+	}
+	if !strings.Contains(buf.String(), "Resolved") || !strings.Contains(buf.String(), "RESOLVED") {
+		t.Errorf("output = %q, want a confirmation naming the resolved state", buf.String())
+	}
+}
+
+func TestRunSecurityFindingsResolve_RejectsNonNumericID(t *testing.T) {
+	oldServer := serverAddr
+	serverAddr = "http://example.invalid"
+	defer func() { serverAddr = oldServer }()
+
+	if err := runSecurityFindingsResolve(testCmd(), []string{"not-a-number"}); err == nil {
+		t.Fatal("expected an error for a non-numeric id")
+	}
+}

--- a/internal/mcp/backend.go
+++ b/internal/mcp/backend.go
@@ -86,6 +86,10 @@ type API interface {
 	AddBadDestination(cidr, label string) (*BadDestinationEntry, error)
 	RemoveBadDestination(cidr string) error
 
+	// Findings delivery + triage (#1643).
+	ListSecuritySentryFindings(severity, tenant, since, state string, limit int) (*ListSentryFindingsResponse, error)
+	ResolveSecuritySentryFinding(id int64) (*ResolveSentryFindingResponse, error)
+
 	// Tokens.
 	RevokeToken(jti, reason, expiresAt string) (string, error)
 

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -684,6 +684,57 @@ func (c *Client) RemoveBadDestination(cidr string) error {
 	return err
 }
 
+// ListSecuritySentryFindings lists findings raised by the background
+// threat-detection sentry (#1643), most recently seen first. Every filter
+// is optional; pass "" / 0 to skip it. severity/state are the lowercase
+// CLI-style names ("high", "open") — this converts them to the wire enum
+// names, same normalization the CLI applies.
+func (c *Client) ListSecuritySentryFindings(severity, tenant, since, state string, limit int) (*ListSentryFindingsResponse, error) {
+	q := url.Values{}
+	if severity != "" {
+		q.Set("severity", "THREAT_SEVERITY_"+strings.ToUpper(severity))
+	}
+	if tenant != "" {
+		q.Set("tenant_id", tenant)
+	}
+	if since != "" {
+		q.Set("since", since)
+	}
+	if state != "" {
+		q.Set("state", "FINDING_STATE_"+strings.ToUpper(state))
+	}
+	if limit > 0 {
+		q.Set("limit", strconv.Itoa(limit))
+	}
+	path := "/v1/security/findings"
+	if enc := q.Encode(); enc != "" {
+		path += "?" + enc
+	}
+	respBody, err := c.doRequest("GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	var resp ListSentryFindingsResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+	return &resp, nil
+}
+
+// ResolveSecuritySentryFinding marks an open finding as resolved.
+func (c *Client) ResolveSecuritySentryFinding(id int64) (*ResolveSentryFindingResponse, error) {
+	path := "/v1/security/findings/" + strconv.FormatInt(id, 10) + "/resolve"
+	respBody, err := c.doRequest("POST", path, []byte("{}"))
+	if err != nil {
+		return nil, err
+	}
+	var resp ResolveSentryFindingResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+	return &resp, nil
+}
+
 func (c *Client) GetKMSStatus() (*KMSStatusResponse, error) {
 	respBody, err := c.doRequest("GET", "/v1/kms/status", nil)
 	if err != nil {

--- a/internal/mcp/security.go
+++ b/internal/mcp/security.go
@@ -95,6 +95,71 @@ type AddBadDestinationResponse struct {
 	Entry BadDestinationEntry `json:"entry"`
 }
 
+// FlowEvidence mirrors the daemon's FlowEvidence (#1639): one triggering
+// flow's 5-tuple and volume.
+// Bytes/Packets are string, not int64 — see SentryFinding's doc comment on
+// why (protojson int64 encoding).
+type FlowEvidence struct {
+	SrcIP    string `json:"srcIp"`
+	DstIP    string `json:"dstIp"`
+	SrcPort  uint32 `json:"srcPort"`
+	DstPort  uint32 `json:"dstPort"`
+	Protocol string `json:"protocol"`
+	Bytes    string `json:"bytes"`
+	Packets  string `json:"packets"`
+}
+
+// DenyEvidence mirrors the daemon's DenyEvidence (#1639): an aggregated
+// count of policy-deny events matching a destination/reason pair. Count is
+// string, not int64 — see SentryFinding's doc comment.
+type DenyEvidence struct {
+	DstIP    string `json:"dstIp"`
+	DstPort  uint32 `json:"dstPort"`
+	Protocol string `json:"protocol"`
+	Reason   string `json:"reason"`
+	Count    string `json:"count"`
+}
+
+// SentryEvidence mirrors the daemon's Evidence message — the wire shape
+// nested under Finding.evidence, not flattened onto SentryFinding.
+type SentryEvidence struct {
+	Flows  []FlowEvidence `json:"flows,omitempty"`
+	Denies []DenyEvidence `json:"denies,omitempty"`
+}
+
+// SentryFinding mirrors the daemon's Finding (#1639/#1643): a single
+// security finding raised by the threat-detection sentry. Named
+// SentryFinding, not Finding, to keep it unambiguous next to
+// SecurityFinding (the unrelated scanner-findings shape above).
+//
+// ID and Count are string, not int64: protojson serializes proto3 int64
+// fields as JSON strings (to survive JS's float64 precision limit), and
+// encoding/json refuses to unmarshal a JSON string into an int64 field.
+type SentryFinding struct {
+	ID        string         `json:"id"`
+	Rule      string         `json:"rule"`
+	Severity  string         `json:"severity"`
+	TenantID  string         `json:"tenantId"`
+	Container string         `json:"container,omitempty"`
+	BackendID string         `json:"backendId,omitempty"`
+	Subject   string         `json:"subject,omitempty"`
+	State     string         `json:"state"`
+	Count     string         `json:"count"`
+	Evidence  SentryEvidence `json:"evidence"`
+	FirstSeen string         `json:"firstSeen,omitempty"`
+	LastSeen  string         `json:"lastSeen,omitempty"`
+}
+
+// ListSentryFindingsResponse mirrors the daemon's ListFindingsResponse.
+type ListSentryFindingsResponse struct {
+	Findings []SentryFinding `json:"findings"`
+}
+
+// ResolveSentryFindingResponse mirrors the daemon's ResolveFindingResponse.
+type ResolveSentryFindingResponse struct {
+	Finding SentryFinding `json:"finding"`
+}
+
 // --- MCP handlers ----------------------------------------------------------
 
 // handleSecurityScan triggers one or more scanners against a container.
@@ -215,6 +280,53 @@ func handleRemoveBadDestination(client API, args map[string]interface{}) (string
 		return "", fmt.Errorf("remove bad destination: %w", err)
 	}
 	return fmt.Sprintf("Removed %s from the known-bad-destination list.", cidr), nil
+}
+
+// handleListSecuritySentryFindings lists findings raised by the background
+// threat-detection sentry (#1639-#1643), most recently seen first. Named
+// distinctly from security_findings (the unrelated scanner-findings tool
+// above) — same naming collision the CLI has between `security findings`
+// (this) and `security-findings <username>` (scanner findings).
+func handleListSecuritySentryFindings(client API, args map[string]interface{}) (string, error) {
+	severity := getStringArg(args, "severity", "")
+	tenant := getStringArg(args, "tenant", "")
+	since := getStringArg(args, "since", "")
+	state := getStringArg(args, "state", "")
+	limit := 0
+	if v, ok := getInt64Arg(args, "limit"); ok {
+		limit = int(v)
+	}
+
+	resp, err := client.ListSecuritySentryFindings(severity, tenant, since, state, limit)
+	if err != nil {
+		return "", fmt.Errorf("list sentry findings: %w", err)
+	}
+	// Strip the enums' repeated prefixes, same normalization
+	// handleSecuritySentryStatus applies.
+	for i := range resp.Findings {
+		f := &resp.Findings[i]
+		f.Rule = strings.TrimPrefix(f.Rule, "THREAT_RULE_ID_")
+		f.Severity = strings.TrimPrefix(f.Severity, "THREAT_SEVERITY_")
+		f.State = strings.TrimPrefix(f.State, "FINDING_STATE_")
+	}
+	out, _ := json.MarshalIndent(resp, "", "  ")
+	return string(out), nil
+}
+
+// handleResolveSecuritySentryFinding marks an open sentry finding as
+// resolved.
+func handleResolveSecuritySentryFinding(client API, args map[string]interface{}) (string, error) {
+	id, ok := getInt64Arg(args, "id")
+	if !ok {
+		return "", fmt.Errorf("id is required")
+	}
+	resp, err := client.ResolveSecuritySentryFinding(id)
+	if err != nil {
+		return "", fmt.Errorf("resolve sentry finding: %w", err)
+	}
+	resp.Finding.State = strings.TrimPrefix(resp.Finding.State, "FINDING_STATE_")
+	out, _ := json.MarshalIndent(resp, "", "  ")
+	return string(out), nil
 }
 
 // handleSecurityRemediate calls the daemon's RemediatePentestFinding

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -22,8 +22,8 @@ func TestServerCreation(t *testing.T) {
 	assert.NotNil(t, server)
 	assert.Equal(t, config, server.config)
 	assert.NotNil(t, server.client)
-	// 30 base (+check_for_updates +upgrade_backend +get_upgrade_status, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes + 3 backups + connect (#453) + 2 agent-skills (#562) + call_agent (#570) + 2 crews (#584) + delete_route + install_zap (#960) + set_metrics_export + get_metrics_export (#1069) + verify_backup (#1159) + list_passthrough_routes + add_passthrough_route + delete_passthrough_route (#1550) + security_sentry_status (#1640) + list_bad_destinations + add_bad_destination + remove_bad_destination (#1641).
-	assert.Len(t, server.tools, 66, "Should have 66 tools registered")
+	// 30 base (+check_for_updates +upgrade_backend +get_upgrade_status, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes + 3 backups + connect (#453) + 2 agent-skills (#562) + call_agent (#570) + 2 crews (#584) + delete_route + install_zap (#960) + set_metrics_export + get_metrics_export (#1069) + verify_backup (#1159) + list_passthrough_routes + add_passthrough_route + delete_passthrough_route (#1550) + security_sentry_status (#1640) + list_bad_destinations + add_bad_destination + remove_bad_destination (#1641) + list_security_sentry_findings + resolve_security_sentry_finding (#1643).
+	assert.Len(t, server.tools, 68, "Should have 68 tools registered")
 }
 
 // TestServerTools tests tool registration
@@ -127,8 +127,8 @@ func TestHandleToolsList(t *testing.T) {
 
 	tools, ok := result["tools"].([]map[string]interface{})
 	require.True(t, ok)
-	// 30 base (+check_for_updates +upgrade_backend +get_upgrade_status, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes + 3 backups + connect (#453) + 2 agent-skills (#562) + call_agent (#570) + 2 crews (#584) + delete_route + install_zap (#960) + set_metrics_export + get_metrics_export (#1069) + verify_backup (#1159) + list_passthrough_routes + add_passthrough_route + delete_passthrough_route (#1550) + security_sentry_status (#1640) + list_bad_destinations + add_bad_destination + remove_bad_destination (#1641).
-	assert.Len(t, tools, 66)
+	// 30 base (+check_for_updates +upgrade_backend +get_upgrade_status, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes + 3 backups + connect (#453) + 2 agent-skills (#562) + call_agent (#570) + 2 crews (#584) + delete_route + install_zap (#960) + set_metrics_export + get_metrics_export (#1069) + verify_backup (#1159) + list_passthrough_routes + add_passthrough_route + delete_passthrough_route (#1550) + security_sentry_status (#1640) + list_bad_destinations + add_bad_destination + remove_bad_destination (#1641) + list_security_sentry_findings + resolve_security_sentry_finding (#1643).
+	assert.Len(t, tools, 68)
 
 	// Check first tool structure
 	firstTool := tools[0]

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -966,6 +966,56 @@ func (s *Server) registerTools() {
 			Handler: handleRemoveBadDestination,
 		},
 		{
+			Name: "list_security_sentry_findings",
+			Description: "List security findings raised by the background threat-detection sentry " +
+				"(#1639-#1642) — mining-abuse egress, cross-tenant flow, and deny-burst detections — " +
+				"with evidence (triggering flow 5-tuples / deny counts). Distinct from " +
+				"`security_findings`, which is the unrelated ClamAV/pentest/ZAP scanner surface.\n\n" +
+				"Every filter is optional. Non-admin callers only ever see their own tenant, " +
+				"regardless of what (if anything) `tenant` is set to.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"severity": map[string]interface{}{
+						"type":        "string",
+						"description": "Filter by severity: low, medium, high, critical. Omit for any severity.",
+					},
+					"tenant": map[string]interface{}{
+						"type":        "string",
+						"description": "Filter by tenant id (admin only — a non-admin caller's own tenant is used regardless).",
+					},
+					"since": map[string]interface{}{
+						"type":        "string",
+						"description": "RFC3339 timestamp; only findings last seen at or after this time.",
+					},
+					"state": map[string]interface{}{
+						"type":        "string",
+						"description": "Filter by state: open, resolved. Omit for any state.",
+					},
+					"limit": map[string]interface{}{
+						"type":        "integer",
+						"description": "Max findings to return. 0 (default) means the server default (50, capped at 200).",
+					},
+				},
+			},
+			Handler: handleListSecuritySentryFindings,
+		},
+		{
+			Name:        "resolve_security_sentry_finding",
+			Description: "Mark an open threat-detection sentry finding as resolved, after triaging and handling it.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"id": map[string]interface{}{
+						"type":        "integer",
+						"description": "Finding id, from list_security_sentry_findings.",
+					},
+				},
+				"required": []string{"id"},
+			},
+			Handler: handleResolveSecuritySentryFinding,
+		},
+		{
 			Name: "install_zap",
 			Description: "Download and install OWASP ZAP into this host's security container. " +
 				"Admin-only, one-time-per-host setup — `security_scan` (kind=zap) and the " +
@@ -1531,6 +1581,11 @@ func toolScopeAssignments() map[string]string {
 		"list_bad_destinations":  auth.ScopeSecurityRead,
 		"add_bad_destination":    auth.ScopeSecurityWrite,
 		"remove_bad_destination": auth.ScopeSecurityWrite,
+		// findings delivery + triage (#1643): listing is a read,
+		// resolving mutates a finding's lifecycle state — same split as
+		// the bad-destination list above.
+		"list_security_sentry_findings":   auth.ScopeSecurityRead,
+		"resolve_security_sentry_finding": auth.ScopeSecurityWrite,
 		// install_zap is admin-only (the daemon also enforces
 		// RoleAdmin server-side); scope-gated the same as the other
 		// security-write tools at the MCP layer.

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -254,6 +254,7 @@ type DualServer struct {
 	// when the engine itself wasn't constructed.
 	threatDetectEngine    *threatdetect.Engine
 	threatDetectServer    *ThreatDetectionServer
+	threatDetectNotifier  *threatdetect.WebhookNotifier // nil unless threatDetectEngine is also non-nil (#1643)
 	threatDetectSweepStop context.CancelFunc
 }
 
@@ -1643,6 +1644,8 @@ skipAppHosting:
 	// so no audit store means no sentry, not a degraded one.
 	threatCfg := appconfig.LoadThreatDetect()
 	var threatDetectEngine *threatdetect.Engine
+	var threatDetectStore threatdetect.FindingReader
+	var threatDetectNotifier *threatdetect.WebhookNotifier
 	sentryAvailable := networkPolicyEnforcer != nil && auditStore != nil
 	sentryUnavailableReason := ""
 	switch {
@@ -1653,6 +1656,7 @@ skipAppHosting:
 	}
 	if threatCfg.SentryEnabled && sentryAvailable {
 		var sink threatdetect.FindingSink
+		var findingsPool *pgxpool.Pool
 		degraded := true
 		if postgresConnString != "" {
 			if fsPool, poolErr := connectToPostgres(postgresConnString, 5, 3*time.Second); poolErr != nil {
@@ -1663,6 +1667,7 @@ skipAppHosting:
 			} else {
 				sink = fs
 				degraded = false
+				findingsPool = fsPool
 			}
 		}
 		if sink == nil {
@@ -1674,6 +1679,36 @@ skipAppHosting:
 			}
 		}
 		if sink != nil {
+			if reader, ok := sink.(threatdetect.FindingReader); ok {
+				threatDetectStore = reader
+			}
+			// Webhook delivery (#1643): deliberately independent of
+			// config.VictoriaMetricsURL — that's the vmalert/alertmanager
+			// pipeline this notifier bypasses on purpose (design doc): a
+			// direct POST works on any backend, including a minimal BYOC
+			// host with no VictoriaMetrics container. Reuses the same
+			// webhook URL/secret config (DaemonConfigStore) as the
+			// existing alert-webhook relay, and — when Postgres-backed —
+			// the same delivery-record table on findingsPool, not a
+			// second connection pool.
+			if config.DaemonConfigStore != nil {
+				var deliveryStore *alert.DeliveryStore
+				if findingsPool != nil {
+					if store, derr := alert.NewDeliveryStore(context.Background(), findingsPool); derr != nil {
+						log.Printf("Warning: threat-detection webhook delivery store init failed (%v); deliveries will be attempted but not recorded", derr)
+					} else {
+						deliveryStore = store
+					}
+				}
+				threatDetectNotifier = threatdetect.NewWebhookNotifier(config.DaemonConfigStore, deliveryStore)
+				switch st := sink.(type) {
+				case *threatdetect.FindingStore:
+					st.SetNotifier(threatDetectNotifier)
+				case *threatdetect.MemFindingStore:
+					st.SetNotifier(threatDetectNotifier)
+				}
+			}
+
 			threatDetectEngine = threatdetect.NewEngine(sink, "", degraded, networkPolicyEnforcer.TenantForIP, nil)
 			// Fence-probe rules (#1642): a breached fence (cross-tenant
 			// flow) and a probed fence (deny-burst) are both continuous
@@ -1692,6 +1727,7 @@ skipAppHosting:
 		}
 	}
 	threatDetectServer := NewThreatDetectionServer(threatDetectEngine, threatCfg.SentryEnabled, sentryAvailable, sentryUnavailableReason)
+	threatDetectServer.SetFindingStore(threatDetectStore)
 
 	// Known-bad-destination rule (#1641): constructed independent of
 	// threatCfg.SentryEnabled — an operator can curate the list via CLI/MCP
@@ -2096,6 +2132,7 @@ skipAppHosting:
 		sandboxServer:          sandboxServer,
 		threatDetectEngine:     threatDetectEngine,
 		threatDetectServer:     threatDetectServer,
+		threatDetectNotifier:   threatDetectNotifier,
 	}
 
 	// Auto-sleep ticker is constructed in Start() once the traffic
@@ -2227,7 +2264,9 @@ const threatDetectSweepInterval = 30 * time.Second
 // rules on a fixed tick, separate from ctx so it can be stopped independent
 // of the daemon's own shutdown (Stop() cancels it via threatDetectSweepStop
 // before the rest of teardown runs). Only called once the enforcer this
-// engine is hooked into has actually started.
+// engine is hooked into has actually started. Also starts the webhook
+// notifier's delivery worker (#1643) on the same lifecycle — both only make
+// sense once the engine they're downstream of is actually running.
 func (ds *DualServer) startThreatDetectSweep(ctx context.Context) {
 	sweepCtx, cancel := context.WithCancel(ctx)
 	ds.threatDetectSweepStop = cancel
@@ -2244,6 +2283,9 @@ func (ds *DualServer) startThreatDetectSweep(ctx context.Context) {
 			}
 		}
 	}()
+	if ds.threatDetectNotifier != nil {
+		ds.threatDetectNotifier.Start(sweepCtx)
+	}
 }
 
 // handleBackendSystemInfo returns system info for a specific backend.

--- a/internal/server/dual_server_wiring_test.go
+++ b/internal/server/dual_server_wiring_test.go
@@ -251,6 +251,12 @@ func TestEverythingStartedIsAlsoStopped(t *testing.T) {
 	// Start needs no separate stop — it returns when the context is done.
 	noStopMethod := map[string]string{
 		"gatewayServer": "Start(ctx) blocks and returns when ctx is done; GatewayServer has no Stop",
+		// threatDetectNotifier.Start is called with the same sweepCtx as the
+		// threat-detect sweep ticker (startThreatDetectSweep, #1643) —
+		// ds.threatDetectSweepStop() cancels that shared context on
+		// shutdown, which stops the notifier's delivery-worker goroutine
+		// too. WebhookNotifier has no separate Stop method by design.
+		"threatDetectNotifier": "Start(sweepCtx) — shares threatDetectSweepStop's context; no separate Stop needed",
 	}
 
 	started := regexp.MustCompile(`ds\.(\w+)\.Start\(`).FindAllStringSubmatch(src, -1)

--- a/internal/server/threatdetect_server.go
+++ b/internal/server/threatdetect_server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"sync"
 
@@ -9,6 +10,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/footprintai/containarium/internal/auth"
 	"github.com/footprintai/containarium/internal/threatdetect"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 )
@@ -16,9 +18,8 @@ import (
 // ThreatDetectionServer implements ThreatDetectionService. GetSentryStatus
 // ships with #1640 (background detection loop); ListBadDestinations/
 // AddBadDestination/RemoveBadDestination ship with #1641 (known-bad
-// destination rule); ListFindings/ResolveFinding/rule-config RPCs are added
-// by later stories in the same umbrella (#1642-#1643) — see
-// docs/architecture/continuous-threat-detection.md.
+// destination rule); ListFindings/ResolveFinding ship with #1643 (findings
+// delivery + triage) — see docs/architecture/continuous-threat-detection.md.
 type ThreatDetectionServer struct {
 	pb.UnimplementedThreatDetectionServiceServer
 
@@ -34,6 +35,13 @@ type ThreatDetectionServer struct {
 	// itself failed (malformed embedded baseline list — a build-time bug,
 	// not a runtime condition).
 	badDestRule *threatdetect.BadDestinationRule
+
+	// store backs ListFindings/ResolveFinding (#1643). Independent of
+	// sentryEnabled/ebpfAvailable — an operator can triage findings a
+	// now-disabled sentry already recorded. nil (both Postgres and the
+	// in-memory fallback failed to construct) reports Unavailable rather
+	// than panicking, same as badDestRule.
+	store threatdetect.FindingReader
 
 	mu                sync.Mutex // guards the two fields below — SetUnavailable can flip them after Start()
 	ebpfAvailable     bool       // eBPF object loaded (networkPolicyEnforcer != nil) AND still running
@@ -64,6 +72,15 @@ func NewThreatDetectionServer(engine *threatdetect.Engine, sentryEnabled, ebpfAv
 // three handlers report that explicitly rather than panicking.
 func (s *ThreatDetectionServer) SetBadDestinationRule(r *threatdetect.BadDestinationRule) {
 	s.badDestRule = r
+}
+
+// SetFindingStore wires the finding store (#1643) into ListFindings and
+// ResolveFinding — *threatdetect.FindingStore (Postgres) or
+// *threatdetect.MemFindingStore (degraded) both satisfy FindingReader. nil
+// is valid (neither store could be constructed); the two handlers report
+// that explicitly rather than panicking.
+func (s *ThreatDetectionServer) SetFindingStore(store threatdetect.FindingReader) {
+	s.store = store
 }
 
 // SetUnavailable flips the server to UNAVAILABLE after construction — for
@@ -182,6 +199,96 @@ func (s *ThreatDetectionServer) RemoveBadDestination(ctx context.Context, req *p
 		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 	return &pb.RemoveBadDestinationResponse{}, nil
+}
+
+// ListFindings lists security findings, most recently seen first.
+// Tenant-scoped the same way ContainerServer.ListContainers scopes by
+// username: a non-admin caller's tenant_id filter is forced to their own
+// subject, and an explicit different tenant_id is denied — findings are the
+// same "who can see whose stuff" boundary as containers.
+func (s *ThreatDetectionServer) ListFindings(ctx context.Context, req *pb.ListFindingsRequest) (*pb.ListFindingsResponse, error) {
+	if err := auth.RequireScope(ctx, auth.ScopeSecurityRead); err != nil {
+		return nil, err
+	}
+	if s.store == nil {
+		return nil, status.Errorf(codes.Unavailable, "finding store not available")
+	}
+	subject, roles, ok := auth.SubjectFromGRPCContext(ctx)
+	if !ok {
+		return nil, status.Error(codes.Unauthenticated, "no authenticated subject")
+	}
+	tenantID := req.GetTenantId()
+	if !auth.HasRole(roles, auth.RoleAdmin) {
+		if tenantID != "" && tenantID != subject {
+			return nil, status.Error(codes.PermissionDenied, "not authorized for this tenant")
+		}
+		tenantID = subject
+	}
+
+	filter := threatdetect.ListFilter{
+		Severity: req.GetSeverity(),
+		TenantID: tenantID,
+		Limit:    int(req.GetLimit()),
+	}
+	if req.GetState() != pb.FindingState_FINDING_STATE_UNSPECIFIED {
+		filter.State = findingStateFromProto(req.GetState())
+	}
+	if req.GetSince() != nil {
+		filter.Since = req.GetSince().AsTime()
+	}
+
+	findings, err := s.store.List(ctx, filter)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "list findings: %v", err)
+	}
+	out := make([]*pb.Finding, 0, len(findings))
+	for _, f := range findings {
+		out = append(out, f.ToProto())
+	}
+	return &pb.ListFindingsResponse{Findings: out}, nil
+}
+
+// ResolveFinding transitions an open finding to resolved. Any authenticated
+// caller with security:write may resolve any finding — findings aren't
+// filtered per-tenant here the way ListFindings is, since resolving one is
+// an operator/on-call action, not a tenant self-service one (matches
+// RemediateSecurityFinding's scoping, the closest existing precedent).
+func (s *ThreatDetectionServer) ResolveFinding(ctx context.Context, req *pb.ResolveFindingRequest) (*pb.ResolveFindingResponse, error) {
+	if err := auth.RequireScope(ctx, auth.ScopeSecurityWrite); err != nil {
+		return nil, err
+	}
+	if s.store == nil {
+		return nil, status.Errorf(codes.Unavailable, "finding store not available")
+	}
+	if req.GetId() <= 0 {
+		return nil, status.Errorf(codes.InvalidArgument, "id is required")
+	}
+	f, err := s.store.Resolve(ctx, req.GetId())
+	if err != nil {
+		switch {
+		case errors.Is(err, threatdetect.ErrFindingNotFound):
+			return nil, status.Errorf(codes.NotFound, "%v", err)
+		case errors.Is(err, threatdetect.ErrFindingNotOpen):
+			return nil, status.Errorf(codes.FailedPrecondition, "%v", err)
+		default:
+			return nil, status.Errorf(codes.Internal, "resolve finding: %v", err)
+		}
+	}
+	return &pb.ResolveFindingResponse{Finding: f.ToProto()}, nil
+}
+
+// findingStateFromProto converts the wire enum to the store's string-typed
+// state — the store's FindingState is a Go string type (matches the
+// security_findings.state column), not the proto enum.
+func findingStateFromProto(s pb.FindingState) threatdetect.FindingState {
+	switch s {
+	case pb.FindingState_FINDING_STATE_OPEN:
+		return threatdetect.FindingStateOpen
+	case pb.FindingState_FINDING_STATE_RESOLVED:
+		return threatdetect.FindingStateResolved
+	default:
+		return ""
+	}
 }
 
 // isBadDestNotFound reports whether err is BadDestinationRule.RemoveDestination's

--- a/internal/server/threatdetect_server_test.go
+++ b/internal/server/threatdetect_server_test.go
@@ -5,6 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/footprintai/containarium/internal/auth"
 	"github.com/footprintai/containarium/internal/netbpf"
 	"github.com/footprintai/containarium/internal/threatdetect"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
@@ -159,6 +163,180 @@ func TestRemoveBadDestination_RoundTrip(t *testing.T) {
 			t.Errorf("entry still listed after removal: %+v", e)
 		}
 	}
+}
+
+func TestListFindings_NoStore_ReturnsUnavailable(t *testing.T) {
+	s := NewThreatDetectionServer(nil, false, false, "")
+	ctx := auth.ContextWithTestSubject(context.Background(), "alice", auth.RoleAdmin)
+	_, err := s.ListFindings(ctx, &pb.ListFindingsRequest{})
+	if status.Code(err) != codes.Unavailable {
+		t.Errorf("code = %v, want Unavailable", status.Code(err))
+	}
+}
+
+func TestListFindings_Unauthenticated(t *testing.T) {
+	s := NewThreatDetectionServer(nil, false, false, "")
+	s.SetFindingStore(&fakeFindingReader{})
+	if _, err := s.ListFindings(context.Background(), &pb.ListFindingsRequest{}); err == nil {
+		t.Fatal("ListFindings with no authenticated subject should error, got nil")
+	}
+}
+
+// Admin sees every tenant: an explicit tenant_id filter passes through
+// unchanged to the store.
+func TestListFindings_Admin_SeesRequestedTenant(t *testing.T) {
+	store := &fakeFindingReader{
+		findings: []*threatdetect.Finding{{ID: 1, TenantID: "bob", Severity: pb.ThreatSeverity_THREAT_SEVERITY_HIGH, State: threatdetect.FindingStateOpen}},
+	}
+	s := NewThreatDetectionServer(nil, false, false, "")
+	s.SetFindingStore(store)
+
+	ctx := auth.ContextWithTestSubject(context.Background(), "alice", auth.RoleAdmin)
+	resp, err := s.ListFindings(ctx, &pb.ListFindingsRequest{TenantId: "bob"})
+	if err != nil {
+		t.Fatalf("ListFindings: %v", err)
+	}
+	if store.lastFilter.TenantID != "bob" {
+		t.Errorf("store received TenantID = %q, want %q (admin's explicit filter passed through)", store.lastFilter.TenantID, "bob")
+	}
+	if len(resp.Findings) != 1 || resp.Findings[0].TenantId != "bob" {
+		t.Errorf("Findings = %+v, want the one bob finding", resp.Findings)
+	}
+}
+
+// Non-admin: an unset tenant_id filter is forced to the caller's own
+// subject, same as ListContainersRequest.username — findings are the same
+// "who can see whose stuff" boundary as containers.
+func TestListFindings_NonAdmin_ForcedToOwnTenant(t *testing.T) {
+	store := &fakeFindingReader{}
+	s := NewThreatDetectionServer(nil, false, false, "")
+	s.SetFindingStore(store)
+
+	ctx := auth.ContextWithTestSubject(context.Background(), "alice", "member")
+	if _, err := s.ListFindings(ctx, &pb.ListFindingsRequest{}); err != nil {
+		t.Fatalf("ListFindings: %v", err)
+	}
+	if store.lastFilter.TenantID != "alice" {
+		t.Errorf("store received TenantID = %q, want %q (forced to subject)", store.lastFilter.TenantID, "alice")
+	}
+}
+
+// Non-admin requesting a different tenant's findings is denied outright —
+// never silently rewritten to their own (that would look like "it worked"
+// while actually returning the wrong data).
+func TestListFindings_NonAdmin_ExplicitOtherTenant_Denied(t *testing.T) {
+	store := &fakeFindingReader{}
+	s := NewThreatDetectionServer(nil, false, false, "")
+	s.SetFindingStore(store)
+
+	ctx := auth.ContextWithTestSubject(context.Background(), "alice", "member")
+	if _, err := s.ListFindings(ctx, &pb.ListFindingsRequest{TenantId: "bob"}); err == nil {
+		t.Fatal("ListFindings for another tenant as non-admin should error, got nil")
+	}
+}
+
+func TestListFindings_FiltersPassThrough(t *testing.T) {
+	store := &fakeFindingReader{}
+	s := NewThreatDetectionServer(nil, false, false, "")
+	s.SetFindingStore(store)
+
+	ctx := auth.ContextWithTestSubject(context.Background(), "alice", auth.RoleAdmin)
+	_, err := s.ListFindings(ctx, &pb.ListFindingsRequest{
+		Severity: pb.ThreatSeverity_THREAT_SEVERITY_CRITICAL,
+		State:    pb.FindingState_FINDING_STATE_OPEN,
+		Limit:    10,
+	})
+	if err != nil {
+		t.Fatalf("ListFindings: %v", err)
+	}
+	if store.lastFilter.Severity != pb.ThreatSeverity_THREAT_SEVERITY_CRITICAL {
+		t.Errorf("Severity = %v, want CRITICAL", store.lastFilter.Severity)
+	}
+	if store.lastFilter.State != threatdetect.FindingStateOpen {
+		t.Errorf("State = %v, want open", store.lastFilter.State)
+	}
+	if store.lastFilter.Limit != 10 {
+		t.Errorf("Limit = %d, want 10", store.lastFilter.Limit)
+	}
+}
+
+func TestResolveFinding_NoStore_ReturnsUnavailable(t *testing.T) {
+	s := NewThreatDetectionServer(nil, false, false, "")
+	ctx := auth.ContextWithTestSubject(context.Background(), "alice", auth.RoleAdmin)
+	_, err := s.ResolveFinding(ctx, &pb.ResolveFindingRequest{Id: 1})
+	if status.Code(err) != codes.Unavailable {
+		t.Errorf("code = %v, want Unavailable", status.Code(err))
+	}
+}
+
+func TestResolveFinding_MissingID(t *testing.T) {
+	s := NewThreatDetectionServer(nil, false, false, "")
+	s.SetFindingStore(&fakeFindingReader{})
+	ctx := auth.ContextWithTestSubject(context.Background(), "alice", auth.RoleAdmin)
+	_, err := s.ResolveFinding(ctx, &pb.ResolveFindingRequest{})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", status.Code(err))
+	}
+}
+
+func TestResolveFinding_NotFound(t *testing.T) {
+	s := NewThreatDetectionServer(nil, false, false, "")
+	s.SetFindingStore(&fakeFindingReader{resolveErr: threatdetect.ErrFindingNotFound})
+	ctx := auth.ContextWithTestSubject(context.Background(), "alice", auth.RoleAdmin)
+	_, err := s.ResolveFinding(ctx, &pb.ResolveFindingRequest{Id: 99})
+	if status.Code(err) != codes.NotFound {
+		t.Errorf("code = %v, want NotFound", status.Code(err))
+	}
+}
+
+func TestResolveFinding_AlreadyResolved(t *testing.T) {
+	s := NewThreatDetectionServer(nil, false, false, "")
+	s.SetFindingStore(&fakeFindingReader{resolveErr: threatdetect.ErrFindingNotOpen})
+	ctx := auth.ContextWithTestSubject(context.Background(), "alice", auth.RoleAdmin)
+	_, err := s.ResolveFinding(ctx, &pb.ResolveFindingRequest{Id: 1})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Errorf("code = %v, want FailedPrecondition", status.Code(err))
+	}
+}
+
+func TestResolveFinding_Success(t *testing.T) {
+	store := &fakeFindingReader{
+		resolved: &threatdetect.Finding{ID: 1, State: threatdetect.FindingStateResolved},
+	}
+	s := NewThreatDetectionServer(nil, false, false, "")
+	s.SetFindingStore(store)
+	ctx := auth.ContextWithTestSubject(context.Background(), "alice", auth.RoleAdmin)
+	resp, err := s.ResolveFinding(ctx, &pb.ResolveFindingRequest{Id: 1})
+	if err != nil {
+		t.Fatalf("ResolveFinding: %v", err)
+	}
+	if resp.Finding.State != pb.FindingState_FINDING_STATE_RESOLVED {
+		t.Errorf("state = %v, want RESOLVED", resp.Finding.State)
+	}
+}
+
+// fakeFindingReader is a minimal threatdetect.FindingReader test double.
+type fakeFindingReader struct {
+	findings   []*threatdetect.Finding
+	lastFilter threatdetect.ListFilter
+	resolved   *threatdetect.Finding
+	resolveErr error
+}
+
+func (f *fakeFindingReader) Get(ctx context.Context, id int64) (*threatdetect.Finding, error) {
+	return nil, threatdetect.ErrFindingNotFound
+}
+
+func (f *fakeFindingReader) List(ctx context.Context, filter threatdetect.ListFilter) ([]*threatdetect.Finding, error) {
+	f.lastFilter = filter
+	return f.findings, nil
+}
+
+func (f *fakeFindingReader) Resolve(ctx context.Context, id int64) (*threatdetect.Finding, error) {
+	if f.resolveErr != nil {
+		return nil, f.resolveErr
+	}
+	return f.resolved, nil
 }
 
 // fakeFindingSink and fakeRule are minimal threatdetect.FindingSink /

--- a/internal/threatdetect/engine.go
+++ b/internal/threatdetect/engine.go
@@ -62,6 +62,17 @@ type FindingSink interface {
 	Upsert(ctx context.Context, f *Finding) (*Finding, error)
 }
 
+// FindingReader is what ThreatDetectionServer's ListFindings/ResolveFinding
+// (#1643) need from a finding store — read/lifecycle operations, distinct
+// from FindingSink's write path so the two stores' Get/List/Resolve
+// implementations (identical contract, Postgres vs. bounded in-memory ring)
+// both satisfy it without the engine's hot-path callers depending on it.
+type FindingReader interface {
+	Get(ctx context.Context, id int64) (*Finding, error)
+	List(ctx context.Context, filter ListFilter) ([]*Finding, error)
+	Resolve(ctx context.Context, id int64) (*Finding, error)
+}
+
 // ruleHealth tracks one rule's panic-recovery state for GetSentryStatus. A
 // rule starts healthy; a recovered panic flips it unhealthy until the
 // process restarts (there's no auto-recovery — an operator should notice and

--- a/internal/threatdetect/finding.go
+++ b/internal/threatdetect/finding.go
@@ -4,12 +4,27 @@
 package threatdetect
 
 import (
+	"errors"
 	"time"
 
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 )
+
+// ErrFindingNotFound reports that Get/Resolve was called with an id that
+// doesn't exist. Both FindingStore and MemFindingStore return this exact
+// sentinel (wrapped, checked with errors.Is) rather than leaking a
+// backend-specific not-found signal (pgx.ErrNoRows for FindingStore) past
+// the store boundary — callers like ThreatDetectionServer.ResolveFinding
+// map it to codes.NotFound without knowing which backend is in play.
+var ErrFindingNotFound = errors.New("finding not found")
+
+// ErrFindingNotOpen reports that Resolve was called on a finding that
+// exists but isn't currently open (already resolved). Distinct from
+// ErrFindingNotFound so callers can map the two to different response
+// codes (NotFound vs. FailedPrecondition).
+var ErrFindingNotOpen = errors.New("finding is not open")
 
 // timestampProto converts a zero-safe time.Time to a *timestamppb.Timestamp,
 // returning nil for a zero time rather than the protobuf epoch.
@@ -75,6 +90,21 @@ const (
 	FindingStateOpen     FindingState = "open"
 	FindingStateResolved FindingState = "resolved"
 )
+
+// ListFilter narrows FindingStore.List / MemFindingStore.List (#1643). Zero
+// values mean "no filter on this field" — Severity's zero value is
+// THREAT_SEVERITY_UNSPECIFIED, which no real finding has, so an unset
+// filter matches every severity rather than none. TenantID empty means
+// "every tenant" — callers enforce the RBAC scoping (admin-only for that
+// case) before reaching the store, same division of responsibility
+// ListPentestFindings uses.
+type ListFilter struct {
+	Severity pb.ThreatSeverity // exact match; unset = any severity
+	TenantID string
+	Since    time.Time
+	State    FindingState // "" = any state
+	Limit    int          // <= 0 or > 200 => default/cap 50/200
+}
 
 // Finding is a single security finding: an open or resolved instance of a
 // rule firing for one tenant. Mirrors the security_findings table.

--- a/internal/threatdetect/mem_store.go
+++ b/internal/threatdetect/mem_store.go
@@ -3,11 +3,14 @@ package threatdetect
 import (
 	"context"
 	"fmt"
+	"log"
+	"sort"
 	"sync"
 	"time"
 
 	"github.com/footprintai/containarium/internal/audit"
 	"github.com/footprintai/containarium/internal/events"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 )
 
 // memFindingRingCap bounds the degraded-mode store so a sustained attack
@@ -31,13 +34,19 @@ type dedupeKey struct {
 // knows detection is running without persistence, rather than silently
 // looking identical to the healthy path.
 type MemFindingStore struct {
-	emitter *events.Emitter
-	audit   *audit.Store
+	emitter  *events.Emitter
+	audit    *audit.Store
+	notifier Notifier // nil = no webhook delivery
 
 	mu     sync.Mutex
 	nextID int64
 	byKey  map[dedupeKey]*Finding // open findings only
 	ring   []*Finding             // insertion order, capped at memFindingRingCap
+}
+
+// SetNotifier wires webhook delivery (#1643) — see FindingStore.SetNotifier.
+func (s *MemFindingStore) SetNotifier(notifier Notifier) {
+	s.notifier = notifier
 }
 
 // NewMemFindingStore builds a degraded-mode store. Both dependencies are
@@ -120,5 +129,91 @@ func (s *MemFindingStore) Upsert(ctx context.Context, f *Finding) (*Finding, err
 		return nil, fmt.Errorf("threatdetect: audit log finding (degraded mode): %w", err)
 	}
 	s.emitter.EmitSecurityFinding(out.ToProto())
+	if s.notifier != nil {
+		s.notifier.Notify(out)
+	}
 	return out, nil
+}
+
+// Get returns the finding with the given id (mirrors FindingStore.Get).
+func (s *MemFindingStore) Get(ctx context.Context, id int64) (*Finding, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, f := range s.ring {
+		if f.ID == id {
+			return f, nil
+		}
+	}
+	return nil, fmt.Errorf("threatdetect: finding %d: %w", id, ErrFindingNotFound)
+}
+
+// List returns findings matching filter, ordered most-recently-seen first
+// (mirrors FindingStore.List — same ListFilter, same zero-value semantics).
+func (s *MemFindingStore) List(ctx context.Context, filter ListFilter) ([]*Finding, error) {
+	limit := filter.Limit
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	matches := make([]*Finding, 0, len(s.ring))
+	for _, f := range s.ring {
+		if filter.Severity != pb.ThreatSeverity_THREAT_SEVERITY_UNSPECIFIED && f.Severity != filter.Severity {
+			continue
+		}
+		if filter.TenantID != "" && f.TenantID != filter.TenantID {
+			continue
+		}
+		if !filter.Since.IsZero() && f.LastSeen.Before(filter.Since) {
+			continue
+		}
+		if filter.State != "" && f.State != filter.State {
+			continue
+		}
+		matches = append(matches, f)
+	}
+	sort.Slice(matches, func(i, j int) bool { return matches[i].LastSeen.After(matches[j].LastSeen) })
+	if len(matches) > limit {
+		matches = matches[:limit]
+	}
+	return matches, nil
+}
+
+// Resolve transitions a finding to FindingStateResolved (mirrors
+// FindingStore.Resolve, including the ErrFindingNotOpen distinction between
+// "no such finding" and "already resolved").
+func (s *MemFindingStore) Resolve(ctx context.Context, id int64) (*Finding, error) {
+	s.mu.Lock()
+	var f *Finding
+	for _, cand := range s.ring {
+		if cand.ID == id {
+			f = cand
+			break
+		}
+	}
+	if f == nil {
+		s.mu.Unlock()
+		return nil, fmt.Errorf("threatdetect: finding %d: %w", id, ErrFindingNotFound)
+	}
+	if f.State != FindingStateOpen {
+		s.mu.Unlock()
+		return nil, fmt.Errorf("threatdetect: finding %d is not open (state=%s): %w", id, f.State, ErrFindingNotOpen)
+	}
+	f.State = FindingStateResolved
+	key := dedupeKey{rule: f.Rule.String(), tenant: f.TenantID, subject: f.Subject}
+	if s.byKey[key] == f {
+		delete(s.byKey, key)
+	}
+	s.mu.Unlock()
+
+	if err := s.audit.Log(ctx, &audit.AuditEntry{
+		Action:       "resolve",
+		ResourceType: auditResourceType,
+		ResourceID:   fmt.Sprintf("%d", f.ID),
+		Detail:       fmt.Sprintf("rule=%s tenant=%s subject=%s", f.Rule, f.TenantID, f.Subject),
+	}); err != nil {
+		log.Printf("threatdetect: audit log resolve for finding %d (degraded mode): %v", f.ID, err)
+	}
+	s.emitter.EmitSecurityFinding(f.ToProto())
+	return f, nil
 }

--- a/internal/threatdetect/notifier.go
+++ b/internal/threatdetect/notifier.go
@@ -1,0 +1,225 @@
+package threatdetect
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/footprintai/containarium/internal/alert"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// webhookURLConfigKey and webhookSecretConfigKey are the exact
+// DaemonConfigStore keys internal/server/alert_server.go already persists
+// the operator's webhook URL/secret under — reused so operators configure
+// alerting once, not once per delivery path.
+const (
+	webhookURLConfigKey    = "alert_webhook_url"
+	webhookSecretConfigKey = "alert_webhook_secret" // #nosec G101 -- a DaemonConfigStore key NAME, not a credential value
+)
+
+const (
+	notifierQueueCap    = 256
+	notifierMaxAttempts = 3
+	notifierHTTPTimeout = 10 * time.Second
+)
+
+// WebhookConfigSource is the subset of app.DaemonConfigStore the notifier
+// needs. A structural interface (rather than depending on package app
+// directly) keeps this package's dependency graph one-directional and the
+// notifier table-testable with a fake.
+type WebhookConfigSource interface {
+	Get(ctx context.Context, key string) (string, error)
+}
+
+// Notifier is what FindingStore/MemFindingStore call after successfully
+// persisting a finding. nil is valid on either store: no notifier means no
+// webhook delivery (e.g. in tests that don't exercise it).
+type Notifier interface {
+	Notify(f *Finding)
+}
+
+// WebhookNotifier delivers MEDIUM+ findings straight to the operator's
+// configured webhook — deliberately bypassing vmalert/alertmanager (design
+// doc: that path needs the VictoriaMetrics container and is metrics-shaped;
+// a direct POST works on any backend, including minimal BYOC hosts). It
+// reuses the same webhook URL/secret config and HMAC-SHA256 signing scheme
+// the existing alert-webhook relay uses, so operators configure alerting
+// once.
+//
+// Delivery is asynchronous relative to the store write that triggers it:
+// Notify enqueues onto a bounded channel and returns immediately. One
+// worker goroutine drains it and does the actual HTTP POST with retry and
+// backoff. A full queue or a dead webhook drops/fails deliveries (recorded
+// as failed, when a DeliveryStore is wired) but never blocks the caller —
+// the caller is the detection hot path, which must never stall behind a
+// slow or unreachable webhook.
+type WebhookNotifier struct {
+	config   WebhookConfigSource
+	delivery *alert.DeliveryStore // nil = attempts are logged, not persisted
+	client   *http.Client
+	queue    chan *Finding
+}
+
+// NewWebhookNotifier builds a notifier. config is required — without
+// somewhere to read the webhook URL/secret from, the notifier can't do
+// anything. delivery is optional (nil in degraded mode, when there's no
+// Postgres pool to back a DeliveryStore).
+func NewWebhookNotifier(config WebhookConfigSource, delivery *alert.DeliveryStore) *WebhookNotifier {
+	return &WebhookNotifier{
+		config:   config,
+		delivery: delivery,
+		client:   &http.Client{Timeout: notifierHTTPTimeout},
+		queue:    make(chan *Finding, notifierQueueCap),
+	}
+}
+
+// Start runs the delivery worker until ctx is done. Call once, before the
+// first Notify.
+func (n *WebhookNotifier) Start(ctx context.Context) {
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case f := <-n.queue:
+				n.deliver(ctx, f)
+			}
+		}
+	}()
+}
+
+// Notify enqueues f for delivery when its severity is MEDIUM or above.
+// Non-blocking: if the queue is full the finding is dropped (and logged)
+// rather than backing up the caller.
+func (n *WebhookNotifier) Notify(f *Finding) {
+	if f == nil || f.Severity < pb.ThreatSeverity_THREAT_SEVERITY_MEDIUM {
+		return
+	}
+	select {
+	case n.queue <- f:
+	default:
+		log.Printf("threatdetect: webhook notify queue full (cap %d), dropping finding %d (rule=%s tenant=%s)",
+			notifierQueueCap, f.ID, f.Rule, f.TenantID)
+	}
+}
+
+func (n *WebhookNotifier) deliver(ctx context.Context, f *Finding) {
+	url, err := n.config.Get(ctx, webhookURLConfigKey)
+	if err != nil || url == "" {
+		return // nothing configured — not an error, just nothing to do
+	}
+	secret, _ := n.config.Get(ctx, webhookSecretConfigKey) // optional: unsigned if absent
+
+	body, merr := json.Marshal(f.ToProto())
+	if merr != nil {
+		log.Printf("threatdetect: marshal finding %d for webhook: %v", f.ID, merr)
+		return
+	}
+
+	var lastErr error
+	var lastStatus int
+	start := time.Now()
+	for attempt := 0; attempt < notifierMaxAttempts; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(backoff(attempt)):
+			}
+		}
+		status, derr := n.postOnce(ctx, url, secret, body)
+		lastStatus, lastErr = status, derr
+		if derr == nil {
+			break
+		}
+	}
+
+	n.record(ctx, f, url, lastErr == nil, lastStatus, lastErr, len(body), time.Since(start))
+}
+
+func (n *WebhookNotifier) postOnce(ctx context.Context, url, secret string, body []byte) (int, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if secret != "" {
+		req.Header.Set("X-Containarium-Signature", signPayload(body, secret))
+	}
+	resp, err := n.client.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return resp.StatusCode, fmt.Errorf("webhook returned HTTP %d", resp.StatusCode)
+	}
+	return resp.StatusCode, nil
+}
+
+func (n *WebhookNotifier) record(ctx context.Context, f *Finding, url string, success bool, httpStatus int, deliverErr error, payloadSize int, dur time.Duration) {
+	errMsg := ""
+	if deliverErr != nil {
+		errMsg = deliverErr.Error()
+		log.Printf("threatdetect: webhook delivery failed for finding %d (rule=%s tenant=%s): %v", f.ID, f.Rule, f.TenantID, deliverErr)
+	}
+	if n.delivery == nil {
+		return
+	}
+	if err := n.delivery.Record(ctx, &alert.WebhookDelivery{
+		AlertName:    f.Rule.String(),
+		Source:       "threatdetect",
+		WebhookURL:   maskWebhookURL(url),
+		Success:      success,
+		HTTPStatus:   httpStatus,
+		ErrorMessage: errMsg,
+		PayloadSize:  payloadSize,
+		DurationMs:   int(dur.Milliseconds()),
+	}); err != nil {
+		log.Printf("threatdetect: record webhook delivery for finding %d: %v", f.ID, err)
+	}
+}
+
+// signPayload computes HMAC-SHA256 of payload using secret, in the same
+// "sha256=<hex>" format internal/server/alert_server.go's signPayload uses,
+// so an operator's existing signature-verification code works unmodified
+// regardless of which path delivered the payload.
+func signPayload(payload []byte, secret string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(payload)
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+// backoff is attempt-indexed linear backoff (attempt 1 -> 500ms, attempt 2
+// -> 1s, ...) — simple and sufficient for a 3-attempt budget; no need for
+// jittered exponential at this scale.
+func backoff(attempt int) time.Duration {
+	return time.Duration(attempt) * 500 * time.Millisecond
+}
+
+// maskWebhookURL mirrors alert_server.go's maskURL: show scheme+host, mask
+// the path (which may embed a secret token). Reimplemented locally rather
+// than imported — package server imports threatdetect, not the reverse.
+func maskWebhookURL(rawURL string) string {
+	if rawURL == "" {
+		return ""
+	}
+	parts := strings.SplitN(rawURL, "//", 2)
+	if len(parts) < 2 {
+		return "***"
+	}
+	hostPart := parts[1]
+	if idx := strings.Index(hostPart, "/"); idx > 0 {
+		return parts[0] + "//" + hostPart[:idx] + "/***"
+	}
+	return rawURL
+}

--- a/internal/threatdetect/notifier_integration_test.go
+++ b/internal/threatdetect/notifier_integration_test.go
@@ -1,0 +1,154 @@
+//go:build integration
+
+// Integration coverage for WebhookNotifier's alert.DeliveryStore recording
+// (#1643): the design doc's Notifier test-strategy row explicitly calls for
+// "httptest server asserting payload + DeliveryStore row recorded" — the
+// notifier_test.go unit tests all pass a nil DeliveryStore (delivery
+// recording is optional there), so this is the one place that actually
+// proves a delivery attempt lands in the real store an operator queries.
+//
+//	CONTAINARIUM_TEST_DSN=postgres://... go test -tags=integration ./internal/threatdetect/
+package threatdetect
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/footprintai/containarium/internal/alert"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+func deliveryPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("CONTAINARIUM_TEST_DSN")
+	if dsn == "" {
+		t.Fatal("CONTAINARIUM_TEST_DSN is unset. Failing rather than skipping, so a lane that " +
+			"loses its database reports it instead of going quietly green.")
+	}
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	// webhook_deliveries is internal/alert's own table; other packages'
+	// integration tests run concurrently against this same database in CI,
+	// so only reset the rows this test writes, not the table itself.
+	if _, err := pool.Exec(context.Background(), `DELETE FROM webhook_deliveries WHERE source = 'threatdetect'`); err != nil {
+		t.Fatalf("reset (webhook_deliveries): %v", err)
+	}
+	return pool
+}
+
+// The #1643 acceptance test: a successful delivery is recorded in the real
+// DeliveryStore an operator queries via the existing alert-delivery surface
+// — not just logged.
+func TestWebhookNotifier_RecordsSuccessfulDeliveryInRealDeliveryStore(t *testing.T) {
+	ctx := context.Background()
+	pool := deliveryPool(t)
+	deliveryStore, err := alert.NewDeliveryStore(ctx, pool)
+	if err != nil {
+		t.Fatalf("alert.NewDeliveryStore: %v", err)
+	}
+
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(buf)
+		gotBody = buf
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := newFakeConfigSource(srv.URL, "")
+	n := NewWebhookNotifier(cfg, deliveryStore)
+	notifyCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	n.Start(notifyCtx)
+
+	f := testFinding(pb.ThreatSeverity_THREAT_SEVERITY_HIGH)
+	n.Notify(f)
+
+	waitFor(t, 2*time.Second, func() bool {
+		deliveries, _, err := deliveryStore.List(ctx, 10, 0)
+		if err != nil {
+			t.Fatalf("List: %v", err)
+		}
+		for _, d := range deliveries {
+			if d.Source == "threatdetect" {
+				return true
+			}
+		}
+		return false
+	})
+
+	deliveries, _, err := deliveryStore.List(ctx, 10, 0)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	var found *alert.WebhookDelivery
+	for i := range deliveries {
+		if deliveries[i].Source == "threatdetect" {
+			found = &deliveries[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("no webhook_deliveries row with source=threatdetect")
+	}
+	if !found.Success {
+		t.Errorf("Success = false, want true (HTTPStatus=%d ErrorMessage=%q)", found.HTTPStatus, found.ErrorMessage)
+	}
+	if found.HTTPStatus != http.StatusOK {
+		t.Errorf("HTTPStatus = %d, want %d", found.HTTPStatus, http.StatusOK)
+	}
+	if found.AlertName != f.Rule.String() {
+		t.Errorf("AlertName = %q, want %q", found.AlertName, f.Rule.String())
+	}
+	if found.PayloadSize != len(gotBody) {
+		t.Errorf("PayloadSize = %d, want %d (actual payload received)", found.PayloadSize, len(gotBody))
+	}
+}
+
+// A failed delivery (dead webhook) is also recorded — an operator triaging
+// "why didn't I get alerted" needs the failure visible, not silently
+// dropped once retries are exhausted.
+func TestWebhookNotifier_RecordsFailedDeliveryInRealDeliveryStore(t *testing.T) {
+	ctx := context.Background()
+	pool := deliveryPool(t)
+	deliveryStore, err := alert.NewDeliveryStore(ctx, pool)
+	if err != nil {
+		t.Fatalf("alert.NewDeliveryStore: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	cfg := newFakeConfigSource(srv.URL, "")
+	n := NewWebhookNotifier(cfg, deliveryStore)
+	notifyCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	n.Start(notifyCtx)
+
+	n.Notify(testFinding(pb.ThreatSeverity_THREAT_SEVERITY_CRITICAL))
+
+	waitFor(t, 3*time.Second, func() bool {
+		deliveries, _, err := deliveryStore.List(ctx, 10, 0)
+		if err != nil {
+			t.Fatalf("List: %v", err)
+		}
+		for _, d := range deliveries {
+			if d.Source == "threatdetect" && !d.Success {
+				return true
+			}
+		}
+		return false
+	})
+}

--- a/internal/threatdetect/notifier_test.go
+++ b/internal/threatdetect/notifier_test.go
@@ -1,0 +1,230 @@
+package threatdetect
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// fakeConfigSource is an in-memory WebhookConfigSource for tests.
+type fakeConfigSource struct {
+	mu     sync.Mutex
+	values map[string]string
+}
+
+func newFakeConfigSource(url, secret string) *fakeConfigSource {
+	return &fakeConfigSource{values: map[string]string{
+		webhookURLConfigKey:    url,
+		webhookSecretConfigKey: secret,
+	}}
+}
+
+func (f *fakeConfigSource) Get(_ context.Context, key string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	v, ok := f.values[key]
+	if !ok || v == "" {
+		return "", fmt.Errorf("no value for %s", key)
+	}
+	return v, nil
+}
+
+func testFinding(severity pb.ThreatSeverity) *Finding {
+	return &Finding{
+		ID:       1,
+		Rule:     pb.ThreatRuleId_THREAT_RULE_ID_BAD_DESTINATION,
+		Severity: severity,
+		TenantID: "tenant-a",
+		Subject:  "203.0.113.7",
+		State:    FindingStateOpen,
+		Count:    1,
+	}
+}
+
+// waitFor polls cond until it's true or the timeout elapses, failing the
+// test on timeout. Delivery is asynchronous (queue + worker goroutine), so
+// tests can't assert on it synchronously after Notify returns.
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("condition not met within %s", timeout)
+}
+
+func TestWebhookNotifier_SeverityThreshold(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	tests := []struct {
+		name     string
+		severity pb.ThreatSeverity
+		wantHit  bool
+	}{
+		{"unspecified skipped", pb.ThreatSeverity_THREAT_SEVERITY_UNSPECIFIED, false},
+		{"low skipped", pb.ThreatSeverity_THREAT_SEVERITY_LOW, false},
+		{"medium delivered", pb.ThreatSeverity_THREAT_SEVERITY_MEDIUM, true},
+		{"high delivered", pb.ThreatSeverity_THREAT_SEVERITY_HIGH, true},
+		{"critical delivered", pb.ThreatSeverity_THREAT_SEVERITY_CRITICAL, true},
+	}
+
+	cfg := newFakeConfigSource(srv.URL, "")
+	n := NewWebhookNotifier(cfg, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	n.Start(ctx)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before := atomic.LoadInt32(&hits)
+			n.Notify(testFinding(tt.severity))
+			if tt.wantHit {
+				waitFor(t, time.Second, func() bool { return atomic.LoadInt32(&hits) > before })
+			} else {
+				time.Sleep(50 * time.Millisecond)
+				if atomic.LoadInt32(&hits) != before {
+					t.Fatalf("expected no delivery for severity %v, but webhook was hit", tt.severity)
+				}
+			}
+		})
+	}
+}
+
+func TestWebhookNotifier_HMACSignature(t *testing.T) {
+	const secret = "shh-its-a-secret"
+	var gotSig string
+	var gotBody []byte
+	done := make(chan struct{}, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotSig = r.Header.Get("X-Containarium-Signature")
+		gotBody = make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(gotBody)
+		w.WriteHeader(http.StatusOK)
+		select {
+		case done <- struct{}{}:
+		default:
+		}
+	}))
+	defer srv.Close()
+
+	cfg := newFakeConfigSource(srv.URL, secret)
+	n := NewWebhookNotifier(cfg, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	n.Start(ctx)
+
+	n.Notify(testFinding(pb.ThreatSeverity_THREAT_SEVERITY_HIGH))
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("webhook was never hit")
+	}
+
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(gotBody)
+	want := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+	if gotSig != want {
+		t.Fatalf("signature mismatch: got %q want %q", gotSig, want)
+	}
+}
+
+func TestWebhookNotifier_NoWebhookConfigured_NoOp(t *testing.T) {
+	cfg := newFakeConfigSource("", "")
+	n := NewWebhookNotifier(cfg, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	n.Start(ctx)
+
+	// Should not panic or block; there's simply nothing to assert on the
+	// network side since no URL is configured.
+	n.Notify(testFinding(pb.ThreatSeverity_THREAT_SEVERITY_CRITICAL))
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestWebhookNotifier_RetriesOnFailureThenSucceeds(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&attempts, 1)
+		if n < 2 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := newFakeConfigSource(srv.URL, "")
+	n := NewWebhookNotifier(cfg, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	n.Start(ctx)
+
+	n.Notify(testFinding(pb.ThreatSeverity_THREAT_SEVERITY_HIGH))
+	waitFor(t, 2*time.Second, func() bool { return atomic.LoadInt32(&attempts) >= 2 })
+}
+
+func TestWebhookNotifier_DeadWebhookNeverBlocksNotify(t *testing.T) {
+	block := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-block // hang until the test closes it
+	}))
+	// LIFO order matters here: srv.Close() blocks until every in-flight
+	// handler returns, and the handler above blocks on <-block. Registering
+	// close(block) AFTER srv.Close() means it runs FIRST during unwind —
+	// unblocking any handler still stuck mid-request before Close() waits on
+	// it. The reverse order deadlocks whenever the delivery worker actually
+	// reaches the handler before the test's own goroutine finishes (racy,
+	// but real: it reproduced under -tags=integration's extra scheduler
+	// contention from concurrent Postgres tests).
+	defer srv.Close()
+	defer close(block)
+
+	cfg := newFakeConfigSource(srv.URL, "")
+	n := NewWebhookNotifier(cfg, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	n.Start(ctx)
+
+	// Fill the queue well past capacity; every call must return immediately
+	// even though the one in-flight delivery is stuck against the hanging
+	// server. A dead/slow webhook must never make the detection hot path
+	// (the caller of Notify) wait.
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < notifierQueueCap*2; i++ {
+			n.Notify(testFinding(pb.ThreatSeverity_THREAT_SEVERITY_CRITICAL))
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Notify blocked — a dead webhook must never block the caller")
+	}
+}
+
+func TestWebhookNotifier_NilFinding_NoPanic(t *testing.T) {
+	cfg := newFakeConfigSource("http://example.invalid", "")
+	n := NewWebhookNotifier(cfg, nil)
+	n.Notify(nil)
+}

--- a/internal/threatdetect/store.go
+++ b/internal/threatdetect/store.go
@@ -32,9 +32,17 @@ const auditResourceType = "security.finding"
 // into the tamper-evident audit hash chain — findings ride the existing
 // chain rather than growing new chain code.
 type FindingStore struct {
-	pool    *pgxpool.Pool
-	emitter *events.Emitter
-	audit   *audit.Store
+	pool     *pgxpool.Pool
+	emitter  *events.Emitter
+	audit    *audit.Store
+	notifier Notifier // nil = no webhook delivery (e.g. #1639/#1640 tests)
+}
+
+// SetNotifier wires webhook delivery (#1643): every finding this store
+// writes from here on is handed to notifier.Notify after the event/audit
+// write succeeds. nil is valid (no delivery) and is the zero-value default.
+func (s *FindingStore) SetNotifier(notifier Notifier) {
+	s.notifier = notifier
 }
 
 // NewFindingStore creates a finding store sharing the given pool, emitting
@@ -149,6 +157,9 @@ func (s *FindingStore) Insert(ctx context.Context, f *Finding) (*Finding, error)
 	}
 
 	s.emitter.EmitSecurityFinding(f.ToProto())
+	if s.notifier != nil {
+		s.notifier.Notify(f)
+	}
 
 	return f, nil
 }
@@ -299,6 +310,9 @@ func (s *FindingStore) tryUpsert(ctx context.Context, f *Finding) (out *Finding,
 		return nil, false, fmt.Errorf("threatdetect: audit log finding: %w", auditErr)
 	}
 	s.emitter.EmitSecurityFinding(out.ToProto())
+	if s.notifier != nil {
+		s.notifier.Notify(out)
+	}
 	return out, false, nil
 }
 
@@ -312,19 +326,41 @@ func (s *FindingStore) Get(ctx context.Context, id int64) (*Finding, error) {
 	return scanFinding(row)
 }
 
-// List returns findings ordered by most recently seen first, up to limit
-// (default/cap 200).
-func (s *FindingStore) List(ctx context.Context, limit int) ([]*Finding, error) {
+// List returns findings matching filter, ordered by most recently seen
+// first. See ListFilter for the zero-value ("no filter") semantics of each
+// field.
+func (s *FindingStore) List(ctx context.Context, filter ListFilter) ([]*Finding, error) {
+	limit := filter.Limit
 	if limit <= 0 || limit > 200 {
 		limit = 50
 	}
-	rows, err := s.pool.Query(ctx, `
+	query := `
 		SELECT id, rule, severity, tenant_id, container, backend_id, subject,
 		       state, count, evidence, first_seen, last_seen
 		FROM security_findings
-		ORDER BY last_seen DESC
-		LIMIT $1
-	`, limit)
+		WHERE 1 = 1
+	`
+	var args []any
+	if filter.Severity != pb.ThreatSeverity_THREAT_SEVERITY_UNSPECIFIED {
+		args = append(args, filter.Severity.String())
+		query += fmt.Sprintf(" AND severity = $%d", len(args))
+	}
+	if filter.TenantID != "" {
+		args = append(args, filter.TenantID)
+		query += fmt.Sprintf(" AND tenant_id = $%d", len(args))
+	}
+	if !filter.Since.IsZero() {
+		args = append(args, filter.Since)
+		query += fmt.Sprintf(" AND last_seen >= $%d", len(args))
+	}
+	if filter.State != "" {
+		args = append(args, string(filter.State))
+		query += fmt.Sprintf(" AND state = $%d", len(args))
+	}
+	args = append(args, limit)
+	query += fmt.Sprintf(" ORDER BY last_seen DESC LIMIT $%d", len(args))
+
+	rows, err := s.pool.Query(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("threatdetect: list findings: %w", err)
 	}
@@ -344,6 +380,39 @@ func (s *FindingStore) List(ctx context.Context, limit int) ([]*Finding, error) 
 	return out, nil
 }
 
+// Resolve transitions a finding to FindingStateResolved. Also emits an
+// updated event and an audit entry (action "resolve") — a resolution is
+// itself an auditable operator action, same as create.
+func (s *FindingStore) Resolve(ctx context.Context, id int64) (*Finding, error) {
+	tag, err := s.pool.Exec(ctx, `UPDATE security_findings SET state = 'resolved' WHERE id = $1 AND state = 'open'`, id)
+	if err != nil {
+		return nil, fmt.Errorf("threatdetect: resolve finding %d: %w", id, err)
+	}
+	if tag.RowsAffected() == 0 {
+		// Distinguish "no such finding" from "already resolved" for the
+		// caller (server maps the two to NotFound vs FailedPrecondition).
+		existing, gerr := s.Get(ctx, id)
+		if gerr != nil {
+			return nil, gerr
+		}
+		return nil, fmt.Errorf("threatdetect: finding %d is not open (state=%s): %w", id, existing.State, ErrFindingNotOpen)
+	}
+	f, err := s.Get(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.audit.Log(ctx, &audit.AuditEntry{
+		Action:       "resolve",
+		ResourceType: auditResourceType,
+		ResourceID:   fmt.Sprintf("%d", f.ID),
+		Detail:       fmt.Sprintf("rule=%s tenant=%s subject=%s", f.Rule, f.TenantID, f.Subject),
+	}); err != nil {
+		log.Printf("threatdetect: audit log resolve for finding %d: %v", f.ID, err)
+	}
+	s.emitter.EmitSecurityFinding(f.ToProto())
+	return f, nil
+}
+
 // rowScanner is the subset of pgx.Row / pgx.Rows that scanFinding needs.
 type rowScanner interface {
 	Scan(dest ...any) error
@@ -356,8 +425,8 @@ func scanFinding(row rowScanner) (*Finding, error) {
 	err := row.Scan(&f.ID, &rule, &severity, &f.TenantID, &f.Container, &f.BackendID,
 		&f.Subject, &state, &f.Count, &evidenceJSON, &f.FirstSeen, &f.LastSeen)
 	if err != nil {
-		if err == pgx.ErrNoRows {
-			return nil, err
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrFindingNotFound
 		}
 		return nil, fmt.Errorf("threatdetect: scan finding: %w", err)
 	}

--- a/pkg/pb/containarium/v1/threatdetection.pb.go
+++ b/pkg/pb/containarium/v1/threatdetection.pb.go
@@ -1108,6 +1108,223 @@ func (*RemoveBadDestinationResponse) Descriptor() ([]byte, []int) {
 	return file_containarium_v1_threatdetection_proto_rawDescGZIP(), []int{13}
 }
 
+// ListFindingsRequest filters ListFindings. Every field is optional; an
+// unset field matches everything. tenant_id is enforced by the server's RBAC
+// interceptor the same way ListContainersRequest.username is: a non-admin
+// caller may only ever see their own tenant_id, regardless of what (if
+// anything) they set here.
+type ListFindingsRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Exact match. THREAT_SEVERITY_UNSPECIFIED (default) matches any severity.
+	Severity ThreatSeverity `protobuf:"varint,1,opt,name=severity,proto3,enum=containarium.v1.ThreatSeverity" json:"severity,omitempty"`
+	TenantId string         `protobuf:"bytes,2,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
+	// Only findings last seen at or after this time. Unset matches everything.
+	Since *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=since,proto3" json:"since,omitempty"`
+	// Exact match. FINDING_STATE_UNSPECIFIED (default) matches any state.
+	State FindingState `protobuf:"varint,4,opt,name=state,proto3,enum=containarium.v1.FindingState" json:"state,omitempty"`
+	// <= 0 or > 200 is treated as the server default (50).
+	Limit         int32 `protobuf:"varint,5,opt,name=limit,proto3" json:"limit,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListFindingsRequest) Reset() {
+	*x = ListFindingsRequest{}
+	mi := &file_containarium_v1_threatdetection_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListFindingsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListFindingsRequest) ProtoMessage() {}
+
+func (x *ListFindingsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_threatdetection_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListFindingsRequest.ProtoReflect.Descriptor instead.
+func (*ListFindingsRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_threatdetection_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *ListFindingsRequest) GetSeverity() ThreatSeverity {
+	if x != nil {
+		return x.Severity
+	}
+	return ThreatSeverity_THREAT_SEVERITY_UNSPECIFIED
+}
+
+func (x *ListFindingsRequest) GetTenantId() string {
+	if x != nil {
+		return x.TenantId
+	}
+	return ""
+}
+
+func (x *ListFindingsRequest) GetSince() *timestamppb.Timestamp {
+	if x != nil {
+		return x.Since
+	}
+	return nil
+}
+
+func (x *ListFindingsRequest) GetState() FindingState {
+	if x != nil {
+		return x.State
+	}
+	return FindingState_FINDING_STATE_UNSPECIFIED
+}
+
+func (x *ListFindingsRequest) GetLimit() int32 {
+	if x != nil {
+		return x.Limit
+	}
+	return 0
+}
+
+type ListFindingsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Findings      []*Finding             `protobuf:"bytes,1,rep,name=findings,proto3" json:"findings,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListFindingsResponse) Reset() {
+	*x = ListFindingsResponse{}
+	mi := &file_containarium_v1_threatdetection_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListFindingsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListFindingsResponse) ProtoMessage() {}
+
+func (x *ListFindingsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_threatdetection_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListFindingsResponse.ProtoReflect.Descriptor instead.
+func (*ListFindingsResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_threatdetection_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *ListFindingsResponse) GetFindings() []*Finding {
+	if x != nil {
+		return x.Findings
+	}
+	return nil
+}
+
+type ResolveFindingRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            int64                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ResolveFindingRequest) Reset() {
+	*x = ResolveFindingRequest{}
+	mi := &file_containarium_v1_threatdetection_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResolveFindingRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResolveFindingRequest) ProtoMessage() {}
+
+func (x *ResolveFindingRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_threatdetection_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ResolveFindingRequest.ProtoReflect.Descriptor instead.
+func (*ResolveFindingRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_threatdetection_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *ResolveFindingRequest) GetId() int64 {
+	if x != nil {
+		return x.Id
+	}
+	return 0
+}
+
+type ResolveFindingResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Finding       *Finding               `protobuf:"bytes,1,opt,name=finding,proto3" json:"finding,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ResolveFindingResponse) Reset() {
+	*x = ResolveFindingResponse{}
+	mi := &file_containarium_v1_threatdetection_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResolveFindingResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResolveFindingResponse) ProtoMessage() {}
+
+func (x *ResolveFindingResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_threatdetection_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ResolveFindingResponse.ProtoReflect.Descriptor instead.
+func (*ResolveFindingResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_threatdetection_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *ResolveFindingResponse) GetFinding() *Finding {
+	if x != nil {
+		return x.Finding
+	}
+	return nil
+}
+
 var File_containarium_v1_threatdetection_proto protoreflect.FileDescriptor
 
 const file_containarium_v1_threatdetection_proto_rawDesc = "" +
@@ -1172,7 +1389,19 @@ const file_containarium_v1_threatdetection_proto_rawDesc = "" +
 	"\x05entry\x18\x01 \x01(\v2$.containarium.v1.BadDestinationEntryR\x05entry\"1\n" +
 	"\x1bRemoveBadDestinationRequest\x12\x12\n" +
 	"\x04cidr\x18\x01 \x01(\tR\x04cidr\"\x1e\n" +
-	"\x1cRemoveBadDestinationResponse*\x9e\x01\n" +
+	"\x1cRemoveBadDestinationResponse\"\xec\x01\n" +
+	"\x13ListFindingsRequest\x12;\n" +
+	"\bseverity\x18\x01 \x01(\x0e2\x1f.containarium.v1.ThreatSeverityR\bseverity\x12\x1b\n" +
+	"\ttenant_id\x18\x02 \x01(\tR\btenantId\x120\n" +
+	"\x05since\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\x05since\x123\n" +
+	"\x05state\x18\x04 \x01(\x0e2\x1d.containarium.v1.FindingStateR\x05state\x12\x14\n" +
+	"\x05limit\x18\x05 \x01(\x05R\x05limit\"L\n" +
+	"\x14ListFindingsResponse\x124\n" +
+	"\bfindings\x18\x01 \x03(\v2\x18.containarium.v1.FindingR\bfindings\"'\n" +
+	"\x15ResolveFindingRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\x03R\x02id\"L\n" +
+	"\x16ResolveFindingResponse\x122\n" +
+	"\afinding\x18\x01 \x01(\v2\x18.containarium.v1.FindingR\afinding*\x9e\x01\n" +
 	"\x0eThreatSeverity\x12\x1f\n" +
 	"\x1bTHREAT_SEVERITY_UNSPECIFIED\x10\x00\x12\x17\n" +
 	"\x13THREAT_SEVERITY_LOW\x10\x01\x12\x1a\n" +
@@ -1193,7 +1422,7 @@ const file_containarium_v1_threatdetection_proto_rawDesc = "" +
 	"\x15SENTRY_STATE_DISABLED\x10\x01\x12\x1c\n" +
 	"\x18SENTRY_STATE_UNAVAILABLE\x10\x02\x12\x19\n" +
 	"\x15SENTRY_STATE_DEGRADED\x10\x03\x12\x13\n" +
-	"\x0fSENTRY_STATE_OK\x10\x042\xd6\t\n" +
+	"\x0fSENTRY_STATE_OK\x10\x042\xc5\x0e\n" +
 	"\x16ThreatDetectionService\x12\xae\x02\n" +
 	"\x0fGetSentryStatus\x12'.containarium.v1.GetSentryStatusRequest\x1a(.containarium.v1.GetSentryStatusResponse\"\xc7\x01\x92A\xa1\x01\n" +
 	"\bSecurity\x12\"Get threat-detection sentry status\x1aqReturns the background detection engine's on/off state (disabled, unavailable, degraded, ok) and per-rule health.\x82\xd3\xe4\x93\x02\x1c\x12\x1a/v1/security/sentry/status\x12\xa5\x02\n" +
@@ -1202,7 +1431,11 @@ const file_containarium_v1_threatdetection_proto_rawDesc = "" +
 	"\x11AddBadDestination\x12).containarium.v1.AddBadDestinationRequest\x1a*.containarium.v1.AddBadDestinationResponse\"\xa1\x01\x92Av\n" +
 	"\bSecurity\x12\x1bAdd a known-bad destination\x1aMAdds an operator-supplied CIDR or exact IP to the known-bad-destination list.\x82\xd3\xe4\x93\x02\":\x01*\"\x1d/v1/security/bad-destinations\x12\xd1\x02\n" +
 	"\x14RemoveBadDestination\x12,.containarium.v1.RemoveBadDestinationRequest\x1a-.containarium.v1.RemoveBadDestinationResponse\"\xdb\x01\x92A\xa8\x01\n" +
-	"\bSecurity\x12(Remove an operator-added bad destination\x1arRemoves a previously operator-added entry from the known-bad-destination list. Baseline entries cannot be removed.\x82\xd3\xe4\x93\x02)*'/v1/security/bad-destinations/{cidr=**}BKZIgithub.com/footprintai/containarium/pkg/pb/containarium/v1;containariumv1b\x06proto3"
+	"\bSecurity\x12(Remove an operator-added bad destination\x1arRemoves a previously operator-added entry from the known-bad-destination list. Baseline entries cannot be removed.\x82\xd3\xe4\x93\x02)*'/v1/security/bad-destinations/{cidr=**}\x12\xb5\x02\n" +
+	"\fListFindings\x12$.containarium.v1.ListFindingsRequest\x1a%.containarium.v1.ListFindingsResponse\"\xd7\x01\x92A\xb6\x01\n" +
+	"\bSecurity\x12\x16List security findings\x1a\x91\x01Lists security findings with optional severity/tenant/since/state filters, most recently seen first. Non-admin callers only see their own tenant.\x82\xd3\xe4\x93\x02\x17\x12\x15/v1/security/findings\x12\xb4\x02\n" +
+	"\x0eResolveFinding\x12&.containarium.v1.ResolveFindingRequest\x1a'.containarium.v1.ResolveFindingResponse\"\xd0\x01\x92A\xa2\x01\n" +
+	"\bSecurity\x12\x1aResolve a security finding\x1azMarks an open finding as resolved. Fails with FAILED_PRECONDITION if it's already resolved, NOT_FOUND if it doesn't exist.\x82\xd3\xe4\x93\x02$\"\"/v1/security/findings/{id}/resolveBKZIgithub.com/footprintai/containarium/pkg/pb/containarium/v1;containariumv1b\x06proto3"
 
 var (
 	file_containarium_v1_threatdetection_proto_rawDescOnce sync.Once
@@ -1217,7 +1450,7 @@ func file_containarium_v1_threatdetection_proto_rawDescGZIP() []byte {
 }
 
 var file_containarium_v1_threatdetection_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_containarium_v1_threatdetection_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
+var file_containarium_v1_threatdetection_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
 var file_containarium_v1_threatdetection_proto_goTypes = []any{
 	(ThreatSeverity)(0),                  // 0: containarium.v1.ThreatSeverity
 	(ThreatRuleId)(0),                    // 1: containarium.v1.ThreatRuleId
@@ -1237,7 +1470,11 @@ var file_containarium_v1_threatdetection_proto_goTypes = []any{
 	(*AddBadDestinationResponse)(nil),    // 15: containarium.v1.AddBadDestinationResponse
 	(*RemoveBadDestinationRequest)(nil),  // 16: containarium.v1.RemoveBadDestinationRequest
 	(*RemoveBadDestinationResponse)(nil), // 17: containarium.v1.RemoveBadDestinationResponse
-	(*timestamppb.Timestamp)(nil),        // 18: google.protobuf.Timestamp
+	(*ListFindingsRequest)(nil),          // 18: containarium.v1.ListFindingsRequest
+	(*ListFindingsResponse)(nil),         // 19: containarium.v1.ListFindingsResponse
+	(*ResolveFindingRequest)(nil),        // 20: containarium.v1.ResolveFindingRequest
+	(*ResolveFindingResponse)(nil),       // 21: containarium.v1.ResolveFindingResponse
+	(*timestamppb.Timestamp)(nil),        // 22: google.protobuf.Timestamp
 }
 var file_containarium_v1_threatdetection_proto_depIdxs = []int32{
 	4,  // 0: containarium.v1.Evidence.flows:type_name -> containarium.v1.FlowEvidence
@@ -1246,27 +1483,36 @@ var file_containarium_v1_threatdetection_proto_depIdxs = []int32{
 	0,  // 3: containarium.v1.Finding.severity:type_name -> containarium.v1.ThreatSeverity
 	2,  // 4: containarium.v1.Finding.state:type_name -> containarium.v1.FindingState
 	6,  // 5: containarium.v1.Finding.evidence:type_name -> containarium.v1.Evidence
-	18, // 6: containarium.v1.Finding.first_seen:type_name -> google.protobuf.Timestamp
-	18, // 7: containarium.v1.Finding.last_seen:type_name -> google.protobuf.Timestamp
+	22, // 6: containarium.v1.Finding.first_seen:type_name -> google.protobuf.Timestamp
+	22, // 7: containarium.v1.Finding.last_seen:type_name -> google.protobuf.Timestamp
 	1,  // 8: containarium.v1.RuleStatus.rule:type_name -> containarium.v1.ThreatRuleId
-	18, // 9: containarium.v1.RuleStatus.last_error_at:type_name -> google.protobuf.Timestamp
+	22, // 9: containarium.v1.RuleStatus.last_error_at:type_name -> google.protobuf.Timestamp
 	3,  // 10: containarium.v1.GetSentryStatusResponse.state:type_name -> containarium.v1.SentryState
 	8,  // 11: containarium.v1.GetSentryStatusResponse.rules:type_name -> containarium.v1.RuleStatus
 	11, // 12: containarium.v1.ListBadDestinationsResponse.entries:type_name -> containarium.v1.BadDestinationEntry
 	11, // 13: containarium.v1.AddBadDestinationResponse.entry:type_name -> containarium.v1.BadDestinationEntry
-	9,  // 14: containarium.v1.ThreatDetectionService.GetSentryStatus:input_type -> containarium.v1.GetSentryStatusRequest
-	12, // 15: containarium.v1.ThreatDetectionService.ListBadDestinations:input_type -> containarium.v1.ListBadDestinationsRequest
-	14, // 16: containarium.v1.ThreatDetectionService.AddBadDestination:input_type -> containarium.v1.AddBadDestinationRequest
-	16, // 17: containarium.v1.ThreatDetectionService.RemoveBadDestination:input_type -> containarium.v1.RemoveBadDestinationRequest
-	10, // 18: containarium.v1.ThreatDetectionService.GetSentryStatus:output_type -> containarium.v1.GetSentryStatusResponse
-	13, // 19: containarium.v1.ThreatDetectionService.ListBadDestinations:output_type -> containarium.v1.ListBadDestinationsResponse
-	15, // 20: containarium.v1.ThreatDetectionService.AddBadDestination:output_type -> containarium.v1.AddBadDestinationResponse
-	17, // 21: containarium.v1.ThreatDetectionService.RemoveBadDestination:output_type -> containarium.v1.RemoveBadDestinationResponse
-	18, // [18:22] is the sub-list for method output_type
-	14, // [14:18] is the sub-list for method input_type
-	14, // [14:14] is the sub-list for extension type_name
-	14, // [14:14] is the sub-list for extension extendee
-	0,  // [0:14] is the sub-list for field type_name
+	0,  // 14: containarium.v1.ListFindingsRequest.severity:type_name -> containarium.v1.ThreatSeverity
+	22, // 15: containarium.v1.ListFindingsRequest.since:type_name -> google.protobuf.Timestamp
+	2,  // 16: containarium.v1.ListFindingsRequest.state:type_name -> containarium.v1.FindingState
+	7,  // 17: containarium.v1.ListFindingsResponse.findings:type_name -> containarium.v1.Finding
+	7,  // 18: containarium.v1.ResolveFindingResponse.finding:type_name -> containarium.v1.Finding
+	9,  // 19: containarium.v1.ThreatDetectionService.GetSentryStatus:input_type -> containarium.v1.GetSentryStatusRequest
+	12, // 20: containarium.v1.ThreatDetectionService.ListBadDestinations:input_type -> containarium.v1.ListBadDestinationsRequest
+	14, // 21: containarium.v1.ThreatDetectionService.AddBadDestination:input_type -> containarium.v1.AddBadDestinationRequest
+	16, // 22: containarium.v1.ThreatDetectionService.RemoveBadDestination:input_type -> containarium.v1.RemoveBadDestinationRequest
+	18, // 23: containarium.v1.ThreatDetectionService.ListFindings:input_type -> containarium.v1.ListFindingsRequest
+	20, // 24: containarium.v1.ThreatDetectionService.ResolveFinding:input_type -> containarium.v1.ResolveFindingRequest
+	10, // 25: containarium.v1.ThreatDetectionService.GetSentryStatus:output_type -> containarium.v1.GetSentryStatusResponse
+	13, // 26: containarium.v1.ThreatDetectionService.ListBadDestinations:output_type -> containarium.v1.ListBadDestinationsResponse
+	15, // 27: containarium.v1.ThreatDetectionService.AddBadDestination:output_type -> containarium.v1.AddBadDestinationResponse
+	17, // 28: containarium.v1.ThreatDetectionService.RemoveBadDestination:output_type -> containarium.v1.RemoveBadDestinationResponse
+	19, // 29: containarium.v1.ThreatDetectionService.ListFindings:output_type -> containarium.v1.ListFindingsResponse
+	21, // 30: containarium.v1.ThreatDetectionService.ResolveFinding:output_type -> containarium.v1.ResolveFindingResponse
+	25, // [25:31] is the sub-list for method output_type
+	19, // [19:25] is the sub-list for method input_type
+	19, // [19:19] is the sub-list for extension type_name
+	19, // [19:19] is the sub-list for extension extendee
+	0,  // [0:19] is the sub-list for field type_name
 }
 
 func init() { file_containarium_v1_threatdetection_proto_init() }
@@ -1280,7 +1526,7 @@ func file_containarium_v1_threatdetection_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_v1_threatdetection_proto_rawDesc), len(file_containarium_v1_threatdetection_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   14,
+			NumMessages:   18,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/pb/containarium/v1/threatdetection.pb.gw.go
+++ b/pkg/pb/containarium/v1/threatdetection.pb.gw.go
@@ -143,6 +143,80 @@ func local_request_ThreatDetectionService_RemoveBadDestination_0(ctx context.Con
 	return msg, metadata, err
 }
 
+var filter_ThreatDetectionService_ListFindings_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
+
+func request_ThreatDetectionService_ListFindings_0(ctx context.Context, marshaler runtime.Marshaler, client ThreatDetectionServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListFindingsRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_ThreatDetectionService_ListFindings_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.ListFindings(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ThreatDetectionService_ListFindings_0(ctx context.Context, marshaler runtime.Marshaler, server ThreatDetectionServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListFindingsRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_ThreatDetectionService_ListFindings_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.ListFindings(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_ThreatDetectionService_ResolveFinding_0(ctx context.Context, marshaler runtime.Marshaler, client ThreatDetectionServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ResolveFindingRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	val, ok := pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+	protoReq.Id, err = runtime.Int64(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.ResolveFinding(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ThreatDetectionService_ResolveFinding_0(ctx context.Context, marshaler runtime.Marshaler, server ThreatDetectionServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ResolveFindingRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	val, ok := pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+	protoReq.Id, err = runtime.Int64(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+	msg, err := server.ResolveFinding(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterThreatDetectionServiceHandlerServer registers the http handlers for service ThreatDetectionService to "mux".
 // UnaryRPC     :call ThreatDetectionServiceServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -228,6 +302,46 @@ func RegisterThreatDetectionServiceHandlerServer(ctx context.Context, mux *runti
 			return
 		}
 		forward_ThreatDetectionService_RemoveBadDestination_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_ThreatDetectionService_ListFindings_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.ThreatDetectionService/ListFindings", runtime.WithHTTPPathPattern("/v1/security/findings"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ThreatDetectionService_ListFindings_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ThreatDetectionService_ListFindings_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_ThreatDetectionService_ResolveFinding_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.ThreatDetectionService/ResolveFinding", runtime.WithHTTPPathPattern("/v1/security/findings/{id}/resolve"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ThreatDetectionService_ResolveFinding_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ThreatDetectionService_ResolveFinding_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 
 	return nil
@@ -337,6 +451,40 @@ func RegisterThreatDetectionServiceHandlerClient(ctx context.Context, mux *runti
 		}
 		forward_ThreatDetectionService_RemoveBadDestination_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodGet, pattern_ThreatDetectionService_ListFindings_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.ThreatDetectionService/ListFindings", runtime.WithHTTPPathPattern("/v1/security/findings"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ThreatDetectionService_ListFindings_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ThreatDetectionService_ListFindings_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_ThreatDetectionService_ResolveFinding_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.ThreatDetectionService/ResolveFinding", runtime.WithHTTPPathPattern("/v1/security/findings/{id}/resolve"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ThreatDetectionService_ResolveFinding_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ThreatDetectionService_ResolveFinding_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
@@ -345,6 +493,8 @@ var (
 	pattern_ThreatDetectionService_ListBadDestinations_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "security", "bad-destinations"}, ""))
 	pattern_ThreatDetectionService_AddBadDestination_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "security", "bad-destinations"}, ""))
 	pattern_ThreatDetectionService_RemoveBadDestination_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 3, 0, 4, 1, 5, 3}, []string{"v1", "security", "bad-destinations", "cidr"}, ""))
+	pattern_ThreatDetectionService_ListFindings_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "security", "findings"}, ""))
+	pattern_ThreatDetectionService_ResolveFinding_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4}, []string{"v1", "security", "findings", "id", "resolve"}, ""))
 )
 
 var (
@@ -352,4 +502,6 @@ var (
 	forward_ThreatDetectionService_ListBadDestinations_0  = runtime.ForwardResponseMessage
 	forward_ThreatDetectionService_AddBadDestination_0    = runtime.ForwardResponseMessage
 	forward_ThreatDetectionService_RemoveBadDestination_0 = runtime.ForwardResponseMessage
+	forward_ThreatDetectionService_ListFindings_0         = runtime.ForwardResponseMessage
+	forward_ThreatDetectionService_ResolveFinding_0       = runtime.ForwardResponseMessage
 )

--- a/pkg/pb/containarium/v1/threatdetection_grpc.pb.go
+++ b/pkg/pb/containarium/v1/threatdetection_grpc.pb.go
@@ -23,6 +23,8 @@ const (
 	ThreatDetectionService_ListBadDestinations_FullMethodName  = "/containarium.v1.ThreatDetectionService/ListBadDestinations"
 	ThreatDetectionService_AddBadDestination_FullMethodName    = "/containarium.v1.ThreatDetectionService/AddBadDestination"
 	ThreatDetectionService_RemoveBadDestination_FullMethodName = "/containarium.v1.ThreatDetectionService/RemoveBadDestination"
+	ThreatDetectionService_ListFindings_FullMethodName         = "/containarium.v1.ThreatDetectionService/ListFindings"
+	ThreatDetectionService_ResolveFinding_FullMethodName       = "/containarium.v1.ThreatDetectionService/ResolveFinding"
 )
 
 // ThreatDetectionServiceClient is the client API for ThreatDetectionService service.
@@ -31,9 +33,10 @@ const (
 //
 // ThreatDetectionService serves the background security-sentry's status and
 // findings. GetSentryStatus ships with #1640 (background detection loop);
-// *BadDestination* ships with #1641 (known-bad destination rule); the
-// findings/rule-config RPCs are added by later stories in the same umbrella
-// (#1642-#1643) — see docs/architecture/continuous-threat-detection.md.
+// *BadDestination* ships with #1641 (known-bad destination rule);
+// ListFindings/ResolveFinding ship with #1643 (findings delivery + triage);
+// rule-config RPCs remain unimplemented — see
+// docs/architecture/continuous-threat-detection.md.
 type ThreatDetectionServiceClient interface {
 	// GetSentryStatus returns the detection engine's on/off state and the
 	// health of every registered rule.
@@ -49,6 +52,12 @@ type ThreatDetectionServiceClient interface {
 	// (embedded) entries cannot be removed this way — a bare "not found" error
 	// covers the case since only additions are ever tracked as removable.
 	RemoveBadDestination(ctx context.Context, in *RemoveBadDestinationRequest, opts ...grpc.CallOption) (*RemoveBadDestinationResponse, error)
+	// ListFindings lists security findings, most recently seen first.
+	// Tenant-scoped: a non-admin caller only ever sees their own tenant_id.
+	ListFindings(ctx context.Context, in *ListFindingsRequest, opts ...grpc.CallOption) (*ListFindingsResponse, error)
+	// ResolveFinding transitions an open finding to resolved. Fails if the
+	// finding is already resolved or doesn't exist.
+	ResolveFinding(ctx context.Context, in *ResolveFindingRequest, opts ...grpc.CallOption) (*ResolveFindingResponse, error)
 }
 
 type threatDetectionServiceClient struct {
@@ -99,15 +108,36 @@ func (c *threatDetectionServiceClient) RemoveBadDestination(ctx context.Context,
 	return out, nil
 }
 
+func (c *threatDetectionServiceClient) ListFindings(ctx context.Context, in *ListFindingsRequest, opts ...grpc.CallOption) (*ListFindingsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListFindingsResponse)
+	err := c.cc.Invoke(ctx, ThreatDetectionService_ListFindings_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *threatDetectionServiceClient) ResolveFinding(ctx context.Context, in *ResolveFindingRequest, opts ...grpc.CallOption) (*ResolveFindingResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ResolveFindingResponse)
+	err := c.cc.Invoke(ctx, ThreatDetectionService_ResolveFinding_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ThreatDetectionServiceServer is the server API for ThreatDetectionService service.
 // All implementations must embed UnimplementedThreatDetectionServiceServer
 // for forward compatibility.
 //
 // ThreatDetectionService serves the background security-sentry's status and
 // findings. GetSentryStatus ships with #1640 (background detection loop);
-// *BadDestination* ships with #1641 (known-bad destination rule); the
-// findings/rule-config RPCs are added by later stories in the same umbrella
-// (#1642-#1643) — see docs/architecture/continuous-threat-detection.md.
+// *BadDestination* ships with #1641 (known-bad destination rule);
+// ListFindings/ResolveFinding ship with #1643 (findings delivery + triage);
+// rule-config RPCs remain unimplemented — see
+// docs/architecture/continuous-threat-detection.md.
 type ThreatDetectionServiceServer interface {
 	// GetSentryStatus returns the detection engine's on/off state and the
 	// health of every registered rule.
@@ -123,6 +153,12 @@ type ThreatDetectionServiceServer interface {
 	// (embedded) entries cannot be removed this way — a bare "not found" error
 	// covers the case since only additions are ever tracked as removable.
 	RemoveBadDestination(context.Context, *RemoveBadDestinationRequest) (*RemoveBadDestinationResponse, error)
+	// ListFindings lists security findings, most recently seen first.
+	// Tenant-scoped: a non-admin caller only ever sees their own tenant_id.
+	ListFindings(context.Context, *ListFindingsRequest) (*ListFindingsResponse, error)
+	// ResolveFinding transitions an open finding to resolved. Fails if the
+	// finding is already resolved or doesn't exist.
+	ResolveFinding(context.Context, *ResolveFindingRequest) (*ResolveFindingResponse, error)
 	mustEmbedUnimplementedThreatDetectionServiceServer()
 }
 
@@ -144,6 +180,12 @@ func (UnimplementedThreatDetectionServiceServer) AddBadDestination(context.Conte
 }
 func (UnimplementedThreatDetectionServiceServer) RemoveBadDestination(context.Context, *RemoveBadDestinationRequest) (*RemoveBadDestinationResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RemoveBadDestination not implemented")
+}
+func (UnimplementedThreatDetectionServiceServer) ListFindings(context.Context, *ListFindingsRequest) (*ListFindingsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListFindings not implemented")
+}
+func (UnimplementedThreatDetectionServiceServer) ResolveFinding(context.Context, *ResolveFindingRequest) (*ResolveFindingResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ResolveFinding not implemented")
 }
 func (UnimplementedThreatDetectionServiceServer) mustEmbedUnimplementedThreatDetectionServiceServer() {
 }
@@ -239,6 +281,42 @@ func _ThreatDetectionService_RemoveBadDestination_Handler(srv interface{}, ctx c
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ThreatDetectionService_ListFindings_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListFindingsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ThreatDetectionServiceServer).ListFindings(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ThreatDetectionService_ListFindings_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ThreatDetectionServiceServer).ListFindings(ctx, req.(*ListFindingsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ThreatDetectionService_ResolveFinding_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ResolveFindingRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ThreatDetectionServiceServer).ResolveFinding(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ThreatDetectionService_ResolveFinding_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ThreatDetectionServiceServer).ResolveFinding(ctx, req.(*ResolveFindingRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // ThreatDetectionService_ServiceDesc is the grpc.ServiceDesc for ThreatDetectionService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -261,6 +339,14 @@ var ThreatDetectionService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "RemoveBadDestination",
 			Handler:    _ThreatDetectionService_RemoveBadDestination_Handler,
+		},
+		{
+			MethodName: "ListFindings",
+			Handler:    _ThreatDetectionService_ListFindings_Handler,
+		},
+		{
+			MethodName: "ResolveFinding",
+			Handler:    _ThreatDetectionService_ResolveFinding_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/proto/containarium/v1/threatdetection.proto
+++ b/proto/containarium/v1/threatdetection.proto
@@ -158,11 +158,41 @@ message RemoveBadDestinationRequest {
 
 message RemoveBadDestinationResponse {}
 
+// ListFindingsRequest filters ListFindings. Every field is optional; an
+// unset field matches everything. tenant_id is enforced by the server's RBAC
+// interceptor the same way ListContainersRequest.username is: a non-admin
+// caller may only ever see their own tenant_id, regardless of what (if
+// anything) they set here.
+message ListFindingsRequest {
+  // Exact match. THREAT_SEVERITY_UNSPECIFIED (default) matches any severity.
+  ThreatSeverity severity = 1;
+  string tenant_id = 2;
+  // Only findings last seen at or after this time. Unset matches everything.
+  google.protobuf.Timestamp since = 3;
+  // Exact match. FINDING_STATE_UNSPECIFIED (default) matches any state.
+  FindingState state = 4;
+  // <= 0 or > 200 is treated as the server default (50).
+  int32 limit = 5;
+}
+
+message ListFindingsResponse {
+  repeated Finding findings = 1;
+}
+
+message ResolveFindingRequest {
+  int64 id = 1;
+}
+
+message ResolveFindingResponse {
+  Finding finding = 1;
+}
+
 // ThreatDetectionService serves the background security-sentry's status and
 // findings. GetSentryStatus ships with #1640 (background detection loop);
-// *BadDestination* ships with #1641 (known-bad destination rule); the
-// findings/rule-config RPCs are added by later stories in the same umbrella
-// (#1642-#1643) — see docs/architecture/continuous-threat-detection.md.
+// *BadDestination* ships with #1641 (known-bad destination rule);
+// ListFindings/ResolveFinding ship with #1643 (findings delivery + triage);
+// rule-config RPCs remain unimplemented — see
+// docs/architecture/continuous-threat-detection.md.
 service ThreatDetectionService {
   // GetSentryStatus returns the detection engine's on/off state and the
   // health of every registered rule.
@@ -215,6 +245,32 @@ service ThreatDetectionService {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Remove an operator-added bad destination";
       description: "Removes a previously operator-added entry from the known-bad-destination list. Baseline entries cannot be removed.";
+      tags: "Security";
+    };
+  }
+
+  // ListFindings lists security findings, most recently seen first.
+  // Tenant-scoped: a non-admin caller only ever sees their own tenant_id.
+  rpc ListFindings(ListFindingsRequest) returns (ListFindingsResponse) {
+    option (google.api.http) = {
+      get: "/v1/security/findings"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "List security findings";
+      description: "Lists security findings with optional severity/tenant/since/state filters, most recently seen first. Non-admin callers only see their own tenant.";
+      tags: "Security";
+    };
+  }
+
+  // ResolveFinding transitions an open finding to resolved. Fails if the
+  // finding is already resolved or doesn't exist.
+  rpc ResolveFinding(ResolveFindingRequest) returns (ResolveFindingResponse) {
+    option (google.api.http) = {
+      post: "/v1/security/findings/{id}/resolve"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Resolve a security finding";
+      description: "Marks an open finding as resolved. Fails with FAILED_PRECONDITION if it's already resolved, NOT_FOUND if it doesn't exist.";
       tags: "Security";
     };
   }


### PR DESCRIPTION
Closes #1643

**Supersedes #1654.** Same squash-merge/stacked-PR artifact the rest of this umbrella hit (#1656, #1657, #1658): #1654's merge-base predates the individual squash-merges of #1639-#1642, so it showed CONFLICTING against \`main\` despite identical content. Same diff, rebased cleanly onto current \`main\` (which now has all four prior stories merged).

## What changed (unchanged from #1654's description)

- `internal/threatdetect/notifier.go` (new) — `WebhookNotifier`: async bounded-queue delivery worker, MEDIUM+ severity threshold, HMAC-SHA256 signing (same scheme + config keys as the existing alert-webhook relay), retry with backoff, records every attempt in `alert.DeliveryStore`. Deliberately bypasses vmalert/alertmanager — works on minimal BYOC hosts.
- `internal/threatdetect/{finding,store,mem_store}.go` — `ErrFindingNotFound` sentinel, `Get`/`List`/`Resolve` on both stores, `FindingReader` interface, `SetNotifier`.
- `proto/containarium/v1/threatdetection.proto` — `ListFindingsRequest/Response`, `ResolveFindingRequest/Response`, `ListFindings`/`ResolveFinding` RPCs.
- `internal/server/threatdetect_server.go` — RPC implementations, tenant-scoped RBAC on `ListFindings` (same pattern as `ContainerServer.ListContainers`).
- `internal/cmd/security_findings.go` (new) — `containarium security findings [--severity --tenant --since --state --limit]` / `security findings resolve <id>`.
- `internal/mcp/{security,client,backend,tools}.go` — MCP tool wrappers.

## Naming collision flagged (unchanged from #1654)

Pre-existing `containarium security-findings <username>` (scanner findings: ClamAV/pentest/ZAP) vs. this story's `security findings` (sentry findings) — confusingly similar, not resolved, flagged for a maintainer decision.

## Scope note: cloud shim (unchanged from #1654)

Out of scope for this OSS repo per the design doc. Filed as a tracked follow-up: `Containarium-cloud#1412`.

## Found and fixed along the way (unchanged from #1654)

A real deadlock in `notifier_test.go`'s `TestWebhookNotifier_DeadWebhookNeverBlocksNotify`: `httptest.Server.Close()` blocks until every in-flight handler returns, and a `defer close(block)` registered before `defer srv.Close()` runs after it (LIFO) — so a handler still parked on `<-block` deadlocked `Close()`. Fixed by reordering the defers; verified stable across repeated runs both with and without `-tags=integration`.

## Test evidence

Same tests as #1654 (all previously green on this exact diff, including the gosec G101 false-positive fix already folded in). Re-verified locally after the rebase:
```
go build ./...                                                    # clean
go vet ./...                                                       # clean
gofmt -l .                                                          # clean
go test ./internal/threatdetect/... ./internal/server/... \
  ./internal/cmd/... ./internal/mcp/... ./internal/config/... \
  ./internal/alert/... ./internal/gateway/...                       # ok
CONTAINARIUM_TEST_DSN=... go test -tags=integration ./internal/threatdetect/...  # ok
make proto                                                           # no drift beyond this PR's own .proto change
```
CI running on the pushed branch now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added security finding retrieval with filters for severity, tenant, timestamp, state, and result limits.
  * Added finding resolution by ID with validation and clear error handling.
  * Added command-line and MCP tool support for listing and resolving findings.
  * Added optional webhook notifications for medium-or-higher severity findings, including retries and signed payloads.
  * Added tenant scoping and security read/write authorization for finding operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->