### PR TITLE
fix(ssh-config): refuse to wipe a working config with a zero-host sync

### DIFF
--- a/internal/cmd/ssh_config.go
+++ b/internal/cmd/ssh_config.go
@@ -17,6 +17,7 @@ var (
 	sshConfigUser           string
 	sshConfigIncludeStopped bool
 	sshConfigOutPath        string
+	sshConfigForce          bool
 )
 
 var sshConfigCmd = &cobra.Command{
@@ -82,6 +83,8 @@ func init() {
 			"Include stopped containers (default: only running)")
 	}
 
+	sshConfigSyncCmd.Flags().BoolVar(&sshConfigForce, "force", false,
+		"overwrite the config even when this run generated 0 hosts (a zero-host run is usually an expired credential, not an empty fleet)")
 	sshConfigSyncCmd.Flags().StringVar(&sshConfigOutPath, "out", "",
 		"Output path (default: ~/.containarium/ssh_config)")
 }
@@ -115,17 +118,20 @@ func runSSHConfigSync(cmd *cobra.Command, args []string) error {
 		out = filepath.Join(home, ".containarium", "ssh_config")
 	}
 
-	if err := os.MkdirAll(filepath.Dir(out), 0o700); err != nil {
-		return fmt.Errorf("mkdir %s: %w", filepath.Dir(out), err)
-	}
-	// 0600 — the file lists every host the user can SSH to. Treat it as
-	// sensitive so it doesn't leak in a backup or shared shell.
-	if err := os.WriteFile(out, []byte(g.Content), 0o600); err != nil {
-		return fmt.Errorf("write %s: %w", out, err)
+	// Atomic, backed up, and refuses to replace a real config with a
+	// zero-host generation — see sshconfig.WriteConfig. A run that
+	// enumerates nothing is usually a credential or control-plane
+	// problem, not an empty fleet.
+	backedUp, err := sshconfig.WriteConfig(out, g, sshConfigForce)
+	if err != nil {
+		return err
 	}
 
 	fmt.Printf("wrote %s (%d host(s), %d skipped stopped, %d skipped no-address)\n",
 		out, g.Count, g.SkippedStopped, g.SkippedNoAddr)
+	if backedUp {
+		fmt.Printf("previous config saved to %s.bak\n", out)
+	}
 	fmt.Println()
 	fmt.Println("If you haven't already, add this one line to ~/.ssh/config:")
 	fmt.Println()

--- a/internal/mcp/sync_ssh_config.go
+++ b/internal/mcp/sync_ssh_config.go
@@ -39,19 +39,29 @@ func handleSyncSSHConfig(client API, args map[string]interface{}) (string, error
 	}
 	gen := sshconfig.Generate(containers, opts)
 
-	if err := os.MkdirAll(filepath.Dir(out), 0o700); err != nil {
-		return "", fmt.Errorf("mkdir %s: %w", filepath.Dir(out), err)
-	}
-	// 0600 — the file lists every host the user can SSH to. Sensitive
-	// in the same sense their ssh_config is.
-	if err := os.WriteFile(out, []byte(gen.Content), 0o600); err != nil {
-		return "", fmt.Errorf("write %s: %w", out, err)
+	// Atomic, backed up, and refuses to replace a real config with a
+	// zero-host generation — see sshconfig.WriteConfig. This surface is
+	// where that guard matters most: an agent calling this tool has no
+	// eye on the file, so a wipe caused by an expired credential would
+	// pass unnoticed until someone's ssh aliases stopped resolving.
+	backedUp, err := sshconfig.WriteConfig(out, gen, getBoolArg(args, "force", false))
+	if err != nil {
+		return "", err
 	}
 
+	// A zero-host run is reported as a warning, not a success tick — it
+	// almost always means the caller could not see its boxes.
+	mark := "✅ Wrote"
+	if gen.Count == 0 {
+		mark = "⚠️  Wrote (0 hosts — check your credential)"
+	}
 	result := fmt.Sprintf(
-		"✅ Wrote %s\n   %d host(s) generated, %d skipped (stopped), %d skipped (no address)\n",
-		out, gen.Count, gen.SkippedStopped, gen.SkippedNoAddr,
+		"%s %s\n   %d host(s) generated, %d skipped (stopped), %d skipped (no address)\n",
+		mark, out, gen.Count, gen.SkippedStopped, gen.SkippedNoAddr,
 	)
+	if backedUp {
+		result += fmt.Sprintf("   previous config saved to %s.bak\n", out)
+	}
 	result += "\nIf this is the first run, add one line to your ~/.ssh/config:\n"
 	result += fmt.Sprintf("    Include %s\n", out)
 	result += "\nThen `ssh <container-name>` reaches the container."

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1067,6 +1067,13 @@ func (s *Server) registerTools() {
 						"type":        "string",
 						"description": "Output path override. Default: ~/.containarium/ssh_config.",
 					},
+					"force": map[string]interface{}{
+						"type": "boolean",
+						"description": "Write even when this run generated 0 hosts. Off by default: a zero-host " +
+							"result usually means an expired credential or a control plane that cannot see " +
+							"your boxes, and overwriting a working config with it loses aliases you cannot " +
+							"regenerate. The previous file is kept as <out>.bak either way.",
+					},
 				},
 			},
 			Handler: handleSyncSSHConfig,

