### PR TITLE
docs(readme): document `containarium code` — running the agent on the box

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,30 @@ Agent has no MCP client? Run it *inside* the box instead — see
 [docs/integrations/pi.md](docs/integrations/pi.md) for the
 [pi](https://pi.dev) walkthrough (installs, keys, code sync, sessions).
 
+Or let the box run the agent itself:
+
+```bash
+containarium code install alice          # Claude Code onto a box you already use
+containarium code run alice --prompt "add a health endpoint and run the tests"
+```
+
+`code run` streams output to your terminal as it is produced — but it is not a
+pipe. The run is detached on the box, its output captured to a log, and your
+terminal is a *resumable reader* over that log. Close your laptop, lose wifi,
+Ctrl-C: the run keeps going, and `containarium code attach alice` picks the
+stream back up **byte-exact** — nothing missing, nothing repeated.
+
+```bash
+containarium code attach alice   # reconnect; replays what you missed
+containarium code status alice   # liveness, and the exit code once it finishes
+containarium code stop alice     # reap it; the log stays readable
+```
+
+The difference from the MCP wiring above is where the agent runs. There, the
+agent is on your laptop and reaches into the box; here, the agent *is* on the
+box — so the work survives your machine sleeping, and the tests run next to the
+code instead of over a network hop.
+
 ### 5. Make it reachable on a public hostname
 
 ```bash
@@ -183,6 +207,7 @@ verbs:
 
 ```
 containarium create             Create a new container
+containarium code               Run a coding agent ON a box (install / run / attach / status / stop)
 containarium list               List all containers
 containarium delete             Delete a container
 containarium expose-port        Expose container:port on a public hostname


### PR DESCRIPTION
## The gap

`containarium code` shipped in #1673/#1674 and is documented **nowhere**. The
only way to find it is to already know the verb exists and type `--help`.

Worse, the README's one section on this topic describes the *opposite* model:

> ### 4. Point your agent at the box
> In `~/.cursor/mcp.json` or `~/.claude.json`: … `"args": ["alice", "agent-box"]`

That is the agent running on **your laptop**, reaching into the box over MCP.
`containarium code` runs the agent **on the box**. Both are valid; only one was
written down.

## The change

- Adds `containarium code` to the CLI verb list.
- Adds a short section under "Point your agent at the box" covering
  install / run / attach / status / stop.

The section leads with the property that actually makes it worth using — that
`run` *streams* like a pipe but **is not** one:

> The run is detached on the box, its output captured to a log, and your
> terminal is a *resumable reader* over that log. Close your laptop, lose wifi,
> Ctrl-C: the run keeps going, and `containarium code attach alice` picks the
> stream back up **byte-exact**.

That property is verified, not aspirational: 132,000 bytes byte-exact across 25
forced mid-run disconnects (#1674), and end-to-end on a real box with an
authenticated Claude — detached run, connection killed, exit code recovered
afterwards (#1693).

## Related gap, not fixed here

There is **no MCP tool** for `code` — 34 tools in `internal/mcp/tools.go`, none
of them this. So an agent driving the platform MCP cannot discover or use it,
which is the CLI-first/MCP-wraps-it convention in CLAUDE.md going one-directional.
Filed separately rather than widening a docs PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added instructions for running coding agents in an isolated environment.
  * Documented installation, detached execution, log resumption, status checks, and stopping agents.
  * Added the `containarium code` command to the CLI reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->