### PR TITLE
fix(agentbox): frame on the child's side so framed runs survive disconnect

### DIFF
--- a/cmd/agent-box/main.go
+++ b/cmd/agent-box/main.go
@@ -66,6 +66,14 @@ func main() {
 		os.Exit(agentbox.RunComposeCLI(os.Args[2:], os.Stdout, os.Stderr))
 	}
 
+	// `agent-box frame <stream> <log>` — the child-side framer for framed
+	// capture (#1701). Not a user-facing verb: spawnBackgroundProcess starts
+	// it inside the run's own setsid'd shell so framing survives agent-box
+	// exiting, which is precisely what the in-process frameWriter did not.
+	if len(os.Args) >= 2 && os.Args[1] == "frame" {
+		os.Exit(agentbox.RunFrameCLI(os.Args[2:], os.Stdin, os.Stderr))
+	}
+
 	mcpServer := server.NewMCPServer(
 		"containarium-agent-box",
 		version.Version,

--- a/internal/agentbox/agentbox_test.go
+++ b/internal/agentbox/agentbox_test.go
@@ -812,6 +812,9 @@ func TestProcessStart_CapturesStdoutToLog(t *testing.T) {
 // then feeds the raw log bytes through logframe.Demuxer and checks each
 // stream's content landed on the right side.
 func TestProcessStart_FramedCaptureMode_DemuxesCleanly(t *testing.T) {
+	// Framing is done by agent-box subprocesses (#1701), and under `go test`
+	// os.Executable() is the test binary — point the framers at a real one.
+	t.Setenv("AGENTBOX_SELF", buildAgentBoxForTest(t))
 	t.Cleanup(setProcessLogDirForTest(t.TempDir()))
 	t.Cleanup(func() { killAllAndReset(t) })
 

--- a/internal/agentbox/exit_sidecar.go
+++ b/internal/agentbox/exit_sidecar.go
@@ -31,25 +31,59 @@ func exitSidecarPath(dir, name string) string {
 	return filepath.Join(dir, sanitizeName(name)+".exit")
 }
 
-// wrapCommandWithExitSidecar returns a shell command that runs the caller's
-// command and then durably records its exit status.
+// framingSpec describes the child-side framing a run needs. nil means
+// combined mode (the child writes the log file directly).
+type framingSpec struct {
+	agentBox string // absolute path to this agent-box binary
+	logPath  string
+	outFIFO  string
+	errFIFO  string
+}
+
+// buildRunScript composes the shell program a spawned run actually executes:
+// the caller's command, its exit status durably recorded (#1693), and — in
+// framed mode — the framing done by child processes rather than by agent-box
+// (#1701).
 //
-// Written temp-then-rename so a reader never observes a half-written status,
-// matching writeRunRecordAt. The status is captured into $__cx immediately
-// after the command so nothing between can clobber $?, and the wrapper exits
-// with the original code so cmd.Wait() (when a reaper IS still alive) still
-// sees the true status and the in-memory path is unchanged.
+// The command runs in a SUBSHELL — "( … )", not "{ …; }". A command ending in
+// `exit N` (or any `exit` on an error path) terminates the whole shell from
+// inside a brace group, so the sidecar write is never reached and #1693
+// reappears for exactly the commands most likely to report a meaningful
+// status. A subshell confines that exit and hands $? back.
 //
-// The command runs in a SUBSHELL — "( … )", not "{ …; }". A command ending
-// in `exit N` (or any `exit` on an error path) terminates the whole shell
-// from inside a brace group, so the sidecar write is never reached and the
-// bug this fixes reappears for exactly the commands most likely to report a
-// meaningful status. A subshell confines that exit and hands $? back.
-func wrapCommandWithExitSidecar(command, sidecar string) string {
-	q := shellSingleQuote(sidecar)
+// $? is captured into $__cx on the line immediately after the command, before
+// anything else — `wait` and the sidecar write both clobber it otherwise. The
+// script exits with the original code, so a reaper that IS still alive sees
+// the true status through cmd.Wait() and the in-memory path is unchanged.
+//
+// In framed mode the two framers are started BEFORE the command and read from
+// FIFOs it writes to. Opening a FIFO blocks until both ends are open, so the
+// readers must be running first. They are children of this shell, which
+// spawnBackgroundProcess has already setsid'd, so nothing here depends on
+// agent-box surviving — which was the whole defect.
+func buildRunScript(command, sidecar string, f *framingSpec) string {
+	qs := shellSingleQuote(sidecar)
+
+	var prologue, redirect, drain string
+	if f != nil {
+		qo, qe := shellSingleQuote(f.outFIFO), shellSingleQuote(f.errFIFO)
+		qb, ql := shellSingleQuote(f.agentBox), shellSingleQuote(f.logPath)
+		prologue = fmt.Sprintf(
+			"rm -f %s %s; mkfifo %s %s || exit 1\n"+
+				"%s frame 1 %s < %s &\n"+
+				"%s frame 2 %s < %s &\n",
+			qo, qe, qo, qe, qb, ql, qo, qb, ql, qe)
+		redirect = fmt.Sprintf(" > %s 2> %s", qo, qe)
+		// Drain before recording the exit status: the sidecar's appearance is
+		// what a reconnecting client reads as "finished", so the log must be
+		// complete by then or a reader can see a finished run with output
+		// still arriving.
+		drain = fmt.Sprintf("wait; rm -f %s %s; ", qo, qe)
+	}
+
 	return fmt.Sprintf(
-		"( %s\n); __cx=$?; printf '%%s %%s' \"$__cx\" \"$(date -u +%%s)\" > %s.tmp 2>/dev/null && mv -f %s.tmp %s 2>/dev/null; exit $__cx",
-		command, q, q, q,
+		"%s( %s\n)%s; __cx=$?; %sprintf '%%s %%s' \"$__cx\" \"$(date -u +%%s)\" > %s.tmp 2>/dev/null && mv -f %s.tmp %s 2>/dev/null; exit $__cx",
+		prologue, command, redirect, drain, qs, qs, qs,
 	)
 }
 

--- a/internal/agentbox/exit_sidecar_test.go
+++ b/internal/agentbox/exit_sidecar_test.go
@@ -19,7 +19,7 @@ func TestExitSidecar_ChildRecordsItsOwnExit_NoReaperInvolved(t *testing.T) {
 
 	// Run the wrapped command to completion with NO Go-side reaper at all —
 	// this is what a detached run looks like after agent-box has exited.
-	wrapped := wrapCommandWithExitSidecar("echo hi; exit 7", sidecar)
+	wrapped := buildRunScript("echo hi; exit 7", sidecar, nil)
 	cmd := exec.Command("/bin/sh", "-c", wrapped)
 	cmd.Stdout, cmd.Stderr = nil, nil
 	err := cmd.Run()
@@ -136,7 +136,7 @@ func TestExitSidecar_KilledRunStaysUnknown(t *testing.T) {
 	name := "killed"
 	sidecar := exitSidecarPath(dir, name)
 
-	cmd := exec.Command("/bin/sh", "-c", wrapCommandWithExitSidecar("sleep 30", sidecar))
+	cmd := exec.Command("/bin/sh", "-c", buildRunScript("sleep 30", sidecar, nil))
 	if err := cmd.Start(); err != nil {
 		t.Fatal(err)
 	}
@@ -156,7 +156,7 @@ func TestExitSidecar_KilledRunStaysUnknown(t *testing.T) {
 	}
 }
 
-func TestWrapCommandWithExitSidecar_QuotesThePath(t *testing.T) {
+func TestBuildRunScript_QuotesThePath(t *testing.T) {
 	dir := t.TempDir()
 	// A directory with a single quote in it would break naive concatenation.
 	odd := filepath.Join(dir, "it's a dir")
@@ -164,7 +164,7 @@ func TestWrapCommandWithExitSidecar_QuotesThePath(t *testing.T) {
 		t.Fatal(err)
 	}
 	sidecar := exitSidecarPath(odd, "q")
-	cmd := exec.Command("/bin/sh", "-c", wrapCommandWithExitSidecar("exit 4", sidecar))
+	cmd := exec.Command("/bin/sh", "-c", buildRunScript("exit 4", sidecar, nil))
 	_ = cmd.Run()
 
 	code, _, found := readExitSidecar(odd, "q")
@@ -173,9 +173,9 @@ func TestWrapCommandWithExitSidecar_QuotesThePath(t *testing.T) {
 	}
 }
 
-func TestWrapCommandWithExitSidecar_LeavesNoTempBehind(t *testing.T) {
+func TestBuildRunScript_LeavesNoTempBehind(t *testing.T) {
 	dir := t.TempDir()
-	cmd := exec.Command("/bin/sh", "-c", wrapCommandWithExitSidecar("exit 0", exitSidecarPath(dir, "t")))
+	cmd := exec.Command("/bin/sh", "-c", buildRunScript("exit 0", exitSidecarPath(dir, "t"), nil))
 	_ = cmd.Run()
 
 	entries, err := os.ReadDir(dir)

--- a/internal/agentbox/frame_cli.go
+++ b/internal/agentbox/frame_cli.go
@@ -1,0 +1,95 @@
+package agentbox
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"syscall"
+
+	"github.com/footprintai/containarium/internal/logframe"
+)
+
+// `agent-box frame <stream> <log>` — the child-side half of framed capture
+// (#1701).
+//
+// Framing used to happen inside agent-box: cmd.Stdout was a frameWriter, an
+// io.Writer rather than an *os.File, so os/exec put a pipe between the child
+// and a copier goroutine in agent-box's address space. agent-box is a stdio
+// MCP server spawned per SSH connection, so when the connection dropped its
+// exit closed the read end and the child died of SIGPIPE on its next write —
+// destroying exactly the detached run that #1672/#1674 exist to keep alive.
+// Combined mode never had the bug: cmd.Stdout was the *os.File itself, whose
+// descriptor the child inherits.
+//
+// So framing moves to the child's side of the fork. spawnBackgroundProcess
+// starts one of these per stream, inside the same setsid'd shell as the
+// command, reading a FIFO the command writes to. Nothing in the path depends
+// on agent-box still being alive.
+//
+// Both framers append to ONE log, so the single-offset contract tail_log
+// serves is unchanged. They serialize with an flock on the log file: frames
+// can exceed PIPE_BUF, so O_APPEND alone would not keep two writers from
+// interleaving mid-frame.
+func RunFrameCLI(args []string, stdin io.Reader, stderr io.Writer) int {
+	if len(args) != 2 {
+		fmt.Fprintln(stderr, "usage: agent-box frame <1|2> <log-path>")
+		return 2
+	}
+	// logframe.Stream is the ASCII BYTE the wire format uses ('1'/'2'), not
+	// the integer 1/2 — so match the argument against the constants directly
+	// rather than parsing it as a number and comparing domains.
+	var stream logframe.Stream
+	switch args[0] {
+	case string(rune(logframe.Stdout)):
+		stream = logframe.Stdout
+	case string(rune(logframe.Stderr)):
+		stream = logframe.Stderr
+	default:
+		fmt.Fprintf(stderr, "frame: stream must be %q (stdout) or %q (stderr), got %q\n",
+			rune(logframe.Stdout), rune(logframe.Stderr), args[0])
+		return 2
+	}
+
+	// #nosec G304 -- the log path is agent-box's own, built from sanitizeName
+	// in spawnBackgroundProcess; this process is spawned by that same code.
+	log, err := os.OpenFile(args[1], os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		fmt.Fprintf(stderr, "frame: open %s: %v\n", args[1], err)
+		return 1
+	}
+	defer func() { _ = log.Close() }()
+
+	buf := make([]byte, 32*1024)
+	for {
+		n, readErr := stdin.Read(buf)
+		if n > 0 {
+			if werr := appendFrameLocked(log, stream, buf[:n]); werr != nil {
+				fmt.Fprintf(stderr, "frame: write: %v\n", werr)
+				return 1
+			}
+		}
+		if readErr == io.EOF {
+			return 0
+		}
+		if readErr != nil {
+			// The writer going away is the normal end of a run, not a fault.
+			return 0
+		}
+	}
+}
+
+// appendFrameLocked writes one frame under an exclusive advisory lock, so the
+// stdout and stderr framers never interleave mid-record in the shared log.
+// This is the cross-process equivalent of the mutex the in-process
+// frameWriter used to share.
+func appendFrameLocked(log *os.File, stream logframe.Stream, payload []byte) error {
+	if err := syscall.Flock(int(log.Fd()), syscall.LOCK_EX); err != nil {
+		return fmt.Errorf("lock: %w", err)
+	}
+	defer func() { _ = syscall.Flock(int(log.Fd()), syscall.LOCK_UN) }()
+
+	if _, err := log.Write(logframe.EncodeFrame(stream, payload)); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/agentbox/framed_survival_test.go
+++ b/internal/agentbox/framed_survival_test.go
@@ -1,0 +1,106 @@
+package agentbox
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/footprintai/containarium/internal/logframe"
+)
+
+// The shape no existing test had, and the reason #1701 shipped: the PARENT
+// exits while the child still has output to write.
+//
+// Every other test keeps the parent alive for the run's duration, so the
+// in-process frameWriter looked fine — but in production agent-box exits with
+// its SSH connection, and the child died of SIGPIPE writing into a pipe
+// nobody was reading. Both capture modes must survive that.
+func TestSpawn_SurvivesParentExit(t *testing.T) {
+	agentBox := buildAgentBoxForTest(t)
+
+	for _, mode := range []CaptureMode{CaptureCombined, CaptureFramed} {
+		t.Run(string(mode), func(t *testing.T) {
+			dir := t.TempDir()
+			name := "survive-" + string(mode)
+
+			// A REAL separate agent-box process starts the run and then
+			// exits — the disconnect. An in-process spawn cannot reproduce
+			// this, because the test binary stays alive.
+			script := mcpStartScript(name, string(mode),
+				"sleep 1; echo LINE1; sleep 1; echo LINE2; exit 5")
+			cmd := exec.Command(agentBox)
+			cmd.Stdin = strings.NewReader(script)
+			cmd.Env = append(os.Environ(), "AGENTBOX_LOG_DIR="+dir, "AGENTBOX_SELF="+agentBox)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("start via agent-box: %v\n%s", err, out)
+			}
+			// agent-box has now exited. The child should still be running.
+
+			logPath := filepath.Join(dir, name+".log")
+			exitPath := filepath.Join(dir, name+".exit")
+			deadline := time.Now().Add(20 * time.Second)
+			for time.Now().Before(deadline) {
+				if _, err := os.Stat(exitPath); err == nil {
+					break
+				}
+				time.Sleep(200 * time.Millisecond)
+			}
+
+			raw, err := os.ReadFile(exitPath)
+			if err != nil {
+				t.Fatalf("no exit sidecar — the run did not survive the parent: %v", err)
+			}
+			code := strings.Fields(string(raw))
+			if len(code) == 0 || code[0] != "5" {
+				// 141 here is SIGPIPE: the #1701 regression.
+				t.Fatalf("exit code = %q, want 5 (141 means SIGPIPE — the child was killed by the parent's exit)", raw)
+			}
+
+			logData, err := os.ReadFile(logPath)
+			if err != nil {
+				t.Fatalf("read log: %v", err)
+			}
+			got := string(logData)
+			if mode == CaptureFramed {
+				var d logframe.Demuxer
+				frames, derr := d.Write(logData)
+				if derr != nil {
+					t.Fatalf("demux: %v", derr)
+				}
+				var b strings.Builder
+				for _, f := range frames {
+					b.Write(f.Payload)
+				}
+				got = b.String()
+			}
+			for _, want := range []string{"LINE1", "LINE2"} {
+				if !strings.Contains(got, want) {
+					t.Errorf("output missing %q — got %q", want, got)
+				}
+			}
+		})
+	}
+}
+
+func mcpStartScript(name, mode, command string) string {
+	esc := strings.ReplaceAll(command, `"`, `\"`)
+	return strings.Join([]string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"1"}}}`,
+		`{"jsonrpc":"2.0","method":"notifications/initialized"}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"process_start","arguments":{"name":"` +
+			name + `","capture_mode":"` + mode + `","command":"` + esc + `"}}}`,
+	}, "\n") + "\n"
+}
+
+func buildAgentBoxForTest(t *testing.T) string {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "agent-box")
+	build := exec.Command("go", "build", "-o", bin, "../../cmd/agent-box")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Skipf("cannot build agent-box for this test: %v\n%s", err, out)
+	}
+	return bin
+}

--- a/internal/agentbox/process.go
+++ b/internal/agentbox/process.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -14,7 +13,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/footprintai/containarium/internal/logframe"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
@@ -45,7 +43,31 @@ var ErrProcessNameInUse = errors.New("process name already in use")
 // processLogDir is a var, not a const, so tests can point it at t.TempDir()
 // (#1672 design doc, finding A1) — run-record tests assert on-disk state
 // and must stay isolated from the real /tmp/agent-box to be parallel-safe.
-var processLogDir = "/tmp/agent-box"
+var processLogDir = defaultProcessLogDir()
+
+// defaultProcessLogDir resolves where run logs, records, and exit sidecars
+// live. AGENTBOX_LOG_DIR overrides it — needed by tests that run a REAL
+// agent-box subprocess (the only way to reproduce the parent-exit case behind
+// #1701, since an in-process spawn keeps the parent alive), and useful to an
+// operator who does not want run state on /tmp.
+// agentBoxSelfPath resolves the agent-box binary the framer children exec
+// (#1701). os.Executable() is right in production — agent-box spawns the run —
+// but it is whatever binary embeds this package, which is not agent-box under
+// `go test`, nor in any host process that imports agentbox as a library.
+// AGENTBOX_SELF names it explicitly for those cases.
+func agentBoxSelfPath() (string, error) {
+	if p := os.Getenv("AGENTBOX_SELF"); p != "" {
+		return p, nil
+	}
+	return os.Executable()
+}
+
+func defaultProcessLogDir() string {
+	if dir := os.Getenv("AGENTBOX_LOG_DIR"); dir != "" {
+		return dir
+	}
+	return "/tmp/agent-box"
+}
 
 const processKillWaitTime = 2 * time.Second
 
@@ -138,28 +160,6 @@ func handleProcessStart(_ context.Context, req mcp.CallToolRequest) (*mcp.CallTo
 	return mcp.NewToolResultText(body), nil
 }
 
-// frameWriter writes to log with each Write call framed as one
-// internal/logframe record for stream (#1674, CaptureFramed). exec.Cmd
-// drives a process's Stdout and Stderr from two separate goroutines
-// concurrently; mu — shared between the stdout and stderr frameWriters for
-// one process — serializes their writes into logFile so frames from the
-// two streams never interleave mid-write, which is what keeps the single
-// on-disk byte stream's ordering meaningful for a demuxing reader.
-type frameWriter struct {
-	log    io.Writer
-	mu     *sync.Mutex
-	stream logframe.Stream
-}
-
-func (w *frameWriter) Write(p []byte) (int, error) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	if _, err := w.log.Write(logframe.EncodeFrame(w.stream, p)); err != nil {
-		return 0, err
-	}
-	return len(p), nil
-}
-
 // spawnBackgroundProcess starts command under /bin/sh -c, detached via
 // Setsid, capturing stdout+stderr to a log file under processLogDir per
 // captureMode (#1674), and registers it in processRegistry under name