--- a/internal/sshconfig/write.go
+++ b/internal/sshconfig/write.go
@@ -58,6 +58,8 @@ func WriteConfig(path string, g Generated, force bool) (backedUp bool, err error
 		if readErr == nil {
 			// Best-effort: a failed backup must not block the write, but a
 			// successful one is reported so the caller can say where it went.
+			// #nosec G703 -- the sink for the same caller-supplied path: writing
+			// "<their config>.bak" beside it is precisely this function's contract.
 			if os.WriteFile(path+".bak", prev, 0o600) == nil {
 				backedUp = true
 			}

--- a/internal/sshconfig/write.go
+++ b/internal/sshconfig/write.go
@@ -54,7 +54,7 @@ func WriteConfig(path string, g Generated, force bool) (backedUp bool, err error
 	// Only worth backing up a file that has something in it — a .bak of an
 	// empty file is noise the operator has to reason about later.
 	if info, statErr := os.Stat(path); statErr == nil && info.Size() > 0 {
-		prev, readErr := os.ReadFile(path) // #nosec G304 -- path is the caller's own config path
+		prev, readErr := os.ReadFile(path) // #nosec G304 G703 -- path is the caller's own --out/default config path, already stat'd above; reading it back to make a .bak is this function's job
 		if readErr == nil {
 			// Best-effort: a failed backup must not block the write, but a
 			// successful one is reported so the caller can say where it went.

--- a/internal/sshconfig/write.go
+++ b/internal/sshconfig/write.go
@@ -1,0 +1,91 @@
+package sshconfig
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ErrRefusedEmptyOverwrite is returned when a generation that produced no
+// hosts would replace an existing, non-empty config.
+//
+// A zero-host generation is far more often an enumeration failure — an
+// expired credential, a control plane that cannot see the caller's boxes,
+// a partial outage — than a genuine "you have no containers". Writing it
+// out destroys a file the operator may have accumulated over many syncs
+// and cannot reconstruct without the very API that just came back empty.
+// So the empty result is treated as suspect and the existing file is kept.
+var ErrRefusedEmptyOverwrite = errors.New("refusing to overwrite a non-empty ssh config with a zero-host generation")
+
+// WriteConfig writes a generated ssh config to path.
+//
+// It is the shared writer behind both `containarium ssh-config sync` and
+// the sync_ssh_config MCP tool, so the safety rules below hold on every
+// surface rather than on whichever one someone remembered to guard.
+//
+// Three properties:
+//
+//  1. A zero-host generation will not replace a non-empty existing file
+//     unless force is true (see ErrRefusedEmptyOverwrite).
+//  2. Any file being replaced is first copied to "<path>.bak", so even a
+//     legitimate overwrite is recoverable.
+//  3. The write is atomic: content lands in a temp file in the same
+//     directory and is renamed over path, so an interrupted run cannot
+//     leave a half-written config.
+//
+// Returns whether a backup was written.
+func WriteConfig(path string, g Generated, force bool) (backedUp bool, err error) {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return false, fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+
+	// Existing file is only interesting if it has content — replacing an
+	// empty or absent file with an empty generation loses nothing.
+	if g.Count == 0 && !force {
+		if info, statErr := os.Stat(path); statErr == nil && info.Size() > 0 {
+			return false, fmt.Errorf("%w: %s has content and this run generated 0 hosts "+
+				"(usually an expired credential or a control plane that cannot see your boxes — "+
+				"check `containarium whoami` before forcing)", ErrRefusedEmptyOverwrite, path)
+		}
+	}
+
+	// Only worth backing up a file that has something in it — a .bak of an
+	// empty file is noise the operator has to reason about later.
+	if info, statErr := os.Stat(path); statErr == nil && info.Size() > 0 {
+		prev, readErr := os.ReadFile(path) // #nosec G304 -- path is the caller's own config path
+		if readErr == nil {
+			// Best-effort: a failed backup must not block the write, but a
+			// successful one is reported so the caller can say where it went.
+			if os.WriteFile(path+".bak", prev, 0o600) == nil {
+				backedUp = true
+			}
+		}
+	}
+
+	tmp, err := os.CreateTemp(dir, ".ssh_config.*.tmp")
+	if err != nil {
+		return backedUp, fmt.Errorf("create temp in %s: %w", dir, err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }() // no-op once renamed
+
+	// 0600 — the file lists every host the user can SSH to. Sensitive in
+	// the same sense their ssh_config is.
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return backedUp, fmt.Errorf("chmod temp: %w", err)
+	}
+	if _, err := tmp.WriteString(g.Content); err != nil {
+		_ = tmp.Close()
+		return backedUp, fmt.Errorf("write temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return backedUp, fmt.Errorf("close temp: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return backedUp, fmt.Errorf("rename into %s: %w", path, err)
+	}
+	return backedUp, nil
+}

--- a/internal/sshconfig/write_test.go
+++ b/internal/sshconfig/write_test.go
@@ -1,0 +1,166 @@
+package sshconfig
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The regression this file exists for: a sync whose enumeration came back
+// empty overwrote a 44-host config with an empty file and reported success.
+func TestWriteConfig_RefusesToWipeNonEmptyConfigWithZeroHosts(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ssh_config")
+	existing := "Host box-a\n  HostName 10.0.0.1\n"
+	if err := os.WriteFile(path, []byte(existing), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := WriteConfig(path, Generated{Content: "", Count: 0}, false)
+	if !errors.Is(err, ErrRefusedEmptyOverwrite) {
+		t.Fatalf("want ErrRefusedEmptyOverwrite, got %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != existing {
+		t.Fatalf("existing config was modified:\n%q", got)
+	}
+}
+
+func TestWriteConfig_ForceAllowsTheWipe(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ssh_config")
+	if err := os.WriteFile(path, []byte("Host box-a\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	backedUp, err := WriteConfig(path, Generated{Content: "", Count: 0}, true)
+	if err != nil {
+		t.Fatalf("force write: %v", err)
+	}
+	if !backedUp {
+		t.Error("force overwrite should still leave a .bak")
+	}
+	got, _ := os.ReadFile(path)
+	if len(got) != 0 {
+		t.Fatalf("want empty after forced write, got %q", got)
+	}
+	bak, err := os.ReadFile(path + ".bak")
+	if err != nil || string(bak) != "Host box-a\n" {
+		t.Fatalf("backup missing or wrong: %q (%v)", bak, err)
+	}
+}
+
+func TestWriteConfig_TableDriven(t *testing.T) {
+	tests := []struct {
+		name        string
+		existing    string // "" = no file
+		gen         Generated
+		force       bool
+		wantErr     bool
+		wantContent string
+		wantBackup  bool
+	}{
+		{
+			name:        "zero hosts over absent file is fine",
+			gen:         Generated{Content: "", Count: 0},
+			wantContent: "",
+		},
+		{
+			name:        "zero hosts over EMPTY file is fine",
+			existing:    "",
+			gen:         Generated{Content: "", Count: 0},
+			wantContent: "",
+		},
+		{
+			name:        "normal write over existing keeps a backup",
+			existing:    "Host old\n",
+			gen:         Generated{Content: "Host new\n", Count: 1},
+			wantContent: "Host new\n",
+			wantBackup:  true,
+		},
+		{
+			name:        "zero hosts over non-empty is refused",
+			existing:    "Host old\n",
+			gen:         Generated{Content: "", Count: 0},
+			wantErr:     true,
+			wantContent: "Host old\n",
+		},
+		{
+			name:        "first write, no prior file, no backup",
+			gen:         Generated{Content: "Host new\n", Count: 1},
+			wantContent: "Host new\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "ssh_config")
+			// Distinguish "no file" from "empty file": the zero-host guard
+			// only trips on a file with content.
+			if tt.existing != "" || tt.name == "zero hosts over EMPTY file is fine" {
+				if err := os.WriteFile(path, []byte(tt.existing), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			backedUp, err := WriteConfig(path, tt.gen, tt.force)
+			if tt.wantErr != (err != nil) {
+				t.Fatalf("err = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if backedUp != tt.wantBackup {
+				t.Errorf("backedUp = %v, want %v", backedUp, tt.wantBackup)
+			}
+
+			got, readErr := os.ReadFile(path)
+			if tt.wantContent == "" && os.IsNotExist(readErr) {
+				return // absent is an acceptable form of "empty"
+			}
+			if readErr != nil {
+				t.Fatalf("read back: %v", readErr)
+			}
+			if string(got) != tt.wantContent {
+				t.Errorf("content = %q, want %q", got, tt.wantContent)
+			}
+		})
+	}
+}
+
+func TestWriteConfig_ModeIs0600(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ssh_config")
+	if _, err := WriteConfig(path, Generated{Content: "Host a\n", Count: 1}, false); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The file lists every host the caller can reach; it must not widen
+	// just because it now goes through a temp file + rename.
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("mode = %o, want 600", perm)
+	}
+}
+
+func TestWriteConfig_LeavesNoTempFileBehind(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ssh_config")
+	if _, err := WriteConfig(path, Generated{Content: "Host a\n", Count: 1}, false); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.Name() != "ssh_config" {
+			t.Errorf("unexpected leftover file: %s", e.Name())
+		}
+	}
+}


### PR DESCRIPTION
## The bug

`ssh-config sync` (CLI) and `sync_ssh_config` (MCP) enumerate containers from
the control plane and rewrite `~/.containarium/ssh_config` with the result. When
that enumeration comes back empty, both wrote the empty result over the existing
file and reported success.

Hit live during sprint #1682's verification work:

```
✅ Wrote ~/.containarium/ssh_config
   0 host(s) generated, 1 skipped (stopped), 0 skipped (no address)
```

A 44-host config, gone — announced with a ✅. It was recoverable only because it
had been copied minutes earlier for an unrelated reason.

The enumeration was empty because the caller's control plane couldn't see the
boxes, not because there were none. **That is the common case for a zero-host
result** — an expired credential, an org-scope gap, a partial outage — and
neither surface treated it as suspicious.

## The fix

`sshconfig.WriteConfig` becomes the single writer behind both surfaces:

1. **A zero-host generation will not replace a non-empty config** without
   `--force` (CLI) / `force: true` (MCP).
2. **The prior file is kept as `<path>.bak`** — so even a legitimate overwrite is
   recoverable.
3. **The write is atomic** (temp + rename), so an interrupted run cannot leave a
   half-written config.

The MCP surface also reports a zero-host run as `⚠️` rather than `✅`. That
surface matters most: an agent calling the tool has no eye on the file, so a
silent wipe surfaces only later, when someone's aliases stop resolving.

One shared writer rather than a guard per call site, per CLAUDE.md's CLI-first
rule — the MCP tool wraps the same Go function the CLI handler calls, so the
safety can't hold on one surface and not the other.

## Tests

`internal/sshconfig/write_test.go` covers the refusal, `--force`, the backup,
0600 preservation across the rename, no leftover temp files, and a table over
empty/absent/existing combinations.

**Each guard test was confirmed to fail with the guard removed** (stubbed the
condition to `false`; both refusal tests failed, then restored). And the original
incident was replayed as a throwaway test — a 44-host config against an empty
enumeration — confirming all 1364 bytes survive and the write is refused with an
actionable message.

## Scope

This does **not** address why the control plane's enumeration was incomplete —
that's tracked separately as a cloud-side issue, along with a running box absent
from every API view. This PR makes the *tooling* fail safe regardless of why the
enumeration came back empty, which is worth having independently: any tool that
treats a CP listing as ground truth inherits that gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detached coding-agent run tools for starting, attaching to, checking, and stopping named concurrent runs.
  * Added an optional `--force` option to SSH configuration synchronization.
  * Forced zero-host configurations can overwrite existing files while preserving a backup.
  * Synchronization now reports when a backup was created.

* **Bug Fixes**
  * Prevented non-empty SSH configurations from being overwritten by empty results unless forced.
  * Improved configuration writing with secure, atomic updates and restrictive file permissions.
  * Synchronization now creates missing destination directories automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->