### PR TITLE
feat(agentbox): record who authorized a run, not just who it ran as

### DIFF
--- a/internal/agentbox/process.go
+++ b/internal/agentbox/process.go
@@ -101,6 +101,12 @@ func processStartTool() mcp.Tool {
 		mcp.WithString("cwd",
 			mcp.Description("Working directory for the spawned process. Default: agent-box's cwd."),
 		),
+		mcp.WithString("actor",
+			mcp.Description("Optional provenance: the principal that authorized this run, recorded on the run record so a later reconnect can say who started it. CALLER-ASSERTED — agent-box cannot verify it (no authenticated context on this transport), so it is weaker evidence than a platform audit row. Omit rather than guess: empty records the run as unattributed, which is better than attributing it wrongly."),
+		),
+		mcp.WithString("delegation_chain",
+			mcp.Description("Optional JSON-serialized delegation chain behind `actor` (the act claim shape). Same caller-asserted caveat."),
+		),
 		mcp.WithString("capture_mode",
 			mcp.Description("How to capture stdout+stderr: 'combined' (default) writes plain text, "+
 				"readable with a plain tail/cat. 'framed' interleaves stdout and stderr as "+
@@ -126,7 +132,10 @@ func handleProcessStart(_ context.Context, req mcp.CallToolRequest) (*mcp.CallTo
 		return mcp.NewToolResultError(fmt.Sprintf("process_start: %v", err)), nil
 	}
 
-	mp, err := spawnBackgroundProcess(name, command, cwd, captureMode)
+	actor, _ := args["actor"].(string)
+	delegationChain, _ := args["delegation_chain"].(string)
+
+	mp, err := spawnBackgroundProcess(name, command, cwd, captureMode, actor, delegationChain)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("process_start: %v", err)), nil
 	}
@@ -170,7 +179,7 @@ func (w *frameWriter) Write(p []byte) (int, error) {
 // SpawnService.Spawn (gRPC, #1488 Phase 2): one implementation, two
 // transports, so a caller reaching agent-box over the fast local socket
 // gets identical spawn/reap semantics to one reaching it over MCP/SSH.
-func spawnBackgroundProcess(name, command, cwd string, captureMode CaptureMode) (*managedProcess, error) {
+func spawnBackgroundProcess(name, command, cwd string, captureMode CaptureMode, actor, delegationChain string) (*managedProcess, error) {
 	if command == "" {
 		return nil, fmt.Errorf("'command' is required")
 	}
@@ -268,6 +277,11 @@ func spawnBackgroundProcess(name, command, cwd string, captureMode CaptureMode) 
 		CaptureMode: captureMode,
 		LogPath:     logPath,
 		StartedAt:   startedAt,
+		// Caller-asserted provenance (#1699) — see RunRecord.Actor for why
+		// this is not, and cannot be on this transport, an authenticated
+		// attribution.
+		Actor:           actor,
+		DelegationChain: delegationChain,
 	}
 	// Written before returning, so the run is discoverable even if the
 	// caller (or agent-box itself) dies immediately after this call. A run
@@ -361,6 +375,11 @@ func handleProcessList(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolR
 		fmt.Fprintf(&b, "%s %s  (pid %d, %s)\n", icon, r.Name, r.PID, outcome)
 		fmt.Fprintf(&b, "   Command:    %s\n", r.Command)
 		fmt.Fprintf(&b, "   Started at: %s\n", r.StartedAt.UTC().Format(time.RFC3339))
+		if r.Actor != "" {
+			// "asserted" is load-bearing: this is what the client claimed, not
+			// what the platform verified (#1699).
+			fmt.Fprintf(&b, "   Actor:      %s (asserted)\n", r.Actor)
+		}
 		if r.ExitCode != nil {
 			fmt.Fprintf(&b, "   Exit code:  %d\n", *r.ExitCode)
 		}

--- a/internal/agentbox/run_record.go
+++ b/internal/agentbox/run_record.go
@@ -25,7 +25,15 @@ import (
 // RunRecordVersion is bumped when the on-disk shape changes incompatibly.
 // readRunRecord rejects a mismatched version rather than guessing at a
 // partially-compatible parse.
-const RunRecordVersion = 1
+const RunRecordVersion = 2
+
+// runRecordMinReadableVersion is the oldest on-disk shape this binary can
+// still read. v1 records predate the Actor/DelegationChain fields (#1699);
+// they load with those fields empty and report as unattributed, which is
+// correct — nothing recorded who started them. Rejecting them instead would
+// discard the only evidence of runs that died unresolved, which is exactly
+// the evidence #1672 exists to preserve.
+const runRecordMinReadableVersion = 1
 
 // RunOutcome classifies a run record against the current boot id and PID
 // liveness. See ResolveOutcome.
@@ -100,6 +108,23 @@ type RunRecord struct {
 	CaptureMode CaptureMode `json:"capture_mode"`
 	LogPath     string      `json:"log_path"`
 	StartedAt   time.Time   `json:"started_at"`
+
+	// Actor is the principal the caller says authorized this run, and
+	// DelegationChain the JSON-serialized auth.Actor chain behind it
+	// (#1699). Both are OPTIONAL and, on this transport, CALLER-ASSERTED:
+	// agent-box has no authenticated context to derive them from — it is
+	// reached over SSH (authenticated by the SSH session) or a unix socket
+	// (by filesystem permissions), never with a JWT. So these carry the same
+	// trust as the command string beside them: as much as you trust whoever
+	// reached this box.
+	//
+	// That is deliberately weaker than the audit store's `actor` column
+	// (#1678), which is resolved server-side from a verified delegation
+	// claim. Do not treat the two as equivalent evidence: this one answers
+	// "who does the client say started this?", not "who did the platform
+	// verify started this?".
+	Actor           string `json:"actor,omitempty"`
+	DelegationChain string `json:"delegation_chain,omitempty"`
 
 	// Written only by the reaper goroutine, at exit. Pointers on purpose:
 	// absent != zero, so a run that hasn't been reaped (or died before the
@@ -252,9 +277,12 @@ func readRunRecord(name string) (record RunRecord, found bool, err error) {
 	if err := json.Unmarshal(data, &record); err != nil {
 		return RunRecord{}, false, fmt.Errorf("parse run record %q: %w", name, err)
 	}
-	if record.Version != RunRecordVersion {
-		return RunRecord{}, false, fmt.Errorf("run record %q: unsupported version %d (this agent-box supports %d)",
-			name, record.Version, RunRecordVersion)
+	// Accept a RANGE, not an exact match. A newer binary must still read
+	// records an older one wrote, or a version bump silently orphans every
+	// in-flight run at upgrade time.
+	if record.Version < runRecordMinReadableVersion || record.Version > RunRecordVersion {
+		return RunRecord{}, false, fmt.Errorf("run record %q: unsupported version %d (this agent-box reads %d-%d)",
+			name, record.Version, runRecordMinReadableVersion, RunRecordVersion)
 	}
 	// Fold in the child-written exit sidecar (#1693) when the record itself
 	// carries no outcome — the case for every run whose connection dropped
@@ -298,7 +326,8 @@ func listRunRecords() ([]RunRecord, error) {
 			continue // best-effort: a file removed mid-scan isn't fatal to the listing
 		}
 		var record RunRecord
-		if err := json.Unmarshal(data, &record); err != nil || record.Version != RunRecordVersion {
+		if err := json.Unmarshal(data, &record); err != nil ||
+			record.Version < runRecordMinReadableVersion || record.Version > RunRecordVersion {
 			continue // malformed or an incompatible version; skip rather than fail the whole list
 		}
 		// Same sidecar fold as readRunRecord (#1693): process_list is the

--- a/internal/agentbox/run_record_actor_test.go
+++ b/internal/agentbox/run_record_actor_test.go
@@ -1,0 +1,127 @@
+package agentbox
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// The upgrade hazard this guards: RunRecordVersion went 1 -> 2 for the actor
+// fields (#1699). readRunRecord used to reject any version != current, so a
+// naive bump would have made every in-flight run unreadable at upgrade time —
+// including the "unknown"-outcome records that are the only evidence of runs
+// that died unresolved.
+func TestReadRunRecord_AcceptsV1AfterTheActorBump(t *testing.T) {
+	dir := t.TempDir()
+	old := processLogDir
+	processLogDir = dir
+	defer func() { processLogDir = old }()
+
+	// A v1 record exactly as a pre-#1699 agent-box would have written it:
+	// no actor, no delegation_chain.
+	v1 := map[string]any{
+		"version":      1,
+		"name":         "legacy",
+		"pid":          4242,
+		"boot_id":      bootID,
+		"command":      "sleep 100",
+		"capture_mode": "combined",
+		"log_path":     filepath.Join(dir, "legacy.log"),
+		"started_at":   time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	data, _ := json.Marshal(v1)
+	if err := os.WriteFile(filepath.Join(dir, "legacy.json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	rec, found, err := readRunRecord("legacy")
+	if err != nil {
+		t.Fatalf("v1 record must still read after the bump: %v", err)
+	}
+	if !found {
+		t.Fatal("v1 record not found")
+	}
+	if rec.PID != 4242 {
+		t.Errorf("PID = %d, want 4242", rec.PID)
+	}
+	if rec.Actor != "" {
+		t.Errorf("Actor = %q, want empty (v1 recorded nobody)", rec.Actor)
+	}
+}
+
+func TestReadRunRecord_RejectsAFutureVersion(t *testing.T) {
+	dir := t.TempDir()
+	old := processLogDir
+	processLogDir = dir
+	defer func() { processLogDir = old }()
+
+	future := map[string]any{"version": RunRecordVersion + 1, "name": "future"}
+	data, _ := json.Marshal(future)
+	if err := os.WriteFile(filepath.Join(dir, "future.json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Forward-incompatibility is a real error: an older binary cannot know
+	// what a newer shape means, and guessing is worse than refusing.
+	if _, _, err := readRunRecord("future"); err == nil {
+		t.Fatal("a newer-than-supported record must be rejected, not parsed")
+	}
+}
+
+func TestRunRecord_ActorRoundTrips(t *testing.T) {
+	dir := t.TempDir()
+	rec := RunRecord{
+		Version:         RunRecordVersion,
+		Name:            "attributed",
+		PID:             1,
+		BootID:          bootID,
+		Command:         "echo hi",
+		CaptureMode:     CaptureCombined,
+		LogPath:         filepath.Join(dir, "attributed.log"),
+		StartedAt:       time.Now(),
+		Actor:           "alice@example.com",
+		DelegationChain: `{"sub":"agent-x","act":{"sub":"alice@example.com"}}`,
+	}
+	if err := writeRunRecordAt(dir, rec); err != nil {
+		t.Fatal(err)
+	}
+	old := processLogDir
+	processLogDir = dir
+	defer func() { processLogDir = old }()
+
+	got, found, err := readRunRecord("attributed")
+	if err != nil || !found {
+		t.Fatalf("read back: %v found=%v", err, found)
+	}
+	if got.Actor != "alice@example.com" {
+		t.Errorf("Actor = %q", got.Actor)
+	}
+	if got.DelegationChain != rec.DelegationChain {
+		t.Errorf("DelegationChain = %q", got.DelegationChain)
+	}
+}
+
+// An unattributed run must stay unattributed — never defaulted to the box
+// user, which would fabricate attribution that nobody supplied.
+func TestSpawn_EmptyActorStaysEmpty(t *testing.T) {
+	dir := t.TempDir()
+	old := processLogDir
+	processLogDir = dir
+	defer func() { processLogDir = old; waitForReapersForTest() }()
+
+	mp, err := spawnBackgroundProcess("noactor", "true", "", CaptureCombined, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec, found, err := readRunRecord(mp.Name)
+	if err != nil || !found {
+		t.Fatalf("read: %v found=%v", err, found)
+	}
+	if rec.Actor != "" || rec.DelegationChain != "" {
+		t.Errorf("actor fabricated: actor=%q chain=%q", rec.Actor, rec.DelegationChain)
+	}
+	if rec.Version != RunRecordVersion {
+		t.Errorf("new records must be written at v%d, got v%d", RunRecordVersion, rec.Version)
+	}
+}

--- a/internal/agentbox/spawn_server.go
+++ b/internal/agentbox/spawn_server.go
@@ -33,7 +33,7 @@ func (s *SpawnServer) Spawn(_ context.Context, req *pb.SpawnRequest) (*pb.SpawnR
 		return nil, status.Error(codes.InvalidArgument, "command is required")
 	}
 
-	mp, err := spawnBackgroundProcess(req.Name, req.Command, req.Cwd, captureModeFromProto(req.CaptureMode))
+	mp, err := spawnBackgroundProcess(req.Name, req.Command, req.Cwd, captureModeFromProto(req.CaptureMode), req.Actor, req.DelegationChain)
 	if err != nil {
 		if errors.Is(err, ErrProcessNameInUse) {
 			return nil, status.Error(codes.AlreadyExists, err.Error())

--- a/pkg/pb/containarium/v1/sandbox.pb.go
+++ b/pkg/pb/containarium/v1/sandbox.pb.go
@@ -1032,9 +1032,22 @@ type SpawnRequest struct {
 	Cwd string `protobuf:"bytes,3,opt,name=cwd,proto3" json:"cwd,omitempty"`
 	// How to capture this process's output (#1674). UNSPECIFIED/omitted ->
 	// COMBINED, so every existing caller is unaffected.
-	CaptureMode   CaptureMode `protobuf:"varint,4,opt,name=capture_mode,json=captureMode,proto3,enum=containarium.v1.CaptureMode" json:"capture_mode,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	CaptureMode CaptureMode `protobuf:"varint,4,opt,name=capture_mode,json=captureMode,proto3,enum=containarium.v1.CaptureMode" json:"capture_mode,omitempty"`
+	// Provenance for the run record (#1699): who the caller says authorized
+	// this run, and the JSON-serialized delegation chain behind it (the
+	// auth.Actor shape from #1677).
+	//
+	// CALLER-ASSERTED, not verified here. agent-box has no authenticated
+	// context on either of its transports — it is reached over SSH, or over a
+	// unix socket whose access control is filesystem permissions. These fields
+	// therefore carry the same trust as `command` beside them, and are
+	// deliberately WEAKER evidence than the audit store's server-resolved
+	// `actor` column (#1678). Both optional; empty means the run is recorded
+	// as unattributed rather than falsely attributed.
+	Actor           string `protobuf:"bytes,5,opt,name=actor,proto3" json:"actor,omitempty"`
+	DelegationChain string `protobuf:"bytes,6,opt,name=delegation_chain,json=delegationChain,proto3" json:"delegation_chain,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *SpawnRequest) Reset() {
@@ -1093,6 +1106,20 @@ func (x *SpawnRequest) GetCaptureMode() CaptureMode {
 		return x.CaptureMode
 	}
 	return CaptureMode_CAPTURE_MODE_UNSPECIFIED
+}
+
+func (x *SpawnRequest) GetActor() string {
+	if x != nil {
+		return x.Actor
+	}
+	return ""
+}
+
+func (x *SpawnRequest) GetDelegationChain() string {
+	if x != nil {
+		return x.DelegationChain
+	}
+	return ""
 }
 
 type SpawnResponse struct {
@@ -1338,12 +1365,14 @@ const file_containarium_v1_sandbox_proto_rawDesc = "" +
 	"\btemplate\x18\x01 \x01(\x0e2 .containarium.v1.SandboxTemplateR\btemplate\x12\x14\n" +
 	"\x05ready\x18\x02 \x01(\x05R\x05ready\x12\x18\n" +
 	"\awarming\x18\x03 \x01(\x05R\awarming\x12\x19\n" +
-	"\bmin_warm\x18\x04 \x01(\x05R\aminWarm\"\x8f\x01\n" +
+	"\bmin_warm\x18\x04 \x01(\x05R\aminWarm\"\xd0\x01\n" +
 	"\fSpawnRequest\x12\x18\n" +
 	"\acommand\x18\x01 \x01(\tR\acommand\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x10\n" +
 	"\x03cwd\x18\x03 \x01(\tR\x03cwd\x12?\n" +
-	"\fcapture_mode\x18\x04 \x01(\x0e2\x1c.containarium.v1.CaptureModeR\vcaptureMode\"P\n" +
+	"\fcapture_mode\x18\x04 \x01(\x0e2\x1c.containarium.v1.CaptureModeR\vcaptureMode\x12\x14\n" +
+	"\x05actor\x18\x05 \x01(\tR\x05actor\x12)\n" +
+	"\x10delegation_chain\x18\x06 \x01(\tR\x0fdelegationChain\"P\n" +
 	"\rSpawnResponse\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x10\n" +
 	"\x03pid\x18\x02 \x01(\x03R\x03pid\x12\x19\n" +

--- a/proto/containarium/v1/sandbox.proto
+++ b/proto/containarium/v1/sandbox.proto
@@ -297,6 +297,20 @@ message SpawnRequest {
   // How to capture this process's output (#1674). UNSPECIFIED/omitted ->
   // COMBINED, so every existing caller is unaffected.
   CaptureMode capture_mode = 4;
+
+  // Provenance for the run record (#1699): who the caller says authorized
+  // this run, and the JSON-serialized delegation chain behind it (the
+  // auth.Actor shape from #1677).
+  //
+  // CALLER-ASSERTED, not verified here. agent-box has no authenticated
+  // context on either of its transports — it is reached over SSH, or over a
+  // unix socket whose access control is filesystem permissions. These fields
+  // therefore carry the same trust as `command` beside them, and are
+  // deliberately WEAKER evidence than the audit store's server-resolved
+  // `actor` column (#1678). Both optional; empty means the run is recorded
+  // as unattributed rather than falsely attributed.
+  string actor = 5;
+  string delegation_chain = 6;
 }
 
 message SpawnResponse {


### PR DESCRIPTION
Closes #1699.

## The gap

`RunRecord` shipped in #1672 with no actor. #1678 then landed `Actor` +
`DelegationChain` on **audit rows** — so the platform can attribute an API call
to a human, but a **detached agent run holding a credential** recorded nobody.

The system could answer *"who called this API?"* and not *"who started the agent
that has been running on this box for six hours?"* — which is the asymmetry epic
#1680 exists to close, in the one place the work was already underway.

## The correction this PR makes to its own issue

#1699's acceptance criteria said to populate the field *"from the authenticated
context, never from caller-supplied input."* **That is not implementable here.**

agent-box has no authenticated context on either transport:

- **MCP** — reached over SSH; the SSH session *is* the authentication
- **gRPC** — a resident unix socket; access control is filesystem permissions,
  and `SpawnServer.Spawn` does not even take its context (`_ context.Context`)

So the honest contract is **caller-asserted provenance**, at the same trust level
as the `command` string beside it, and explicitly weaker than #1678's
server-resolved audit column. That is documented at every point it appears — the
struct field, the proto field, the MCP tool description, and `process_list`'s
output, which renders `Actor: alice@example.com (asserted)`.

Recording that distinction matters more than the field itself: two things both
called "actor", one cryptographically derived and one not, will otherwise be read
as equivalent evidence by whoever inherits this.

An empty actor **stays empty** rather than defaulting to the box user —
fabricating attribution nobody supplied is worse than recording none.

## The upgrade hazard

`RunRecordVersion` 1 → 2. `readRunRecord` previously rejected any version !=
current:

```go
if record.Version != RunRecordVersion { return …, fmt.Errorf("unsupported version") }
```

So the bump **alone** would have made every in-flight run unreadable at upgrade
time — including the `unknown`-outcome records that are the only evidence of runs
that died unresolved, which is exactly what #1672 exists to preserve.

It now accepts a **range**: v1 records load with empty actor fields and report as
unattributed; a newer-than-supported record is still rejected rather than guessed
at. Both directions are tested, and the range check was confirmed to fail the
test when neutered.

## Tests

v1-reads-after-the-bump, future-version-rejected, actor round-trip, and
empty-actor-is-not-fabricated. Pre-existing on this branch and unrelated: two
`TestStartSpawnListener_*` failures on macOS only (socket path exceeds the
104-char `sun_path` limit; added by #1517, green on Linux CI).

Generated `.pb.gw.go` churn dropped per the repo convention; only `.pb.go` and
the `.proto` are committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Process launches can now include caller-provided actor and delegation-chain information.
  * Process listings display the asserted actor when available.
  * Attribution details are preserved in run records, including unattributed runs.

* **Compatibility**
  * Existing run records remain readable while unsupported future versions are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->