@@ -233,21 +233,37 @@ func spawnBackgroundProcess(name, command, cwd string, captureMode CaptureMode) 
 	// agent-box dies with its SSH connection — so for a detached run (the
 	// whole point of #1672) nothing in-process survives to write the
 	// outcome. The setsid'd child does, so it writes the sidecar itself.
-	cmd := exec.Command("/bin/sh", "-c", wrapCommandWithExitSidecar(command, exitSidecarPath(logDir, name)))
+	// Framed capture frames on the CHILD's side of the fork (#1701). Handing
+	// exec.Cmd an io.Writer instead of an *os.File makes it insert a pipe and
+	// a copier goroutine inside agent-box; when the SSH connection drops and
+	// agent-box exits, the child dies of SIGPIPE on its next write. So both
+	// modes now give the child a real descriptor: combined writes the log
+	// directly, framed writes FIFOs that setsid'd framer children drain.
+	var framing *framingSpec
+	if captureMode == CaptureFramed {
+		self, err := agentBoxSelfPath()
+		if err != nil {
+			_ = logFile.Close()
+			return nil, fmt.Errorf("locate agent-box for framed capture: %w", err)
+		}
+		framing = &framingSpec{
+			agentBox: self,
+			logPath:  logPath,
+			outFIFO:  filepath.Join(logDir, sanitizeName(name)+".out.fifo"),
+			errFIFO:  filepath.Join(logDir, sanitizeName(name)+".err.fifo"),
+		}
+	}
+
+	// #nosec G204 -- spawning agent-supplied commands is the entire feature.
+	cmd := exec.Command("/bin/sh", "-c", buildRunScript(command, exitSidecarPath(logDir, name), framing))
 	if cwd != "" {
 		cmd.Dir = cwd
 	}
