### PR TITLE
fix(terraform): trust the incus bridge for PROXY protocol automatically

### DIFF
--- a/terraform/modules/containarium/spot-instance.tf
+++ b/terraform/modules/containarium/spot-instance.tf
@@ -77,6 +77,28 @@ resource "google_compute_resource_policy" "incus_data_snapshot_policy" {
 
 locals {
   spot_vm_name = local.use_sentinel && var.spot_vm_name_suffix != "" ? "${var.instance_name}${var.spot_vm_name_suffix}" : var.instance_name
+
+  # The incus bridge gateway. startup-spot.sh creates incusbr0 at a fixed
+  # ipv4.address=10.0.3.1/24, so this is a module constant, not a guess.
+  incus_bridge_gateway = "10.0.3.1/32"
+
+  # Caddy runs INSIDE the containarium-core-caddy LXC, so PROXY v2 frames from
+  # the sentinel cross the bridge and arrive with a source of 10.0.3.1 — never
+  # the sentinel's own address. A trust list naming only the sentinel (or its
+  # whole subnet) therefore matches nothing: Caddy treats every frame as
+  # untrusted, discards it, and logs the bridge as the client.
+  #
+  # That failure is silent — no error, well-formed logs, just the wrong IP in
+  # them — and it defeats anything keyed on client IP. Both of our production
+  # primaries shipped this way; one logged 1037 of 1038 requests as 10.0.3.1
+  # before it was noticed (#1668).
+  #
+  # So append the gateway rather than relying on operators to know about the
+  # LXC hop. /32 not /24: trusting the whole bridge would let any container on
+  # it assert an arbitrary client_ip via its own PROXY header, trading a
+  # logging bug for a spoofing hole. distinct() keeps it idempotent when an
+  # operator has already listed it.
+  proxy_protocol_trusted_effective = var.enable_proxy_protocol ? distinct(concat(var.proxy_protocol_trusted_cidrs, [local.incus_bridge_gateway])) : var.proxy_protocol_trusted_cidrs
 }
 
 resource "google_compute_instance" "jump_server_spot" {
@@ -154,7 +176,7 @@ resource "google_compute_instance" "jump_server_spot" {
       enable_app_hosting           = var.enable_app_hosting
       base_domain                  = var.base_domain
       enable_proxy_protocol        = var.enable_proxy_protocol
-      proxy_protocol_trusted_cidrs = var.proxy_protocol_trusted_cidrs
+      proxy_protocol_trusted_cidrs = local.proxy_protocol_trusted_effective
       zfs_encryption_keyfile       = var.zfs_encryption_keyfile
     })
   }

--- a/terraform/modules/containarium/variables.tf
+++ b/terraform/modules/containarium/variables.tf
@@ -444,7 +444,7 @@ variable "enable_proxy_protocol" {
 }
 
 variable "proxy_protocol_trusted_cidrs" {
-  description = "CIDR blocks the backend's Caddy will trust as sources of PROXY v2 frames. Typically the sentinel's internal IP plus loopback. Required when enable_proxy_protocol=true. Wildcard 0.0.0.0/0 is rejected at startup to prevent IP spoofing."
+  description = "Additional CIDR blocks the backend's Caddy will trust as sources of PROXY v2 frames — typically the sentinel's internal IP plus loopback. The incus bridge gateway (10.0.3.1/32) is appended automatically when enable_proxy_protocol=true and does NOT need listing here: Caddy runs inside the core-caddy LXC, so frames cross the bridge and arrive from 10.0.3.1 rather than the sentinel's own address, and a list without it silently drops every client IP. Wildcard 0.0.0.0/0 is rejected at startup to prevent IP spoofing."
   type        = list(string)
   default     = []
 }


### PR DESCRIPTION
Closes #1668

## The bug is in the guidance

The module told operators:

> `proxy_protocol_trusted_cidrs` — *"Typically the sentinel's internal IP plus loopback."*

Following that produces a deployment where **every client IP is silently discarded.**

Caddy runs inside the `containarium-core-caddy` LXC, so PROXY v2 frames from the sentinel cross the incus bridge and reach Caddy with a source of `10.0.3.1` — never the sentinel's own address. A trust list naming only the sentinel matches nothing: Caddy treats every frame as untrusted, discards it, and falls back to the connection's source.

Nothing errors. The listener wrapper is configured, frames are sent, the logs are well-formed — they just name the bridge instead of the visitor.

**Both our production primaries shipped this way.** One logged **1037 of 1038** requests as `client_ip=10.0.3.1` over 48h before anyone noticed.

The tell that this is a *wrong network*, not a *too-narrow CIDR*: asia already trusted the sentinel's entire `/16` and still failed.

## Why append rather than document

`startup-spot.sh` creates `incusbr0` at a hardcoded `ipv4.address=10.0.3.1/24` (lines 462, 530). The gateway is therefore a **module constant** — nothing to derive, nothing to ask the operator for. So the module now appends it whenever `enable_proxy_protocol = true`:

```hcl
proxy_protocol_trusted_effective = var.enable_proxy_protocol
  ? distinct(concat(var.proxy_protocol_trusted_cidrs, [local.incus_bridge_gateway]))
  : var.proxy_protocol_trusted_cidrs
```

Documenting the requirement would have left the footgun in place for the next operator. Removing it seemed better than warning about it.

`/32`, not the `10.0.3.0/24` bridge subnet — trusting the whole bridge would let **any container on it assert an arbitrary `client_ip`** via its own PROXY header, trading a logging bug for a spoofing hole. `distinct()` keeps it idempotent for operators who already list it.

The variable description now states the gateway is appended automatically, instead of describing the *logical* source of the frames as though it were the *observed* one.

## Verification

`terraform validate` passes. Logic checked with `terraform console` across four cases, including both primaries' real values:

| `enable` | input | result |
|---|---|---|
| true | `["10.140.0.0/16"]` (asia's real value) | `["10.140.0.0/16","10.0.3.1/32"]` |
| true | `["10.130.0.13/32","127.0.0.0/8","::1/128"]` (usw1's real value) | + `10.0.3.1/32` |
| true | already contains the gateway | unchanged — no duplicate |
| false | anything | unchanged — feature off, no injection |

Behaviour was confirmed live before writing this: adding the gateway by hand on both primaries changed a marked request from a known address from `client_ip: 10.0.3.1` to its real IP.

## Blast radius

Existing deployments with `enable_proxy_protocol = false` are unaffected — the local passes the variable through untouched.

Deployments with it **true** will see the gateway added on next apply, which rewrites `override.conf` and restarts the daemon. That is the intended fix, but it is a restart, so it should land during a normal maintenance window rather than being applied casually.

## Related

- Containarium-cloud#1415 — the live fix on both primaries (already applied and verified)
- FootprintAI/kafeido-infra#47 — pins the value for asia so it survives an apply; **becomes redundant once this merges**, since the module will supply the gateway itself

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PROXY protocol handling for spot instances by automatically trusting traffic from the Incus bridge gateway when enabled.
  * Preserved existing configured trusted CIDRs while adding the required bridge gateway address.

* **Documentation**
  * Clarified the automatic bridge gateway trust behavior in the PROXY protocol configuration documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->