### PR TITLE
fix(app-hosting): give the ACME issuer email a config surface (#1616)

### DIFF
--- a/docs/TLS-PROVISIONING.md
+++ b/docs/TLS-PROVISIONING.md
@@ -44,8 +44,8 @@ Caddy uses an automation policy to manage certificates. When a domain is added, 
 {
   "subjects": ["myapp.example.com", "other.example.com"],
   "issuers": [
-    {"module": "acme"},
-    {"module": "acme", "ca": "https://acme.zerossl.com/v2/DV90"}
+    {"module": "acme", "email": "ops@example.com"},
+    {"module": "acme", "ca": "https://acme.zerossl.com/v2/DV90", "email": "ops@example.com"}
   ]
 }
 ```
@@ -53,6 +53,25 @@ Caddy uses an automation policy to manage certificates. When a domain is added, 
 This configures:
 - **Let's Encrypt** as the primary certificate authority
 - **ZeroSSL** as a fallback CA
+
+### ACME contact address
+
+Set `CONTAINARIUM_ACME_EMAIL` to an address the operators read. It is applied
+to every issuer, and it is **required to get a fallback CA at all**:
+
+- **ZeroSSL refuses ACME account registration without a contact address**
+  (`your email address is required to use ZeroSSL's ACME endpoint`). With no
+  email configured, the daemon emits the Let's Encrypt issuer *only* — a
+  ZeroSSL issuer that cannot register is worse than none, because the policy
+  looks like it has redundancy while every issuance pays a guaranteed-failed
+  round trip.
+- Both CAs mail certificate-expiry warnings to this address. Without it a
+  stalled renewal is silent until the certificate actually expires.
+
+The daemon logs a startup warning when it is unset. Existing hosts are
+repaired in place: the TLS reconciler writes the address onto issuers of
+policies that predate the setting, so it takes effect without recreating
+policies. An address set by hand through Caddy's admin API is never blanked.
 
 ## Certificate Issuance Process
 
@@ -138,9 +157,10 @@ that serves each node at a per-region hostname (`region-a.example.com`,
    repeatable `--public-base-domain` flag (in addition to `--base-domain`);
    each gets a route to the daemon's REST endpoint (#213).
 2. **Enable DNS-01.** Set `CONTAINARIUM_ACME_DNS_PROVIDER=cloudflare` (plus the
-   provider token, e.g. `CF_API_TOKEN`). The daemon builds `core-caddy` with the
-   matching `caddy-dns` module and configures the ACME/ZeroSSL issuers to solve
-   DNS-01 (#378).
+   provider token, e.g. `CF_API_TOKEN`), and `CONTAINARIUM_ACME_EMAIL` so the
+   ZeroSSL fallback issuer can register at all. The daemon builds `core-caddy`
+   with the matching `caddy-dns` module and configures the ACME/ZeroSSL issuers
+   to solve DNS-01 (#378).
 3. **Wildcard is auto-provisioned.** With DNS-01 configured, the daemon adds a
    single `*.<base-domain>` wildcard subject to TLS automation at edge startup
    (and re-adds it after a Caddy reload). One DNS-01 issuance then covers every

--- a/internal/app/caddy_dns01_test.go
+++ b/internal/app/caddy_dns01_test.go
@@ -7,23 +7,45 @@ import (
 )
 
 // TestIssuersFor_NoDNS_MatchesLegacyDefault locks in that, without a DNS
-// challenge, the emitted issuers JSON is byte-identical to the pre-#378
-// default (acme + zerossl, no `challenges` field) — so existing HTTP-01
-// deployments are unaffected.
+// challenge, the emitted issuers JSON carries no `challenges` field — so
+// existing HTTP-01 deployments are unaffected by #378.
+//
+// The issuer *set* now depends on CONTAINARIUM_ACME_EMAIL. ZeroSSL refuses
+// ACME registration without a contact address, so emitting it unconfigured
+// wrote a fallback issuer that could never obtain a certificate; #1616 emits
+// only the issuer that can work instead. Both branches are pinned here.
 func TestIssuersFor_NoDNS_MatchesLegacyDefault(t *testing.T) {
-	got, err := json.Marshal(issuersFor(nil))
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := `[{"module":"acme"},{"module":"acme","ca":"https://acme.zerossl.com/v2/DV90"}]`
-	if string(got) != want {
-		t.Errorf("no-DNS issuers changed shape:\n got: %s\nwant: %s", got, want)
-	}
+	t.Run("with an email → both CAs, each carrying it", func(t *testing.T) {
+		t.Setenv("CONTAINARIUM_ACME_EMAIL", "ops@example.com")
+		got, err := json.Marshal(issuersFor(nil))
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := `[{"module":"acme","email":"ops@example.com"},` +
+			`{"module":"acme","ca":"https://acme.zerossl.com/v2/DV90","email":"ops@example.com"}]`
+		if string(got) != want {
+			t.Errorf("no-DNS issuers changed shape:\n got: %s\nwant: %s", got, want)
+		}
+	})
+
+	t.Run("without an email → Let's Encrypt only", func(t *testing.T) {
+		t.Setenv("CONTAINARIUM_ACME_EMAIL", "")
+		got, err := json.Marshal(issuersFor(nil))
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := `[{"module":"acme"}]`
+		if string(got) != want {
+			t.Errorf("no-DNS issuers changed shape:\n got: %s\nwant: %s", got, want)
+		}
+	})
 }
 
 // TestIssuersFor_DNS_AttachesChallengeToBoth verifies the DNS-01 challenge
 // block lands on both the ACME and ZeroSSL issuers.
 func TestIssuersFor_DNS_AttachesChallengeToBoth(t *testing.T) {
+	// Both issuers only exist when an email is configured (#1616).
+	t.Setenv("CONTAINARIUM_ACME_EMAIL", "ops@example.com")
 	dns := &CaddyACMEChallenges{DNS: &CaddyDNSChallenge{Provider: map[string]interface{}{
 		"name": "cloudflare", "api_token": "{env.CF_API_TOKEN}",
 	}}}

--- a/internal/app/caddy_issuer_email_test.go
+++ b/internal/app/caddy_issuer_email_test.go
@@ -1,0 +1,210 @@
+package app
+
+import (
+	"testing"
+)
+
+// #1616: CaddyTLSIssuer.Email was declared but nothing could set it — no env
+// var, no flag, nothing in the tree. Because ZeroSSL refuses ACME account
+// registration without a contact address, the second issuer on every policy
+// was permanently dead:
+//
+//	"could not get certificate from issuer","issuer":"acme.zerossl.com-v2-DV90",
+//	"error":"account pre-registration callback: your email address is required"
+//
+// Corroborated on both production primaries: the Caddy certificate store held
+// only a Let's Encrypt account directory — no ZeroSSL account had ever been
+// created anywhere. So every host ran with exactly one working issuer and a
+// fallback that looked configured and could not function.
+//
+// Missing contact also means no expiry warnings from either CA, which is one
+// of the few external signals that would have surfaced the stalled renewals
+// behind #1068 and the cloud-side ACME issues.
+
+func TestACMEEmailFromEnv_ReadsTheVariable(t *testing.T) {
+	t.Setenv("CONTAINARIUM_ACME_EMAIL", "ops@example.com")
+	if got := ACMEEmailFromEnv(); got != "ops@example.com" {
+		t.Errorf("ACMEEmailFromEnv() = %q, want ops@example.com", got)
+	}
+}
+
+func TestACMEEmailFromEnv_TrimsAndTolerAtesUnset(t *testing.T) {
+	t.Setenv("CONTAINARIUM_ACME_EMAIL", "   ops@example.com  ")
+	if got := ACMEEmailFromEnv(); got != "ops@example.com" {
+		t.Errorf("whitespace not trimmed: %q", got)
+	}
+	t.Setenv("CONTAINARIUM_ACME_EMAIL", "")
+	if got := ACMEEmailFromEnv(); got != "" {
+		t.Errorf("unset should yield empty, got %q", got)
+	}
+}
+
+// With an email configured, both CAs are usable and both must carry it —
+// ZeroSSL because it refuses to register without one, Let's Encrypt because
+// that is where expiry warnings are sent.
+func TestIssuersFor_AppliesEmailToEveryIssuer(t *testing.T) {
+	t.Setenv("CONTAINARIUM_ACME_EMAIL", "ops@example.com")
+
+	issuers := issuersFor(nil)
+	if len(issuers) != 2 {
+		t.Fatalf("want 2 issuers when an email is configured, got %d", len(issuers))
+	}
+	for i, is := range issuers {
+		if is.Email != "ops@example.com" {
+			t.Errorf("issuer %d (%s) has email %q, want ops@example.com", i, is.CA, is.Email)
+		}
+	}
+}
+
+// THE fix for the dead fallback: with no email, ZeroSSL cannot register, so
+// emitting it buys a guaranteed-failed round trip and a log line on every
+// issuance. Emit only the issuer that can actually work.
+func TestIssuersFor_OmitsZeroSSLWithoutAnEmail(t *testing.T) {
+	t.Setenv("CONTAINARIUM_ACME_EMAIL", "")
+
+	issuers := issuersFor(nil)
+	for _, is := range issuers {
+		if is.CA == zeroSSLDirectory {
+			t.Fatalf("ZeroSSL emitted with no email — it cannot register, so every " +
+				"issuance pays a failed attempt for an issuer that can never succeed (#1616)")
+		}
+	}
+	if len(issuers) != 1 {
+		t.Errorf("want just the Let's Encrypt issuer, got %d", len(issuers))
+	}
+}
+
+// The DNS-01 wiring must survive the email change: issuers still need their
+// challenge config, or wildcard subjects silently never issue (#1066).
+func TestIssuersFor_StillAttachesDNSChallenge(t *testing.T) {
+	t.Setenv("CONTAINARIUM_ACME_EMAIL", "ops@example.com")
+
+	for i, is := range issuersFor(testDNSChallenge()) {
+		if is.Challenges == nil || is.Challenges.DNS == nil {
+			t.Errorf("issuer %d lost its DNS-01 challenge config", i)
+		}
+	}
+}
+
+// Existing hosts already have policies, and ProvisionTLS/EnsureTLSSubjects
+// only append subjects — issuers are left alone unless something repairs
+// them. Without this, configuring the email would fix nothing on any host
+// that is already running, which is every host we have.
+func TestEnsureIssuerEmail_RepairsAPolicyMissingIt(t *testing.T) {
+	t.Setenv("CONTAINARIUM_ACME_EMAIL", "ops@example.com")
+	p := NewProxyManager("http://127.0.0.1:1", "example.com")
+
+	policy := CaddyTLSAutomationPolicy{
+		Subjects: []string{"app.example.com"},
+		Issuers:  []CaddyTLSIssuer{{Module: "acme"}, {Module: "acme", CA: zeroSSLDirectory}},
+	}
+
+	if !p.ensureIssuerEmail(&policy) {
+		t.Fatal("expected a repair when issuers carry no email")
+	}
+	for i, is := range policy.Issuers {
+		if is.Email != "ops@example.com" {
+			t.Errorf("issuer %d still has email %q after repair", i, is.Email)
+		}
+	}
+}
+
+// Runs on every reconcile tick, so a no-change tick must write nothing.
+func TestEnsureIssuerEmail_NoOpWhenAlreadySet(t *testing.T) {
+	t.Setenv("CONTAINARIUM_ACME_EMAIL", "ops@example.com")
+	p := NewProxyManager("http://127.0.0.1:1", "example.com")
+
+	policy := CaddyTLSAutomationPolicy{
+		Issuers: []CaddyTLSIssuer{{Module: "acme", Email: "ops@example.com"}},
+	}
+	if p.ensureIssuerEmail(&policy) {
+		t.Error("reported a change when the email was already correct — this runs every tick")
+	}
+}
+
+// With nothing configured there is nothing to repair. Critically it must not
+// blank an email an operator set by hand outside the daemon.
+func TestEnsureIssuerEmail_LeavesPolicyAloneWhenUnset(t *testing.T) {
+	t.Setenv("CONTAINARIUM_ACME_EMAIL", "")
+	p := NewProxyManager("http://127.0.0.1:1", "example.com")
+
+	policy := CaddyTLSAutomationPolicy{
+		Issuers: []CaddyTLSIssuer{{Module: "acme", Email: "set-by-hand@example.com"}},
+	}
+	if p.ensureIssuerEmail(&policy) {
+		t.Error("reported a change when no email is configured")
+	}
+	if policy.Issuers[0].Email != "set-by-hand@example.com" {
+		t.Errorf("clobbered an operator-set email: %q", policy.Issuers[0].Email)
+	}
+}
+
+// The decision to omit ZeroSSL without an email has to reach hosts that are
+// already running, not just newly-created policies — otherwise every host in
+// the fleet keeps the dead issuer it has today and goes on paying a
+// guaranteed-failed issuance attempt per certificate (#1616).
+func TestEnsureIssuerEmail_DropsUnregisterableZeroSSLWhenUnset(t *testing.T) {
+	t.Setenv("CONTAINARIUM_ACME_EMAIL", "")
+	p := NewProxyManager("http://127.0.0.1:1", "example.com")
+
+	policy := CaddyTLSAutomationPolicy{
+		Subjects: []string{"app.example.com"},
+		Issuers:  []CaddyTLSIssuer{{Module: "acme"}, {Module: "acme", CA: zeroSSLDirectory}},
+	}
+
+	if !p.ensureIssuerEmail(&policy) {
+		t.Fatal("expected the unregisterable ZeroSSL issuer to be dropped")
+	}
+	if len(policy.Issuers) != 1 || policy.Issuers[0].CA == zeroSSLDirectory {
+		t.Fatalf("want only the Let's Encrypt issuer left, got %+v", policy.Issuers)
+	}
+	// Idempotent — this runs on every reconcile tick.
+	if p.ensureIssuerEmail(&policy) {
+		t.Error("second pass reported a change; every tick would write to Caddy")
+	}
+}
+
+// A ZeroSSL issuer carrying an address an operator set by hand through Caddy's
+// admin API can register perfectly well. Dropping it because the daemon's own
+// env is unset would delete a working fallback.
+func TestEnsureIssuerEmail_KeepsZeroSSLThatHasItsOwnEmail(t *testing.T) {
+	t.Setenv("CONTAINARIUM_ACME_EMAIL", "")
+	p := NewProxyManager("http://127.0.0.1:1", "example.com")
+
+	policy := CaddyTLSAutomationPolicy{
+		Issuers: []CaddyTLSIssuer{
+			{Module: "acme", Email: "set-by-hand@example.com"},
+			{Module: "acme", CA: zeroSSLDirectory, Email: "set-by-hand@example.com"},
+		},
+	}
+	if p.ensureIssuerEmail(&policy) {
+		t.Error("reported a change against issuers that are already registerable")
+	}
+	if len(policy.Issuers) != 2 {
+		t.Fatalf("dropped a ZeroSSL issuer that has its own contact address: %+v", policy.Issuers)
+	}
+}
+
+// Dropping the dead issuer must never empty the list: `issuers` is
+// `omitempty`, so an empty array disappears from the emitted JSON and Caddy
+// silently falls back to its own defaults — reinstating the very ZeroSSL
+// issuer we just removed.
+func TestEnsureIssuerEmail_NeverLeavesAPolicyWithNoIssuers(t *testing.T) {
+	t.Setenv("CONTAINARIUM_ACME_EMAIL", "")
+	p := NewProxyManager("http://127.0.0.1:1", "example.com")
+
+	policy := CaddyTLSAutomationPolicy{
+		Subjects: []string{"app.example.com"},
+		Issuers:  []CaddyTLSIssuer{{Module: "acme", CA: zeroSSLDirectory}},
+	}
+
+	p.ensureIssuerEmail(&policy)
+	if len(policy.Issuers) == 0 {
+		t.Fatal("policy left with no issuers — Caddy would fall back to its defaults")
+	}
+	for _, is := range policy.Issuers {
+		if is.CA == zeroSSLDirectory {
+			t.Errorf("unregisterable ZeroSSL issuer survived: %+v", is)
+		}
+	}
+}

--- a/internal/app/caddy_types.go
+++ b/internal/app/caddy_types.go
@@ -315,6 +315,12 @@ func NewGRPCReverseProxyRoute(id string, hosts []string, upstreamDial string) Ca
 	}
 }
 
+// zeroSSLDirectory is ZeroSSL's ACME v2 directory URL — the `ca` that
+// identifies the fallback issuer in an emitted policy, and the value
+// ensureIssuerEmail matches on when deciding whether an existing policy still
+// carries an issuer that can never register (#1616).
+const zeroSSLDirectory = "https://acme.zerossl.com/v2/DV90"
+
 // NewACMEIssuer creates a Let's Encrypt ACME issuer
 func NewACMEIssuer() CaddyTLSIssuer {
 	return CaddyTLSIssuer{
@@ -326,20 +332,53 @@ func NewACMEIssuer() CaddyTLSIssuer {
 func NewZeroSSLIssuer() CaddyTLSIssuer {
 	return CaddyTLSIssuer{
 		Module: "acme",
-		CA:     "https://acme.zerossl.com/v2/DV90",
+		CA:     zeroSSLDirectory,
 	}
 }
 
-// issuersFor returns the standard ACME + ZeroSSL issuers, attaching the
-// DNS-01 challenge config to each when dns is non-nil (both CAs support
-// DNS-01). When dns is nil the issuers carry no `challenges` field, so the
-// emitted JSON is identical to the pre-DNS-01 default (HTTP-01 + TLS-ALPN-01).
+// ACMEEmailFromEnv returns the ACME account contact address from
+// CONTAINARIUM_ACME_EMAIL, or "" when unset.
+//
+// Read at emit time rather than threaded through the ProxyManager because
+// every construction path for a policy's issuers funnels through issuersFor,
+// and the address is a property of the CA account, not of any one policy.
+func ACMEEmailFromEnv() string {
+	return strings.TrimSpace(os.Getenv("CONTAINARIUM_ACME_EMAIL"))
+}
+
+// issuersFor returns the ACME issuers for a policy, attaching the DNS-01
+// challenge config to each when dns is non-nil (both CAs support DNS-01).
+// When dns is nil the issuers carry no `challenges` field, so the emitted
+// JSON keeps the pre-DNS-01 default (HTTP-01 + TLS-ALPN-01).
+//
+// Whether ZeroSSL is emitted at all depends on CONTAINARIUM_ACME_EMAIL,
+// because ZeroSSL refuses ACME account registration without a contact address
+// ("your email address is required to use ZeroSSL's ACME endpoint"). Emitting
+// it unconfigured produced a policy that *looked* like it had a fallback
+// issuer and could never obtain a certificate from it — the failure only
+// visible as a per-issuance error line, so hosts ran on a single working
+// issuer without any signal that redundancy was gone (#1616). With no email
+// we emit the one issuer that can actually work instead, and skip a
+// guaranteed-failed round trip on every issuance.
+//
+// The address also goes on the Let's Encrypt issuer: it is where a CA sends
+// expiry warnings, one of the few external signals for a stalled renewal.
 func issuersFor(dns *CaddyACMEChallenges) []CaddyTLSIssuer {
+	email := ACMEEmailFromEnv()
+
 	acme := NewACMEIssuer()
-	zerossl := NewZeroSSLIssuer()
+	acme.Email = email
 	acme.Challenges = dns
+	issuers := []CaddyTLSIssuer{acme}
+
+	if email == "" {
+		return issuers
+	}
+
+	zerossl := NewZeroSSLIssuer()
+	zerossl.Email = email
 	zerossl.Challenges = dns
-	return []CaddyTLSIssuer{acme, zerossl}
+	return append(issuers, zerossl)
 }
 
 // NewTLSPolicy creates a TLS automation policy with default issuers

--- a/internal/app/manager.go
+++ b/internal/app/manager.go
@@ -43,6 +43,7 @@ func NewManager(store AppStore, incusClient incus.Backend, config ManagerConfig)
 	detector := buildpack.NewDetector()
 	builder := NewBuilder(incusClient, detector)
 	proxy := NewProxyManager(config.CaddyAdminURL, config.BaseDomain).WithDNSChallenge(DNSChallengeFromEnv())
+	warnIfACMEEmailUnset()
 
 	return &Manager{
 		store:       store,
@@ -51,6 +52,24 @@ func NewManager(store AppStore, incusClient incus.Backend, config ManagerConfig)
 		incusClient: incusClient,
 		baseDomain:  config.BaseDomain,
 	}
+}
+
+// warnIfACMEEmailUnset logs at startup when no ACME contact address is
+// configured.
+//
+// The effect of leaving it unset is otherwise silent: the emitted policy just
+// has one issuer instead of two, and no CA has an address to send expiry
+// warnings to. Both only become visible at the moment they matter — when the
+// primary issuer is rate-limited, or when a renewal has been stalled long
+// enough to expire (#1616).
+func warnIfACMEEmailUnset() {
+	if ACMEEmailFromEnv() != "" {
+		return
+	}
+	log.Printf("WARNING: CONTAINARIUM_ACME_EMAIL is unset — TLS policies will carry a single " +
+		"Let's Encrypt issuer with no fallback (ZeroSSL refuses ACME registration without a " +
+		"contact address), and neither CA can send certificate-expiry warnings. Set it to an " +
+		"address the operators read.")
 }
 
 // DeployApp deploys a new application or updates an existing one

--- a/internal/app/proxy.go
+++ b/internal/app/proxy.go
@@ -366,6 +366,75 @@ func (p *ProxyManager) ensureDNSIssuers(policy *CaddyTLSAutomationPolicy) bool {
 	return true
 }
 
+// ensureIssuerEmail gives a policy's issuers the configured ACME contact
+// address, reporting whether it changed anything.
+//
+// Every host we run already has TLS policies, and both ProvisionTLS and
+// EnsureTLSSubjects only ever append *subjects* — issuers on an existing
+// policy are left exactly as they were written. So configuring
+// CONTAINARIUM_ACME_EMAIL would fix nothing anywhere without a repair here:
+// the address would only reach hosts that had never provisioned TLS before,
+// which is none of them (#1616).
+//
+// A no-op when no email is configured — in particular it never blanks an
+// address an operator set by hand through Caddy's admin API — and a no-op
+// when every issuer already carries the right one, so the every-tick
+// no-change path performs no write.
+func (p *ProxyManager) ensureIssuerEmail(policy *CaddyTLSAutomationPolicy) bool {
+	email := ACMEEmailFromEnv()
+
+	// Nothing configured: there is no address to write, but there may still be
+	// a ZeroSSL issuer that can never register sitting in the policy — which
+	// is the state every host in the fleet is in today. Drop it, for the same
+	// reason issuersFor no longer emits it: a fallback that cannot register is
+	// worse than no fallback, because the policy reads as redundant while
+	// every issuance pays a failed round trip for it.
+	//
+	// An issuer carrying its own address (set by hand through Caddy's admin
+	// API) can register, so it is left alone — as is any address already
+	// there.
+	if email == "" {
+		return p.dropUnregisterableZeroSSL(policy)
+	}
+
+	changed := false
+	for i := range policy.Issuers {
+		if policy.Issuers[i].Email != email {
+			policy.Issuers[i].Email = email
+			changed = true
+		}
+	}
+	return changed
+}
+
+// dropUnregisterableZeroSSL removes ZeroSSL issuers that carry no contact
+// address at all, reporting whether it removed any. Idempotent: once removed
+// there is nothing left to match, so the reconcile tick goes back to writing
+// nothing.
+func (p *ProxyManager) dropUnregisterableZeroSSL(policy *CaddyTLSAutomationPolicy) bool {
+	kept := make([]CaddyTLSIssuer, 0, len(policy.Issuers))
+	dropped := false
+	for _, issuer := range policy.Issuers {
+		if issuer.CA == zeroSSLDirectory && issuer.Email == "" {
+			dropped = true
+			continue
+		}
+		kept = append(kept, issuer)
+	}
+	if !dropped {
+		return false
+	}
+	// `issuers` is omitempty: an empty array vanishes from the emitted JSON
+	// and Caddy falls back to its own defaults — which include the ZeroSSL
+	// issuer we just removed. Substitute the issuers we would emit for a fresh
+	// policy instead, so the field is always explicitly present.
+	if len(kept) == 0 {
+		kept = issuersFor(p.dnsChallenge)
+	}
+	policy.Issuers = kept
+	return true
+}
+
 // policyHasDNSChallenge reports whether EVERY issuer can solve DNS-01.
 //
 // Every, not any: Caddy tries issuers in order, and one that cannot solve the
@@ -479,9 +548,23 @@ func (p *ProxyManager) ProvisionTLS(domain string) error {
 				// host that ALREADY hit the bug. Such a host has the subject
 				// in the array from a previous run, so an append-only fix
 				// would return early every time and never heal it.
-				if p.ensureDNSIssuers(&policies[i]) {
-					log.Printf("[ProxyManager] policy for %s had no DNS-01 issuers; adding them so the "+
-						"wildcard subject can actually be issued (#1066)", domain)
+				dnsRepaired := p.ensureDNSIssuers(&policies[i])
+				// Same reasoning one field over (#1616): a policy written
+				// before an ACME email was configured carries issuers with no
+				// contact, so ZeroSSL can never register and neither CA can
+				// mail an expiry warning. An append-only fix would return
+				// early here forever and never reach a host already in that
+				// state, which is every host that has provisioned TLS.
+				emailRepaired := p.ensureIssuerEmail(&policies[i])
+				if dnsRepaired || emailRepaired {
+					if dnsRepaired {
+						log.Printf("[ProxyManager] policy for %s had no DNS-01 issuers; adding them so the "+
+							"wildcard subject can actually be issued (#1066)", domain)
+					}
+					if emailRepaired {
+						log.Printf("[ProxyManager] policy for %s had issuers with no ACME contact address; "+
+							"setting it so ZeroSSL can register and expiry warnings are delivered (#1616)", domain)
+					}
 					return p.patchTLSPolicies(url, policies)
 				}
 				return nil
@@ -496,10 +579,13 @@ func (p *ProxyManager) ProvisionTLS(domain string) error {
 		policies[0].Subjects = append(policies[0].Subjects, domain)
 
 		// The policy we are appending to may predate DNS-01 being configured,
-		// in which case its issuers cannot satisfy a wildcard subject (#1066).
-		// The create-new-policy branch below gets this right via
-		// NewTLSPolicyWithDNS; this branch has to do the same explicitly.
+		// in which case its issuers cannot satisfy a wildcard subject (#1066),
+		// or predate the ACME email being configured, leaving a ZeroSSL issuer
+		// that can never register (#1616). The create-new-policy branch below
+		// gets both right via NewTLSPolicyWithDNS; this branch has to do the
+		// same explicitly.
 		p.ensureDNSIssuers(&policies[0])
+		p.ensureIssuerEmail(&policies[0])
 
 		return p.patchTLSPolicies(url, policies)
 	}
@@ -657,15 +743,22 @@ func (p *ProxyManager) EnsureTLSSubjects(domains []string) error {
 	// the every-tick no-change path still performs no write.
 	repaired := false
 	for i := range policies {
-		if covering[i] && p.ensureDNSIssuers(&policies[i]) {
+		if !covering[i] {
+			continue
+		}
+		if p.ensureDNSIssuers(&policies[i]) {
+			repaired = true
+		}
+		if p.ensureIssuerEmail(&policies[i]) {
 			repaired = true
 		}
 	}
 
 	if len(missing) == 0 {
 		if repaired {
-			log.Printf("[ProxyManager] repaired issuers on TLS policies covering %d host(s) so "+
-				"their wildcard subject can actually be issued (#1066)", len(seen))
+			log.Printf("[ProxyManager] repaired issuers on TLS policies covering %d host(s): DNS-01 "+
+				"challenge config and/or the ACME contact address were missing, either of which "+
+				"leaves a subject that is never successfully issued (#1066, #1616)", len(seen))
 			return p.patchTLSPolicies(url, policies)
 		}
 		return nil
@@ -679,8 +772,10 @@ func (p *ProxyManager) EnsureTLSSubjects(domains []string) error {
 		policies[0].Subjects = append(policies[0].Subjects, missing...)
 		// The policy we're appending to may predate DNS-01 being configured,
 		// in which case its issuers cannot satisfy the subject we just added
-		// and Caddy would never attempt it (#1066).
+		// and Caddy would never attempt it (#1066) — or predate the ACME email
+		// being configured, leaving an issuer that can never register (#1616).
 		p.ensureDNSIssuers(&policies[0])
+		p.ensureIssuerEmail(&policies[0])
 		return p.patchTLSPolicies(url, policies)
 	}
 


### PR DESCRIPTION
Closes #1616

## What changed

- **`CONTAINARIUM_ACME_EMAIL`** — read alongside `CONTAINARIUM_ACME_DNS_PROVIDER` and applied to every issuer `issuersFor()` emits. `CaddyTLSIssuer.Email` existed but nothing in the tree could set it, so the field never appeared in the emitted JSON.
- **No email → no ZeroSSL issuer.** ZeroSSL refuses ACME account registration without a contact address, so the emitted fallback could never obtain a certificate — a policy that *reads* as redundant while paying a guaranteed-failed round trip and a log line on every issuance. The issue put this decision on the table explicitly; the honest single-issuer policy is what ships.
- **Existing policies are repaired in place.** `ProvisionTLS` / `EnsureTLSSubjects` only ever append *subjects* — issuers on an existing policy are left as written. Without a repair, setting the env var would reach no host that has already provisioned TLS, which is all of them. `ensureIssuerEmail()` runs at the four sites `ensureDNSIssuers()` already runs at, and is a no-op on the no-change tick. An address an operator set by hand through Caddy's admin API is never blanked, and a dropped ZeroSSL issuer never leaves the policy with an empty `issuers` array (`omitempty` would make Caddy fall back to its own defaults — reinstating the issuer just removed).
- **Startup warning when unset**, since the effect (no fallback issuer, no expiry mail) is otherwise silent. Belongs with the startup validation raised in #1597.
- `docs/TLS-PROVISIONING.md` documents the variable and why the fallback CA depends on it.

## Review first

`ProxyManager.ensureIssuerEmail` / `dropUnregisterableZeroSSL` in `internal/app/proxy.go` — the in-place repair is what makes this reach the running fleet, and it writes to Caddy on a reconcile tick, so the idempotence and the never-blank/never-empty guards are the parts worth a careful read.

## Test evidence

New file `internal/app/caddy_issuer_email_test.go`, written before the implementation and confirmed red for the right reason at each step:

| Acceptance criterion | Test |
| --- | --- |
| Email is readable from config | `TestACMEEmailFromEnv_ReadsTheVariable`, `TestACMEEmailFromEnv_TrimsAndTolerAtesUnset` |
| Applied to **both** issuers | `TestIssuersFor_AppliesEmailToEveryIssuer` |
| ZeroSSL not emitted when it cannot register | `TestIssuersFor_OmitsZeroSSLWithoutAnEmail` |
| DNS-01 wiring (#1066/#378) survives the change | `TestIssuersFor_StillAttachesDNSChallenge` |
| Reaches hosts that already have policies | `TestEnsureIssuerEmail_RepairsAPolicyMissingIt` |
| No write on a no-change reconcile tick | `TestEnsureIssuerEmail_NoOpWhenAlreadySet` |
| Never blanks an operator-set address | `TestEnsureIssuerEmail_LeavesPolicyAloneWhenUnset`, `TestEnsureIssuerEmail_KeepsZeroSSLThatHasItsOwnEmail` |
| Dead ZeroSSL pruned from existing policies, idempotently | `TestEnsureIssuerEmail_DropsUnregisterableZeroSSLWhenUnset` |
| Repair never empties `issuers` | `TestEnsureIssuerEmail_NeverLeavesAPolicyWithNoIssuers` |

**Two existing tests were updated, not weakened.** `TestIssuersFor_NoDNS_MatchesLegacyDefault` and `TestIssuersFor_DNS_AttachesChallengeToBoth` in `caddy_dns01_test.go` pinned the old always-emit-ZeroSSL default — the exact behavior this issue decides to change. The first now pins **both** branches (with an email → both CAs each carrying it; without → Let's Encrypt only) and both are made hermetic against ambient env, so coverage grows rather than shrinks.

**CI green on this branch** — `Unit + default e2e` pass 6m25s, plus `Real Caddy wire-compat e2e` pass 2m2s (the meaningful one here: it proves a real Caddy still accepts the emitted policy JSON), `golangci-lint`, `gosec`, `govulncheck`, `Trivy`, and the Postgres store lane all pass: https://github.com/FootprintAI/Containarium/actions/runs/33571582141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added ACME contact email configuration through `CONTAINARIUM_ACME_EMAIL`.
  - Configured emails now apply to Let’s Encrypt and ZeroSSL certificate issuers.
  - Existing TLS policies are updated to include the configured contact email while preserving manually configured addresses.
  - DNS-01 certificate provisioning continues to support the configured issuers.

- **Bug Fixes**
  - Removed unusable ZeroSSL issuers when no contact email is available.
  - Added startup warnings explaining limited issuer availability and missing expiry notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->