-	if captureMode == CaptureFramed {
-		// Separate stdout/stderr writers exec.Cmd drives from two goroutines
-		// concurrently, sharing one mutex so their frames never interleave
-		// mid-write in logFile — see frameWriter's own doc comment.
-		var mu sync.Mutex
-		cmd.Stdout = &frameWriter{log: logFile, mu: &mu, stream: logframe.Stdout}
-		cmd.Stderr = &frameWriter{log: logFile, mu: &mu, stream: logframe.Stderr}
-	} else {
-		cmd.Stdout = logFile
-		cmd.Stderr = logFile
-	}
+	// Both modes hand the child a real *os.File. In framed mode the child's
+	// own stdout/stderr are redirected to the FIFOs by the script, so these
+	// only carry anything the script itself emits (e.g. an mkfifo failure).
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
 	// Detach from agent-box's process group so a child of the spawned
 	// process survives an agent-box restart and can be reaped later.
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}


### PR DESCRIPTION
Closes #1701.

## The bug

A framed run (`--output-format-stream-json`) **died the instant the client
disconnected**, losing its output — the exact property #1672/#1674 exist to
provide. A/B on a live box, identical command, agent-box exiting right after
start:

| mode | log | exit |
|---|---|---|
| `combined` | `LINE1`, `LINE2` | **5** — survived |
| `framed` | *(empty)* | **141** = SIGPIPE |

