### PR TITLE
ci: eBPF load path — build + real load/attach/traffic-evaluation lane

### DIFF
--- a/.github/workflows/ebpf-load.yml
+++ b/.github/workflows/ebpf-load.yml
@@ -1,0 +1,137 @@
+name: eBPF load path
+
+# Proves the compiled netpolicy eBPF object (internal/netbpf/netpolicy.bpf.o)
+# actually loads into a real kernel, actually attaches its TC hooks via
+# AttachTCX, and its attached program actually evaluates real traffic — not
+# just that it compiles. See docs/EBPF-CI-LOADING-LANE-DESIGN.md (#1663,
+# split from #1660, umbrella #1645) for the full design.
+#
+# release.yml already proves the OTHER half (`make build-bpf` succeeds in
+# CI); this lane exists because nothing anywhere proved the load/attach
+# half, and a verifier-rejected instruction or a broken AttachTCX call would
+# ship invisibly today.
+#
+# Deliberately NOT built on incus-create.yml's Incus/ZFS setup: AttachVeth
+# takes any real interface's ifindex, so this lane needs neither — a
+# throwaway veth pair + netns created directly on the bare runner is
+# sufficient. Coupling this to an unrelated Incus/ZFS dependency would make
+# every netbpf-only change wait on an image pull for no benefit, the same
+# reasoning incus-create.yml's own header gives for staying separate from
+# zfs-encryption.yml. That's also why this lane is fast (minutes, not
+# incus-create.yml's 45-minute budget).
+#
+# Runs as root (sudo) inside the ephemeral, secret-less runner VM this job
+# gets on a `pull_request` trigger (not `pull_request_target` — a fork's PR
+# never sees repo secrets or a write-capable GITHUB_TOKEN regardless of
+# what runs as root inside the VM). The kernel's own eBPF verifier is the
+# actual safety boundary for what a loaded program can do, not this
+# workflow's permission scoping — see the design doc's Security section.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'internal/netbpf/**'
+      - 'experimental/ebpf-phaseA/**'
+      - '.github/workflows/ebpf-load.yml'
+  # No `branches:` filter — a base filter leaves stacked PRs with no checks
+  # at all, which looks the same as checks not having started (#1215, same
+  # reasoning incus-create.yml documents).
+  pull_request:
+    paths:
+      - 'internal/netbpf/**'
+      - 'experimental/ebpf-phaseA/**'
+      - '.github/workflows/ebpf-load.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ebpf-load:
+    name: Load + attach the real eBPF network-policy object
+    runs-on: ubuntu-latest
+    # No image pull, no Incus — this is a compile + a few `ip` commands + a
+    # short Go test. Generous headroom over the expected ~1-2 minutes for a
+    # first-run apt-get on a cold cache.
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      # release.yml's already-proven recipe (see its "Compile eBPF
+      # network-policy object" step) — copied verbatim rather than shared
+      # via a composite action, since it's three lines and this is the only
+      # other place that needs it.
+      - name: Install eBPF toolchain
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y clang llvm libbpf-dev linux-libc-dev
+
+      - name: Compile the eBPF network-policy object
+        run: |
+          set -euo pipefail
+          make build-bpf
+          test -s internal/netbpf/netpolicy.bpf.o || {
+            echo "::error::make build-bpf reported success but netpolicy.bpf.o is missing or empty"
+            exit 1
+          }
+
+      # sudo -E env "PATH=$PATH" is incus-create.yml's own fix for #1614:
+      # plain `sudo go test` drops $PATH (no `go` binary found) and, if it
+      # DOES find go some other way, leaves $HOME pointing at the invoking
+      # user's dir while running as root — writing root-owned build-cache
+      # entries a later same-user step then can't read. Matching that exact
+      # invocation here avoids rediscovering the same failure mode.
+      #
+      # -v so a failure's own test log (not just the exit code) is visible
+      # in the CI log directly; -count=1 disables Go's test cache, which
+      # would be actively wrong here (a cached PASS from a previous kernel
+      # state proves nothing about this run's kernel).
+      - name: Load, attach, and evaluate real traffic against the object
+        working-directory: internal/netbpf
+        run: |
+          set -euo pipefail
+          sudo -E env "PATH=$PATH" go test -tags=ebpf_load -v -count=1 -timeout 5m . | tee ebpf-load-test.log
+
+      # A skip here means the build tag or the environment silently didn't
+      # engage — a lane whose entire purpose is proving real-kernel behavior
+      # must fail loud on that, not report green (same #1234 reasoning
+      # incus-create.yml's own "Assert nothing was skipped" step documents).
+      - name: Assert nothing was skipped
+        if: always()
+        run: |
+          set -euo pipefail
+          test -f internal/netbpf/ebpf-load-test.log || {
+            echo "::error::no test log — the load/attach test step never produced output"
+            exit 1
+          }
+          if grep -q -- "--- SKIP" internal/netbpf/ebpf-load-test.log; then
+            echo "::error::an ebpf_load test SKIPPED on a runner where it should have run for real"
+            grep -- "--- SKIP" internal/netbpf/ebpf-load-test.log
+            exit 1
+          fi
+          echo "No skips — the load/attach/evaluate path actually ran."
+
+      - name: Collect diagnostics on failure
+        if: failure()
+        run: |
+          echo "--- kernel version ---"
+          uname -a
+          echo "--- ip link (detail) ---"
+          sudo ip -d link show || true
+          echo "--- ip netns list ---"
+          sudo ip netns list || true
+          echo "--- dmesg tail ---"
+          sudo dmesg | tail -80 || true
+          echo "--- bpftool prog list (if available) ---"
+          sudo bpftool prog list 2>/dev/null || echo "bpftool not installed"

