### PR TITLE
fix(agentbox): record a run's exit status from the child, not the reaper

### DIFF
--- a/internal/agentbox/exit_sidecar.go
+++ b/internal/agentbox/exit_sidecar.go
@@ -1,0 +1,104 @@
+package agentbox
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Exit sidecar (#1693). The reap goroutine in spawnBackgroundProcess runs
+// INSIDE agent-box, and agent-box is a stdio MCP server spawned per SSH
+// connection — so when the connection drops, the reaper dies with it while
+// the setsid'd child keeps running. Its exit status was then never written
+// anywhere, and every detached run reported "unknown" forever: precisely
+// the case #1672 exists for.
+//
+// The child outlives the connection, so the child records its own outcome.
+// spawnBackgroundProcess wraps the command in a shell that writes its exit
+// status to "<log-dir>/<name>.exit" on completion, and readRunRecord folds
+// that sidecar into a record whose ExitCode is still nil.
+//
+// What deliberately still yields "unknown": a run whose wrapper shell was
+// itself SIGKILLed, or a box that died mid-run. Nothing wrote a status
+// because nothing survived to write one — and an OOM must stay
+// distinguishable from a clean exit (design doc Part A, row 3).
+
+// exitSidecarPath returns the sidecar path for a run in dir.
+func exitSidecarPath(dir, name string) string {
+	return filepath.Join(dir, sanitizeName(name)+".exit")
+}
+
+// wrapCommandWithExitSidecar returns a shell command that runs the caller's
+// command and then durably records its exit status.
+//
+// Written temp-then-rename so a reader never observes a half-written status,
+// matching writeRunRecordAt. The status is captured into $__cx immediately
+// after the command so nothing between can clobber $?, and the wrapper exits
+// with the original code so cmd.Wait() (when a reaper IS still alive) still
+// sees the true status and the in-memory path is unchanged.
+//
+// The command runs in a SUBSHELL — "( … )", not "{ …; }". A command ending
+// in `exit N` (or any `exit` on an error path) terminates the whole shell
+// from inside a brace group, so the sidecar write is never reached and the
+// bug this fixes reappears for exactly the commands most likely to report a
+// meaningful status. A subshell confines that exit and hands $? back.
+func wrapCommandWithExitSidecar(command, sidecar string) string {
+	q := shellSingleQuote(sidecar)
+	return fmt.Sprintf(
+		"( %s\n); __cx=$?; printf '%%s %%s' \"$__cx\" \"$(date -u +%%s)\" > %s.tmp 2>/dev/null && mv -f %s.tmp %s 2>/dev/null; exit $__cx",
+		command, q, q, q,
+	)
+}
+
+// shellSingleQuote renders s as a single-quoted shell word, closing the
+// quote around any embedded single quote. sanitizeName already constrains
+// the name, but the log dir is configurable, so the path is quoted rather
+// than assumed safe.
+func shellSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// readExitSidecar reads a sidecar written by the wrapper. Returns found=false
+// when absent or unparseable — a corrupt sidecar must leave the run
+// "unknown" rather than assert a wrong exit code.
+func readExitSidecar(dir, name string) (code int, finishedAt time.Time, found bool) {
+	data, err := os.ReadFile(exitSidecarPath(dir, name)) // #nosec G304 -- path built from sanitizeName + the configured log dir
+	if err != nil {
+		return 0, time.Time{}, false
+	}
+	fields := strings.Fields(string(data))
+	if len(fields) == 0 {
+		return 0, time.Time{}, false
+	}
+	code, err = strconv.Atoi(fields[0])
+	if err != nil {
+		return 0, time.Time{}, false
+	}
+	finishedAt = time.Now()
+	if len(fields) > 1 {
+		if secs, cerr := strconv.ParseInt(fields[1], 10, 64); cerr == nil {
+			finishedAt = time.Unix(secs, 0).UTC()
+		}
+	}
+	return code, finishedAt, true
+}
+
+// applyExitSidecar fills in ExitCode/FinishedAt from the sidecar when the
+// record itself carries no outcome. A record that already has an ExitCode
+// wins: the in-process reaper wrote it with cmd.ProcessState, which
+// distinguishes a signaled exit that the shell's $? flattens.
+func applyExitSidecar(dir string, record RunRecord) RunRecord {
+	if record.ExitCode != nil {
+		return record
+	}
+	code, finishedAt, found := readExitSidecar(dir, record.Name)
+	if !found {
+		return record
+	}
+	record.ExitCode = &code
+	record.FinishedAt = &finishedAt
+	return record
+}

--- a/internal/agentbox/exit_sidecar_test.go
+++ b/internal/agentbox/exit_sidecar_test.go
@@ -1,0 +1,190 @@
+package agentbox
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The regression: a run whose connection dropped before it finished
+// reported "unknown" forever, because the only thing that wrote the exit
+// status was a goroutine inside the agent-box that died with the
+// connection. This asserts the CHILD records it instead.
+func TestExitSidecar_ChildRecordsItsOwnExit_NoReaperInvolved(t *testing.T) {
+	dir := t.TempDir()
+	sidecar := exitSidecarPath(dir, "run-a")
+
+	// Run the wrapped command to completion with NO Go-side reaper at all —
+	// this is what a detached run looks like after agent-box has exited.
+	wrapped := wrapCommandWithExitSidecar("echo hi; exit 7", sidecar)
+	cmd := exec.Command("/bin/sh", "-c", wrapped)
+	cmd.Stdout, cmd.Stderr = nil, nil
+	err := cmd.Run()
+
+	// The wrapper must preserve the original exit code for any caller that
+	// IS still waiting.
+	var ee *exec.ExitError
+	if err == nil {
+		t.Fatal("want non-zero exit from the wrapper")
+	} else if !asExitError(err, &ee) || ee.ExitCode() != 7 {
+		t.Fatalf("wrapper changed the exit code: %v", err)
+	}
+
+	code, finishedAt, found := readExitSidecar(dir, "run-a")
+	if !found {
+		t.Fatal("no sidecar written — the detached-run case is still broken")
+	}
+	if code != 7 {
+		t.Errorf("exit code = %d, want 7", code)
+	}
+	if finishedAt.IsZero() {
+		t.Error("finishedAt not recorded")
+	}
+}
+
+func asExitError(err error, target **exec.ExitError) bool {
+	ee, ok := err.(*exec.ExitError)
+	if ok {
+		*target = ee
+	}
+	return ok
+}
+
+func TestApplyExitSidecar(t *testing.T) {
+	seven := 7
+	tests := []struct {
+		name        string
+		record      RunRecord
+		sidecar     string // "" = none written
+		wantCode    *int
+		wantApplied bool
+	}{
+		{
+			name:        "no outcome, sidecar present -> folded in",
+			record:      RunRecord{Name: "r1"},
+			sidecar:     "7 1788000000",
+			wantApplied: true,
+		},
+		{
+			name:    "no outcome, no sidecar -> stays unresolved",
+			record:  RunRecord{Name: "r2"},
+			sidecar: "",
+		},
+		{
+			name:     "record already has an exit code -> reaper's value wins",
+			record:   RunRecord{Name: "r3", ExitCode: &seven},
+			sidecar:  "99 1788000000",
+			wantCode: &seven,
+		},
+		{
+			name:    "corrupt sidecar -> stays unresolved, never a wrong code",
+			record:  RunRecord{Name: "r4"},
+			sidecar: "not-a-number",
+		},
+		{
+			name:    "empty sidecar -> stays unresolved",
+			record:  RunRecord{Name: "r5"},
+			sidecar: "",
+		},
+		{
+			name:        "sidecar without a timestamp still yields the code",
+			record:      RunRecord{Name: "r6"},
+			sidecar:     "3",
+			wantApplied: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if tt.sidecar != "" {
+				if err := os.WriteFile(exitSidecarPath(dir, tt.record.Name), []byte(tt.sidecar), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			got := applyExitSidecar(dir, tt.record)
+
+			switch {
+			case tt.wantCode != nil:
+				if got.ExitCode == nil || *got.ExitCode != *tt.wantCode {
+					t.Fatalf("ExitCode = %v, want %d", got.ExitCode, *tt.wantCode)
+				}
+			case tt.wantApplied:
+				if got.ExitCode == nil {
+					t.Fatal("sidecar was not folded in")
+				}
+				if got.FinishedAt == nil {
+					t.Error("FinishedAt not set alongside ExitCode")
+				}
+			default:
+				if got.ExitCode != nil {
+					t.Fatalf("ExitCode = %d, want nil (must stay unresolved)", *got.ExitCode)
+				}
+			}
+		})
+	}
+}
+
+// A run killed outright writes nothing — and must stay "unknown" rather
+// than being reported as a clean exit. This is the distinction the design
+// doc's row 3 asks for (an OOM must not look like exit 0).
+func TestExitSidecar_KilledRunStaysUnknown(t *testing.T) {
+	dir := t.TempDir()
+	name := "killed"
+	sidecar := exitSidecarPath(dir, name)
+
+	cmd := exec.Command("/bin/sh", "-c", wrapCommandWithExitSidecar("sleep 30", sidecar))
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(150 * time.Millisecond)
+	_ = cmd.Process.Kill()
+	_ = cmd.Wait()
+
+	if _, _, found := readExitSidecar(dir, name); found {
+		t.Fatal("a SIGKILLed wrapper must leave no sidecar — otherwise an OOM reads as a clean exit")
+	}
+	rec := applyExitSidecar(dir, RunRecord{Name: name})
+	if rec.ExitCode != nil {
+		t.Fatalf("ExitCode = %d, want nil", *rec.ExitCode)
+	}
+	if got := ResolveOutcome(rec, bootID, func(int) bool { return false }); got != RunOutcomeUnknown {
+		t.Errorf("outcome = %q, want %q", got, RunOutcomeUnknown)
+	}
+}
+
+func TestWrapCommandWithExitSidecar_QuotesThePath(t *testing.T) {
+	dir := t.TempDir()
+	// A directory with a single quote in it would break naive concatenation.
+	odd := filepath.Join(dir, "it's a dir")
+	if err := os.MkdirAll(odd, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	sidecar := exitSidecarPath(odd, "q")
+	cmd := exec.Command("/bin/sh", "-c", wrapCommandWithExitSidecar("exit 4", sidecar))
+	_ = cmd.Run()
+
+	code, _, found := readExitSidecar(odd, "q")
+	if !found || code != 4 {
+		t.Fatalf("sidecar in an awkward path: found=%v code=%d", found, code)
+	}
+}
+
+func TestWrapCommandWithExitSidecar_LeavesNoTempBehind(t *testing.T) {
+	dir := t.TempDir()
+	cmd := exec.Command("/bin/sh", "-c", wrapCommandWithExitSidecar("exit 0", exitSidecarPath(dir, "t")))
+	_ = cmd.Run()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("leftover temp file: %s", e.Name())
+		}
+	}
+}

--- a/internal/agentbox/process.go
+++ b/internal/agentbox/process.go
@@ -228,7 +228,12 @@ func spawnBackgroundProcess(name, command, cwd string, captureMode CaptureMode) 
 
 	// #nosec G204 -- spawning agent-supplied commands is the entire
 	// feature, on both transports this function serves.
-	cmd := exec.Command("/bin/sh", "-c", command)
+	// Wrap so the CHILD records its own exit status (#1693). The reap
+	// goroutine below only runs while this agent-box is alive, and
+	// agent-box dies with its SSH connection — so for a detached run (the
+	// whole point of #1672) nothing in-process survives to write the
+	// outcome. The setsid'd child does, so it writes the sidecar itself.
+	cmd := exec.Command("/bin/sh", "-c", wrapCommandWithExitSidecar(command, exitSidecarPath(logDir, name)))
 	if cwd != "" {
 		cmd.Dir = cwd
 	}

--- a/internal/agentbox/run_record.go
+++ b/internal/agentbox/run_record.go
@@ -256,7 +256,10 @@ func readRunRecord(name string) (record RunRecord, found bool, err error) {
 		return RunRecord{}, false, fmt.Errorf("run record %q: unsupported version %d (this agent-box supports %d)",
 			name, record.Version, RunRecordVersion)
 	}
-	return record, true, nil
+	// Fold in the child-written exit sidecar (#1693) when the record itself
+	// carries no outcome — the case for every run whose connection dropped
+	// before it finished, since the in-process reaper died with it.
+	return applyExitSidecar(processLogDir, record), true, nil
 }
 
 // rotatedRecordSuffix matches the ".<started-at-unix-seconds>.json" suffix
