### PR TITLE
feat(code): containarium code run/attach/status/stop — resumable reader

### DIFF
--- a/internal/agentbox/agentbox_test.go
+++ b/internal/agentbox/agentbox_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/footprintai/containarium/internal/logframe"
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
@@ -803,4 +804,74 @@ func TestProcessStart_CapturesStdoutToLog(t *testing.T) {
 		time.Sleep(50 * time.Millisecond)
 	}
 	t.Errorf("log file %s never contained 'hello from process'", logPath)
+}
+
+// TestProcessStart_FramedCaptureMode_DemuxesCleanly is the #1674 AC: in
+// framed mode the client reconstructs stdout and stderr separately from the
+// single on-disk byte stream. Spawns a process that writes to both streams,
+// then feeds the raw log bytes through logframe.Demuxer and checks each
+// stream's content landed on the right side.
+func TestProcessStart_FramedCaptureMode_DemuxesCleanly(t *testing.T) {
+	t.Cleanup(setProcessLogDirForTest(t.TempDir()))
+	t.Cleanup(func() { killAllAndReset(t) })
+
+	out, res := callTool(t, handleProcessStart, map[string]interface{}{
+		"command":      "echo out-line 1>&1; echo err-line 1>&2",
+		"name":         "framed-proc",
+		"capture_mode": "framed",
+	})
+	if res.IsError {
+		t.Fatalf("process_start returned an error:\n%s", out)
+	}
+	var logPath string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "log_path: ") {
+			logPath = strings.TrimPrefix(line, "log_path: ")
+			break
+		}
+	}
+	if logPath == "" {
+		t.Fatalf("no log_path in output:\n%s", out)
+	}
+
+	var stdout, stderr []byte
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(logPath)
+		if err != nil {
+			time.Sleep(50 * time.Millisecond)
+			continue
+		}
+		var d logframe.Demuxer
+		frames, derr := d.Write(data)
+		if derr != nil {
+			t.Fatalf("Demuxer.Write: %v\nraw log:\n%s", derr, data)
+		}
+		stdout, stderr = nil, nil
+		for _, f := range frames {
+			switch f.Stream {
+			case logframe.Stdout:
+				stdout = append(stdout, f.Payload...)
+			case logframe.Stderr:
+				stderr = append(stderr, f.Payload...)
+			}
+		}
+		if strings.Contains(string(stdout), "out-line") && strings.Contains(string(stderr), "err-line") {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Errorf("demuxed stdout=%q stderr=%q, want out-line on stdout and err-line on stderr", stdout, stderr)
+}
+
+func TestProcessStart_UnknownCaptureModeIsRejected(t *testing.T) {
+	t.Cleanup(setProcessLogDirForTest(t.TempDir()))
+	t.Cleanup(func() { killAllAndReset(t) })
+	_, res := callTool(t, handleProcessStart, map[string]interface{}{
+		"command":      "true",
+		"capture_mode": "bogus",
+	})
+	if !res.IsError {
+		t.Error("expected an error for an unrecognized capture_mode")
+	}
 }

--- a/internal/agentbox/process.go
+++ b/internal/agentbox/process.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,6 +14,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/footprintai/containarium/internal/logframe"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
@@ -99,6 +101,14 @@ func processStartTool() mcp.Tool {
 		mcp.WithString("cwd",
 			mcp.Description("Working directory for the spawned process. Default: agent-box's cwd."),
 		),
+		mcp.WithString("capture_mode",
+			mcp.Description("How to capture stdout+stderr: 'combined' (default) writes plain text, "+
+				"readable with a plain tail/cat. 'framed' interleaves stdout and stderr as "+
+				"line-framed, base64-encoded records a client can demultiplex — opt in only if "+
+				"you're driving this process through a demuxing client (#1674); a human tailing "+
+				"the log wants 'combined'."),
+			mcp.Enum("combined", "framed"),
+		),
 	)
 }
 
@@ -110,8 +120,13 @@ func handleProcessStart(_ context.Context, req mcp.CallToolRequest) (*mcp.CallTo
 	}
 	name, _ := args["name"].(string)
 	cwd, _ := args["cwd"].(string)
+	captureModeArg, _ := args["capture_mode"].(string)
+	captureMode, err := parseCaptureMode(captureModeArg)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("process_start: %v", err)), nil
+	}
 
-	mp, err := spawnBackgroundProcess(name, command, cwd)
+	mp, err := spawnBackgroundProcess(name, command, cwd, captureMode)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("process_start: %v", err)), nil
 	}
@@ -123,17 +138,39 @@ func handleProcessStart(_ context.Context, req mcp.CallToolRequest) (*mcp.CallTo
 	return mcp.NewToolResultText(body), nil
 }
 
+// frameWriter writes to log with each Write call framed as one
+// internal/logframe record for stream (#1674, CaptureFramed). exec.Cmd
+// drives a process's Stdout and Stderr from two separate goroutines
+// concurrently; mu — shared between the stdout and stderr frameWriters for
+// one process — serializes their writes into logFile so frames from the
+// two streams never interleave mid-write, which is what keeps the single
+// on-disk byte stream's ordering meaningful for a demuxing reader.
+type frameWriter struct {
+	log    io.Writer
+	mu     *sync.Mutex
+	stream logframe.Stream
+}
+
+func (w *frameWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if _, err := w.log.Write(logframe.EncodeFrame(w.stream, p)); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
 // spawnBackgroundProcess starts command under /bin/sh -c, detached via
-// Setsid, capturing combined stdout+stderr to a log file under
-// processLogDir, and registers it in processRegistry under name (auto-
-// generated if empty). Reaped asynchronously — a goroutine calls
+// Setsid, capturing stdout+stderr to a log file under processLogDir per
+// captureMode (#1674), and registers it in processRegistry under name
+// (auto-generated if empty). Reaped asynchronously — a goroutine calls
 // cmd.Wait() — so it never zombies.
 //
 // Shared core between the process_start MCP tool (handleProcessStart) and
 // SpawnService.Spawn (gRPC, #1488 Phase 2): one implementation, two
 // transports, so a caller reaching agent-box over the fast local socket
 // gets identical spawn/reap semantics to one reaching it over MCP/SSH.
-func spawnBackgroundProcess(name, command, cwd string) (*managedProcess, error) {
+func spawnBackgroundProcess(name, command, cwd string, captureMode CaptureMode) (*managedProcess, error) {
 	if command == "" {
 		return nil, fmt.Errorf("'command' is required")
 	}
@@ -195,8 +232,17 @@ func spawnBackgroundProcess(name, command, cwd string) (*managedProcess, error) 
 	if cwd != "" {
 		cmd.Dir = cwd
 	}
-	cmd.Stdout = logFile
-	cmd.Stderr = logFile
+	if captureMode == CaptureFramed {
+		// Separate stdout/stderr writers exec.Cmd drives from two goroutines
+		// concurrently, sharing one mutex so their frames never interleave
+		// mid-write in logFile — see frameWriter's own doc comment.
+		var mu sync.Mutex
+		cmd.Stdout = &frameWriter{log: logFile, mu: &mu, stream: logframe.Stdout}
+		cmd.Stderr = &frameWriter{log: logFile, mu: &mu, stream: logframe.Stderr}
+	} else {
+		cmd.Stdout = logFile
+		cmd.Stderr = logFile
+	}
 	// Detach from agent-box's process group so a child of the spawned
 	// process survives an agent-box restart and can be reaped later.
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
@@ -214,7 +260,7 @@ func spawnBackgroundProcess(name, command, cwd string) (*managedProcess, error) 
 		BootID:      bootID,
 		Command:     command,
 		Cwd:         cwd,
-		CaptureMode: CaptureCombined,
+		CaptureMode: captureMode,
 		LogPath:     logPath,
 		StartedAt:   startedAt,
 	}

--- a/internal/agentbox/run_record.go
+++ b/internal/agentbox/run_record.go
@@ -8,6 +8,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 )
 
 // Durable run records (#1672). agent-box is a stdio MCP server spawned per
@@ -42,16 +44,47 @@ const (
 	RunOutcomeUnknown RunOutcome = "unknown"
 )
 
-// CaptureMode names how a run's output stream is framed on disk. Only
-// CaptureCombined is implemented; CaptureFramed is reserved for #1674's
-// resumable-reader work and is not produced or interpreted by this package
-// yet — every record written today carries CaptureCombined.
+// CaptureMode names how a run's output stream is written to its log file.
+// CaptureCombined is plain text (the only mode before #1674, still the
+// default): stdout and stderr interleaved as-is, readable with a plain
+// `cat`/`tail`. CaptureFramed multiplexes them using internal/logframe, so
+// a demuxing client (containarium code) can split them back apart from the
+// single offset stream tail_log still serves unchanged.
 type CaptureMode string
 
 const (
 	CaptureCombined CaptureMode = "combined"
 	CaptureFramed   CaptureMode = "framed"
 )
+
+// parseCaptureMode maps process_start's optional capture_mode argument to
+// the typed enum. Empty input defaults to CaptureCombined — process_start's
+// contract for callers who never pass capture_mode at all (every caller
+// before #1674) is that nothing about their invocation changes. Anything
+// else that isn't a recognized value is a caller error (most likely a
+// typo), not a silent fallback.
+func parseCaptureMode(s string) (CaptureMode, error) {
+	switch s {
+	case "", string(CaptureCombined):
+		return CaptureCombined, nil
+	case string(CaptureFramed):
+		return CaptureFramed, nil
+	default:
+		return "", fmt.Errorf("capture_mode: unknown value %q (want %q or %q)", s, CaptureCombined, CaptureFramed)
+	}
+}
+
+// captureModeFromProto maps SpawnRequest.CaptureMode (the gRPC transport's
+// typed enum) to this package's CaptureMode. CAPTURE_MODE_UNSPECIFIED maps
+// to CaptureCombined — additive/backward-compatible, per the proto field's
+// own doc comment: every SpawnRequest sent before #1674 omits the field
+// and gets today's behavior unchanged.
+func captureModeFromProto(m pb.CaptureMode) CaptureMode {
+	if m == pb.CaptureMode_CAPTURE_MODE_FRAMED {
+		return CaptureFramed
+	}
+	return CaptureCombined
+}
 
 // RunRecord is the durable, on-disk counterpart to managedProcess: written
 // by the agent-box process that started a run, read by whichever agent-box

--- a/internal/agentbox/run_record_test.go
+++ b/internal/agentbox/run_record_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 )
 
 // setProcessLogDirForTest points processLogDir at an isolated temp dir (A1