## Cause

```go
cmd.Stdout = &frameWriter{log: logFile, …}   // an io.Writer
```

Per `os/exec`: an `*os.File` is passed to the child as a descriptor; **any other
`io.Writer` gets a pipe plus a copier goroutine inside the parent.** agent-box is
a stdio MCP server spawned per SSH connection, so its exit closed the read end
and the child died writing into it.

The `setsid` that saves combined-mode runs is irrelevant here — the child is
killed by its own output, not by process-group signalling. Combined mode never
had the bug because `cmd.Stdout` was the `*os.File` itself.

## Fix

Framing moves to the child's side of the fork. A hidden
`agent-box frame <stream> <log>` subcommand drains a FIFO and appends frames
under an `flock` — frames can exceed `PIPE_BUF`, so `O_APPEND` alone would not
stop two writers interleaving mid-record; this is the cross-process equivalent of
the mutex `frameWriter` shared.

`buildRunScript` starts one framer per stream **inside the run's already-setsid'd
shell**, before the command (opening a FIFO blocks until both ends are open). One
log, one offset — `tail_log`'s contract is unchanged.

`frameWriter` is **deleted** rather than left unused: it is the shape that caused
this, and a dead `io.Writer` sitting next to `exec.Cmd` invites its return.

## The test that would have caught it

