### PR TITLE
feat(audit): rows carry actor, token_id, org_id and run_id

### DIFF
--- a/internal/audit/hash_chain.go
+++ b/internal/audit/hash_chain.go
@@ -34,19 +34,48 @@ const (
 	HashEmpty = ""
 )
 
-// computeRowHash returns the SHA-256 hex of the canonical
-// serialization of an AuditEntry's user-visible fields followed
-// by the previous row's hash. The serialization is length-
-// prefixed so a field containing the separator can't collide
-// with a different field shape.
+// Hash-chain schema versions (#1678). A row's stored hash_version says
+// which field set computeRowHash used to build its digest — VerifyChain
+// looks this up PER ROW rather than always using CurrentHashVersion, so a
+// chain spanning the #1678 migration (some rows written before it, some
+// after) still verifies as a whole. Recomputing an old row's hash under a
+// newer field set would never match what was actually stored — that would
+// corrupt the tamper-evidence the chain exists for, exactly the
+// "schedule risk" #1678 called out before any of this was written.
+const (
+	// HashVersion1 is the original Phase 4.5 eight-field digest. Every row
+	// written before #1678 is backfilled to this version by initSchema's
+	// `ADD COLUMN hash_version SMALLINT NOT NULL DEFAULT 1` — Postgres
+	// applies a column default to existing rows in place, so no backfill
+	// migration script is needed.
+	HashVersion1 int16 = 1
+
+	// HashVersion2 adds actor, delegation_chain, token_id, org_id and
+	// run_id to the digest (#1678: audit attribution).
+	HashVersion2 int16 = 2
+
+	// CurrentHashVersion is the version every newly-written row uses.
+	CurrentHashVersion = HashVersion2
+)
+
+// computeRowHash returns the SHA-256 hex of the canonical serialization of
+// an AuditEntry's user-visible fields followed by the previous row's hash.
+// The serialization is length-prefixed so a field containing the separator
+// can't collide with a different field shape.
 //