@@ -288,5 +290,55 @@ func TestRotateFinishedRun_MovesRecordAndLogAside(t *testing.T) {
 	rotatedLogPath := filepath.Join(dir, "old-run.1780000000.log")
 	if !fileExistsForTest(rotatedLogPath) {
 		t.Errorf("expected rotated log at %s", rotatedLogPath)
+	}
+}
+
+// ----- parseCaptureMode / captureModeFromProto -----
+
+func TestParseCaptureMode(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    CaptureMode
+		wantErr bool
+	}{
+		{"", CaptureCombined, false},
+		{"combined", CaptureCombined, false},
+		{"framed", CaptureFramed, false},
+		{"bogus", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got, err := parseCaptureMode(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseCaptureMode(%q): expected an error", tc.in)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseCaptureMode(%q): %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Errorf("parseCaptureMode(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCaptureModeFromProto(t *testing.T) {
+	cases := []struct {
+		in   pb.CaptureMode
+		want CaptureMode
+	}{
+		{pb.CaptureMode_CAPTURE_MODE_UNSPECIFIED, CaptureCombined},
+		{pb.CaptureMode_CAPTURE_MODE_COMBINED, CaptureCombined},
+		{pb.CaptureMode_CAPTURE_MODE_FRAMED, CaptureFramed},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in.String(), func(t *testing.T) {
+			if got := captureModeFromProto(tc.in); got != tc.want {
+				t.Errorf("captureModeFromProto(%v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/agentbox/spawn_server.go
+++ b/internal/agentbox/spawn_server.go
@@ -33,7 +33,7 @@ func (s *SpawnServer) Spawn(_ context.Context, req *pb.SpawnRequest) (*pb.SpawnR
 		return nil, status.Error(codes.InvalidArgument, "command is required")
 	}
 
-	mp, err := spawnBackgroundProcess(req.Name, req.Command, req.Cwd)
+	mp, err := spawnBackgroundProcess(req.Name, req.Command, req.Cwd, captureModeFromProto(req.CaptureMode))
 	if err != nil {
 		if errors.Is(err, ErrProcessNameInUse) {
 			return nil, status.Error(codes.AlreadyExists, err.Error())

--- a/internal/agentbox/spawn_server_test.go
+++ b/internal/agentbox/spawn_server_test.go
@@ -55,6 +55,33 @@ func TestSpawnServer_Spawn_ReturnsPidAndReaps(t *testing.T) {
 	}
 }
 
+// TestSpawnServer_Spawn_FramedCaptureMode is the #1674 contract-change AC:
+// capture_mode must land on SpawnRequest so the gRPC transport isn't
+// asymmetric with the MCP tool over the same shared core.
+func TestSpawnServer_Spawn_FramedCaptureMode(t *testing.T) {
+	dir := t.TempDir()
+	t.Cleanup(setProcessLogDirForTest(dir))
+	t.Cleanup(func() { killAllAndReset(t) })
+	s := NewSpawnServer()
+
+	resp, err := s.Spawn(context.Background(), &pb.SpawnRequest{
+		Command:     "echo hi",
+		Name:        "framed-grpc",
+		CaptureMode: pb.CaptureMode_CAPTURE_MODE_FRAMED,
+	})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+
+	record, found, err := readRunRecord(resp.Name)
+	if err != nil || !found {
+		t.Fatalf("readRunRecord: found=%v err=%v", found, err)
+	}
+	if record.CaptureMode != CaptureFramed {
+		t.Errorf("record.CaptureMode = %q, want %q", record.CaptureMode, CaptureFramed)
+	}
+}
+
 func TestSpawnServer_Spawn_RejectsEmptyCommand(t *testing.T) {
 	s := NewSpawnServer()
 	_, err := s.Spawn(context.Background(), &pb.SpawnRequest{Name: "no-command"})

--- a/internal/cmd/code.go
+++ b/internal/cmd/code.go
@@ -1,0 +1,229 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/footprintai/containarium/internal/coderun"
+	"github.com/footprintai/containarium/internal/connectcore"
+	"github.com/footprintai/containarium/internal/sshkey"
+	"github.com/spf13/cobra"
+)
+
+// `containarium code run/attach/status/stop` (#1674) is the resumable
+// reader over agent-box's tail_log/process_start/process_kill: it feels
+// like running the agent in a pipe, but survives the local client's
+// network dying mid-run. See docs/architecture/remote-coding-agent.md,
+// Part B, and internal/coderun for the resumable-reader core this command
+// wraps. `code install` (#1673, a sibling PR) lands the toolchain these
+// commands assume is already on the box.
+//
+// Box resolution/SSH-key authorization here deliberately mirrors
+// connect.go's runConnect: same connectAPI, same obtainConnectKey, same
+// connectcore helpers — this is the third caller of that pattern (after
+// `connect` and `code install`), which is why obtainConnectKey takes
+// explicit params instead of reading connect's own package vars.
+
+// defaultCodeRunName is the process name used when --name is omitted, so
+// the common case ("one coding task per box at a time") never requires the
+// user to track an arbitrary generated name across run/attach/status/stop.
+const defaultCodeRunName = "code"
+
+// codeStreamFollow bounds how long each tail_log call blocks server-side
+// polling for new content — most of the "streaming" feel comes from this,
+// not from client-side poll frequency. Short enough that the post-exit
+// grace period (codeStreamFollow + codeExitPollInterval) stays well under
+// what a human notices as a delay before the command returns.
+const codeStreamFollow = 3 * time.Second
+
+// codeExitPollInterval is how often run/attach checks process_list for the
+// run's own exit, independent of the tail_log streaming loop.
+const codeExitPollInterval = 1 * time.Second
+
+var (
+	codeSSHServer string
+	codeKeyPath   string
+	codeIdentity  string
+	codeUser      string
+	codeHost      string
+	codePort      int
+	codeName      string
+)
+
+var codeCmd = &cobra.Command{
+	Use:   "code",
+	Short: "Run a coding agent on a box and watch it over a connection that may drop",
+}
+
+func init() {
+	rootCmd.AddCommand(codeCmd)
+	codeCmd.PersistentFlags().StringVar(&codeSSHServer, "ssh-server", "", "server to talk to for box resolution / SSH-key authorization (default: --server / CONTAINARIUM_SERVER, else your logged-in server)")
+	codeCmd.PersistentFlags().StringVar(&codeKeyPath, "key", "", "public key to authorize (default: the managed key from `containarium ssh setup`)")
+	codeCmd.PersistentFlags().StringVar(&codeIdentity, "identity", "", "private key path to authenticate with (default: derived from --key)")
+	codeCmd.PersistentFlags().StringVar(&codeUser, "user", "", "override the SSH username (default: the box's own user)")
+	codeCmd.PersistentFlags().StringVar(&codeHost, "host", "", "override the SSH host (default: the box's sentinel host)")
+	codeCmd.PersistentFlags().IntVar(&codePort, "port", 0, "override the SSH port")
+	codeCmd.PersistentFlags().StringVar(&codeName, "name", "", "process name for this run (default: \""+defaultCodeRunName+"\" — override to run more than one task on the same box concurrently)")
+
+	codeCmd.AddCommand(codeRunCmd)
+	codeCmd.AddCommand(codeAttachCmd)
+	codeCmd.AddCommand(codeStatusCmd)
+	codeCmd.AddCommand(codeStopCmd)
+
+	codeRunCmd.Flags().StringVar(&codeRunPrompt, "prompt", "", "prompt to give the agent (required)")
+	codeRunCmd.Flags().BoolVar(&codeRunStreamJSON, "output-format-stream-json", false,
+		"capture stdout/stderr separately (framed capture_mode) so a JSON stream on stdout isn't corrupted by diagnostics; without this, both are interleaved as plain text")
+	codeAttachCmd.Flags().BoolVar(&codeAttachStreamJSON, "output-format-stream-json", false,
+		"demultiplex stdout/stderr — must match the capture_mode the run was actually started with")
+	codeStopCmd.Flags().BoolVar(&codeStopForce, "force", false, "SIGKILL instead of SIGTERM")
+}
+
+func codeRunName() string {
+	if codeName != "" {
+		return codeName
+	}
+	return defaultCodeRunName
+}
+
+// resolveCodeSession authorizes the caller's managed SSH key on box (same
+// flow as `containarium connect`) and opens an MCP session to its
+// agent-box over that SSH path.
+func resolveCodeSession(ctx context.Context, box string, diag io.Writer) (*coderun.Session, error) {
+	if err := validateBoxName(box); err != nil {
+		return nil, err
+	}
+
+	sshServer := codeSSHServer
+	if sshServer == "" {
+		sshServer = serverAddr
+	}
+	server := pickSSHServer(sshServer)
+	api, err := newConnectAPI(server)
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := api.GetContainer(ctx, box)
+	if err != nil {
+		return nil, err
+	}
+	if !connectcore.IsRunning(c.State) {
+		return nil, fmt.Errorf("box %q is %s, not running — start it first (`containarium start %s`)",
+			box, connectcore.PrettyState(c.State), box)
+	}
+	target, err := connectcore.BuildTarget(c, codeUser, codeHost, codePort)
+	if err != nil {
+		return nil, err
+	}
+
+	pub, privPath, err := obtainConnectKey(codeKeyPath, codeIdentity)
+	if err != nil {
+		return nil, err
+	}
+	if err := api.AuthorizeKey(ctx, box, pub); err != nil {
+		return nil, fmt.Errorf("authorize key on %q: %w", box, err)
+	}
+	fp, _ := sshkey.Fingerprint(pub)
+	fmt.Fprintf(diag, "✓ %s → %s@%s (authorized %s)\n", box, target.User, target.Host, fp)
+
+	sshArgs := connectcore.BuildSSHArgs(target, privPath, "") // no remote command — Connect appends "agent-box"
+	sess, err := coderun.Connect(ctx, sshArgs)
+	if err != nil {
+		return nil, fmt.Errorf("connect to agent-box on %q: %w", box, err)
+	}
+	return sess, nil
+}
+
+// shellQuoteSingle single-quotes s for a POSIX shell, escaping any embedded
+// single quote by closing the quoted string, emitting a backslash-escaped
+// single quote, then reopening it. process_start runs its command under
+// /bin/sh -c on the box, so an unescaped user-supplied --prompt would be
+// shell-interpreted there — this is what stands between "the agent's
+// prompt" and arbitrary command injection into that shell.
+func shellQuoteSingle(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// buildClaudeRunCommand renders the command process_start actually spawns:
+// source whatever secrets delivery `containarium code install` (#1673) set
+// up, then invoke claude non-interactively. Sourcing here — not relying on
+// a login-shell profile — is self-contained per invocation, matching the
+// same reasoning code_install.go's verify script uses.
+func buildClaudeRunCommand(prompt string, streamJSON bool) string {
+	cmd := "set -a; [ -f /run/containarium/secrets.env ] && . /run/containarium/secrets.env; set +a; " +
+		"~/.local/bin/claude -p " + shellQuoteSingle(prompt)
+	if streamJSON {
+		cmd += " --output-format stream-json"
+	}
+	return cmd
+}
+
+// runOutcomeLine finds name's own line in process_list's raw text
+// (handleProcessList's "<icon> <name>  (pid <pid>, <outcome>)" format,
+// internal/agentbox/process.go) and reports whether it's still running.
+// A name that doesn't appear at all (never started under this name, or its
+// record was rotated away by a later same-name run) counts as not-running
+// — there is nothing left to wait for either way.
+func runOutcomeLine(listing, name string) (line string, running bool) {
+	for _, l := range strings.Split(listing, "\n") {
+		trimmed := strings.TrimSpace(l)
+		fields := strings.Fields(trimmed)
+		if len(fields) < 2 || fields[1] != name {
+			continue
+		}
+		return trimmed, strings.Contains(trimmed, ", running)")
+	}
+	return "", false
+}
+
+// streamAndWait streams path's output to stdout (demultiplexed to
+// stdout+stderr when streamJSON) until ctx is cancelled or name's run has
+// exited, polling process_list independently of the tail_log loop to
+// notice the exit. After noticing, it waits one more codeStreamFollow
+// cycle so a last in-flight read can flush trailing output before
+// stopping — tail_log has no "you've caught up, nothing more is coming"
+// signal of its own, so watching liveness is the only way to know when to
+// stop asking.
+func streamAndWait(ctx context.Context, sess *coderun.Session, name, logPath string, stdout, stderr io.Writer, streamJSON bool) error {
+	w := stdout
+	if streamJSON {
+		w = coderun.NewDemuxWriter(stdout, stderr)
+	}
+
+	streamCtx, cancelStream := context.WithCancel(ctx)
+	defer cancelStream()
+
+	streamDone := make(chan error, 1)
+	go func() {
+		_, err := coderun.StreamOutput(streamCtx, sess, w, logPath, 0, codeStreamFollow, func(err error) {
+			fmt.Fprintf(stderr, "[containarium code] reconnecting after: %v\n", err)
+		})
+		streamDone <- err
+	}()
+
+	ticker := time.NewTicker(codeExitPollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			listing, err := sess.ProcessList(ctx)
+			if err != nil {
+				continue // transient; the streaming loop's own retry handles reconnection
+			}
+			if _, running := runOutcomeLine(listing, name); !running {
+				select {
+				case <-time.After(codeStreamFollow + time.Second):
+				case <-ctx.Done():
+				}
+				cancelStream()
+				<-streamDone
+				return nil
+			}
+		}
+	}
+}

--- a/internal/cmd/code_run.go
+++ b/internal/cmd/code_run.go
@@ -1,0 +1,204 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	codeRunPrompt        string
+	codeRunStreamJSON    bool
+	codeAttachStreamJSON bool
+	codeStopForce        bool
+)
+
+var codeRunCmd = &cobra.Command{
+	Use:   "run <box>",
+	Short: "Start a coding agent on a box and stream its output as it's produced",
+	Long: `Starts claude on <box> with --prompt, detached (it survives this command's
+own connection dying — see Killing the local client does not kill the run,
+below), and streams its output to your terminal as it's produced: not
+buffered to completion, and with no timeout on the run itself.
+
+A mid-run network drop is recovered automatically by resuming at the last
+byte offset seen — nothing is re-issued, nothing is lost or duplicated.
+Killing this command (Ctrl-C, closing the laptop) does NOT kill the run;
+reconnect with 'containarium code attach <box>'.
+
+Requires the box to already have Claude Code installed and credentialed —
+see 'containarium code install <box>'.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runCodeRun,
+}
+
+var codeAttachCmd = &cobra.Command{
+	Use:   "attach <box>",
+	Short: "Reconnect to a running (or just-finished) run and replay its output",
+	Long: `Reconnects to the run 'containarium code run' started (or one dispatched
+another way with the same --name) and replays everything it has produced
+since it started, byte-exact, then keeps streaming until it exits or you
+disconnect again.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runCodeAttach,
+}
+
+var codeStatusCmd = &cobra.Command{
+	Use:   "status <box>",
+	Short: "Report a run's liveness and, once finished, its exit code",
+	Long: `Reports whether the run is still alive and, once it has finished
+(including a run that finished while you were disconnected), its exit
+code — 'unknown' rather than a false "finished" if the box died before
+recording one.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runCodeStatus,
+}
+
+var codeStopCmd = &cobra.Command{
+	Use:   "stop <box>",
+	Short: "Stop a run and leave its log readable",
+	Long: `Sends SIGTERM (or SIGKILL with --force) to the run and reaps it. The log
+stays on the box, readable via 'containarium code status' or another
+'code attach'.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runCodeStop,
+}
+
+func runCodeRun(cmd *cobra.Command, args []string) error {
+	box := args[0]
+	if strings.TrimSpace(codeRunPrompt) == "" {
+		return fmt.Errorf("--prompt is required")
+	}
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	diag := cmd.ErrOrStderr()
+	name := codeRunName()
+
+	sess, err := resolveCodeSession(ctx, box, diag)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = sess.Close() }()
+
+	captureMode := "combined"
+	if codeRunStreamJSON {
+		captureMode = "framed"
+	}
+	command := buildClaudeRunCommand(codeRunPrompt, codeRunStreamJSON)
+
+	started, err := sess.ProcessStart(ctx, name, command, "", captureMode)
+	if err != nil {
+		return fmt.Errorf("start run on %q: %w", box, err)
+	}
+	fmt.Fprintf(diag, "✓ started %q (pid %d) on %s\n", started.Name, started.PID, box)
+
+	return streamAndWait(ctx, sess, started.Name, started.LogPath, cmd.OutOrStdout(), diag, codeRunStreamJSON)
+}
+
+func runCodeAttach(cmd *cobra.Command, args []string) error {
+	box := args[0]
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	diag := cmd.ErrOrStderr()
+	name := codeRunName()
+
+	sess, err := resolveCodeSession(ctx, box, diag)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = sess.Close() }()
+
+	listing, err := sess.ProcessList(ctx)
+	if err != nil {
+		return fmt.Errorf("process_list on %q: %w", box, err)
+	}
+	line, _ := runOutcomeLine(listing, name)
+	if line == "" {
+		return fmt.Errorf("no run named %q on %q — start one with `containarium code run %s --prompt ...`", name, box, box)
+	}
+	logPath, err := logPathFromListing(listing, name)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(diag, "✓ attaching to %s\n", line)
+
+	return streamAndWait(ctx, sess, name, logPath, cmd.OutOrStdout(), diag, codeAttachStreamJSON)
+}
+
+func runCodeStatus(cmd *cobra.Command, args []string) error {
+	box := args[0]
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	diag := cmd.ErrOrStderr()
+	name := codeRunName()
+
+	sess, err := resolveCodeSession(ctx, box, diag)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = sess.Close() }()
+
+	listing, err := sess.ProcessList(ctx)
+	if err != nil {
+		return fmt.Errorf("process_list on %q: %w", box, err)
+	}
+	line, _ := runOutcomeLine(listing, name)
+	if line == "" {
+		return fmt.Errorf("no run named %q on %q", name, box)
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), line)
+	return nil
+}
+
+func runCodeStop(cmd *cobra.Command, args []string) error {
+	box := args[0]
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	diag := cmd.ErrOrStderr()
+	name := codeRunName()
+
+	sess, err := resolveCodeSession(ctx, box, diag)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = sess.Close() }()
+
+	res, err := sess.ProcessKill(ctx, name, codeStopForce)
+	if err != nil {
+		return fmt.Errorf("stop %q on %q: %w", name, box, err)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "name: %s\npid: %d\nsignal: %s\nexited: %v\nlog_path: %s\n",
+		res.Name, res.PID, res.Signal, res.Exited, res.LogPath)
+	return nil
+}
+
+// logPathFromListing recovers a run's log_path from process_list's raw
+// text. process_list doesn't expose per-name lookup, so `code attach`
+// greps its own name's block the same way runOutcomeLine does, then reads
+// the "Log path:" line immediately under it.
+func logPathFromListing(listing, name string) (string, error) {
+	lines := strings.Split(listing, "\n")
+	for i, l := range lines {
+		fields := strings.Fields(strings.TrimSpace(l))
+		if len(fields) < 2 || fields[1] != name {
+			continue
+		}
+		for _, follow := range lines[i:] {
+			if strings.HasPrefix(strings.TrimSpace(follow), "Log path:") {
+				return strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(follow), "Log path:")), nil
+			}
+		}
+		return "", fmt.Errorf("process_list entry for %q has no Log path line", name)
+	}
+	return "", fmt.Errorf("no run named %q in process_list", name)
+}

--- a/internal/cmd/code_test.go
+++ b/internal/cmd/code_test.go
@@ -1,0 +1,121 @@
+package cmd
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestShellQuoteSingle_RoundTripsThroughARealShell(t *testing.T) {
+	cases := []string{
+		"plain text",
+		"it's got an apostrophe",
+		"multiple ''' quotes '' in a row",
+		"",
+		"$(rm -rf /) and `also this`",
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			quoted := shellQuoteSingle(in)
+			// #nosec G204 -- fixed "sh -c" with a single literal-quoted
+			// argument built by the function under test; this is the
+			// injection check itself, not a caller-reachable path.
+			out, err := exec.Command("/bin/sh", "-c", "printf '%s' "+quoted).Output()
+			if err != nil {
+				t.Fatalf("shell rejected %q (quoted as %q): %v", in, quoted, err)
+			}
+			if string(out) != in {
+				t.Errorf("round-trip = %q, want %q (quoted form was %q)", out, in, quoted)
+			}
+		})
+	}
+}
+
+func TestShellQuoteSingle_NeverEscapesOutOfTheQuotedString(t *testing.T) {
+	// The classic injection shape: a naive quoter that doesn't handle
+	// embedded quotes lets this argument terminate early and run a second
+	// command.
+	malicious := "'; touch /tmp/pwned; echo '"
+	quoted := shellQuoteSingle(malicious)
+	// #nosec G204 -- see above.
+	out, err := exec.Command("/bin/sh", "-c", "echo "+quoted).Output()
+	if err != nil {
+		t.Fatalf("shell rejected quoted input: %v", err)
+	}
+	got := strings.TrimSuffix(string(out), "\n")
+	if got != malicious {
+		t.Errorf("got %q, want the argument echoed back verbatim (%q) — the shell ran something other than plain echo", got, malicious)
+	}
+}
+
+func TestBuildClaudeRunCommand(t *testing.T) {
+	cmd := buildClaudeRunCommand("fix the bug", false)
+	for _, want := range []string{"secrets.env", "~/.local/bin/claude", "-p", shellQuoteSingle("fix the bug")} {
+		if !strings.Contains(cmd, want) {
+			t.Errorf("command missing %q:\n%s", want, cmd)
+		}
+	}
+	if strings.Contains(cmd, "stream-json") {
+		t.Errorf("combined-mode command should not request stream-json:\n%s", cmd)
+	}
+}
+
+func TestBuildClaudeRunCommand_StreamJSON(t *testing.T) {
+	cmd := buildClaudeRunCommand("fix the bug", true)
+	if !strings.Contains(cmd, "--output-format stream-json") {
+		t.Errorf("expected --output-format stream-json in:\n%s", cmd)
+	}
+}
+
+func TestRunOutcomeLine(t *testing.T) {
+	listing := "Found 2 process(es):\n\n" +
+		"🟢 code  (pid 111, running)\n" +
+		"   Command:    sleep 5\n" +
+		"   Started at: 2026-09-02T12:00:00Z\n" +
+		"   Log path:   /tmp/agent-box/code.log\n\n" +
+		"⚪ old-task  (pid 222, exited)\n" +
+		"   Command:    true\n" +
+		"   Exit code:  0\n" +
+		"   Log path:   /tmp/agent-box/old-task.log\n\n"
+
+	line, running := runOutcomeLine(listing, "code")
+	if !running {
+		t.Errorf("code should be reported running, line=%q", line)
+	}
+	if !strings.Contains(line, "code") || !strings.Contains(line, "running") {
+		t.Errorf("line = %q", line)
+	}
+
+	line, running = runOutcomeLine(listing, "old-task")
+	if running {
+		t.Errorf("old-task should not be reported running, line=%q", line)
+	}
+	if !strings.Contains(line, "old-task") {
+		t.Errorf("line = %q", line)
+	}
+
+	line, running = runOutcomeLine(listing, "does-not-exist")
+	if running || line != "" {
+		t.Errorf("unknown name should report not-running/empty line, got running=%v line=%q", running, line)
+	}
+}
+
+func TestLogPathFromListing(t *testing.T) {
+	listing := "Found 1 process(es):\n\n" +
+		"🟢 code  (pid 111, running)\n" +
+		"   Command:    claude -p hi\n" +
+		"   Started at: 2026-09-02T12:00:00Z\n" +
+		"   Log path:   /tmp/agent-box/code.log\n\n"
+
+	got, err := logPathFromListing(listing, "code")
+	if err != nil {
+		t.Fatalf("logPathFromListing: %v", err)
+	}
+	if got != "/tmp/agent-box/code.log" {
+		t.Errorf("got %q, want /tmp/agent-box/code.log", got)
+	}
+
+	if _, err := logPathFromListing(listing, "nope"); err == nil {
+		t.Error("expected an error for a name not in the listing")
+	}
+}

