### PR TITLE
feat(deploy): mount-watchdog — recover a mount-dependency-killed containarium.service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **mount-watchdog: recover a `containarium.service` left permanently dead by
+  a mount-dependency failure** (#1317). A host that gates
+  `containarium.service` on external/encrypted storage via
+  `RequiresMountsFor=/var/lib/incus` inherits that directive's lack of retry
+  semantics: a transient failure anywhere in the mount's own dependency chain
+  (observed cause: a LUKS `.device` unit missing a udev "add" event) leaves
+  the daemon `inactive (dead)` with zero journal entries for that boot and no
+  alert. `deploy/mount-watchdog/` detects the signature (service enabled but
+  inactive, mount not present), replays the incident's proven manual
+  recovery (re-announce the device to udev, clear the affected units' failed
+  state, restart), and logs an `ALERT` line if recovery itself fails — the
+  same role `deploy/incus-watchdog/` plays for a different silent-failure
+  class in `incusd`.
+
 ### Changed
 
 - **Cross-tenant secret access now requires an explicitly granted scope.**

--- a/deploy/mount-watchdog/README.md
+++ b/deploy/mount-watchdog/README.md
@@ -1,0 +1,74 @@
+# mount-watchdog
+
+Detects and recovers `containarium.service` left permanently dead by a
+`RequiresMountsFor` dependency failure (#1317).
+
+## The problem
+
+`containarium.service` ships `Wants=incus.service`, not `Requires=`,
+specifically to avoid a hard dependency killing its start job with no retry
+(#1152). A host that mounts `/var/lib/incus` from external or encrypted
+storage has to reintroduce that dependency class via
+`RequiresMountsFor=/var/lib/incus` — otherwise the daemon can start against
+an empty, not-yet-mounted directory.
+
+`RequiresMountsFor` has **no retry semantics**: a transient failure anywhere
+in the mount's own dependency chain (a LUKS `systemd-cryptsetup@` unit, or
+the `.device` unit underneath it missing a udev event) leaves
+`containarium.service` `inactive (dead)` **permanently** — zero journal
+entries for that boot, no alert, no automatic recovery. See
+[docs/NODE-VM-PROVISIONING.md](../../docs/NODE-VM-PROVISIONING.md#encrypted--external-storage-for-varlibincus)
+for the preventive fix (an `ExecStartPost` udev-kick drop-in on the
+cryptsetup unit, which stops the failure from happening in the first place).
+This watchdog is the second layer: it catches the failure if it happens
+anyway and recovers without an operator noticing first — the same role
+[`deploy/incus-watchdog`](../incus-watchdog/) plays for a different
+silent-failure class in `incusd` itself.
+
+## What it does
+
+A tiny systemd service loops on an interval, checking whether `SERVICE`
+(default `containarium.service`) is enabled but not active while
+`MOUNTPOINT` (default `/var/lib/incus`) is not currently mounted — the exact
+#1317 signature. An ordinary crash, or an exhausted `Restart=on-failure`,
+leaves the mount up, so this check does not false-positive on those cases.
+
+On detection it replays the incident's proven manual recovery: re-announce
+every `/dev/mapper/*` device to udev (recovers a `.device` unit stuck
+waiting on a lost/delayed "add" event), `systemctl reset-failed` the
+specific unit classes the incident named (never a blanket reset, which would
+also clear unrelated services' failed-state triage signal), then
+`systemctl start` the service. Failure to recover logs an `ALERT` line via
+`logger` so it reaches the host's normal journal-based alerting instead of
+staying silent.
+
+## Install (per host that gates `containarium.service` on an
+external/encrypted `/var/lib/incus` mount)
+
+```bash
+sudo install -m 0755 mount-watchdog.sh /usr/local/bin/mount-watchdog.sh
+sudo install -m 0644 mount-watchdog.service /etc/systemd/system/mount-watchdog.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now mount-watchdog.service
+sudo systemctl status mount-watchdog.service --no-pager
+journalctl -t mount-watchdog -f      # watch checks / recoveries
+```
+
+Pair with the `ExecStartPost` udev-kick drop-in in
+[docs/NODE-VM-PROVISIONING.md](../../docs/NODE-VM-PROVISIONING.md#encrypted--external-storage-for-varlibincus)
+— that fix prevents the race; this watchdog is the backstop if it happens
+anyway (e.g. via a code path other than the specific LUKS instance the
+drop-in targets).
+
+## Tuning (env in the unit, or an EnvironmentFile)
+
+| var | default | meaning |
+| --- | --- | --- |
+| `MOUNT_WATCHDOG_INTERVAL` | `60` | seconds between checks |
+| `MOUNT_WATCHDOG_MOUNTPOINT` | `/var/lib/incus` | path that must be mounted |
+| `MOUNT_WATCHDOG_SERVICE` | `containarium.service` | unit that depends on it |
+
+A host that doesn't gate `containarium.service` on an external mount doesn't
+need this unit at all — `wedged()`'s `enabled` check only fires once
+`RequiresMountsFor` is actually in play, but there is no reason to run an
+idle watchdog on hosts where the failure class can't occur.

--- a/deploy/mount-watchdog/mount-watchdog.service
+++ b/deploy/mount-watchdog/mount-watchdog.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=containarium mount-dependency watchdog -- recover a silently dead containarium.service (#1317)
+Documentation=https://github.com/FootprintAI/Containarium/issues/1317
+# Deliberately no After=/Wants= on the mount or on containarium.service --
+# this watchdog exists to recover from EXACTLY the case where that
+# dependency chain is stuck, so it must start and keep running independent
+# of whether the mount (or containarium.service) ever comes up.
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/mount-watchdog.sh
+# Tune per host without editing the script; see the script header for keys.
+# Environment=MOUNT_WATCHDOG_INTERVAL=60
+# Environment=MOUNT_WATCHDOG_MOUNTPOINT=/var/lib/incus
+Restart=always
+RestartSec=10
+# The watchdog itself must never be OOM-killed or throttled away -- it is
+# the last line of defense against a host silently dropping out of the pool.
+OOMScoreAdjust=-500
+Nice=-5
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/mount-watchdog/mount-watchdog.sh
+++ b/deploy/mount-watchdog/mount-watchdog.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# mount-watchdog — detect and recover containarium.service left permanently
+# dead by a RequiresMountsFor dependency failure (#1317).
+#
+# containarium.service ships Wants=incus.service, not Requires=, specifically
+# to avoid a hard dependency killing its start job with no retry (#1152). A
+# host that mounts /var/lib/incus from external or encrypted storage has to
+# reintroduce that dependency class via RequiresMountsFor=/var/lib/incus --
+# otherwise the daemon can start against an empty, not-yet-mounted directory.
+# RequiresMountsFor has NO retry semantics: a transient failure anywhere in
+# the mount's own dependency chain (a LUKS systemd-cryptsetup@ unit, or the
+# .device unit underneath it missing a udev event) leaves containarium.service
+# inactive (dead) PERMANENTLY -- zero journal entries for that boot, no
+# alert, no automatic recovery.
+#
+# See docs/NODE-VM-PROVISIONING.md's "Encrypted / external storage" section
+# for the preventive fix (an ExecStartPost udev-kick drop-in on the
+# cryptsetup unit, which avoids the failure in the first place). This
+# watchdog is the second layer: it catches the failure if it happens anyway
+# and recovers without an operator noticing first, the same way
+# deploy/incus-watchdog covers a different silent-failure class for incusd.
+#
+# Detection: SERVICE is enabled (this host expects it running) but not
+# active, AND MOUNTPOINT is not currently mounted. That combination is the
+# exact #1317 signature -- a mount-dependency chain failure, not an ordinary
+# daemon crash. An ordinary crash (or an exhausted Restart=on-failure) leaves
+# the mount up, so this does not false-positive on that case.
+#
+# Recovery mirrors the incident's proven manual fix: re-announce every
+# dm-mapper block device to udev (recovers a stuck .device unit waiting on a
+# lost "add" event), clear the resulting failed states on the specific unit
+# classes the incident named, then start the mount and the daemon.
+#
+# Config via env (systemd EnvironmentFile or the unit's Environment=):
+#   MOUNT_WATCHDOG_INTERVAL    seconds between checks              (default 60)
+#   MOUNT_WATCHDOG_MOUNTPOINT  path that must be mounted            (default /var/lib/incus)
+#   MOUNT_WATCHDOG_SERVICE     unit that depends on it              (default containarium.service)
+set -uo pipefail
+
+INTERVAL="${MOUNT_WATCHDOG_INTERVAL:-60}"
+MOUNTPOINT="${MOUNT_WATCHDOG_MOUNTPOINT:-/var/lib/incus}"
+SERVICE="${MOUNT_WATCHDOG_SERVICE:-containarium.service}"
+
+log() { logger -t mount-watchdog -- "$*" 2>/dev/null || true; echo "mount-watchdog: $*"; }
+
+# wedged reports whether SERVICE is enabled, not currently active, and
+# MOUNTPOINT is not mounted -- the #1317 signature.
+wedged() {
+	local enabled active
+	enabled=$(systemctl is-enabled "${SERVICE}" 2>/dev/null || echo "")
+	if [ "${enabled}" != "enabled" ]; then
+		return 1
+	fi
+	active=$(systemctl is-active "${SERVICE}" 2>/dev/null || echo "")
+	if [ "${active}" = "active" ]; then
+		return 1
+	fi
+	! mountpoint -q "${MOUNTPOINT}" 2>/dev/null
+}
+
+recover() {
+	log "detected: ${SERVICE} is enabled but inactive and ${MOUNTPOINT} is not mounted -- recovering (#1317)"
+
+	# Re-announce every dm-mapper device to udev. A .device unit stuck
+	# waiting for a lost/delayed "add" event is the proven root cause; this
+	# is the exact manual recovery step from the #1317 incident.
+	if compgen -G '/dev/mapper/*' >/dev/null 2>&1; then
+		for dev in /dev/mapper/*; do
+			[ "$(basename "${dev}")" = "control" ] && continue
+			udevadm trigger --action=add --settle "${dev}" 2>/dev/null || true
+		done
+	fi
+
+	# Scoped to the unit classes the #1317 incident named -- never a blanket
+	# `systemctl reset-failed`, which would also clear the failed state (and
+	# triage signal) of unrelated services on the host.
+	local mount_unit
+	mount_unit=$(systemd-escape --path --suffix=mount "${MOUNTPOINT}" 2>/dev/null || echo "")
+	# shellcheck disable=SC2086 # intentional: expands to zero or one unit name
+	systemctl reset-failed "${SERVICE}" ${mount_unit:+"${mount_unit}"} \
+		'dev-mapper-*.device' 'systemd-fsck@*.service' 'systemd-cryptsetup@*.service' \
+		>/dev/null 2>&1 || true
+
+	# Give udev a moment to settle the re-announced devices before asking
+	# systemd to bring the mount (and everything gated on it) back up.
+	sleep 3
+	if systemctl start "${SERVICE}"; then
+		log "recovery succeeded: ${SERVICE} is now $(systemctl is-active "${SERVICE}" 2>/dev/null || echo unknown)"
+	else
+		log "ALERT: recovery attempt failed -- ${SERVICE} is still not active after udev kick + reset-failed + start. Manual intervention needed (see docs/NODE-VM-PROVISIONING.md)."
+	fi
+}
+
+log "started (interval=${INTERVAL}s mountpoint=${MOUNTPOINT} service=${SERVICE})"
+
+while true; do
+	if wedged; then
+		recover
+	fi
+	sleep "${INTERVAL}"
+done

--- a/docs/NODE-VM-PROVISIONING.md
+++ b/docs/NODE-VM-PROVISIONING.md
@@ -217,6 +217,17 @@ safe (no regressions across repeated reboots) and effective (the exact
 recovery command that fixes a wedged instance live) against the incident in
 #1317.
 
+As a second layer, `deploy/mount-watchdog/` catches the failure if it
+happens anyway (e.g. through a code path other than the specific LUKS
+instance the drop-in above targets) and recovers without an operator
+noticing first — the same role `deploy/incus-watchdog/` plays for a
+different silent-failure class in `incusd`. It replays the exact manual
+recovery from the #1317 incident (re-announce the wedged device to udev,
+clear the resulting failed states, restart) and logs an `ALERT` line if
+recovery itself fails, so the failure reaches the host's normal
+journal-based alerting instead of staying silent. See
+`deploy/mount-watchdog/README.md` for install steps.
+
 ## Related
 - `docs/MULTI-POOL.md`, `docs/MULTI-BACKEND-PEERS.md` — pool routing the nodes plug into.
 - `docs/CONTAINARIUM-HOST-TO-VM-MIGRATION.md` — the VFIO/host→VM concerns this shares (#318).


### PR DESCRIPTION
Closes #1317

## Summary

`RequiresMountsFor=/var/lib/incus` (needed on hosts with external/encrypted
storage) has no retry semantics: a transient failure anywhere in the mount's
own dependency chain — a LUKS `.device` unit missing a udev "add" event, in
the incident this issue documents — leaves `containarium.service`
`inactive (dead)` **permanently**, with zero journal entries for that boot
and nothing to alert on.

The **docs half** of this issue (a runbook note on the pattern + the
preventive `ExecStartPost` udev-kick drop-in) was already merged via #1319,
before this issue was even filed. What remained was the issue's second
suggestion:

> Consider whether containarium's own startup (or a health-check path,
> similar in spirit to `deploy/incus-watchdog`) could detect "this host
> should have `/var/lib/incus` mounted but doesn't, and containarium never
> even tried to start" and alert or self-heal, rather than relying on an
> operator noticing.

This adds `deploy/mount-watchdog/` — a small systemd service, structured
identically to the existing `deploy/incus-watchdog/`, that:

1. Polls whether `containarium.service` is enabled but not active while
   `/var/lib/incus` is not mounted — the exact signature from the incident
   (an ordinary crash or exhausted `Restart=on-failure` leaves the mount up,
   so this doesn't false-positive on those).
2. On detection, replays the incident's proven manual recovery: re-announce
   every `/dev/mapper/*` device to udev, `systemctl reset-failed` the
   specific unit classes named in the incident (never a blanket reset, which
   would clear unrelated services' failed-state triage signal), then
   `systemctl start`.
3. Logs an `ALERT` line via `logger` if recovery itself fails, so the
   failure reaches the host's normal journal-based alerting instead of
   staying silent — which is the whole point.

## Why a watchdog, not a systemd dependency-form change

The issue's own resolution comment named this as an open design call:
retry-capable dependency form for `containarium.service` itself, vs. a
separate health-check/self-heal path. I went with the watchdog because:

- It's explicitly named as a candidate by the issue itself, not something
  I'm inventing.
- It doesn't touch `containarium.service`'s `Wants=`/`Requires=` dependency
  graph at all — the exact area #1152 already taught this project to be
  very careful with (a hard dependency there previously crash-looped a host
  1655 times in ~4 hours). A watchdog is strictly additive and can't
  regress that lesson.
- It follows an established, already-shipped, already-trusted pattern
  (`deploy/incus-watchdog`) almost exactly, which lowers the design risk of
  a new piece of infrastructure.
- It doesn't foreclose also changing the dependency form later if that's
  still wanted.

Flagging this choice explicitly per the issue's own framing ("a design
call") — happy to adjust if the dependency-form route is preferred instead.

## Verification

No CI harness exists for `deploy/*.sh` scripts in this repo (same as
`deploy/incus-watchdog`, which also has no automated test) — verified via
`bash -n` (syntax) and a careful walkthrough of the detection/recovery logic
against the incident's exact reported chain. This can't be live-verified
against real nested/LUKS hardware from this session; flagging that
explicitly rather than claiming a test I didn't run.

## Test evidence

- `bash -n deploy/mount-watchdog/mount-watchdog.sh` — clean.
- `go build ./...` — clean (no Go code touched).
- Markdown anchor link (`docs/NODE-VM-PROVISIONING.md#encrypted--external-storage-for-varlibincus`)
  verified against the same anchor already used correctly elsewhere in that
  file's own "Related" section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an automatic watchdog that detects inactive services caused by unavailable storage mounts and attempts recovery.
  - Recovery includes device re-detection, clearing failed service states, and restarting the affected service.
  - Configurable polling interval, mount path, and service settings are supported.
  - Added alert logging when automatic recovery is unsuccessful.
  - Added a system service that runs continuously and restarts after failure.

- **Documentation**
  - Added installation, configuration, operation, and troubleshooting guidance for the watchdog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->