New test starts a run through a **real agent-box process**, lets that process
**exit**, and asserts the child still completes — in both modes. Every previous
test kept the parent alive for the run's duration, which is precisely why unit
tests could not have caught this. It fails with exit 141 against the old
behaviour.

Two env overrides exist because that test needs a real subprocess:
`AGENTBOX_SELF` (the binary framers exec — `os.Executable()` is correct in
production but is the test binary under `go test`, and is not agent-box in any
host embedding this package as a library) and `AGENTBOX_LOG_DIR`.

## Verified live, after the fix

```
=== ab-combined ===  log: LINE1|LINE2|              exit: 5
=== ab-framed   ===  log: 1 TElORTEK|1 TElORTIK|    exit: 5
```

(base64 `LINE1\n` / `LINE2\n` on stream 1.)

Pre-existing on this branch and unrelated: two `TestStartSpawnListener_*`
failures on macOS only (socket path exceeds the 104-char `sun_path` limit; added
by #1517, green on Linux CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `frame` command for encoding and safely recording process output.
  * Added framed output capture for stdout and stderr, preserving messages from concurrently running processes.
  * Added configurable log directory and executable resolution for process capture.
  * Added optional actor and delegation information to process records and listings.

* **Bug Fixes**
  * Improved process survival and exit-code reporting when the parent process exits.
  * Prevented output loss and SIGPIPE-related failures during framed capture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->