--- a/internal/cmd/connect.go
+++ b/internal/cmd/connect.go
@@ -163,27 +163,33 @@ func (c *connectAPI) AuthorizeKey(ctx context.Context, box, pub string) error {
 
 // ---- command handler ---------------------------------------------------
 
-// obtainConnectKey returns the public key to authorize and the private
-// key path to authenticate with. With --key it uses the supplied public
-// key; otherwise it reuses (or generates once) the managed key the
-// `ssh setup` flow already uses, so the user never hand-manages a key.
-// The private path defaults to the public path minus ".pub" unless
-// --identity overrides it.
-func obtainConnectKey() (pub, privPath string, err error) {
+// obtainConnectKey returns the public key to authorize and the private key
+// path to authenticate with. With a non-empty keyPath it uses that
+// supplied public key; otherwise it reuses (or generates once) the managed
+// key the `ssh setup` flow already uses, so the user never hand-manages a
+// key. The private path defaults to the public path minus ".pub" unless
+// identity overrides it.
+//
+// Parameterized (not reading connect's own connectKeyPath/connectIdentity
+// package vars) so other commands needing the same "authorize a managed
+// key, connect over SSH" flow — e.g. `code run`/`attach`/`status`/`stop`
+// (#1674) — can call it with their own flag values instead of colliding
+// with connect's.
+func obtainConnectKey(keyPath, identity string) (pub, privPath string, err error) {
 	var pubPath string
-	if connectKeyPath != "" {
-		pub, err = sshkey.ReadPublicKey(connectKeyPath)
+	if keyPath != "" {
+		pub, err = sshkey.ReadPublicKey(keyPath)
 		if err != nil {
 			return "", "", err
 		}
-		pubPath = connectKeyPath
+		pubPath = keyPath
 	} else {
 		pubPath, pub, _, err = sshkey.LocateOrGenerate(sshkey.LocateOpts{})
 		if err != nil {
 			return "", "", fmt.Errorf("locate or generate managed key: %w", err)
 		}
 	}
-	privPath = connectIdentity
+	privPath = identity
 	if privPath == "" {
 		privPath = strings.TrimSuffix(pubPath, ".pub")
 	}
@@ -222,7 +228,7 @@ func runConnect(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	pub, privPath, err := obtainConnectKey()
+	pub, privPath, err := obtainConnectKey(connectKeyPath, connectIdentity)
 	if err != nil {
 		return err
 	}

--- a/internal/coderun/demux.go
+++ b/internal/coderun/demux.go
@@ -1,0 +1,42 @@
+package coderun
+
+import (
+	"io"
+
+	"github.com/footprintai/containarium/internal/logframe"
+)
+
+// DemuxWriter decodes a framed (CaptureFramed) byte stream and routes each
+// frame's payload to the matching underlying writer, in arrival order — the
+// bytes routed to stdout (or to stderr) concatenate back into that
+// stream's original content exactly, regardless of how the framed bytes
+// were chunked across separate Write calls. Pass it as StreamOutput's w
+// when a run's capture_mode is "framed"; pass the plain stdout writer
+// directly when it's "combined".
+type DemuxWriter struct {
+	stdout, stderr io.Writer
+	d              logframe.Demuxer
+}
+
+// NewDemuxWriter returns a DemuxWriter routing decoded stdout frames to
+// stdout and stderr frames to stderr.
+func NewDemuxWriter(stdout, stderr io.Writer) *DemuxWriter {
+	return &DemuxWriter{stdout: stdout, stderr: stderr}
+}
+
+func (w *DemuxWriter) Write(p []byte) (int, error) {
+	frames, err := w.d.Write(p)
+	for _, f := range frames {
+		dst := w.stdout
+		if f.Stream == logframe.Stderr {
+			dst = w.stderr
+		}
+		if _, werr := dst.Write(f.Payload); werr != nil {
+			return 0, werr
+		}
+	}
+	if err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}

--- a/internal/coderun/demux_test.go
+++ b/internal/coderun/demux_test.go
@@ -1,0 +1,52 @@
+package coderun
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/footprintai/containarium/internal/logframe"
+)
+
+func TestDemuxWriter_RoutesEachStream(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	w := NewDemuxWriter(&stdout, &stderr)
+
+	var framed bytes.Buffer
+	framed.Write(logframe.EncodeFrame(logframe.Stdout, []byte("out-a")))
+	framed.Write(logframe.EncodeFrame(logframe.Stderr, []byte("err-a")))
+	framed.Write(logframe.EncodeFrame(logframe.Stdout, []byte("out-b")))
+
+	if _, err := w.Write(framed.Bytes()); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if stdout.String() != "out-aout-b" {
+		t.Errorf("stdout = %q, want %q", stdout.String(), "out-aout-b")
+	}
+	if stderr.String() != "err-a" {
+		t.Errorf("stderr = %q, want %q", stderr.String(), "err-a")
+	}
+}
+
+// TestDemuxWriter_SplitAcrossChunks mirrors how StreamOutput actually
+// drives a Writer: whatever byte range tail_log returned, not
+// frame-aligned by construction.
+func TestDemuxWriter_SplitAcrossChunks(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	w := NewDemuxWriter(&stdout, &stderr)
+
+	var framed bytes.Buffer
+	framed.Write(logframe.EncodeFrame(logframe.Stdout, []byte("hello")))
+	framed.Write(logframe.EncodeFrame(logframe.Stderr, []byte("world")))
+	full := framed.Bytes()
+
+	split := len(full) / 2
+	if _, err := w.Write(full[:split]); err != nil {
+		t.Fatalf("Write(first half): %v", err)
+	}
+	if _, err := w.Write(full[split:]); err != nil {
+		t.Fatalf("Write(second half): %v", err)
+	}
+	if stdout.String() != "hello" || stderr.String() != "world" {
+		t.Errorf("stdout=%q stderr=%q, want hello/world", stdout.String(), stderr.String())
+	}
+}

--- a/internal/coderun/reader.go
+++ b/internal/coderun/reader.go
@@ -1,0 +1,83 @@
+// Package coderun implements the client half of `containarium code`
+// (#1674): a resumable reader over agent-box's tail_log, so a run started
+// on a box survives the local client's connection dying mid-stream. See
+// docs/architecture/remote-coding-agent.md, Part B.
+package coderun
+
+import (
+	"context"
+	"io"
+	"time"
+)
+
+// LogReader abstracts tail_log so the resume logic in StreamOutput is
+// testable without a live box — "that seam is the whole design for
+// testability" (design doc). A real implementation (session.go) reconnects
+// its own underlying SSH/MCP session on a transport failure, internally;
+// StreamOutput only needs to know that a failed Read can be retried from
+// the same offset.
+type LogReader interface {
+	// Read returns bytes from startOffset, the new end offset, and whether
+	// the read was cut short by tail_log's output cap (never EOF — more
+	// data may already exist past endOffset).
+	Read(ctx context.Context, path string, startOffset int64, follow time.Duration) (data []byte, endOffset int64, truncated bool, err error)
+}
+
+// retryBackoff bounds how long StreamOutput waits before retrying a failed
+// Read. Short: a dropped SSH connection reconnects in well under a second
+// in practice, and the whole point of this loop is not making the user
+// re-issue a command.
+const retryBackoff = 250 * time.Millisecond
+
+// StreamOutput reads path via r from startOffset, writing bytes to w as
+// they arrive, until ctx is cancelled. Returns the final offset reached.
+//
+// Two rules carry the north-star metric (0 bytes missing or duplicated
+// across >=20 forced mid-run disconnects):
+//
+//   - On a Read error, retry from the SAME offset after a brief backoff —
+//     never skip ahead, never re-derive a new starting point. onErr, if
+//     non-nil, is called with each error (for logging/diagnostics); it does
+//     not affect retry behavior.
+//   - On truncated:true (tail_log hit its output cap), re-read
+//     IMMEDIATELY — no backoff, no waiting out `follow`. Treating a capped
+//     read like "no more data yet" silently slow-drips the run's output;
+//     since more data is already known to exist, sleeping here has no
+//     upside and only means an agent watching the stream sees an
+//     artificial stall.
+func StreamOutput(ctx context.Context, r LogReader, w io.Writer, path string, startOffset int64, follow time.Duration, onErr func(error)) (int64, error) {
+	offset := startOffset
+	for {
+		select {
+		case <-ctx.Done():
+			return offset, ctx.Err()
+		default:
+		}
+
+		// truncated is not branched on: every non-error path already loops
+		// back to the top immediately, with no client-side delay of any
+		// kind — the only throttle anywhere in this loop is retryBackoff
+		// on an actual error. So a truncated read is, by construction,
+		// already re-read as fast as any other read; there is no separate
+		// "sleep the poll interval" behavior here to skip.
+		data, end, _, err := r.Read(ctx, path, offset, follow)
+		if err != nil {
+			if onErr != nil {
+				onErr(err)
+			}
+			select {
+			case <-ctx.Done():
+				return offset, ctx.Err()
+			case <-time.After(retryBackoff):
+			}
+			continue
+		}
+
+		if len(data) > 0 {
+			if _, werr := w.Write(data); werr != nil {
+				return offset, werr
+			}
+		}
+		offset = end
+	}
+}

--- a/internal/coderun/reader_test.go
+++ b/internal/coderun/reader_test.go
@@ -1,0 +1,233 @@
+package coderun
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"math/rand"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// syncBuffer is a mutex-guarded bytes.Buffer: StreamOutput writes from its
+// own goroutine while tests poll the accumulated output from the test
+// goroutine, and bytes.Buffer alone isn't safe for that.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func (b *syncBuffer) Len() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Len()
+}
+
+// fakeReader is a deterministic, seeded stand-in for a real tail_log
+// transport (#1674 design doc, Part B1: "that seam is the whole design for
+// testability"). It serves a fixed underlying byte string from an
+// in-memory offset, optionally failing on a seeded schedule and optionally
+// capping reads to simulate tail_log's 256 KiB truncation.
+type fakeReader struct {
+	data []byte
+
+	// failEveryN, when > 0, fails (a transient transport error) every Nth
+	// call rather than serving data — the seed for a reproducible drop
+	// schedule.
+	failEveryN int
+	calls      int
+
+	// capBytes, when > 0, caps a single successful read to at most this
+	// many bytes and reports truncated=true when more data remains —
+	// simulating tailLogOutputLimit.
+	capBytes int
+}
+
+func (f *fakeReader) Read(_ context.Context, _ string, startOffset int64, _ time.Duration) ([]byte, int64, bool, error) {
+	f.calls++
+	if f.failEveryN > 0 && f.calls%f.failEveryN == 0 {
+		return nil, startOffset, false, errors.New("simulated transport failure")
+	}
+	if startOffset >= int64(len(f.data)) {
+		return nil, startOffset, false, nil // caught up, nothing new yet
+	}
+	end := int64(len(f.data))
+	truncated := false
+	if f.capBytes > 0 && end-startOffset > int64(f.capBytes) {
+		end = startOffset + int64(f.capBytes)
+		truncated = true
+	}
+	return f.data[startOffset:end], end, truncated, nil
+}
+
+func TestStreamOutput_CleanRead(t *testing.T) {
+	r := &fakeReader{data: []byte("hello world")}
+	var out syncBuffer
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := StreamOutput(ctx, r, &out, "log", 0, 10*time.Millisecond, nil)
+		done <- err
+	}()
+
+	waitForContent(t, &out, "hello world")
+	cancel()
+	<-done
+
+	if out.String() != "hello world" {
+		t.Errorf("out = %q, want %q", out.String(), "hello world")
+	}
+}
+
+// TestStreamOutput_RetriesFromSameOffsetOnTransportError is the core
+// north-star property: a transport failure must never skip ahead or
+// duplicate — the next successful read after N failures resumes at
+// EXACTLY the offset the last successful read left off at.
+func TestStreamOutput_RetriesFromSameOffsetOnTransportError(t *testing.T) {
+	r := &fakeReader{data: []byte("no bytes lost or duplicated"), failEveryN: 3}
+	var out syncBuffer
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var errCount int
+	done := make(chan error, 1)
+	go func() {
+		_, err := StreamOutput(ctx, r, &out, "log", 0, 10*time.Millisecond, func(error) { errCount++ })
+		done <- err
+	}()
+
+	waitForContent(t, &out, "no bytes lost or duplicated")
+	cancel()
+	<-done
+
+	if out.String() != "no bytes lost or duplicated" {
+		t.Errorf("out = %q, want exact content with no loss/duplication", out.String())
+	}
+	if errCount == 0 {
+		t.Error("expected at least one simulated transport error to have been observed")
+	}
+}
+
+// TestStreamOutput_SurvivesTwentyForcedDrops pins the PRD's own north-star
+// metric directly: "0 bytes missing or duplicated across >= 20 forced
+// mid-run disconnects."
+func TestStreamOutput_SurvivesTwentyForcedDrops(t *testing.T) {
+	// A generator that is NOT a repeating/constant pattern — per the design
+	// doc, a constant stream can't distinguish loss from duplication.
+	rng := rand.New(rand.NewSource(1))
+	var want bytes.Buffer
+	for i := 0; i < 4000; i++ {
+		want.WriteByte("abcdefghijklmnopqrstuvwxyz"[rng.Intn(26)])
+	}
+
+	// capBytes forces many small reads to drain 4000 bytes (rather than one
+	// big read), so failEveryN actually gets enough opportunities to fire
+	// >=20 times, matching "across >=20 forced mid-run disconnects".
+	r := &fakeReader{data: want.Bytes(), failEveryN: 7, capBytes: 100}
+	var out syncBuffer
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := StreamOutput(ctx, r, &out, "log", 0, time.Millisecond, nil)
+		done <- err
+	}()
+
+	waitForContent(t, &out, want.String())
+	cancel()
+	<-done
+
+	if out.String() != want.String() {
+		// Report the first divergent byte offset, not the whole (large) strings.
+		got := out.String()
+		i := 0
+		for i < len(got) && i < want.Len() && got[i] == want.String()[i] {
+			i++
+		}
+		t.Fatalf("diverges at byte %d: got %q..., want %q...", i, safeSlice(got, i), safeSlice(want.String(), i))
+	}
+	if r.calls < 20 {
+		t.Errorf("only %d Read calls; want enough to actually exercise repeated drops", r.calls)
+	}
+}
+
+func safeSlice(s string, from int) string {
+	end := from + 20
+	if end > len(s) {
+		end = len(s)
+	}
+	if from > len(s) {
+		from = len(s)
+	}
+	return s[from:end]
+}
+
+// TestStreamOutput_TruncatedRereadsImmediately is the explicit AC: on
+// truncated:true the client re-reads immediately rather than sleeping the
+// poll interval. Uses a long follow/poll duration and a small capBytes —
+// if StreamOutput slept between the capped reads, catching up would take
+// several multiples of that duration; asserts it doesn't.
+func TestStreamOutput_TruncatedRereadsImmediately(t *testing.T) {
+	data := bytes.Repeat([]byte("x"), 10_000)
+	r := &fakeReader{data: data, capBytes: 500}
+	var out syncBuffer
+	ctx, cancel := context.WithCancel(context.Background())
+
+	longPoll := 2 * time.Second
+	start := time.Now()
+	done := make(chan error, 1)
+	go func() {
+		_, err := StreamOutput(ctx, r, &out, "log", 0, longPoll, nil)
+		done <- err
+	}()
+
+	waitForContentLen(t, &out, len(data))
+	elapsed := time.Since(start)
+	cancel()
+	<-done
+
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("catching up 20 capped reads took %s — truncated:true must re-read immediately, not sleep %s each time", elapsed, longPoll)
+	}
+	if out.Len() != len(data) {
+		t.Errorf("out.Len() = %d, want %d (nothing silently dropped at the cap)", out.Len(), len(data))
+	}
+}
+
+func waitForContent(t *testing.T, out *syncBuffer, want string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.Contains(out.String(), want) {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for output to contain %q, got %q", want, out.String())
+}
+
+func waitForContentLen(t *testing.T, out *syncBuffer, n int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if out.Len() >= n {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d bytes of output, got %d", n, out.Len())
+}

--- a/internal/coderun/session.go
+++ b/internal/coderun/session.go
@@ -1,0 +1,235 @@
+package coderun
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// tailLogContentMarker is tail_log's own literal separator between its
+// key:value header and raw file content (internal/agentbox/tail_log.go).
+const tailLogContentMarker = "--- content ---\n"
+
+// Session is a live MCP connection to one box's agent-box, reached the same
+// way any MCP client (Claude Code, Claude Desktop) reaches it: spawn
+// `ssh <sshArgs...> -- agent-box` as a subprocess and speak MCP over its
+// stdio (docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md). Implements LogReader
+// directly, transparently reconnecting once on a transport-level failure
+// (a dropped SSH connection) before surfacing an error — StreamOutput's own
+// retry loop is the second line of defense for anything that doesn't
+// self-heal on one reconnect attempt.
+type Session struct {
+	sshArgs []string // ssh's own flags/target; "agent-box" is appended as the remote command
+
+	mu  sync.Mutex
+	mcp *client.Client
+}
+
+// Connect spawns ssh with sshArgs (host/user/identity/port flags — NOT
+// including a remote command) plus "agent-box" appended as the remote
+// command, and initializes an MCP session over its stdio.
+func Connect(ctx context.Context, sshArgs []string) (*Session, error) {
+	s := &Session{sshArgs: sshArgs}
+	c, err := s.dial(ctx)
+	if err != nil {
+		return nil, err
+	}
+	s.mcp = c
+	return s, nil
+}
+
+func (s *Session) dial(ctx context.Context) (*client.Client, error) {
+	args := append(append([]string{}, s.sshArgs...), "agent-box")
+	// #nosec G204 -- sshArgs is built by the CLI command from a
+	// daemon-resolved target + validated flags, the same construction
+	// connectcore.BuildSSHArgs already uses for `connect`/`code install`;
+	// "agent-box" is a fixed literal, never caller input.
+	c, err := client.NewStdioMCPClient("ssh", nil, args...)
+	if err != nil {
+		return nil, fmt.Errorf("start agent-box over ssh: %w", err)
+	}
+	initReq := mcp.InitializeRequest{}
+	initReq.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	initReq.Params.ClientInfo = mcp.Implementation{Name: "containarium-code", Version: "1"}
+	if _, err := c.Initialize(ctx, initReq); err != nil {
+		_ = c.Close()
+		return nil, fmt.Errorf("initialize MCP session: %w", err)
+	}
+	return c, nil
+}
+
+// Close ends the underlying ssh subprocess and MCP session.
+func (s *Session) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.mcp.Close()
+}
+
+// callTool invokes name with args and returns its concatenated text
+// content. reconnect=true retries once over a freshly-dialed session on
+// any error (transport-level failures — a dead ssh subprocess, a closed
+// pipe — look identical to a tool-level error at this layer, so the retry
+// is harmless when it wasn't actually a transport failure: a genuine
+// application error simply repeats).
+func (s *Session) callTool(ctx context.Context, name string, args map[string]any, reconnect bool) (string, error) {
+	s.mu.Lock()
+	c := s.mcp
+	s.mu.Unlock()
+
+	text, err := doCallTool(ctx, c, name, args)
+	if err == nil || !reconnect {
+		return text, err
+	}
+
+	fresh, dialErr := s.dial(ctx)
+	if dialErr != nil {
+		return "", fmt.Errorf("%v (reconnect also failed: %w)", err, dialErr)
+	}
+	s.mu.Lock()
+	_ = s.mcp.Close()
+	s.mcp = fresh
+	s.mu.Unlock()
+
+	return doCallTool(ctx, fresh, name, args)
+}
+
+func doCallTool(ctx context.Context, c *client.Client, name string, args map[string]any) (string, error) {
+	res, err := c.CallTool(ctx, mcp.CallToolRequest{Params: mcp.CallToolParams{Name: name, Arguments: args}})
+	if err != nil {
+		return "", err
+	}
+	var sb strings.Builder
+	for _, content := range res.Content {
+		if tc, ok := content.(mcp.TextContent); ok {
+			sb.WriteString(tc.Text)
+		}
+	}
+	text := sb.String()
+	if res.IsError {
+		return "", fmt.Errorf("%s", strings.TrimSpace(text))
+	}
+	return text, nil
+}
+
+// parseKV splits agent-box's plain-text "key: value\n" tool-result
+// convention into a map. When marker is non-empty and present in body
+// (tail_log's "--- content ---\n" separator), only the text before it is
+// parsed as key:value pairs; everything after is returned separately as
+// raw content, since it is arbitrary file bytes, not more header lines.
+func parseKV(body, marker string) (kv map[string]string, rest string) {
+	head := body
+	if marker != "" {
+		if idx := strings.Index(body, marker); idx >= 0 {
+			head = body[:idx]
+			rest = body[idx+len(marker):]
+		}
+	}
+	kv = make(map[string]string)
+	for _, line := range strings.Split(head, "\n") {
+		if line == "" {
+			continue
+		}
+		k, v, ok := strings.Cut(line, ": ")
+		if !ok {
+			continue
+		}
+		kv[k] = v
+	}
+	return kv, rest
+}
+
+// ProcessStartResult is process_start's response, typed (per CLAUDE.md)
+// from agent-box's plain-text body.
+type ProcessStartResult struct {
+	Name, Command, LogPath string
+	PID                    int
+	StartedAt              time.Time
+}
+
+// ProcessStart spawns command on the box. captureMode is "combined" or
+// "framed" ("" defaults to "combined", matching process_start's own
+// default) — see internal/agentbox's CaptureMode for what each means.
+func (s *Session) ProcessStart(ctx context.Context, name, command, cwd, captureMode string) (*ProcessStartResult, error) {
+	args := map[string]any{"command": command}
+	if name != "" {
+		args["name"] = name
+	}
+	if cwd != "" {
+		args["cwd"] = cwd
+	}
+	if captureMode != "" {
+		args["capture_mode"] = captureMode
+	}
+	text, err := s.callTool(ctx, "process_start", args, true)
+	if err != nil {
+		return nil, fmt.Errorf("process_start: %w", err)
+	}
+	kv, _ := parseKV(text, "")
+	pid, _ := strconv.Atoi(kv["pid"])
+	startedAt, _ := time.Parse(time.RFC3339, kv["started_at"])
+	return &ProcessStartResult{
+		Name: kv["name"], Command: kv["command"], LogPath: kv["log_path"],
+		PID: pid, StartedAt: startedAt,
+	}, nil
+}
+
+// Read implements LogReader by calling tail_log. followSeconds bounds how
+// long the SERVER blocks polling for new content before returning — most
+// of StreamOutput's "streaming" feel comes from this blocking, not from
+// polling frequency on the client side.
+func (s *Session) Read(ctx context.Context, path string, startOffset int64, follow time.Duration) ([]byte, int64, bool, error) {
+	args := map[string]any{
+		"path":           path,
+		"start_offset":   float64(startOffset),
+		"follow_seconds": follow.Seconds(),
+	}
+	text, err := s.callTool(ctx, "tail_log", args, true)
+	if err != nil {
+		return nil, startOffset, false, fmt.Errorf("tail_log: %w", err)
+	}
+	kv, content := parseKV(text, tailLogContentMarker)
+	end, _ := strconv.ParseInt(kv["end_offset"], 10, 64)
+	truncated := kv["truncated"] == "true"
+	return []byte(content), end, truncated, nil
+}
+
+// ProcessKillResult is process_kill's response, typed from agent-box's
+// plain-text body.
+type ProcessKillResult struct {
+	Name, Signal, LogPath string
+	PID                   int
+	Exited                bool
+}
+
+// ProcessKill stops name on the box.
+func (s *Session) ProcessKill(ctx context.Context, name string, force bool) (*ProcessKillResult, error) {
+	text, err := s.callTool(ctx, "process_kill", map[string]any{"name": name, "force": force}, true)
+	if err != nil {
+		return nil, fmt.Errorf("process_kill: %w", err)
+	}
+	kv, _ := parseKV(text, "")
+	pid, _ := strconv.Atoi(kv["pid"])
+	return &ProcessKillResult{
+		Name: kv["name"], Signal: kv["signal"], LogPath: kv["log_path"],
+		PID: pid, Exited: kv["exited"] == "true",
+	}, nil
+}
+
+// ProcessList returns process_list's raw text body — a multi-process
+// listing agent-box formats for humans, not single-record key:value pairs.
+// Callers that need one run's status (containarium code status) grep this
+// for the run's own block rather than this package re-parsing agent-box's
+// display format into a second, redundant typed shape.
+func (s *Session) ProcessList(ctx context.Context) (string, error) {
+	text, err := s.callTool(ctx, "process_list", nil, true)
+	if err != nil {
+		return "", fmt.Errorf("process_list: %w", err)
+	}
+	return text, nil
+}

--- a/internal/coderun/session_test.go
+++ b/internal/coderun/session_test.go
@@ -1,0 +1,86 @@
+package coderun
+
+import (
+	"strconv"
+	"testing"
+)
+
+// These fixtures are agent-box's own output formats (internal/agentbox's
+// handleProcessStart/handleTailLog/handleProcessKill Sprintf bodies) —
+// kept in sync by hand since coderun deliberately doesn't import agentbox
+// (a CLI-side package pulling in agent-box's exec/syscall internals for a
+// string format would be the wrong coupling; the wire contract is text,
+// not a shared Go type).
+
+func TestParseKV_ProcessStartBody(t *testing.T) {
+	body := "name: my-run\npid: 12345\ncommand: sleep 5\nlog_path: /tmp/agent-box/my-run.log\nstarted_at: 2026-09-02T12:00:00Z\n"
+	kv, rest := parseKV(body, "")
+	if rest != "" {
+		t.Errorf("rest = %q, want empty (no content marker in this body)", rest)
+	}
+	want := map[string]string{
+		"name": "my-run", "pid": "12345", "command": "sleep 5",
+		"log_path": "/tmp/agent-box/my-run.log", "started_at": "2026-09-02T12:00:00Z",
+	}
+	for k, v := range want {
+		if kv[k] != v {
+			t.Errorf("kv[%q] = %q, want %q", k, kv[k], v)
+		}
+	}
+}
+
+func TestParseKV_TailLogBody_SeparatesHeaderFromContent(t *testing.T) {
+	body := "path: /tmp/x.log\nstart_offset: 0\nend_offset: 11\nbytes_returned: 11\ntruncated: false\nfollow_seconds: 10\n--- content ---\nhello: not-a-header\nworld"
+	kv, content := parseKV(body, tailLogContentMarker)
+	if kv["end_offset"] != "11" {
+		t.Errorf(`kv["end_offset"] = %q, want "11"`, kv["end_offset"])
+	}
+	if kv["truncated"] != "false" {
+		t.Errorf(`kv["truncated"] = %q, want "false"`, kv["truncated"])
+	}
+	// "hello: not-a-header" must NOT be parsed as a kv pair — it's file
+	// content that happens to look like one.
+	if _, present := kv["hello"]; present {
+		t.Error(`content line "hello: not-a-header" was parsed as a header key — content marker split failed`)
+	}
+	if content != "hello: not-a-header\nworld" {
+		t.Errorf("content = %q, want the raw text after the marker verbatim", content)
+	}
+}
+
+func TestParseKV_TailLogBody_EmptyContent(t *testing.T) {
+	body := "path: /tmp/x.log\nstart_offset: 5\nend_offset: 5\nbytes_returned: 0\ntruncated: false\nfollow_seconds: 10\n--- content ---\n"
+	kv, content := parseKV(body, tailLogContentMarker)
+	if kv["start_offset"] != "5" || kv["end_offset"] != "5" {
+		t.Errorf("kv = %+v", kv)
+	}
+	if content != "" {
+		t.Errorf("content = %q, want empty", content)
+	}
+}
+
+func TestParseKV_ProcessKillBody(t *testing.T) {
+	body := "name: kill-me\npid: 999\nsignal: SIGTERM\nexited: true\nlog_path: /tmp/agent-box/kill-me.log\n"
+	kv, _ := parseKV(body, "")
+	if kv["signal"] != "SIGTERM" {
+		t.Errorf(`kv["signal"] = %q, want "SIGTERM"`, kv["signal"])
+	}
+	if kv["exited"] != "true" {
+		t.Errorf(`kv["exited"] = %q, want "true"`, kv["exited"])
+	}
+	pid, err := strconv.Atoi(kv["pid"])
+	if err != nil || pid != 999 {
+		t.Errorf("pid = %q (err=%v), want 999", kv["pid"], err)
+	}
+}
+
+func TestParseKV_MarkerAbsentReturnsWholeBodyAsHead(t *testing.T) {
+	body := "name: x\npid: 1\n"
+	kv, rest := parseKV(body, tailLogContentMarker) // marker not actually present
+	if rest != "" {
+		t.Errorf("rest = %q, want empty when the marker never appears", rest)
+	}
+	if kv["name"] != "x" || kv["pid"] != "1" {
+		t.Errorf("kv = %+v", kv)
+	}
+}

--- a/internal/logframe/logframe.go
+++ b/internal/logframe/logframe.go
@@ -1,0 +1,91 @@
+// Package logframe implements the #1674 text-safe framing format shared by
+// agent-box's writer (internal/agentbox, framed capture_mode) and the
+// `containarium code` client's demuxer: one frame per line,
+// "<stream> <base64(payload)>\n". See
+// docs/architecture/remote-coding-agent.md, Part A "Framing" for why: the
+// log is read back through tail_log inside an MCP TEXT result
+// (mcp.NewToolResultText), so raw binary framing bytes — and any multi-byte
+// rune split across a read/write boundary — would be mangled by JSON's
+// UTF-8 encoding. base64 makes every frame valid UTF-8 regardless of what
+// bytes it carries.
+package logframe
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+)
+
+// Stream identifies which of a spawned process's two output streams a
+// frame belongs to.
+type Stream byte
+
+const (
+	Stdout Stream = '1'
+	Stderr Stream = '2'
+)
+
+// EncodeFrame renders payload as one frame: "<stream> <base64(payload)>\n".
+// payload may be any byte slice, including one that splits a UTF-8 rune —
+// base64 doesn't care about rune boundaries. The decoder reassembles
+// complete runes by concatenating consecutive same-stream frames' decoded
+// bytes, never by inspecting a single frame in isolation.
+func EncodeFrame(stream Stream, payload []byte) []byte {
+	encoded := base64.StdEncoding.EncodeToString(payload)
+	out := make([]byte, 0, 3+len(encoded))
+	out = append(out, byte(stream), ' ')
+	out = append(out, encoded...)
+	out = append(out, '\n')
+	return out
+}
+
+// Frame is one decoded frame: which stream it belongs to, and its raw
+// (already base64-decoded) payload bytes.
+type Frame struct {
+	Stream  Stream
+	Payload []byte
+}
+
+// Demuxer incrementally decodes a framed byte stream that may arrive in
+// arbitrary chunks — including mid-line, e.g. tail_log resuming right in
+// the middle of a not-yet-fully-written frame (a read cut mid-line must be
+// detectable and completed on the next read, per the design doc). Feed it
+// every chunk, in stream order, via Write; it returns every complete frame
+// it can now decode, leaving any trailing partial line buffered internally
+// for the next call. Zero value is ready to use.
+type Demuxer struct {
+	buf []byte
+}
+
+// Write appends chunk to the internal buffer and returns every complete
+// frame it can now decode, in order. A malformed line (this should never
+// happen against a real agent-box writer, only against corrupted/foreign
+// input) stops decoding and returns an error alongside whatever valid
+// frames were already decoded from this call.
+func (d *Demuxer) Write(chunk []byte) ([]Frame, error) {
+	d.buf = append(d.buf, chunk...)
+
+	var frames []Frame
+	for {
+		i := bytes.IndexByte(d.buf, '\n')
+		if i < 0 {
+			break // no complete line yet — wait for more
+		}
+		line := d.buf[:i]
+		d.buf = d.buf[i+1:]
+
+		if len(line) < 2 || line[1] != ' ' {
+			return frames, fmt.Errorf("logframe: malformed frame line %q", line)
+		}
+		stream := Stream(line[0])
+		if stream != Stdout && stream != Stderr {
+			return frames, fmt.Errorf("logframe: unknown stream id %q", line[0])
+		}
+		payload, err := base64.StdEncoding.DecodeString(string(line[2:]))
+		if err != nil {
+			return frames, fmt.Errorf("logframe: decode frame: %w", err)
+		}
+		frames = append(frames, Frame{Stream: stream, Payload: payload})
+	}
+	return frames, nil
+}