@@ -298,7 +301,10 @@ func listRunRecords() ([]RunRecord, error) {
 		if err := json.Unmarshal(data, &record); err != nil || record.Version != RunRecordVersion {
 			continue // malformed or an incompatible version; skip rather than fail the whole list
 		}
-		records = append(records, record)
+		// Same sidecar fold as readRunRecord (#1693): process_list is the
+		// surface a reconnecting client actually calls, so a run that
+		// finished while disconnected must report its exit code here too.
+		records = append(records, applyExitSidecar(processLogDir, record))
 	}
 	return records, nil
 }
@@ -321,6 +327,16 @@ func rotateFinishedRun(record RunRecord) error {
 	newLogPath := strings.TrimSuffix(oldLogPath, ".log") + suffix + ".log"
 	if err := os.Rename(oldLogPath, newLogPath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("rotate log %q: %w", record.Name, err)
+	}
+
+	// The exit sidecar (#1693) rotates with its record. Leaving it in place
+	// would let the NEXT run under this name inherit the previous run's exit
+	// code the moment applyExitSidecar looks — reporting a still-running run
+	// as long since finished.
+	oldExitPath := exitSidecarPath(processLogDir, record.Name)
+	newExitPath := strings.TrimSuffix(oldExitPath, ".exit") + suffix + ".exit"
+	if err := os.Rename(oldExitPath, newExitPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("rotate exit sidecar %q: %w", record.Name, err)
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #1693.

## The bug

The exit status was written by a goroutine inside agent-box:

```go
go func() {
    _ = cmd.Wait()
    …
    _ = writeRunRecordAt(logDir, finished)   // never reached on a dropped connection
}()
```

agent-box is a stdio MCP server spawned **per SSH connection**, so that
goroutine dies with the connection while the `setsid`'d child keeps running.
Nothing was left to record how the run ended.

So every **detached** run reported `unknown` forever — the exact case #1672
exists for. You could watch a remote run and never lose a byte of its output,
but never learn whether it succeeded.

Isolated live before fixing, two runs differing only in whether the connection
outlived the child:

| Run | Connection at child exit | `process_list` |
|---|---|---|
| `rec-test` (exit 7) | dropped | `unknown`, no exit code — though the log showed it ran to completion |
| `same-session` (exit 9) | held open | `exited`, **code 9**, finished_at |

## The fix

The child outlives the connection, so **the child records its own outcome**.
`spawnBackgroundProcess` wraps the command in a shell that writes its status to
`<log-dir>/<name>.exit` (temp + rename, so a reader never sees a partial
status), and `readRunRecord` / `listRunRecords` fold that sidecar into any
record whose `ExitCode` is still nil.

A record written by the in-process reaper still **wins** when present: it
carries `cmd.ProcessState`, which distinguishes a signaled exit that the
shell's `$?` flattens.

### Two details worth review attention

**Subshell, not brace group.** The command runs in `( … )`. A command ending in
`exit N` terminates the whole shell from inside `{ …; }`, skipping the sidecar
write — reintroducing this exact bug for the commands *most* likely to report a
meaningful status. A test caught it; the first implementation had it wrong.

**Rotation moves the sidecar.** `rotateFinishedRun` now rotates `.exit`
alongside `.json` and `.log`. Otherwise the next run reusing a name inherits the
previous run's exit code the moment `applyExitSidecar` looks — reporting a live
run as long finished.

### Deliberately still `unknown`

A run whose wrapper was itself SIGKILLed, or a box that died mid-run. Nothing
survived to write a status, and an OOM must stay distinguishable from a clean
exit (design doc Part A, row 3).

## Verification

**On a live box, after deploying this build** — the original failing scenario:

```
process_start {"name":"fix-verify","command":"echo working; sleep 4; exit 7"}
  → connection closed immediately (the reaper is now dead)
  → reconnect, process_list from a FRESH agent-box:

⚪ fix-verify  (pid 17860, exited)
   Exit code:  7
   Finished at: 2026-09-03T08:20:42Z
```

Tests cover the no-reaper-at-all path, the killed-run-stays-unknown case, the
reaper-wins precedence, corrupt/empty/timestamp-less sidecars, an awkwardly
quoted log dir, and no leftover temp files.

## Why this matters for the sprint

#1674's north-star metric already passes — 132,000 bytes byte-exact across 25
forced disconnects. This was the remaining gap between that flow being
*verified* and being *done*: a user who walked away could see every byte of
output and still not know whether the run worked.

Pre-existing on this branch and unrelated: two `TestStartSpawnListener_*`
failures on macOS only (socket path exceeds the 104-char `sun_path` limit;
added by #1517, green on Linux CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Detached agent-box runs can now preserve and report their exit status even when the supervising process is unavailable.
  - Added a `--force` option to SSH configuration synchronization, allowing zero-host configurations to replace existing files.
  - SSH configuration synchronization now creates backups when replacing existing configurations.

- **Bug Fixes**
  - Prevented stale exit-status data from being applied to later runs.
  - Improved protection against accidentally overwriting usable SSH configurations with empty ones.
  - SSH configuration files are written more safely and retain restrictive permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->