--- a/internal/netbpf/ebpf_load_test.go
+++ b/internal/netbpf/ebpf_load_test.go
@@ -1,0 +1,281 @@
+//go:build ebpf_load
+
+// Real-kernel coverage for the netpolicy eBPF object (#1663). Every other
+// test in this package runs against a mocked/stubbed BPF layer or doesn't
+// touch the kernel at all — this is the one place that proves the compiled
+// object (built by `make build-bpf`) actually passes the kernel verifier,
+// actually attaches its TC hooks via AttachTCX, and its attached program
+// actually evaluates real packets, not just that Load/AttachVeth returned no
+// error. Gated behind -tags=ebpf_load (mirrors this repo's -tags=incus /
+// -tags=integration convention) because it needs CAP_BPF/CAP_NET_ADMIN, a
+// compiled netpolicy.bpf.o, and a kernel that supports AttachTCX (≥6.6) —
+// none of which a normal dev laptop `go test ./...` has.
+//
+// Run via .github/workflows/ebpf-load.yml, which builds the object and
+// creates the veth pair + netns this file expects before invoking:
+//
+//	sudo -E env "PATH=$PATH" go test -tags=ebpf_load -v ./internal/netbpf/...
+//
+// TestMain creates the veth pair and netns itself (see setupEbpfLoadEnv)
+// rather than relying solely on a workflow shell step, so the whole
+// environment this file needs is defined in one place, in Go, next to the
+// tests that consume it — easier to read and debug from a CI log than a
+// shell/Go handoff for interface names and namespaces would be.
+package netbpf
+
+import (
+	"fmt"
+	"net/netip"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// Test topology: a throwaway veth pair, one end (ebpfLoadHostVeth) left in
+// the host's default network namespace — this is the side the loader
+// attaches to, playing the role of a container's HOST veth in production.
+// The other end (ebpfLoadPeerVeth) is moved into its own netns
+// (ebpfLoadNetns) and given a peer IP — playing the role of the container
+// itself. Traffic generated from inside the netns arrives as TC_INGRESS on
+// the host-side veth, which is exactly the direction AttachVeth's doc
+// comment describes ("TC_INGRESS ... the sender side of every flow").
+const (
+	ebpfLoadHostVeth = "ebpfload-h"
+	ebpfLoadPeerVeth = "ebpfload-p"
+	ebpfLoadNetns    = "ebpfload-ns"
+	ebpfLoadHostAddr = "10.250.111.1"
+	ebpfLoadPeerAddr = "10.250.111.2"
+	ebpfLoadPrefix   = "/30"
+	ebpfLoadTenant   = uint32(1)
+	ebpfLoadObjPath  = "netpolicy.bpf.o" // matches BPF_OBJ's basename; Makefile writes it under internal/netbpf, i.e. this package's own directory
+)
+
+// TestMain creates the shared kernel-level fixtures once for every
+// -tags=ebpf_load test in this package, and tears them down afterward. A
+// setup failure here (no CAP_NET_ADMIN, `ip` missing, etc.) fails the whole
+// run loudly rather than letting individual tests report confusing,
+// unrelated errors.
+func TestMain(m *testing.M) {
+	if err := setupEbpfLoadEnv(); err != nil {
+		fmt.Fprintf(os.Stderr, "ebpf_load: setup failed: %v\n", err)
+		// Best-effort cleanup in case setup got partway through before
+		// failing (e.g. netns created, veth add failed).
+		teardownEbpfLoadEnv()
+		os.Exit(1)
+	}
+	code := m.Run()
+	teardownEbpfLoadEnv()
+	os.Exit(code)
+}
+
+func setupEbpfLoadEnv() error {
+	if _, err := os.Stat(ebpfLoadObjPath); err != nil {
+		return fmt.Errorf("%s not found — run `make build-bpf` before this test (that's the workflow's job): %w", ebpfLoadObjPath, err)
+	}
+
+	steps := [][]string{
+		{"ip", "netns", "add", ebpfLoadNetns},
+		{"ip", "link", "add", ebpfLoadHostVeth, "type", "veth", "peer", "name", ebpfLoadPeerVeth},
+		{"ip", "link", "set", ebpfLoadPeerVeth, "netns", ebpfLoadNetns},
+		{"ip", "addr", "add", ebpfLoadHostAddr + ebpfLoadPrefix, "dev", ebpfLoadHostVeth},
+		{"ip", "link", "set", ebpfLoadHostVeth, "up"},
+		{"ip", "link", "set", "lo", "up"}, // host lo; usually already up, asserted rather than assumed
+		{"ip", "netns", "exec", ebpfLoadNetns, "ip", "addr", "add", ebpfLoadPeerAddr + ebpfLoadPrefix, "dev", ebpfLoadPeerVeth},
+		{"ip", "netns", "exec", ebpfLoadNetns, "ip", "link", "set", ebpfLoadPeerVeth, "up"},
+		{"ip", "netns", "exec", ebpfLoadNetns, "ip", "link", "set", "lo", "up"},
+	}
+	for _, args := range steps {
+		if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); /* #nosec G204 -- fixed argv, no user input */ err != nil {
+			return fmt.Errorf("%v: %w\n%s", args, err, out)
+		}
+	}
+	return nil
+}
+
+func teardownEbpfLoadEnv() {
+	// Deleting the host-side end of a veth pair removes both ends; deleting
+	// the netns cleans up anything still inside it. Both best-effort — a
+	// leaked interface/netns on a GitHub-hosted ephemeral runner doesn't
+	// matter (the VM is destroyed at job end), this is hygiene for anyone
+	// re-running the package interactively on a real machine.
+	_ = exec.Command("ip", "link", "delete", ebpfLoadHostVeth).Run() // #nosec G204 -- fixed argv
+	_ = exec.Command("ip", "netns", "delete", ebpfLoadNetns).Run()   // #nosec G204 -- fixed argv
+}
+
+// TestLoad_RealObjectPassesVerifier proves the object make build-bpf just
+// compiled is accepted by the real kernel verifier — the failure mode a
+// verifier-rejected instruction or a map/program mismatch takes today
+// (silently, since go build/go test never load the real object) closes
+// here instead.
+func TestLoad_RealObjectPassesVerifier(t *testing.T) {
+	loader, err := Load(ebpfLoadObjPath)
+	if err != nil {
+		t.Fatalf("Load(%q): %v", ebpfLoadObjPath, err)
+	}
+	defer func() { _ = loader.Close() }()
+
+	if !loader.hasEgressProgram() {
+		t.Log("object has no egress program (pre-#631 build) — ingress-only coverage, not a failure")
+	}
+}
+
+// TestAttachVeth_RealInterface proves AttachTCX actually succeeds on this
+// runner's kernel — the design doc's flagged, unverified-until-now
+// assumption that AttachTCX's documented "kernel >= 6.6" requirement holds
+// on ubuntu-latest.
+func TestAttachVeth_RealInterface(t *testing.T) {
+	loader, err := Load(ebpfLoadObjPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	defer func() { _ = loader.Close() }()
+
+	ifindex, err := VethIndex(ebpfLoadHostVeth)
+	if err != nil {
+		t.Fatalf("VethIndex(%q): %v", ebpfLoadHostVeth, err)
+	}
+
+	if err := loader.AttachVeth(ifindex); err != nil {
+		t.Fatalf("AttachVeth(%d): %v", ifindex, err)
+	}
+	// Idempotent per the doc comment — attaching twice must not error or
+	// create a second link.
+	if err := loader.AttachVeth(ifindex); err != nil {
+		t.Fatalf("second AttachVeth(%d) (idempotency): %v", ifindex, err)
+	}
+
+	if err := loader.AttachVethEgress(ifindex); err != nil {
+		t.Fatalf("AttachVethEgress(%d): %v", ifindex, err)
+	}
+}
+
+// TestAttachedProgram_EvaluatesRealTraffic is the actual point of this
+// lane: not that AttachTCX returned nil, but that the attached program
+// evaluates real packets. Installs a policy (tenant + a deny rule for the
+// peer's address), sends real ICMP traffic from the peer netns across the
+// veth pair, and asserts the seen/would-deny counters — "the validator's
+// success signal" per Loader.Stats's doc comment, the same signal
+// cmd/ebpf-phaseA's manual validator watches — actually moved.
+func TestAttachedProgram_EvaluatesRealTraffic(t *testing.T) {
+	loader, err := Load(ebpfLoadObjPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	defer func() { _ = loader.Close() }()
+
+	ifindex, err := VethIndex(ebpfLoadHostVeth)
+	if err != nil {
+		t.Fatalf("VethIndex(%q): %v", ebpfLoadHostVeth, err)
+	}
+
+	if err := loader.SetVethPolicy(ifindex, PolicyConfig{TenantID: ebpfLoadTenant, Mode: ModeLogOnly}); err != nil {
+		t.Fatalf("SetVethPolicy: %v", err)
+	}
+
+	if loader.HasDenyRules() {
+		peer, err := netip.ParseAddr(ebpfLoadPeerAddr)
+		if err != nil {
+			t.Fatalf("parse peer addr: %v", err)
+		}
+		if err := loader.AddDeny(DenyEntry{
+			PrefixLen: 32 + 32, // exact tenant match + a /32 host route, mirroring EgressEntry's PrefixLen convention
+			TenantID:  ebpfLoadTenant,
+			Addr:      peer.As4(),
+		}); err != nil {
+			t.Fatalf("AddDeny: %v", err)
+		}
+	} else {
+		t.Log("object has no deny_cidr map (pre-#660 build) — asserting seen only, not would_deny")
+	}
+
+	if err := loader.AttachVeth(ifindex); err != nil {
+		t.Fatalf("AttachVeth: %v", err)
+	}
+
+	seenBefore, denyBefore, err := loader.Stats()
+	if err != nil {
+		t.Fatalf("Stats (before): %v", err)
+	}
+
+	// Real traffic: ping from the peer netns to the host-side address. That
+	// direction (peer -> host) is what arrives as TC_INGRESS on the
+	// host-side veth, which is what's attached above.
+	out, err := exec.Command("ip", "netns", "exec", ebpfLoadNetns, // #nosec G204 -- fixed argv
+		"ping", "-c", "3", "-i", "0.2", "-W", "1", ebpfLoadHostAddr).CombinedOutput()
+	if err != nil {
+		// ping itself may report loss (irrelevant — a log-only/deny policy
+		// doesn't actually drop, and ICMP isn't guaranteed anyway); what
+		// matters below is whether the KERNEL PROGRAM saw the packets, so a
+		// nonzero ping exit code alone isn't fatal. Still log the output for
+		// a failing run's diagnostics.
+		t.Logf("ping exit: %v\n%s", err, out)
+	}
+
+	// Give the map update a moment to be observable (no synchronization
+	// primitive between "packet processed" and "counter read" other than
+	// the ping call itself having returned, and TC processing is
+	// effectively synchronous with packet delivery, but poll briefly rather
+	// than assume zero latency).
+	var seenAfter, denyAfter uint64
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		seenAfter, denyAfter, err = loader.Stats()
+		if err != nil {
+			t.Fatalf("Stats (after): %v", err)
+		}
+		if seenAfter > seenBefore {
+			break
+		}
+		if time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	if seenAfter <= seenBefore {
+		t.Fatalf("seen counter did not increase after sending real traffic across the attached veth: before=%d after=%d — "+
+			"the program is attached but did not evaluate real packets", seenBefore, seenAfter)
+	}
+	t.Logf("seen: %d -> %d", seenBefore, seenAfter)
+
+	if loader.HasDenyRules() {
+		if denyAfter <= denyBefore {
+			t.Fatalf("would_deny counter did not increase for traffic to a denied destination: before=%d after=%d", denyBefore, denyAfter)
+		}
+		t.Logf("would_deny: %d -> %d", denyBefore, denyAfter)
+	}
+}
+
+// TestDetachVeth_RemovesLink proves the cleanup path the daemon itself
+// relies on when a container stops: after Detach, a fresh attach to the
+// same ifindex must succeed again (a leaked/stuck link would make the
+// second AttachVeth fail or silently no-op against the wrong program).
+func TestDetachVeth_RemovesLink(t *testing.T) {
+	loader, err := Load(ebpfLoadObjPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	defer func() { _ = loader.Close() }()
+
+	ifindex, err := VethIndex(ebpfLoadHostVeth)
+	if err != nil {
+		t.Fatalf("VethIndex(%q): %v", ebpfLoadHostVeth, err)
+	}
+
+	if err := loader.AttachVeth(ifindex); err != nil {
+		t.Fatalf("AttachVeth: %v", err)
+	}
+	if err := loader.DetachVeth(ifindex); err != nil {
+		t.Fatalf("DetachVeth: %v", err)
+	}
+
+	// Re-attach: only succeeds cleanly if Detach actually released the TCX
+	// link rather than merely forgetting it in the Go-side map.
+	if err := loader.AttachVeth(ifindex); err != nil {
+		t.Fatalf("AttachVeth after Detach (link not actually released?): %v", err)
+	}
+	if err := loader.DetachVeth(ifindex); err != nil {
+		t.Fatalf("final DetachVeth: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #1663

Implements the accepted design in `docs/EBPF-CI-LOADING-LANE-DESIGN.md` (#1665). This is the CI-infra half split out of #1660 — the actual gap that left the threat-detection fence-probe rules (#1642) with only fake-based test coverage: nothing anywhere loaded the real `netpolicy.bpf.o` object into a real kernel. `release.yml` already proves the *compile* half; this proves the *load, attach, and evaluate real traffic* half.

## What this cannot prove locally

This dev environment has no clang toolchain and no real kernel/device access (confirmed repeatedly during #1660/#1663's investigation and design). I could not run `make build-bpf`, could not load the object, could not create/attach to a veth pair, and could not execute the new test locally. **CI on this pushed branch is the actual proof this lane works** — I'll be watching it and iterating on real failures, not claiming success from local checks alone. What I *did* verify locally: the new test file builds and vets clean with `-tags=ebpf_load` (it's excluded from the default `go test ./...` lane, confirmed), `golangci-lint`/`gosec` are clean on it, the workflow YAML is `actionlint`-clean, and every `PolicyConfig`/`DenyEntry`/`PrefixLen` value in the test matches the exact construction pattern production code (`CompileDeny` in `internal/netbpf/policymap.go`) already uses — not guessed.

## What's new

- **`internal/netbpf/ebpf_load_test.go`** (`-tags=ebpf_load`, mirrors this repo's `-tags=incus`/`-tags=integration` convention):
  - `TestMain` creates a throwaway veth pair + a netns for one end (modeling container-side vs. host-side, the same topology `AttachVeth`'s own doc comment describes), and tears both down after.
  - `TestLoad_RealObjectPassesVerifier` — the object `make build-bpf` just compiled actually passes the kernel verifier.
  - `TestAttachVeth_RealInterface` — `AttachTCX` actually succeeds on this runner's kernel, confirming the design doc's flagged (until now, unverified) "kernel ≥ 6.6" assumption for `ubuntu-latest`. Also checks idempotency and `AttachVethEgress`.
  - `TestAttachedProgram_EvaluatesRealTraffic` — the actual point of this lane, per the design doc: installs a policy + a deny rule for the peer's address, sends real ICMP traffic across the veth pair, and asserts the `seen`/`would_deny` counters (`Loader.Stats()` — "the validator's success signal", the same signal `cmd/ebpf-phaseA`'s manual validator watches) actually moved. Not just "attach didn't error."
  - `TestDetachVeth_RemovesLink` — the cleanup path the daemon relies on when a container stops; a re-attach after detach must succeed cleanly.
- **`.github/workflows/ebpf-load.yml`** — installs the toolchain (`release.yml`'s proven recipe, copied), `make build-bpf`, then `sudo -E env "PATH=$PATH" go test -tags=ebpf_load` (the exact invocation `incus-create.yml` uses, for the same #1614 reason: plain `sudo go test` drops `$PATH` and leaves root-owned build-cache entries a later step can't read). Follows `incus-create.yml`'s conventions: `permissions: contents: read`, no `branches:` filter on `pull_request` (stacked PRs need checks), a `concurrency` group, an "assert nothing was skipped" guard, a diagnostics-on-failure step.

## Deviation from the design doc

The design doc's Components section describes the veth pair as created by a workflow shell step. This implementation creates it (plus a netns, for a more realistic container-side/host-side split) inside the Go test's `TestMain` instead — one source of truth for the whole test environment, easier to read and debug from a CI log than a shell/Go handoff for interface names would be. The workflow's own steps are otherwise as designed: toolchain → build → run the test → assert → diagnose-on-failure.

## Local verification

```
go build ./...                                                    # clean
go vet ./...                                                       # clean
go build -tags=ebpf_load ./...                                     # clean
go vet -tags=ebpf_load ./internal/netbpf/...                       # clean
gofmt -l .                                                          # clean
golangci-lint run --build-tags=ebpf_load ./internal/netbpf/...     # 0 issues
gosec -tests -tags ebpf_load ./internal/netbpf/...                 # 0 issues
actionlint .github/workflows/ebpf-load.yml                          # clean
go test ./internal/netbpf/...                                      # ok (unaffected, tag not passed)
```

CI running on the pushed branch now — watching for the new `ebpf-load` job specifically, since that's the one that actually proves this works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added automated kernel-level validation for network policy enforcement.
  - Verifies traffic evaluation, policy counters, attachment behavior, and safe detach/re-attach operations.
  - Confirms setup and cleanup across isolated network environments.

- **Chores**
  - Added continuous integration coverage that builds and exercises the networking policy component on a real kernel.
  - Failed or skipped validation now produces diagnostic information to simplify troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->