--- a/internal/logframe/logframe_test.go
+++ b/internal/logframe/logframe_test.go
@@ -1,0 +1,163 @@
+package logframe
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestEncodeFrame_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name    string
+		stream  Stream
+		payload []byte
+	}{
+		{"stdout text", Stdout, []byte("hello world\n")},
+		{"stderr text", Stderr, []byte("warning: something\n")},
+		{"empty payload", Stdout, []byte{}},
+		{"binary payload", Stderr, []byte{0x00, 0xff, 0x10, 0x80}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var d Demuxer
+			frames, err := d.Write(EncodeFrame(tc.stream, tc.payload))
+			if err != nil {
+				t.Fatalf("Write: %v", err)
+			}
+			if len(frames) != 1 {
+				t.Fatalf("got %d frames, want 1", len(frames))
+			}
+			if frames[0].Stream != tc.stream {
+				t.Errorf("Stream = %v, want %v", frames[0].Stream, tc.stream)
+			}
+			if !bytes.Equal(frames[0].Payload, tc.payload) {
+				t.Errorf("Payload = %q, want %q", frames[0].Payload, tc.payload)
+			}
+		})
+	}
+}
+
+func TestDemuxer_BuffersPartialLine(t *testing.T) {
+	var d Demuxer
+	full := EncodeFrame(Stdout, []byte("hello"))
+	// Split the encoded frame mid-line — no trailing newline yet.
+	split := len(full) - 3
+
+	frames, err := d.Write(full[:split])
+	if err != nil {
+		t.Fatalf("Write (partial): %v", err)
+	}
+	if len(frames) != 0 {
+		t.Fatalf("got %d frames from a partial line, want 0", len(frames))
+	}
+
+	frames, err = d.Write(full[split:])
+	if err != nil {
+		t.Fatalf("Write (rest): %v", err)
+	}
+	if len(frames) != 1 || string(frames[0].Payload) != "hello" {
+		t.Fatalf("got %+v, want one frame with payload %q", frames, "hello")
+	}
+}
+
+// TestDemuxer_MultiByteRuneSplitAcrossFrames pins the whole reason framing
+// is base64: a UTF-8 rune split across two separate writer chunks must not
+// corrupt either frame — each decodes cleanly on its own, and concatenating
+// the decoded payloads (the caller's job, not the demuxer's) reconstructs
+// the original bytes exactly.
+func TestDemuxer_MultiByteRuneSplitAcrossFrames(t *testing.T) {
+	original := []byte("héllo") // 'é' is 2 bytes in UTF-8
+	splitAt := 2                // lands inside the 2-byte rune
+
+	var d Demuxer
+	var got []byte
+	for _, chunk := range [][]byte{original[:splitAt], original[splitAt:]} {
+		frames, err := d.Write(EncodeFrame(Stdout, chunk))
+		if err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+		for _, f := range frames {
+			got = append(got, f.Payload...)
+		}
+	}
+	if !bytes.Equal(got, original) {
+		t.Errorf("reassembled = %q, want %q", got, original)
+	}
+}
+
+func TestDemuxer_InterleavedStreamsPreserveOrder(t *testing.T) {
+	var buf bytes.Buffer
+	buf.Write(EncodeFrame(Stdout, []byte("out1")))
+	buf.Write(EncodeFrame(Stderr, []byte("err1")))
+	buf.Write(EncodeFrame(Stdout, []byte("out2")))
+	buf.Write(EncodeFrame(Stderr, []byte("err2")))
+
+	var d Demuxer
+	frames, err := d.Write(buf.Bytes())
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	want := []struct {
+		stream  Stream
+		payload string
+	}{
+		{Stdout, "out1"}, {Stderr, "err1"}, {Stdout, "out2"}, {Stderr, "err2"},
+	}
+	if len(frames) != len(want) {
+		t.Fatalf("got %d frames, want %d", len(frames), len(want))
+	}
+	for i, w := range want {
+		if frames[i].Stream != w.stream || string(frames[i].Payload) != w.payload {
+			t.Errorf("frame %d = %v %q, want %v %q", i, frames[i].Stream, frames[i].Payload, w.stream, w.payload)
+		}
+	}
+}
+
+// TestDemuxer_ChunkedArbitrarily feeds the same multi-frame buffer split at
+// several different byte offsets (not aligned to frame boundaries) and
+// checks the decoded result is identical every time — the resumable
+// reader will hand the demuxer whatever byte range tail_log happened to
+// return, never frame-aligned by construction.
+func TestDemuxer_ChunkedArbitrarily(t *testing.T) {
+	var buf bytes.Buffer
+	for i := 0; i < 5; i++ {
+		buf.Write(EncodeFrame(Stdout, []byte("line-out")))
+		buf.Write(EncodeFrame(Stderr, []byte("line-err")))
+	}
+	full := buf.Bytes()
+
+	splits := []int{1, 7, 13, 29, 40}
+	for _, split := range splits {
+		if split >= len(full) {
+			continue
+		}
+		var d Demuxer
+		f1, err := d.Write(full[:split])
+		if err != nil {
+			t.Fatalf("split=%d: Write(first): %v", split, err)
+		}
+		f2, err := d.Write(full[split:])
+		if err != nil {
+			t.Fatalf("split=%d: Write(second): %v", split, err)
+		}
+		got := append(f1, f2...)
+		if len(got) != 10 {
+			t.Fatalf("split=%d: got %d frames, want 10", split, len(got))
+		}
+	}
+}
+
+func TestDemuxer_MalformedLine(t *testing.T) {
+	var d Demuxer
+	_, err := d.Write([]byte("not-a-valid-frame\n"))
+	if err == nil {
+		t.Fatal("expected an error for a malformed frame line")
+	}
+}
+
+func TestDemuxer_UnknownStreamID(t *testing.T) {
+	var d Demuxer
+	_, err := d.Write([]byte("9 aGVsbG8=\n"))
+	if err == nil {
+		t.Fatal("expected an error for an unrecognized stream id")
+	}
+}

