### PR TITLE
fix(auth): intersect agent-skill token scopes with the caller's own grant

### DIFF
--- a/internal/auth/scopes.go
+++ b/internal/auth/scopes.go
@@ -211,6 +211,48 @@ func HasScope(granted []string, required string) bool {
 	return false
 }
 
+// IntersectScopes bounds a manifest's scopes by the caller's own granted
+// scopes, so a scope catalog (e.g. a skill's allowed_scopes) is a ceiling and
+// never a floor (#1676). Semantics mirror HasScope:
+//
+//   - caller == nil → unrestricted caller (no scopes claim, the Phase 1.7
+//     backwards-compat path); the manifest passes through unchanged.
+//   - caller containing the wildcard → same as unrestricted.
+//   - manifest containing the wildcard → the caller's own scopes pass through
+//     unchanged (the manifest imposes no additional ceiling).
+//   - otherwise → the set intersection: only scopes present in both.
+//
+// A non-nil but empty caller (explicit zero-scope token) intersects to empty
+// regardless of the manifest — fail closed, matching HasScope's explicit-deny
+// semantics for an empty granted list.
+//
+// Always returns a non-nil slice, so a caller can safely range over or mint a
+// token from the result without a nil check.
+func IntersectScopes(caller, manifest []string) []string {
+	if caller == nil || HasExplicitScope(caller, ScopeWildcard) {
+		out := make([]string, len(manifest))
+		copy(out, manifest)
+		return out
+	}
+	if HasExplicitScope(manifest, ScopeWildcard) {
+		out := make([]string, len(caller))
+		copy(out, caller)
+		return out
+	}
+	callerSet := make(map[string]struct{}, len(caller))
+	for _, s := range caller {
+		callerSet[strings.TrimSpace(s)] = struct{}{}
+	}
+	out := make([]string, 0, len(manifest))
+	for _, s := range manifest {
+		s = strings.TrimSpace(s)
+		if _, ok := callerSet[s]; ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
 // ParseScopes normalizes a comma-separated scope string
 // into a []string suitable for the JWT claim. Whitespace
 // and empty elements are dropped; the order of remaining

--- a/internal/auth/scopes_test.go
+++ b/internal/auth/scopes_test.go
@@ -64,6 +64,97 @@ func TestHasScope_TrimsWhitespace(t *testing.T) {
 	}
 }
 
+func TestIntersectScopes(t *testing.T) {
+	cases := []struct {
+		name     string
+		caller   []string
+		manifest []string
+		want     []string
+	}{
+		{
+			name:     "nil caller is unrestricted, manifest stays the ceiling",
+			caller:   nil,
+			manifest: []string{ScopeContainersRead, ScopeSecretsRead},
+			want:     []string{ScopeContainersRead, ScopeSecretsRead},
+		},
+		{
+			name:     "wildcard caller intersects down to the manifest",
+			caller:   []string{ScopeWildcard},
+			manifest: []string{ScopeContainersRead, ScopeSecretsRead},
+			want:     []string{ScopeContainersRead, ScopeSecretsRead},
+		},
+		{
+			name:     "wildcard manifest intersects down to the caller",
+			caller:   []string{ScopeContainersRead},
+			manifest: []string{ScopeWildcard},
+			want:     []string{ScopeContainersRead},
+		},
+		{
+			name:     "empty caller grants nothing regardless of manifest",
+			caller:   []string{},
+			manifest: []string{ScopeContainersRead, ScopeSecretsRead},
+			want:     []string{},
+		},
+		{
+			name:     "empty manifest grants nothing regardless of caller",
+			caller:   []string{ScopeWildcard},
+			manifest: []string{},
+			want:     []string{},
+		},
+		{
+			name:     "disjoint sets intersect to nothing",
+			caller:   []string{ScopeContainersRead},
+			manifest: []string{ScopeSecretsRead},
+			want:     []string{},
+		},
+		{
+			name:     "caller with only agents:run gets no resource scopes",
+			caller:   []string{ScopeAgentsRun},
+			manifest: []string{ScopeContainersRead},
+			want:     []string{},
+		},
+		{
+			name:     "strict subset keeps only the shared scopes",
+			caller:   []string{ScopeContainersRead, ScopeSecretsRead, ScopeRoutesWrite},
+			manifest: []string{ScopeContainersRead, ScopeSecretsRead},
+			want:     []string{ScopeContainersRead, ScopeSecretsRead},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IntersectScopes(tc.caller, tc.manifest)
+			if len(got) != len(tc.want) {
+				t.Fatalf("IntersectScopes(%v, %v) = %v, want %v", tc.caller, tc.manifest, got, tc.want)
+			}
+			gotSet := map[string]bool{}
+			for _, s := range got {
+				gotSet[s] = true
+			}
+			for _, s := range tc.want {
+				if !gotSet[s] {
+					t.Fatalf("IntersectScopes(%v, %v) = %v, want %v (missing %q)", tc.caller, tc.manifest, got, tc.want, s)
+				}
+			}
+		})
+	}
+}
+
+func TestIntersectScopes_ManifestScopeCallerLacksIsNeverGranted(t *testing.T) {
+	// Regression for #1676: a manifest declaring a scope the caller doesn't
+	// hold must never leak that scope into the minted token.
+	caller := []string{ScopeContainersRead}
+	manifest := []string{ScopeContainersRead, ScopeSecretsWrite}
+	got := IntersectScopes(caller, manifest)
+	for _, s := range got {
+		if s == ScopeSecretsWrite {
+			t.Fatalf("IntersectScopes(%v, %v) = %v; caller never held %q", caller, manifest, got, ScopeSecretsWrite)
+		}
+	}
+	if len(got) != 1 || got[0] != ScopeContainersRead {
+		t.Fatalf("IntersectScopes(%v, %v) = %v, want [%q]", caller, manifest, got, ScopeContainersRead)
+	}
+}
+
 func TestParseScopes(t *testing.T) {
 	cases := map[string][]string{
 		"":                                   nil,

--- a/internal/server/agent_server.go
+++ b/internal/server/agent_server.go
@@ -176,6 +176,19 @@ func agentRuntimeReleaseTag() string {
 // into the per-box egress policy. It does NOT run the loop — RunAgentSkill runs
 // it one-shot, RunCrew starts it in serve mode. Returns the container name +
 // the provisioned Container.
+// mintedAgentTokenScopes computes the scopes for a skill's in-box token: the
+// intersection of the caller's own granted scopes and the skill manifest's
+// allowed_scopes (#1676). auth.ScopesFromGRPCContext — not the plain
+// ScopesFromContext — is required here: the primary API surface is REST via
+// grpc-gateway, and the HTTP middleware propagates the caller's scopes claim
+// through outgoing gRPC metadata (internal/auth/middleware.go), not a context
+// value that would survive the HTTP→gateway→gRPC hop. RequireScope and
+// AuthorizeTenant already read the caller this same way.
+func mintedAgentTokenScopes(ctx context.Context, skill *pb.AgentSkill) []string {
+	callerScopes, _ := auth.ScopesFromGRPCContext(ctx)
+	return auth.IntersectScopes(callerScopes, skill.AllowedScopes)
+}
+
 func (s *AgentSkillServer) provisionSkillBox(ctx context.Context, skill *pb.AgentSkill, backendID, pool, inputJSON string) (string, *pb.Container, error) {
 	// Phase 0 supports only the recipe_id box form (catalog skills). Inline
 	// recipes are an API-only construct deferred to a later phase.
@@ -231,9 +244,12 @@ func (s *AgentSkillServer) provisionSkillBox(ctx context.Context, skill *pb.Agen
 		container = dep.Container
 	}
 
-	// Mint a JWT scoped to EXACTLY the skill's allowed_scopes (catalog
-	// guarantees >= 1, so this is bounded, not the nil-claim "no restriction").
-	token, err := s.tokens.GenerateToken(name, []string{}, agentTokenTTL, skill.AllowedScopes...)
+	// Mint a JWT scoped to the intersection of the CALLER's own granted scopes
+	// and the skill's allowed_scopes (#1676): the manifest is a ceiling, never
+	// a floor. A caller with no scopes claim (nil, the Phase 1.7 backwards-compat
+	// "unrestricted" path) or the wildcard gets the manifest unchanged; anyone
+	// else only receives the scopes they already hold.
+	token, err := s.tokens.GenerateToken(name, []string{}, agentTokenTTL, mintedAgentTokenScopes(ctx, skill)...)
 	if err != nil {
 		return "", nil, status.Errorf(codes.Internal, "failed to mint scoped agent token: %v", err)
 	}

--- a/internal/server/agent_server_test.go
+++ b/internal/server/agent_server_test.go
@@ -65,6 +65,54 @@ func TestSendAgentTaskRejectsDisallowedPeer(t *testing.T) {
 	}
 }
 
+// TestMintedAgentTokenScopes_CallerRestrictedToAgentsRunGetsNoResourceScopes
+// is the #1676 regression: a caller holding only agents:run must not receive
+// a token carrying a manifest scope it never held itself.
+func TestMintedAgentTokenScopes_CallerRestrictedToAgentsRunGetsNoResourceScopes(t *testing.T) {
+	skill := &pb.AgentSkill{Id: "hello-agent", AllowedScopes: []string{auth.ScopeContainersRead}}
+	ctx := auth.ContextWithTestSubjectScopes(
+		context.Background(), "some-caller", nil, []string{auth.ScopeAgentsRun})
+
+	got := mintedAgentTokenScopes(ctx, skill)
+	if len(got) != 0 {
+		t.Fatalf("mintedAgentTokenScopes = %v, want no resource scopes for a caller holding only agents:run", got)
+	}
+}
+
+// TestMintedAgentTokenScopes_ManifestScopeCallerLacksNeverGranted is the
+// regression named explicitly in #1676's acceptance criteria: a manifest
+// declaring a scope the caller doesn't hold must never produce a token
+// carrying it.
+func TestMintedAgentTokenScopes_ManifestScopeCallerLacksNeverGranted(t *testing.T) {
+	skill := &pb.AgentSkill{
+		Id:            "escalating-skill",
+		AllowedScopes: []string{auth.ScopeContainersRead, auth.ScopeSecretsWrite},
+	}
+	ctx := auth.ContextWithTestSubjectScopes(
+		context.Background(), "some-caller", nil, []string{auth.ScopeAgentsRun, auth.ScopeContainersRead})
+
+	got := mintedAgentTokenScopes(ctx, skill)
+	if slices.Contains(got, auth.ScopeSecretsWrite) {
+		t.Fatalf("mintedAgentTokenScopes = %v; caller never held %q", got, auth.ScopeSecretsWrite)
+	}
+	if len(got) != 1 || got[0] != auth.ScopeContainersRead {
+		t.Fatalf("mintedAgentTokenScopes = %v, want [%q]", got, auth.ScopeContainersRead)
+	}
+}
+
+// TestMintedAgentTokenScopes_UnrestrictedCallerKeepsManifestUnchanged covers
+// the Phase 1.7 backwards-compat path: a pre-scopes-claim caller (nil scopes)
+// is unrestricted, so the manifest passes through as it did before #1676.
+func TestMintedAgentTokenScopes_UnrestrictedCallerKeepsManifestUnchanged(t *testing.T) {
+	skill := &pb.AgentSkill{Id: "hello-agent", AllowedScopes: []string{auth.ScopeContainersRead}}
+	ctx := auth.ContextWithTestSubjectScopes(context.Background(), "some-caller", nil, nil)
+
+	got := mintedAgentTokenScopes(ctx, skill)
+	if len(got) != 1 || got[0] != auth.ScopeContainersRead {
+		t.Fatalf("mintedAgentTokenScopes = %v, want manifest unchanged [%q]", got, auth.ScopeContainersRead)
+	}
+}
+
 // TestSendAgentTaskRequiresCallScope confirms the agents:call gate.
 func TestSendAgentTaskRequiresCallScope(t *testing.T) {
 	s := &AgentSkillServer{catalog: skills.GetDefault()}


### PR DESCRIPTION
## Summary
- `RunAgentSkill` minted an in-box JWT carrying the skill manifest's `allowed_scopes` directly (`internal/server/agent_server.go:236`), never consulting the caller's own granted scopes. A caller holding only `agents:run` could obtain a token for any scope an installed skill declares.
- Adds `auth.IntersectScopes(caller, manifest)` — the manifest is a ceiling, never a floor. Wired the mint site through a new `mintedAgentTokenScopes(ctx, skill)` helper.
- Uses `auth.ScopesFromGRPCContext`, not the plain `ScopesFromContext` the issue's suggested snippet named — the primary API surface is REST via grpc-gateway, and the caller's `scopes` claim only survives the HTTP→gateway→gRPC hop as gRPC metadata (`internal/auth/middleware.go:130-138`), not the context value `ScopesFromContext` reads. `RequireScope`/`AuthorizeTenant` already read the caller this same way in this file. Using the plain context accessor would have made the fix a no-op for every grpc-gateway caller — flagging per the design-deviation convention.

## Not covered by this PR
Per the issue thread's resolved discussion: the cloud-originated path is **not** fixed by this change. The cloud control plane calls this daemon's REST surface with a shared, long-lived service credential rather than the end user's own scopes, so the intersection returns the manifest unchanged for cloud-originated runs. Companion issue already filed: `Containarium-cloud#1427` (private repo).

## Test evidence
- `TestIntersectScopes` (table-driven: nil/unrestricted caller, wildcard caller, wildcard manifest, empty caller, empty manifest, disjoint, strict subset) — `internal/auth/scopes_test.go`
- `TestIntersectScopes_ManifestScopeCallerLacksIsNeverGranted` — regression named in the issue's acceptance criteria
- `TestMintedAgentTokenScopes_CallerRestrictedToAgentsRunGetsNoResourceScopes` — a caller holding only `agents:run` gets a token with no resource scopes
- `TestMintedAgentTokenScopes_ManifestScopeCallerLacksNeverGranted` — same regression at the `RunAgentSkill` call site
- `TestMintedAgentTokenScopes_UnrestrictedCallerKeepsManifestUnchanged` — Phase 1.7 backwards-compat path unaffected

Local: `go test ./internal/auth/... ./internal/server/...` — green. `go vet` clean, `gofmt -l` clean. CI run: (link once checks complete on this PR).

Closes #1676

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Agent tokens now include only permissions shared by the caller and the requested skill.
  * Prevents resource permissions from being granted when they are absent from the caller’s authorization.
  * Preserves existing behavior for unrestricted callers and token expiration handling.

* **Bug Fixes**
  * Corrected permission propagation for requests routed through REST or gateway interfaces.

* **Tests**
  * Added coverage for restricted, unrestricted, wildcard, empty, and non-overlapping permission scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->