-// The ID is NOT included (it's assigned by BIGSERIAL at insert
-// time and an attacker could replay an old row at a different ID
-// — including it would create false-positives on legitimate
-// renumbering during db restore). The timestamp IS included with
-// nanosecond precision; clock-skew within a single daemon is
-// bounded.
-func computeRowHash(e *AuditEntry, prevHash string) string {
+// The ID is NOT included (it's assigned by BIGSERIAL at insert time and an
+// attacker could replay an old row at a different ID — including it would
+// create false-positives on legitimate renumbering during db restore). The
+// timestamp IS included with nanosecond precision; clock-skew within a
+// single daemon is bounded.
+//
+// version selects which field set is hashed (see the HashVersion*
+// constants) — a stored row's own hash_version, not always
+// CurrentHashVersion, so VerifyChain can replay a mixed-version chain
+// correctly. Returns an error for an unrecognized version rather than
+// silently hashing under the wrong field set, which would make every row
+// after a corruption look intact.
+func computeRowHash(e *AuditEntry, prevHash string, version int16) (string, error) {
 	h := sha256.New()
 	// Length-prefixed field serialization. lenN is decimal,
 	// terminated by ':', then the raw bytes. Trivial to parse,
@@ -59,8 +88,20 @@ func computeRowHash(e *AuditEntry, prevHash string) string {
 	writeField(h, e.Detail)
 	writeField(h, e.SourceIP)
 	writeField(h, strconv.Itoa(e.StatusCode))
+	switch version {
+	case HashVersion1:
+		// Original eight-field digest; nothing further.
+	case HashVersion2:
+		writeField(h, e.Actor)
+		writeField(h, e.DelegationChain)
+		writeField(h, e.TokenID)
+		writeField(h, e.OrgID)
+		writeField(h, e.RunID)
+	default:
+		return "", fmt.Errorf("audit: unrecognized hash_version %d", version)
+	}
 	writeField(h, prevHash)
-	return hex.EncodeToString(h.Sum(nil))
+	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 func writeField(h interface{ Write([]byte) (int, error) }, s string) {
@@ -86,7 +127,10 @@ func VerifyChain(entries []ChainEntry, expectedRoot string) (firstBad int64, err
 			return e.ID, fmt.Errorf("row %d prev_hash mismatch: stored=%q expected=%q (chain broken at or before this row)",
 				e.ID, e.PrevHash, prev)
 		}
-		want := computeRowHash(&e.AuditEntry, e.PrevHash)
+		want, herr := computeRowHash(&e.AuditEntry, e.PrevHash, e.HashVersion)
+		if herr != nil {
+			return e.ID, fmt.Errorf("row %d: %w", e.ID, herr)
+		}
 		if e.RowHash != want {
 			return e.ID, fmt.Errorf("row %d row_hash mismatch: stored=%q computed=%q (this row was modified after insert)",
 				e.ID, abbrev(e.RowHash), abbrev(want))
@@ -96,13 +140,14 @@ func VerifyChain(entries []ChainEntry, expectedRoot string) (firstBad int64, err
 	return 0, nil
 }
 
-// ChainEntry augments AuditEntry with the two hash-chain columns,
-// for verification consumers. The base Log/Query path returns
-// plain AuditEntry — most callers don't care about chain state.
+// ChainEntry augments AuditEntry with the hash-chain columns, for
+// verification consumers. The base Log/Query path returns plain
+// AuditEntry — most callers don't care about chain state.
 type ChainEntry struct {
 	AuditEntry
-	RowHash  string
-	PrevHash string
+	RowHash     string
+	PrevHash    string
+	HashVersion int16
 }
 
 func abbrev(h string) string {

--- a/internal/audit/hash_chain_test.go
+++ b/internal/audit/hash_chain_test.go
@@ -24,10 +24,19 @@ func entry(ts int64, user, action, detail string) AuditEntry {
 	}
 }
 
+func mustHash(t *testing.T, e *AuditEntry, prevHash string, version int16) string {
+	t.Helper()
+	h, err := computeRowHash(e, prevHash, version)
+	if err != nil {
+		t.Fatalf("computeRowHash: %v", err)
+	}
+	return h
+}
+
 func TestComputeRowHash_Deterministic(t *testing.T) {
 	e := entry(123, "alice", "api_get", "duration=5s")
-	h1 := computeRowHash(&e, "")
-	h2 := computeRowHash(&e, "")
+	h1 := mustHash(t, &e, "", CurrentHashVersion)
+	h2 := mustHash(t, &e, "", CurrentHashVersion)
 	if h1 != h2 {
 		t.Fatalf("same entry produced different hashes: %s vs %s", h1, h2)
 	}
@@ -38,7 +47,7 @@ func TestComputeRowHash_Deterministic(t *testing.T) {
 
 func TestComputeRowHash_DistinctFieldsProduceDistinctHashes(t *testing.T) {
 	base := entry(123, "alice", "api_get", "duration=5s")
-	hBase := computeRowHash(&base, "")
+	hBase := mustHash(t, &base, "", CurrentHashVersion)
 
 	// Each field change must perturb the hash.
 	cases := []struct {
@@ -52,12 +61,17 @@ func TestComputeRowHash_DistinctFieldsProduceDistinctHashes(t *testing.T) {
 		{"resource_id", func(e *AuditEntry) { e.ResourceID = "GET /v1/y" }},
 		{"source_ip", func(e *AuditEntry) { e.SourceIP = "10.0.0.2" }},
 		{"timestamp", func(e *AuditEntry) { e.Timestamp = time.Unix(0, 124) }},
+		{"actor", func(e *AuditEntry) { e.Actor = "human-alice" }},
+		{"delegation_chain", func(e *AuditEntry) { e.DelegationChain = `{"sub":"human-alice"}` }},
+		{"token_id", func(e *AuditEntry) { e.TokenID = "jti-123" }},
+		{"org_id", func(e *AuditEntry) { e.OrgID = "org-1" }},
+		{"run_id", func(e *AuditEntry) { e.RunID = "run-1" }},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			e := base
 			tc.tweak(&e)
-			if computeRowHash(&e, "") == hBase {
+			if mustHash(t, &e, "", CurrentHashVersion) == hBase {
 				t.Fatalf("changing %s did not perturb the hash", tc.name)
 			}
 		})
@@ -66,8 +80,8 @@ func TestComputeRowHash_DistinctFieldsProduceDistinctHashes(t *testing.T) {
 
 func TestComputeRowHash_PrevHashIncluded(t *testing.T) {
 	e := entry(123, "alice", "api_get", "duration=5s")
-	hA := computeRowHash(&e, "prev-a")
-	hB := computeRowHash(&e, "prev-b")
+	hA := mustHash(t, &e, "prev-a", CurrentHashVersion)
+	hB := mustHash(t, &e, "prev-b", CurrentHashVersion)
 	if hA == hB {
 		t.Fatal("different prev_hash must produce different row_hash")
 	}
@@ -84,13 +98,57 @@ func TestComputeRowHash_LengthPrefixingPreventsCollision(t *testing.T) {
 	// Adjust so the concat-without-length-prefix would be equal.
 	a.SourceIP = "x10.0.0.1"
 	b.SourceIP = "10.0.0.1"
-	if computeRowHash(&a, "") == computeRowHash(&b, "") {
+	if mustHash(t, &a, "", CurrentHashVersion) == mustHash(t, &b, "", CurrentHashVersion) {
 		t.Fatal("length-prefixing must prevent boundary-shift collisions")
 	}
 }
 
+// #1678 — hash-version-specific behavior.
+
+// TestComputeRowHash_Version1IgnoresNewFields pins the backward-compat
+// contract: HashVersion1's digest must be blind to the #1678 attribution
+// fields, so a legitimately pre-migration row (whose stored hash never
+// included them) keeps verifying no matter what those columns' zero values
+// happen to be.
+func TestComputeRowHash_Version1IgnoresNewFields(t *testing.T) {
+	base := entry(1, "alice", "api_get", "d=1")
+	withAttribution := base
+	withAttribution.Actor = "human-alice"
+	withAttribution.TokenID = "jti-123"
+	withAttribution.OrgID = "org-1"
+	withAttribution.RunID = "run-1"
+	withAttribution.DelegationChain = `{"sub":"human-alice"}`
+
+	hBase := mustHash(t, &base, "prev", HashVersion1)
+	hWith := mustHash(t, &withAttribution, "prev", HashVersion1)
+	if hBase != hWith {
+		t.Fatalf("HashVersion1 must ignore attribution fields: base=%s with=%s", hBase, hWith)
+	}
+}
+
+// TestComputeRowHash_Version2IncludesNewFields is the mirror check: under
+// CurrentHashVersion, the same fields DO perturb the hash (already covered
+// per-field by TestComputeRowHash_DistinctFieldsProduceDistinctHashes, this
+// just pins the version number explicitly).
+func TestComputeRowHash_Version2IncludesNewFields(t *testing.T) {
+	base := entry(1, "alice", "api_get", "d=1")
+	withActor := base
+	withActor.Actor = "human-alice"
+
+	if mustHash(t, &base, "prev", HashVersion2) == mustHash(t, &withActor, "prev", HashVersion2) {
+		t.Fatal("HashVersion2 must include the actor field")
+	}
+}
+
+func TestComputeRowHash_UnknownVersionErrors(t *testing.T) {
+	e := entry(1, "alice", "api_get", "d=1")
+	if _, err := computeRowHash(&e, "", 99); err == nil {
+		t.Fatal("expected an error for an unrecognized hash_version")
+	}
+}
+
 func TestVerifyChain_IntactChainReturnsZero(t *testing.T) {
-	es := buildChain(t,
+	es := buildChain(t, CurrentHashVersion,
 		entry(1, "alice", "api_get", "d=1"),
 		entry(2, "alice", "api_post", "d=2"),
 		entry(3, "bob", "api_delete", "d=3"),
@@ -105,7 +163,7 @@ func TestVerifyChain_IntactChainReturnsZero(t *testing.T) {
 }
 
 func TestVerifyChain_TamperedFieldDetected(t *testing.T) {
-	es := buildChain(t,
+	es := buildChain(t, CurrentHashVersion,
 		entry(1, "alice", "api_get", "d=1"),
 		entry(2, "alice", "api_post", "d=2"),
 		entry(3, "bob", "api_delete", "d=3"),
@@ -126,7 +184,7 @@ func TestVerifyChain_TamperedFieldDetected(t *testing.T) {
 }
 
 func TestVerifyChain_TamperedPrevHashDetected(t *testing.T) {
-	es := buildChain(t,
+	es := buildChain(t, CurrentHashVersion,
 		entry(1, "alice", "api_get", "d=1"),
 		entry(2, "alice", "api_post", "d=2"),
 		entry(3, "bob", "api_delete", "d=3"),
@@ -148,9 +206,7 @@ func TestVerifyChain_TamperedPrevHashDetected(t *testing.T) {
 }
 
 func TestVerifyChain_WrongExpectedRootDetected(t *testing.T) {
-	es := buildChain(t,
-		entry(1, "alice", "api_get", "d=1"),
-	)
+	es := buildChain(t, CurrentHashVersion, entry(1, "alice", "api_get", "d=1"))
 	// Caller claims the chain started somewhere else.
 	got, err := VerifyChain(es, "some-other-root-hash")
 	if err == nil {
@@ -171,19 +227,71 @@ func TestVerifyChain_EmptyEntriesReturnsZero(t *testing.T) {
 	}
 }
 
+// TestVerifyChain_MixedVersionChainVerifies is the #1678 migration-safety
+// AC: a chain containing a pre-migration (HashVersion1) row followed by a
+// post-migration (HashVersion2) row must verify as a whole. VerifyChain
+// must apply each row's OWN stored hash_version — always using
+// CurrentHashVersion here would recompute the v1 row's hash under the
+// wrong (larger) field set and wrongly report it as tampered.
+func TestVerifyChain_MixedVersionChainVerifies(t *testing.T) {
+	pre := entry(1, "alice", "api_get", "d=1") // a real pre-migration row: attribution fields are all zero-value
+	preHash := mustHash(t, &pre, HashEmpty, HashVersion1)
+
+	post := entry(2, "alice", "api_post", "d=2")
+	post.Actor = "human-alice"
+	post.TokenID = "jti-123"
+	postHash := mustHash(t, &post, preHash, HashVersion2)
+
+	entries := []ChainEntry{
+		{AuditEntry: pre, RowHash: preHash, PrevHash: HashEmpty, HashVersion: HashVersion1},
+		{AuditEntry: post, RowHash: postHash, PrevHash: preHash, HashVersion: HashVersion2},
+	}
+	entries[0].ID = 1
+	entries[1].ID = 2
+
+	got, err := VerifyChain(entries, HashEmpty)
+	if err != nil {
+		t.Fatalf("mixed-version chain should verify intact: %v", err)
+	}
+	if got != 0 {
+		t.Fatalf("firstBad=%d, want 0", got)
+	}
+}
+
+// TestVerifyChain_RejectsUnknownHashVersion covers a row whose hash_version
+// doesn't match any known scheme (corruption, or a future version this
+// build doesn't understand yet) — must fail closed, not silently pass.
+func TestVerifyChain_RejectsUnknownHashVersion(t *testing.T) {
+	e := entry(1, "alice", "api_get", "d=1")
+	entries := []ChainEntry{
+		{AuditEntry: e, RowHash: "irrelevant", PrevHash: HashEmpty, HashVersion: 99},
+	}
+	entries[0].ID = 1
+
+	got, err := VerifyChain(entries, HashEmpty)
+	if err == nil {
+		t.Fatal("unknown hash_version should produce an error, not pass silently")
+	}
+	if got != 1 {
+		t.Fatalf("firstBad=%d, want 1", got)
+	}
+}
+
 // buildChain stitches a slice of entries into a proper hash chain
-// (each row's prev_hash = previous row's row_hash). Test helper —
-// mirrors what the Store does inside its transaction.
-func buildChain(t *testing.T, es ...AuditEntry) []ChainEntry {
+// (each row's prev_hash = previous row's row_hash), all written at the
+// given hash version. Test helper — mirrors what the Store does inside its
+// transaction.
+func buildChain(t *testing.T, version int16, es ...AuditEntry) []ChainEntry {
 	t.Helper()
 	out := make([]ChainEntry, len(es))
 	prev := HashEmpty
 	for i, e := range es {
-		hash := computeRowHash(&e, prev)
+		hash := mustHash(t, &e, prev, version)
 		out[i] = ChainEntry{
-			AuditEntry: e,
-			RowHash:    hash,
-			PrevHash:   prev,
+			AuditEntry:  e,
+			RowHash:     hash,
+			PrevHash:    prev,
+			HashVersion: version,
 		}
 		out[i].ID = int64(i + 1)
 		prev = hash

--- a/internal/audit/store.go
+++ b/internal/audit/store.go
@@ -21,6 +21,31 @@ type AuditEntry struct {
 	Detail       string
 	SourceIP     string
 	StatusCode   int
+
+	// #1678 — attribution columns. All default to "" (pre-migration rows
+	// backfilled by ADD COLUMN, and rows written by a call site that
+	// hasn't been updated to populate them).
+
+	// Actor is the root human/service principal at the base of the
+	// caller's delegation chain (auth.RootActor), distinct from Username
+	// (the token's own subject — an agent's synthetic identity when the
+	// call was delegated). Empty for a direct, non-delegated call, where
+	// the acting entity IS Username; callers don't need to duplicate it.
+	Actor string
+	// DelegationChain is the JSON-serialized auth.Actor chain (empty when
+	// there was no delegation), kept for full depth reconstruction beyond
+	// what the flat Actor column can show.
+	DelegationChain string
+	// TokenID is the acting token's jti, so "what did this credential do"
+	// is one query (QueryParams.TokenID).
+	TokenID string
+	// OrgID is tenant attribution. Empty on an OSS single-tenant daemon;
+	// the cloud control plane's own audit path is out of scope here (see
+	// FootprintAI/Containarium-cloud#1428).
+	OrgID string
+	// RunID groups a session's actions. Empty when the caller didn't
+	// supply one.
+	RunID string
 }
 
 // QueryParams holds parameters for querying audit logs
@@ -28,10 +53,15 @@ type QueryParams struct {
 	Username     string
 	Action       string
 	ResourceType string
-	From         time.Time
-	To           time.Time
-	Limit        int
-	Offset       int
+	// #1678 — attribution filters. Each is an exact-match equality filter,
+	// same convention as Username/Action/ResourceType above.
+	Actor   string
+	TokenID string
+	OrgID   string
+	From    time.Time
+	To      time.Time
+	Limit   int
+	Offset  int
 }
 
 // Store handles persistent storage of audit log entries
@@ -74,6 +104,19 @@ func (s *Store) initSchema(ctx context.Context) error {
 		ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS row_hash TEXT NOT NULL DEFAULT '';
 		ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS prev_hash TEXT NOT NULL DEFAULT '';
 
+		-- #1678: attribution columns. hash_version defaults every
+		-- pre-existing row to HashVersion1 (Postgres applies a column
+		-- DEFAULT to existing rows in place on ADD COLUMN) — Log() always
+		-- writes CurrentHashVersion (HashVersion2) going forward, so
+		-- VerifyChain can tell old rows from new ones without a separate
+		-- migration script.
+		ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS actor TEXT NOT NULL DEFAULT '';
+		ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS delegation_chain TEXT NOT NULL DEFAULT '';
+		ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS token_id TEXT NOT NULL DEFAULT '';
+		ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS org_id TEXT NOT NULL DEFAULT '';
+		ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS run_id TEXT NOT NULL DEFAULT '';
+		ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS hash_version SMALLINT NOT NULL DEFAULT 1;
+
 		CREATE INDEX IF NOT EXISTS idx_audit_logs_timestamp
 			ON audit_logs(timestamp DESC);
 		CREATE INDEX IF NOT EXISTS idx_audit_logs_username
@@ -82,6 +125,12 @@ func (s *Store) initSchema(ctx context.Context) error {
 			ON audit_logs(action);
 		CREATE INDEX IF NOT EXISTS idx_audit_logs_resource_type
 			ON audit_logs(resource_type);
+		CREATE INDEX IF NOT EXISTS idx_audit_logs_actor
+			ON audit_logs(actor);
+		CREATE INDEX IF NOT EXISTS idx_audit_logs_token_id
+			ON audit_logs(token_id);
+		CREATE INDEX IF NOT EXISTS idx_audit_logs_org_id
+			ON audit_logs(org_id);
 	`
 
 	_, err := s.pool.Exec(ctx, schema)
@@ -160,13 +209,21 @@ func (s *Store) Log(ctx context.Context, entry *AuditEntry) error {
 		}
 	}
 
-	rowHash := computeRowHash(entry, prevHash)
+	// #1678 — every newly-written row uses CurrentHashVersion; a row's
+	// hash_version is what VerifyChain later replays it under, so old
+	// rows (backfilled to HashVersion1 by initSchema's column default)
+	// stay verifiable without this write path ever touching them.
+	rowHash, err := computeRowHash(entry, prevHash, CurrentHashVersion)
+	if err != nil {
+		return fmt.Errorf("audit: compute hash: %w", err)
+	}
 
 	_, err = tx.Exec(ctx, `
 		INSERT INTO audit_logs (
 			timestamp, username, action, resource_type, resource_id,
-			detail, source_ip, status_code, row_hash, prev_hash
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+			detail, source_ip, status_code, actor, delegation_chain,
+			token_id, org_id, run_id, row_hash, prev_hash, hash_version
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
 	`,
 		ts,
 		entry.Username,
@@ -176,8 +233,14 @@ func (s *Store) Log(ctx context.Context, entry *AuditEntry) error {
 		entry.Detail,
 		entry.SourceIP,
 		entry.StatusCode,
+		entry.Actor,
+		entry.DelegationChain,
+		entry.TokenID,
+		entry.OrgID,
+		entry.RunID,
 		rowHash,
 		prevHash,
+		CurrentHashVersion,
 	)
 	if err != nil {
 		return fmt.Errorf("audit: insert: %w", err)
@@ -222,7 +285,8 @@ func (s *Store) VerifyChainSinceID(ctx context.Context, fromID int64, limit int)
 	rows, err := s.pool.Query(ctx, `
 		SELECT id, timestamp, username, action, resource_type,
 		       resource_id, detail, source_ip, status_code,
-		       row_hash, prev_hash
+		       actor, delegation_chain, token_id, org_id, run_id,
+		       row_hash, prev_hash, hash_version
 		FROM audit_logs
 		WHERE id > $1 AND row_hash <> ''
 		ORDER BY id ASC
@@ -238,7 +302,8 @@ func (s *Store) VerifyChainSinceID(ctx context.Context, fromID int64, limit int)
 		var c ChainEntry
 		if err := rows.Scan(&c.ID, &c.Timestamp, &c.Username, &c.Action,
 			&c.ResourceType, &c.ResourceID, &c.Detail, &c.SourceIP, &c.StatusCode,
-			&c.RowHash, &c.PrevHash); err != nil {
+			&c.Actor, &c.DelegationChain, &c.TokenID, &c.OrgID, &c.RunID,
+			&c.RowHash, &c.PrevHash, &c.HashVersion); err != nil {
 			return -1, fmt.Errorf("audit: scan chain row: %w", err)
 		}
 		entries = append(entries, c)
@@ -266,7 +331,8 @@ func (s *Store) VerifyChainSinceID(ctx context.Context, fromID int64, limit int)
 // Query retrieves audit log entries with optional filters and pagination
 func (s *Store) Query(ctx context.Context, params QueryParams) ([]AuditEntry, int32, error) {
 	baseQuery := `SELECT id, timestamp, username, action, resource_type, resource_id,
-		detail, source_ip, status_code FROM audit_logs WHERE 1=1`
+		detail, source_ip, status_code, actor, delegation_chain, token_id, org_id, run_id
+		FROM audit_logs WHERE 1=1`
 	countQuery := `SELECT COUNT(*) FROM audit_logs WHERE 1=1`
 
 	var args []interface{}
@@ -290,6 +356,28 @@ func (s *Store) Query(ctx context.Context, params QueryParams) ([]AuditEntry, in
 		baseQuery += fmt.Sprintf(" AND resource_type = $%d", argIdx)
 		countQuery += fmt.Sprintf(" AND resource_type = $%d", argIdx)
 		args = append(args, params.ResourceType)
+		argIdx++
+	}
+
+	// #1678 — attribution filters, same exact-match convention as above.
+	if params.Actor != "" {
+		baseQuery += fmt.Sprintf(" AND actor = $%d", argIdx)
+		countQuery += fmt.Sprintf(" AND actor = $%d", argIdx)
+		args = append(args, params.Actor)
+		argIdx++
+	}
+
+	if params.TokenID != "" {
+		baseQuery += fmt.Sprintf(" AND token_id = $%d", argIdx)
+		countQuery += fmt.Sprintf(" AND token_id = $%d", argIdx)
+		args = append(args, params.TokenID)
+		argIdx++
+	}
+
+	if params.OrgID != "" {
+		baseQuery += fmt.Sprintf(" AND org_id = $%d", argIdx)
+		countQuery += fmt.Sprintf(" AND org_id = $%d", argIdx)
+		args = append(args, params.OrgID)
 		argIdx++
 	}
 
@@ -336,7 +424,8 @@ func (s *Store) Query(ctx context.Context, params QueryParams) ([]AuditEntry, in
 	for rows.Next() {
 		var e AuditEntry
 		if err := rows.Scan(&e.ID, &e.Timestamp, &e.Username, &e.Action,
-			&e.ResourceType, &e.ResourceID, &e.Detail, &e.SourceIP, &e.StatusCode); err != nil {
+			&e.ResourceType, &e.ResourceID, &e.Detail, &e.SourceIP, &e.StatusCode,
+			&e.Actor, &e.DelegationChain, &e.TokenID, &e.OrgID, &e.RunID); err != nil {
 			return nil, 0, fmt.Errorf("failed to scan audit row: %w", err)
 		}
 		entries = append(entries, e)

--- a/internal/auth/authz.go
+++ b/internal/auth/authz.go
@@ -22,11 +22,16 @@ import (
 // #1677 — `act` joined too. Unlike scopes it's a nested struct, not a
 // flat list, so it's carried as a single JSON-encoded string rather than
 // a delimited join.
+// #1678 — `jti` joined too, so audit rows can name the acting credential
+// ("given a token_id, what did it do"). It wasn't propagated before because
+// nothing needed it off the HTTP layer; the audit package is the first
+// gRPC-side consumer.
 const (
 	MDKeyUsername = "username"
 	MDKeyRoles    = "roles"
 	MDKeyScopes   = "scopes"
 	MDKeyAct      = "act"
+	MDKeyJTI      = "jti"
 )
 
 // RoleAdmin is the role granted to operator / system tokens. Holders
@@ -85,6 +90,19 @@ func ContextWithTestSubjectAct(ctx context.Context, username string, roles []str
 		}
 	}
 	md := metadata.Pairs(pairs...)
+	return metadata.NewIncomingContext(ctx, md)
+}
+
+// ContextWithTestJTI is a test-only helper that stamps a jti onto an
+// existing gRPC-incoming test context (e.g. one built by
+// ContextWithTestSubject or ContextWithTestSubjectAct), the same way a
+// chain of HTTP middleware would layer metadata onto a single request.
+// Merges into whatever metadata is already present rather than replacing
+// it, so it composes with the other ContextWithTestSubject* helpers. #1678.
+func ContextWithTestJTI(ctx context.Context, jti string) context.Context {
+	md, _ := metadata.FromIncomingContext(ctx)
+	md = md.Copy()
+	md.Set(MDKeyJTI, jti)
 	return metadata.NewIncomingContext(ctx, md)
 }
 
@@ -160,6 +178,24 @@ func ActFromGRPCContext(ctx context.Context) (act *Actor, present bool) {
 		return a, a != nil
 	}
 	return nil, false
+}
+
+// JTIFromGRPCContext returns the authenticated token's own `jti` claim
+// (#1678), propagated through metadata or context the same way
+// ActFromGRPCContext's claim is. Audit attribution is the first gRPC-side
+// consumer — nothing needed jti off the HTTP layer before. Returns ("",
+// false) when no jti was carried (pre-1.2 tokens minted without one, or a
+// caller that bypassed the standard mint path).
+func JTIFromGRPCContext(ctx context.Context) (jti string, present bool) {
+	if md, mdOk := metadata.FromIncomingContext(ctx); mdOk {
+		if vals := md.Get(MDKeyJTI); len(vals) > 0 && vals[0] != "" {
+			return vals[0], true
+		}
+	}
+	if j, found := JTIFromContext(ctx); found && j != "" {
+		return j, true
+	}
+	return "", false
 }
 
 // HasRole reports whether `roles` contains `wanted`.

--- a/internal/auth/authz_test.go
+++ b/internal/auth/authz_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/golang-jwt/jwt/v5"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -98,6 +99,36 @@ func TestActFromGRPCContext_None(t *testing.T) {
 	act, ok := ActFromGRPCContext(context.Background())
 	if ok || act != nil {
 		t.Fatalf("got act=%+v ok=%v, want nil/false for a context with no delegation claim", act, ok)
+	}
+}
+
+// #1678 — JTIFromGRPCContext is how audit attribution recovers the acting
+// token's own jti, propagated the same way MDKeyAct is.
+
+func TestJTIFromGRPCContext_Metadata(t *testing.T) {
+	md := metadata.Pairs(MDKeyJTI, "abc123")
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+
+	got, ok := JTIFromGRPCContext(ctx)
+	if !ok || got != "abc123" {
+		t.Fatalf("got %q ok=%v, want abc123/true", got, ok)
+	}
+}
+
+func TestJTIFromGRPCContext_ContextFallback(t *testing.T) {
+	claims := &Claims{Username: "alice", RegisteredClaims: jwt.RegisteredClaims{ID: "xyz789"}}
+	ctx := ContextWithClaims(context.Background(), claims)
+
+	got, ok := JTIFromGRPCContext(ctx)
+	if !ok || got != "xyz789" {
+		t.Fatalf("got %q ok=%v, want xyz789/true", got, ok)
+	}
+}
+
+func TestJTIFromGRPCContext_None(t *testing.T) {
+	got, ok := JTIFromGRPCContext(context.Background())
+	if ok || got != "" {
+		t.Fatalf("got %q ok=%v, want empty/false for a context with no jti", got, ok)
 	}
 }
 

--- a/internal/auth/delegation.go
+++ b/internal/auth/delegation.go
@@ -48,3 +48,18 @@ func validateActDepth(a *Actor) error {
 	}
 	return nil
 }
+
+// RootActor walks a's chain to its base and returns that Subject — the
+// human/service principal furthest from the leaf, which is the one an
+// auditor most needs (#1678: this is how the audit package's `actor` column
+// is resolved from a request's delegation claim). Returns "" for a nil
+// chain, matching Actor's own "absence is valid, not an error" contract.
+func RootActor(a *Actor) string {
+	if a == nil {
+		return ""
+	}
+	for a.Act != nil {
+		a = a.Act
+	}
+	return a.Subject
+}

--- a/internal/auth/delegation_test.go
+++ b/internal/auth/delegation_test.go
@@ -46,6 +46,29 @@ func chainOfDepth(n int) *Actor {
 	return a
 }
 
+// #1678 — RootActor is how the audit package resolves the `actor` column:
+// the root human/service principal at the base of a delegation chain.
+
+func TestRootActor_NilReturnsEmpty(t *testing.T) {
+	if got := RootActor(nil); got != "" {
+		t.Errorf("RootActor(nil) = %q, want empty", got)
+	}
+}
+
+func TestRootActor_NoDelegationReturnsOwnSubject(t *testing.T) {
+	a := &Actor{Subject: "alice"}
+	if got := RootActor(a); got != "alice" {
+		t.Errorf("RootActor(%+v) = %q, want %q", a, got, "alice")
+	}
+}
+
+func TestRootActor_WalksToBase(t *testing.T) {
+	a := &Actor{Subject: "agent-c", Act: &Actor{Subject: "agent-b", Act: &Actor{Subject: "human-alice"}}}
+	if got := RootActor(a); got != "human-alice" {
+		t.Errorf("RootActor(%+v) = %q, want the deepest Subject %q", a, got, "human-alice")
+	}
+}
+
 func TestValidateActDepth(t *testing.T) {
 	if err := validateActDepth(nil); err != nil {
 		t.Errorf("nil act should always pass, got %v", err)

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -143,6 +143,12 @@ func (am *AuthMiddleware) HTTPMiddleware(next http.Handler) http.Handler {
 				mdPairs = append(mdPairs, MDKeyAct, string(encoded))
 			}
 		}
+		// #1678 — propagate the token's own jti the same way, so audit
+		// attribution (the first gRPC-side consumer) can name the acting
+		// credential without a new plumbing hop of its own.
+		if claims.ID != "" {
+			mdPairs = append(mdPairs, MDKeyJTI, claims.ID)
+		}
 		md := metadata.Pairs(mdPairs...)
 		ctx = metadata.NewOutgoingContext(ctx, md)
 

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -397,6 +397,7 @@ const (
 	ContextKeyRoles    contextKey = "roles"
 	ContextKeyScopes   contextKey = "scopes" // Phase 1.7b
 	ContextKeyAct      contextKey = "act"    // #1677
+	ContextKeyJTI      contextKey = "jti"    // #1678
 )
 
 // ContextWithClaims adds authentication claims to context
@@ -408,6 +409,9 @@ func ContextWithClaims(ctx context.Context, claims *Claims) context.Context {
 	}
 	if claims.Act != nil {
 		ctx = context.WithValue(ctx, ContextKeyAct, claims.Act)
+	}
+	if claims.ID != "" {
+		ctx = context.WithValue(ctx, ContextKeyJTI, claims.ID)
 	}
 	return ctx
 }
@@ -440,4 +444,11 @@ func ScopesFromContext(ctx context.Context) ([]string, bool) {
 func ActFromContext(ctx context.Context) (*Actor, bool) {
 	act, ok := ctx.Value(ContextKeyAct).(*Actor)
 	return act, ok
+}
+
+// JTIFromContext retrieves the JWT `jti` claim from context. Returns ("",
+// false) when no jti was carried. #1678.
+func JTIFromContext(ctx context.Context) (string, bool) {
+	jti, ok := ctx.Value(ContextKeyJTI).(string)
+	return jti, ok
 }

--- a/internal/server/agent_server.go
+++ b/internal/server/agent_server.go
@@ -668,6 +668,12 @@ func genTraceID() string {
 
 // auditHop records one A2A delegation under the shared trace id. Best-effort:
 // audit must never fail the call. No-op until the audit store is wired.
+//
+// #1678 — an A2A call is agent-performed: username (from) is the agent's own
+// synthetic subject, so this also resolves and records the dispatching
+// human (auth.RootActor, walked from the caller's delegation chain) and the
+// acting token's jti, per the AC that every agent-performed action records
+// both.
 func (s *AgentSkillServer) auditHop(ctx context.Context, trace, from, to, outcome, detail string) {
 	if s.audit == nil {
 		return
@@ -683,15 +689,44 @@ func (s *AgentSkillServer) auditHop(ctx context.Context, trace, from, to, outcom
 		"outcome":  outcome,
 		"detail":   detail,
 	})
+
+	actor, delegationChain, tokenID := auditAttributionFromContext(ctx)
+
 	if err := s.audit.Log(ctx, &audit.AuditEntry{
-		Username:     username,
-		Action:       "agent.a2a_call",
-		ResourceType: "agent_skill",
-		ResourceID:   to,
-		Detail:       string(payload),
+		Username:        username,
+		Action:          "agent.a2a_call",
+		ResourceType:    "agent_skill",
+		ResourceID:      to,
+		Detail:          string(payload),
+		Actor:           actor,
+		DelegationChain: delegationChain,
+		TokenID:         tokenID,
 	}); err != nil {
 		log.Printf("[agent-skill] audit A2A hop %s->%s: %v", from, to, err)
 	}
+}
+
+// auditAttributionFromContext resolves the #1678 audit attribution fields
+// from an authenticated request context: actor is the root human/service
+// principal at the base of the caller's delegation chain (auth.RootActor),
+// delegationChain is that chain's own JSON serialization (kept for full
+// depth reconstruction beyond what the flat actor column shows), and
+// tokenID is the acting token's jti. All three are "" when the context
+// carries no delegation claim / no jti — the valid, backward-compatible
+// case for a direct (non-delegated) or pre-#1677/#1678 caller.
+//
+// Extracted as a pure function (no audit.Store dependency) specifically so
+// it's unit-testable without a live Postgres — auditHop's own Log() call
+// only runs against a real *audit.Store, which the test suite can't fake.
+func auditAttributionFromContext(ctx context.Context) (actor, delegationChain, tokenID string) {
+	if act, ok := auth.ActFromGRPCContext(ctx); ok {
+		actor = auth.RootActor(act)
+		if encoded, err := json.Marshal(act); err == nil {
+			delegationChain = string(encoded)
+		}
+	}
+	tokenID, _ = auth.JTIFromGRPCContext(ctx)
+	return actor, delegationChain, tokenID
 }
 
 // resolvePeerA2A finds a running peer's in-box A2A base URL and its agent card.

--- a/internal/server/agent_server_test.go
+++ b/internal/server/agent_server_test.go
@@ -316,6 +316,41 @@ func TestAuditHopNilStoreNoPanic(t *testing.T) {
 	s.auditHop(context.Background(), "trace", "from", "to", "delivered", "")
 }
 
+// #1678 — auditAttributionFromContext is what makes auditHop's "record both
+// the agent and the dispatching human" AC true; it's unit-tested directly
+// since auditHop itself only runs against a real *audit.Store.
+
+func TestAuditAttributionFromContext_NoDelegation(t *testing.T) {
+	ctx := auth.ContextWithTestSubject(context.Background(), "agent-hello-agent", "user")
+	actor, chain, tokenID := auditAttributionFromContext(ctx)
+	if actor != "" || chain != "" || tokenID != "" {
+		t.Fatalf("got actor=%q chain=%q tokenID=%q, want all empty for a non-delegated context", actor, chain, tokenID)
+	}
+}
+
+func TestAuditAttributionFromContext_ResolvesRootActor(t *testing.T) {
+	act := &auth.Actor{Subject: "agent-relay-agent", Act: &auth.Actor{Subject: "human-alice"}}
+	ctx := auth.ContextWithTestSubjectAct(context.Background(), "agent-hello-agent", []string{"user"}, act)
+
+	actor, chain, _ := auditAttributionFromContext(ctx)
+	if actor != "human-alice" {
+		t.Fatalf("actor = %q, want the root human human-alice", actor)
+	}
+	if !strings.Contains(chain, "human-alice") || !strings.Contains(chain, "agent-relay-agent") {
+		t.Fatalf("delegationChain = %q, want the full chain serialized", chain)
+	}
+}
+
+func TestAuditAttributionFromContext_ResolvesTokenID(t *testing.T) {
+	ctx := auth.ContextWithTestSubject(context.Background(), "agent-hello-agent", "user")
+	ctx = auth.ContextWithTestJTI(ctx, "jti-abc123")
+
+	_, _, tokenID := auditAttributionFromContext(ctx)
+	if tokenID != "jti-abc123" {
+		t.Fatalf("tokenID = %q, want jti-abc123", tokenID)
+	}
+}
+
 func TestBuildAgentSeedScriptEscapesSingleQuotes(t *testing.T) {
 	// A system prompt containing a single quote must be escaped so it can't
 	// break out of the shell-quoted printf argument.


### PR DESCRIPTION
Closes #1678

## Summary

`AuditEntry` conflated actor and subject in one `Username` field, had no
`token_id` (so "this credential leaked; what did it do?" was
unanswerable), and no `org_id`/`run_id`. This adds the columns, threads
them through the hash chain with a **versioned digest**, and exposes them
in queries.

- `AuditEntry`/`audit_logs` gain `actor`, `delegation_chain`, `token_id`,
  `org_id`, `run_id` — via `ADD COLUMN IF NOT EXISTS` (existing pattern),
  each indexed except `delegation_chain` (raw JSON, not filtered on).
- `computeRowHash` is now versioned (`HashVersion1`/`HashVersion2`, see
  `internal/audit/hash_chain.go`): pre-migration rows are backfilled to
  `HashVersion1` by the new `hash_version` column's Postgres default, so
  `VerifyChain` replays each row under its **own stored version** instead
  of always the latest.
- `QueryParams` gains `Actor`/`TokenID`/`OrgID` equality filters.
- `auth.RootActor` (new) + a new jti propagation hop
  (`auth.JTIFromGRPCContext`, mirroring how #1677's `act` claim already
  reaches gRPC handlers via metadata) let `agent_server.go`'s `auditHop`
  record both the acting agent (`Username`) and the dispatching human
  (`Actor`) for `agent.a2a_call` — the one currently-audited agent-performed
  action.

## Schedule risk this issue called out

> Adding fields to `computeRowHash` changes the hash of every future row.
> Old rows must keep verifying, so the hash function needs a version and
> `VerifyChain` must apply the right one per row.

Addressed exactly as described: `ChainEntry.HashVersion` carries each row's
own version; `VerifyChain` calls `computeRowHash(&e.AuditEntry, e.PrevHash,
e.HashVersion)` per row, never a fixed "current" version.
`TestVerifyChain_MixedVersionChainVerifies` constructs a chain with a
`HashVersion1` row followed by a `HashVersion2` row and asserts the whole
chain verifies intact — the exact scenario the issue asked to be tested.

## Acceptance criteria → tests

- [x] Schema gains actor/token_id/org_id/run_id via `ADD COLUMN IF NOT
  EXISTS` — `internal/audit/store.go` `initSchema`
- [x] New columns included in `computeRowHash` —
  `TestComputeRowHash_Version2IncludesNewFields`,
  `TestComputeRowHash_DistinctFieldsProduceDistinctHashes` (per-field cases
  for actor/delegation_chain/token_id/org_id/run_id)
- [x] Chain does not break on migration —
  `TestVerifyChain_MixedVersionChainVerifies`,
  `TestComputeRowHash_Version1IgnoresNewFields` (locks the backward-compat
  contract), `TestVerifyChain_RejectsUnknownHashVersion` (fails closed on
  corruption/an unrecognized version, rather than silently passing)
- [x] `QueryParams` supports filtering by actor/token_id/org_id, each
  indexed — `Store.Query`/`initSchema`
- [x] Agent-performed actions record both agent and dispatching human —
  `TestAuditAttributionFromContext_ResolvesRootActor`,
  `TestAuditAttributionFromContext_ResolvesTokenID`,
  `TestAuditAttributionFromContext_NoDelegation` (backward-compat: no
  delegation → empty actor, not an error)
- [x] Given a token_id, one query returns every action that credential
  performed — `QueryParams.TokenID` (equality filter, same convention as
  the existing `Username`/`Action` filters)

## Test evidence

- `go build ./...`, `go vet ./...`, `gofmt -l`, `golangci-lint run` — all
  clean.
- `go test ./internal/auth/... ./internal/audit/... ./internal/server/...`
  — all green.
- `go test -race ./internal/audit/... ./internal/auth/...` — clean.
- `go build -tags integration ./...` — the Postgres-bound integration
  suite (`internal/audit/store_integration_test.go`, requires a live DB)
  compiles clean against the new schema/signatures; not run here (no local
  Postgres).
- `go test ./...` — clean except two pre-existing `test/integration`
  tests requiring a live server + certs, unrelated to this change (same
  two noted on #1691).

## Notes for reviewers

- `delegation_chain` stores the raw JSON `auth.Actor` chain (same
  serialization already used to propagate `act` over gRPC metadata) —
  kept alongside the flat `actor` column per the issue thread's own
  resolution ("nesting the claim does not nest the schema... one flat,
  indexed `actor` column holding the root human principal, plus
  `delegation_chain` for full depth reconstruction").
- Only `agent.a2a_call` (the one existing agent-performed audit call site)
  was wired with attribution. The other ~8 `audit.Log` call sites
  (WAF blocks, threat-detect, container ops) are direct human/system calls
  where actor == the existing Username already answers "who did this" —
  wiring them is unrelated scope creep for this issue, which is about the
  column/hash-chain/query contract, not a sweep of every call site.
- `org_id` is present in the schema for forward-compat but is empty on an
  OSS single-tenant daemon; the cloud control plane's equivalent audit gap
  is tracked separately (`FootprintAI/Containarium-cloud#1428`), out of
  scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audit records now include actor, delegation, token, organization, and run attribution.
  * Audit searches can filter by actor, token ID, and organization.
  * Delegated actions identify the originating actor for clearer accountability.
* **Improvements**
  * Audit integrity verification supports versioned hash formats, including records created under mixed versions.
  * Unsupported hash versions are reported during verification.
  * Token identity is propagated across authenticated requests to improve audit attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->