--- a/pkg/pb/containarium/v1/sandbox.pb.go
+++ b/pkg/pb/containarium/v1/sandbox.pb.go
@@ -193,6 +193,61 @@ func (SandboxTemplate) EnumDescriptor() ([]byte, []int) {
 	return file_containarium_v1_sandbox_proto_rawDescGZIP(), []int{2}
 }
 
+// CaptureMode selects how a spawned process's combined stdout+stderr is
+// written to its log file (#1674). COMBINED is today's plain-text behavior;
+// FRAMED is opt-in, text-safe per-line framing ("<stream> <base64(payload)>")
+// so a client can demux stdout/stderr from the single offset stream without
+// corrupting invalid UTF-8 or runes split across a write — see
+// docs/architecture/remote-coding-agent.md, Part A "Framing".
+type CaptureMode int32
+
+const (
+	CaptureMode_CAPTURE_MODE_UNSPECIFIED CaptureMode = 0 // treated as COMBINED
+	CaptureMode_CAPTURE_MODE_COMBINED    CaptureMode = 1
+	CaptureMode_CAPTURE_MODE_FRAMED      CaptureMode = 2
+)
+
+// Enum value maps for CaptureMode.
+var (
+	CaptureMode_name = map[int32]string{
+		0: "CAPTURE_MODE_UNSPECIFIED",
+		1: "CAPTURE_MODE_COMBINED",
+		2: "CAPTURE_MODE_FRAMED",
+	}
+	CaptureMode_value = map[string]int32{
+		"CAPTURE_MODE_UNSPECIFIED": 0,
+		"CAPTURE_MODE_COMBINED":    1,
+		"CAPTURE_MODE_FRAMED":      2,
+	}
+)
+
+func (x CaptureMode) Enum() *CaptureMode {
+	p := new(CaptureMode)
+	*p = x
+	return p
+}
+
+func (x CaptureMode) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (CaptureMode) Descriptor() protoreflect.EnumDescriptor {
+	return file_containarium_v1_sandbox_proto_enumTypes[3].Descriptor()
+}
+
+func (CaptureMode) Type() protoreflect.EnumType {
+	return &file_containarium_v1_sandbox_proto_enumTypes[3]
+}
+
+func (x CaptureMode) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use CaptureMode.Descriptor instead.
+func (CaptureMode) EnumDescriptor() ([]byte, []int) {
+	return file_containarium_v1_sandbox_proto_rawDescGZIP(), []int{3}
+}
+
 // Sandbox describes one sandbox's identity and lifecycle state.
 type Sandbox struct {
 	state      protoimpl.MessageState `protogen:"open.v1"`
@@ -974,7 +1029,10 @@ type SpawnRequest struct {
 	// be unique among this box's currently-registered processes.
 	Name string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
 	// Working directory. Empty = agent-box's own cwd.
-	Cwd           string `protobuf:"bytes,3,opt,name=cwd,proto3" json:"cwd,omitempty"`
+	Cwd string `protobuf:"bytes,3,opt,name=cwd,proto3" json:"cwd,omitempty"`
+	// How to capture this process's output (#1674). UNSPECIFIED/omitted ->
+	// COMBINED, so every existing caller is unaffected.
+	CaptureMode   CaptureMode `protobuf:"varint,4,opt,name=capture_mode,json=captureMode,proto3,enum=containarium.v1.CaptureMode" json:"capture_mode,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1028,6 +1086,13 @@ func (x *SpawnRequest) GetCwd() string {
 		return x.Cwd
 	}
 	return ""
+}
+
+func (x *SpawnRequest) GetCaptureMode() CaptureMode {
+	if x != nil {
+		return x.CaptureMode
+	}
+	return CaptureMode_CAPTURE_MODE_UNSPECIFIED
 }
 
 type SpawnResponse struct {
@@ -1273,11 +1338,12 @@ const file_containarium_v1_sandbox_proto_rawDesc = "" +
 	"\btemplate\x18\x01 \x01(\x0e2 .containarium.v1.SandboxTemplateR\btemplate\x12\x14\n" +
 	"\x05ready\x18\x02 \x01(\x05R\x05ready\x12\x18\n" +
 	"\awarming\x18\x03 \x01(\x05R\awarming\x12\x19\n" +
-	"\bmin_warm\x18\x04 \x01(\x05R\aminWarm\"N\n" +
+	"\bmin_warm\x18\x04 \x01(\x05R\aminWarm\"\x8f\x01\n" +
 	"\fSpawnRequest\x12\x18\n" +
 	"\acommand\x18\x01 \x01(\tR\acommand\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x10\n" +
-	"\x03cwd\x18\x03 \x01(\tR\x03cwd\"P\n" +
+	"\x03cwd\x18\x03 \x01(\tR\x03cwd\x12?\n" +
+	"\fcapture_mode\x18\x04 \x01(\x0e2\x1c.containarium.v1.CaptureModeR\vcaptureMode\"P\n" +
 	"\rSpawnResponse\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x10\n" +
 	"\x03pid\x18\x02 \x01(\x03R\x03pid\x12\x19\n" +
@@ -1303,7 +1369,11 @@ const file_containarium_v1_sandbox_proto_rawDesc = "" +
 	"\x10SERVED_FROM_POOL\x10\x02*N\n" +
 	"\x0fSandboxTemplate\x12 \n" +
 	"\x1cSANDBOX_TEMPLATE_UNSPECIFIED\x10\x00\x12\x19\n" +
-	"\x15SANDBOX_TEMPLATE_BASE\x10\x012\xe1\v\n" +
+	"\x15SANDBOX_TEMPLATE_BASE\x10\x01*_\n" +
+	"\vCaptureMode\x12\x1c\n" +
+	"\x18CAPTURE_MODE_UNSPECIFIED\x10\x00\x12\x19\n" +
+	"\x15CAPTURE_MODE_COMBINED\x10\x01\x12\x17\n" +
+	"\x13CAPTURE_MODE_FRAMED\x10\x022\xe1\v\n" +
 	"\x0eSandboxService\x12\xf2\x02\n" +
 	"\fSpawnSandbox\x12$.containarium.v1.SpawnSandboxRequest\x1a%.containarium.v1.SpawnSandboxResponse\"\x94\x02\x92A\xf8\x01\n" +
 	"\tSandboxes\x12\x0fSpawn a sandbox\x1a\xd9\x01Creates an ephemeral, unauthenticated-shell-free sandbox. Phase 1: always the cold path (served_from = COLD); Phase 3+: a pool claim when a warm member is ready, else RESOURCE_EXHAUSTED unless allow_cold_start is set.\x82\xd3\xe4\x93\x02\x12:\x01*\"\r/v1/sandboxes\x12\xb8\x01\n" +
@@ -1333,63 +1403,65 @@ func file_containarium_v1_sandbox_proto_rawDescGZIP() []byte {
 	return file_containarium_v1_sandbox_proto_rawDescData
 }
 
-var file_containarium_v1_sandbox_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
+var file_containarium_v1_sandbox_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
 var file_containarium_v1_sandbox_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
 var file_containarium_v1_sandbox_proto_goTypes = []any{
 	(SandboxState)(0),                  // 0: containarium.v1.SandboxState
 	(ServedFrom)(0),                    // 1: containarium.v1.ServedFrom
 	(SandboxTemplate)(0),               // 2: containarium.v1.SandboxTemplate
-	(*Sandbox)(nil),                    // 3: containarium.v1.Sandbox
-	(*SpawnSandboxRequest)(nil),        // 4: containarium.v1.SpawnSandboxRequest
-	(*SpawnSandboxResponse)(nil),       // 5: containarium.v1.SpawnSandboxResponse
-	(*ExecInSandboxRequest)(nil),       // 6: containarium.v1.ExecInSandboxRequest
-	(*ExecInSandboxResponse)(nil),      // 7: containarium.v1.ExecInSandboxResponse
-	(*WriteFileInSandboxRequest)(nil),  // 8: containarium.v1.WriteFileInSandboxRequest
-	(*WriteFileInSandboxResponse)(nil), // 9: containarium.v1.WriteFileInSandboxResponse
-	(*ReadFileInSandboxRequest)(nil),   // 10: containarium.v1.ReadFileInSandboxRequest
-	(*ReadFileInSandboxResponse)(nil),  // 11: containarium.v1.ReadFileInSandboxResponse
-	(*DeleteSandboxRequest)(nil),       // 12: containarium.v1.DeleteSandboxRequest
-	(*DeleteSandboxResponse)(nil),      // 13: containarium.v1.DeleteSandboxResponse
-	(*GetPoolStatusRequest)(nil),       // 14: containarium.v1.GetPoolStatusRequest
-	(*GetPoolStatusResponse)(nil),      // 15: containarium.v1.GetPoolStatusResponse
-	(*PoolTemplateStatus)(nil),         // 16: containarium.v1.PoolTemplateStatus
-	(*SpawnRequest)(nil),               // 17: containarium.v1.SpawnRequest
-	(*SpawnResponse)(nil),              // 18: containarium.v1.SpawnResponse
-	(*AgentExecRequest)(nil),           // 19: containarium.v1.AgentExecRequest
-	(*AgentExecResponse)(nil),          // 20: containarium.v1.AgentExecResponse
-	(*timestamppb.Timestamp)(nil),      // 21: google.protobuf.Timestamp
+	(CaptureMode)(0),                   // 3: containarium.v1.CaptureMode
+	(*Sandbox)(nil),                    // 4: containarium.v1.Sandbox
+	(*SpawnSandboxRequest)(nil),        // 5: containarium.v1.SpawnSandboxRequest
+	(*SpawnSandboxResponse)(nil),       // 6: containarium.v1.SpawnSandboxResponse
+	(*ExecInSandboxRequest)(nil),       // 7: containarium.v1.ExecInSandboxRequest
+	(*ExecInSandboxResponse)(nil),      // 8: containarium.v1.ExecInSandboxResponse
+	(*WriteFileInSandboxRequest)(nil),  // 9: containarium.v1.WriteFileInSandboxRequest
+	(*WriteFileInSandboxResponse)(nil), // 10: containarium.v1.WriteFileInSandboxResponse
+	(*ReadFileInSandboxRequest)(nil),   // 11: containarium.v1.ReadFileInSandboxRequest
+	(*ReadFileInSandboxResponse)(nil),  // 12: containarium.v1.ReadFileInSandboxResponse
+	(*DeleteSandboxRequest)(nil),       // 13: containarium.v1.DeleteSandboxRequest
+	(*DeleteSandboxResponse)(nil),      // 14: containarium.v1.DeleteSandboxResponse
+	(*GetPoolStatusRequest)(nil),       // 15: containarium.v1.GetPoolStatusRequest
+	(*GetPoolStatusResponse)(nil),      // 16: containarium.v1.GetPoolStatusResponse
+	(*PoolTemplateStatus)(nil),         // 17: containarium.v1.PoolTemplateStatus
+	(*SpawnRequest)(nil),               // 18: containarium.v1.SpawnRequest
+	(*SpawnResponse)(nil),              // 19: containarium.v1.SpawnResponse
+	(*AgentExecRequest)(nil),           // 20: containarium.v1.AgentExecRequest
+	(*AgentExecResponse)(nil),          // 21: containarium.v1.AgentExecResponse
+	(*timestamppb.Timestamp)(nil),      // 22: google.protobuf.Timestamp
 }
 var file_containarium_v1_sandbox_proto_depIdxs = []int32{
 	0,  // 0: containarium.v1.Sandbox.state:type_name -> containarium.v1.SandboxState
 	2,  // 1: containarium.v1.Sandbox.template:type_name -> containarium.v1.SandboxTemplate
 	1,  // 2: containarium.v1.Sandbox.served_from:type_name -> containarium.v1.ServedFrom
-	21, // 3: containarium.v1.Sandbox.created_at:type_name -> google.protobuf.Timestamp
-	21, // 4: containarium.v1.Sandbox.expires_at:type_name -> google.protobuf.Timestamp
+	22, // 3: containarium.v1.Sandbox.created_at:type_name -> google.protobuf.Timestamp
+	22, // 4: containarium.v1.Sandbox.expires_at:type_name -> google.protobuf.Timestamp
 	2,  // 5: containarium.v1.SpawnSandboxRequest.template:type_name -> containarium.v1.SandboxTemplate
-	3,  // 6: containarium.v1.SpawnSandboxResponse.sandbox:type_name -> containarium.v1.Sandbox
-	16, // 7: containarium.v1.GetPoolStatusResponse.templates:type_name -> containarium.v1.PoolTemplateStatus
+	4,  // 6: containarium.v1.SpawnSandboxResponse.sandbox:type_name -> containarium.v1.Sandbox
+	17, // 7: containarium.v1.GetPoolStatusResponse.templates:type_name -> containarium.v1.PoolTemplateStatus
 	2,  // 8: containarium.v1.PoolTemplateStatus.template:type_name -> containarium.v1.SandboxTemplate
-	4,  // 9: containarium.v1.SandboxService.SpawnSandbox:input_type -> containarium.v1.SpawnSandboxRequest
-	6,  // 10: containarium.v1.SandboxService.ExecInSandbox:input_type -> containarium.v1.ExecInSandboxRequest
-	8,  // 11: containarium.v1.SandboxService.WriteFileInSandbox:input_type -> containarium.v1.WriteFileInSandboxRequest
-	10, // 12: containarium.v1.SandboxService.ReadFileInSandbox:input_type -> containarium.v1.ReadFileInSandboxRequest
-	12, // 13: containarium.v1.SandboxService.DeleteSandbox:input_type -> containarium.v1.DeleteSandboxRequest
-	14, // 14: containarium.v1.SandboxService.GetPoolStatus:input_type -> containarium.v1.GetPoolStatusRequest
-	17, // 15: containarium.v1.SpawnService.Spawn:input_type -> containarium.v1.SpawnRequest
-	19, // 16: containarium.v1.SpawnService.Exec:input_type -> containarium.v1.AgentExecRequest
-	5,  // 17: containarium.v1.SandboxService.SpawnSandbox:output_type -> containarium.v1.SpawnSandboxResponse
-	7,  // 18: containarium.v1.SandboxService.ExecInSandbox:output_type -> containarium.v1.ExecInSandboxResponse
-	9,  // 19: containarium.v1.SandboxService.WriteFileInSandbox:output_type -> containarium.v1.WriteFileInSandboxResponse
-	11, // 20: containarium.v1.SandboxService.ReadFileInSandbox:output_type -> containarium.v1.ReadFileInSandboxResponse
-	13, // 21: containarium.v1.SandboxService.DeleteSandbox:output_type -> containarium.v1.DeleteSandboxResponse
-	15, // 22: containarium.v1.SandboxService.GetPoolStatus:output_type -> containarium.v1.GetPoolStatusResponse
-	18, // 23: containarium.v1.SpawnService.Spawn:output_type -> containarium.v1.SpawnResponse
-	20, // 24: containarium.v1.SpawnService.Exec:output_type -> containarium.v1.AgentExecResponse
-	17, // [17:25] is the sub-list for method output_type
-	9,  // [9:17] is the sub-list for method input_type
-	9,  // [9:9] is the sub-list for extension type_name
-	9,  // [9:9] is the sub-list for extension extendee
-	0,  // [0:9] is the sub-list for field type_name
+	3,  // 9: containarium.v1.SpawnRequest.capture_mode:type_name -> containarium.v1.CaptureMode
+	5,  // 10: containarium.v1.SandboxService.SpawnSandbox:input_type -> containarium.v1.SpawnSandboxRequest
+	7,  // 11: containarium.v1.SandboxService.ExecInSandbox:input_type -> containarium.v1.ExecInSandboxRequest
+	9,  // 12: containarium.v1.SandboxService.WriteFileInSandbox:input_type -> containarium.v1.WriteFileInSandboxRequest
+	11, // 13: containarium.v1.SandboxService.ReadFileInSandbox:input_type -> containarium.v1.ReadFileInSandboxRequest
+	13, // 14: containarium.v1.SandboxService.DeleteSandbox:input_type -> containarium.v1.DeleteSandboxRequest
+	15, // 15: containarium.v1.SandboxService.GetPoolStatus:input_type -> containarium.v1.GetPoolStatusRequest
+	18, // 16: containarium.v1.SpawnService.Spawn:input_type -> containarium.v1.SpawnRequest
+	20, // 17: containarium.v1.SpawnService.Exec:input_type -> containarium.v1.AgentExecRequest
+	6,  // 18: containarium.v1.SandboxService.SpawnSandbox:output_type -> containarium.v1.SpawnSandboxResponse
+	8,  // 19: containarium.v1.SandboxService.ExecInSandbox:output_type -> containarium.v1.ExecInSandboxResponse
+	10, // 20: containarium.v1.SandboxService.WriteFileInSandbox:output_type -> containarium.v1.WriteFileInSandboxResponse
+	12, // 21: containarium.v1.SandboxService.ReadFileInSandbox:output_type -> containarium.v1.ReadFileInSandboxResponse
+	14, // 22: containarium.v1.SandboxService.DeleteSandbox:output_type -> containarium.v1.DeleteSandboxResponse
+	16, // 23: containarium.v1.SandboxService.GetPoolStatus:output_type -> containarium.v1.GetPoolStatusResponse
+	19, // 24: containarium.v1.SpawnService.Spawn:output_type -> containarium.v1.SpawnResponse
+	21, // 25: containarium.v1.SpawnService.Exec:output_type -> containarium.v1.AgentExecResponse
+	18, // [18:26] is the sub-list for method output_type
+	10, // [10:18] is the sub-list for method input_type
+	10, // [10:10] is the sub-list for extension type_name
+	10, // [10:10] is the sub-list for extension extendee
+	0,  // [0:10] is the sub-list for field type_name
 }
 
 func init() { file_containarium_v1_sandbox_proto_init() }
@@ -1402,7 +1474,7 @@ func file_containarium_v1_sandbox_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_v1_sandbox_proto_rawDesc), len(file_containarium_v1_sandbox_proto_rawDesc)),
-			NumEnums:      3,
+			NumEnums:      4,
 			NumMessages:   18,
 			NumExtensions: 0,
 			NumServices:   2,

--- a/proto/containarium/v1/sandbox.proto
+++ b/proto/containarium/v1/sandbox.proto
@@ -273,6 +273,18 @@ service SpawnService {
   rpc Exec(AgentExecRequest) returns (AgentExecResponse);
 }
 
+// CaptureMode selects how a spawned process's combined stdout+stderr is
+// written to its log file (#1674). COMBINED is today's plain-text behavior;
+// FRAMED is opt-in, text-safe per-line framing ("<stream> <base64(payload)>")
+// so a client can demux stdout/stderr from the single offset stream without
+// corrupting invalid UTF-8 or runes split across a write — see
+// docs/architecture/remote-coding-agent.md, Part A "Framing".
+enum CaptureMode {
+  CAPTURE_MODE_UNSPECIFIED = 0; // treated as COMBINED
+  CAPTURE_MODE_COMBINED = 1;
+  CAPTURE_MODE_FRAMED = 2;
+}
+
 message SpawnRequest {
   // Shell command to run, e.g. "npm run dev". Runs under /bin/sh -c,
   // matching process_start's existing MCP contract.
@@ -282,6 +294,9 @@ message SpawnRequest {
   string name = 2;
   // Working directory. Empty = agent-box's own cwd.
   string cwd = 3;
+  // How to capture this process's output (#1674). UNSPECIFIED/omitted ->
+  // COMBINED, so every existing caller is unaffected.
+  CaptureMode capture_mode = 4;
 }
 
 message SpawnResponse {


### PR DESCRIPTION
## Stacked on #1684 (feat/1672-durable-run-records)

This PR's base is that branch, not `main` — #1674 explicitly depends on #1672 (`RunRecord.CaptureMode`, `processLogDir` injection for tests). The diff below is only this PR's own commit; once #1684 merges, retarget this PR's base to `main` and the diff will resolve to just these changes.

## Summary

Implements Story 3 of `docs/product/remote-coding-agent.md` and the framing decision resolved on the issue thread: one framed log (not two files), text-safe base64 line framing (**not** Docker's `stdcopy` binary header — corrected on the thread because `tail_log` returns content inside an MCP **text** result, and binary framing would be mangled by JSON's UTF-8 encoding), `capture_mode` carried in the run record, and `capture_mode` added to `SpawnRequest` so the gRPC transport isn't asymmetric with the MCP tool.

**`internal/logframe`** (new) — the wire format: one frame per line, `<stream> <base64(payload)>\n`. Shared by the server-side writer and the client-side demuxer so both sides agree on the format from one source. `Demuxer` buffers a trailing partial line across chunk boundaries and is chunk-boundary-agnostic (tested by splitting the same buffer at several unaligned offsets).

**agent-box `capture_mode`** — proto `CaptureMode` enum + `SpawnRequest.capture_mode` (additive, `UNSPECIFIED`→`COMBINED`; regenerated via `buf generate`, only `sandbox.pb.go` changed — `SpawnService` has no REST annotations, so no gateway churn). `process_start` gains an optional `capture_mode` arg; `SpawnServer.Spawn` reads the same field from the proto. `frameWriter` shares one mutex between a process's stdout/stderr writers (`exec.Cmd` drives them from separate goroutines) so frames never interleave mid-write. `RunRecord.CaptureMode` is now set from the actual mint-time value (#1672 always wrote `CaptureCombined`; this is its first real consumer).

**`internal/coderun`** (new) — the resumable-reader core: `LogReader` + `StreamOutput`, "the valuable layer... the one that runs in CI" per the design doc. Retries a failed read from the *same* offset after a bounded backoff — never skips ahead. Tested with a seeded fake reader: clean read, retry-from-same-offset under repeated failures, **byte-exact reassembly across ≥20 forced drops** (the PRD's own north-star metric, pinned directly), and a timing assertion that catching up after a `truncated:true` read doesn't wait out a long follow/poll duration. `Session` is an MCP-over-SSH client (`ssh <target> -- agent-box`, the same mechanism any MCP client uses against agent-box) implementing `LogReader` directly and reconnecting once, transparently, on a transport failure. `DemuxWriter` routes a framed stream's decoded frames to separate stdout/stderr writers in order.

**CLI** — `code run <box> --prompt "..."` / `code attach <box>` / `code status <box>` / `code stop <box>`, sharing box-resolution/SSH-key authorization with `connect`. `--name` defaults to `"code"` so the common one-task-per-box case never needs a generated name tracked; `--ssh-server` is deliberately not named `--server` (see below). `shellQuoteSingle` guards `--prompt` against breaking out of the single-quoted shell argument `process_start` passes to `/bin/sh -c` — tested by actually invoking `/bin/sh` with adversarial input.

## A repeat lesson applied

`--ssh-server`, not `--server`: #1673 found that a same-named command-local flag silently shadows the root persistent `--server` flag a command also needs. Named this one `--ssh-server` from the start rather than rediscovering that bug a third time.

## Deviation flagged: `obtainConnectKey` refactor conflicts with #1673's branch

Both this PR and #1673 independently parameterize `obtainConnectKey` (it originally read `connect`'s own package vars, which collides with a second caller defining its own `--key`/`--identity` flags) and both define `codeCmd`. Expect a small, easy merge conflict on whichever of #1673/#1674 merges second — same refactor, same shape, nothing surprising to resolve.

## Deferred, flagged

- The MCP tool wrapping the same Go function ("per the CLI-first convention") — daemon-side MCP surface parity is a separate, bounded follow-up.
- B2 (real transport, real forced drops, `test/integration` lane) is `needs-verification` — see Verify section below.
- `code attach` replays full-from-offset-0 by design (simplest correct behavior, no local state to desync, at the cost of re-printing prior output on a fresh invocation). An `--offset` flag to skip that is a cheap follow-up if wanted.

## Verify on dev (needs-verification)

CI can't prove the live behavior below:

1. `containarium code install <box>` (from #1673) so `claude` is present and credentialed.
2. `containarium code run <box> --prompt "list files in the current directory"` — expect streamed output as it's produced, not buffered to completion.
3. Ctrl-C the command mid-run, then `containarium code attach <box>` — expect the full output replayed byte-exact, then live streaming resumes.
4. Mid-run, force a network drop (e.g. `sudo ip link set <iface> down` briefly, or kill the ssh process by pid) — expect automatic recovery with a `[containarium code] reconnecting after: ...` diagnostic on stderr, no re-issued command, no duplicated/missing output.
5. `containarium code status <box>` after the run finishes — expect the exit code reported.
6. `containarium code run <box> --prompt "..." --output-format-stream-json` — expect valid JSON lines on stdout with no diagnostic text interleaved, and diagnostics separately on stderr.
7. `containarium code stop <box>` on a still-running task — expect SIGTERM, then the log still readable via `code status`/`code attach`.

## Test evidence

- `internal/logframe`: `TestEncodeFrame_RoundTrip`, `TestDemuxer_BuffersPartialLine`, `TestDemuxer_MultiByteRuneSplitAcrossFrames`, `TestDemuxer_InterleavedStreamsPreserveOrder`, `TestDemuxer_ChunkedArbitrarily`, `TestDemuxer_MalformedLine`, `TestDemuxer_UnknownStreamID`
- `internal/coderun`: `TestStreamOutput_CleanRead`, `TestStreamOutput_RetriesFromSameOffsetOnTransportError`, `TestStreamOutput_SurvivesTwentyForcedDrops`, `TestStreamOutput_TruncatedRereadsImmediately`, `TestParseKV_*` (agent-box wire-format fixtures), `TestDemuxWriter_*`
- `internal/agentbox`: `TestProcessStart_FramedCaptureMode_DemuxesCleanly`, `TestProcessStart_UnknownCaptureModeIsRejected`, `TestParseCaptureMode`, `TestCaptureModeFromProto`, `TestSpawnServer_Spawn_FramedCaptureMode`
- `internal/cmd`: `TestShellQuoteSingle_RoundTripsThroughARealShell`, `TestShellQuoteSingle_NeverEscapesOutOfTheQuotedString`, `TestBuildClaudeRunCommand*`, `TestRunOutcomeLine`, `TestLogPathFromListing`

Local: `go build ./...`, `go vet ./...`, `gofmt -l`, `golangci-lint run` on every touched package (0 issues), `gosec` (0 new findings — diffed against untouched files), `go test ./internal/... -race -count=2` on every touched package — all green. `buf generate` output verified to touch only `sandbox.pb.go` (no gateway churn, as expected for a REST-un-annotated service). CI run: (link once checks complete on this PR).

Closes #1674