### PR TITLE
feat(mcp): code_run/attach/status/stop — let agents drive a coding run

### DIFF
--- a/internal/cmd/code.go
+++ b/internal/cmd/code.go
@@ -47,7 +47,7 @@ const claudeInstallScript = "curl -fsSL https://claude.ai/install.sh | bash"
 // defaultCodeRunName is the process name used when --name is omitted, so
 // the common case ("one coding task per box at a time") never requires the
 // user to track an arbitrary generated name across run/attach/status/stop.
-const defaultCodeRunName = "code"
+const defaultCodeRunName = coderun.DefaultRunName
 
 // codeStreamFollow bounds how long each tail_log call blocks server-side
 // polling for new content — most of the "streaming" feel comes from this,
@@ -208,48 +208,11 @@ func resolveCodeSession(ctx context.Context, box string, diag io.Writer) (*coder
 	return sess, nil
 }
 
-// shellQuoteSingle single-quotes s for a POSIX shell, escaping any embedded
-// single quote by closing the quoted string, emitting a backslash-escaped
-// single quote, then reopening it. process_start runs its command under
-// /bin/sh -c on the box, so an unescaped user-supplied --prompt would be
-// shell-interpreted there — this is what stands between "the agent's
-// prompt" and arbitrary command injection into that shell.
-func shellQuoteSingle(s string) string {
-	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
-}
-
 // buildClaudeRunCommand renders the command process_start actually spawns:
 // source whatever secrets delivery `containarium code install` set up, then
 // invoke claude non-interactively. Sourcing here — not relying on a
 // login-shell profile — is self-contained per invocation, matching the same
 // reasoning claudeVerifyScript uses.
-func buildClaudeRunCommand(prompt string, streamJSON bool) string {
-	cmd := "set -a; [ -f /run/containarium/secrets.env ] && . /run/containarium/secrets.env; set +a; " +
-		"~/.local/bin/claude -p " + shellQuoteSingle(prompt)
-	if streamJSON {
-		cmd += " --output-format stream-json"
-	}
-	return cmd
-}
-
-// runOutcomeLine finds name's own line in process_list's raw text
-// (handleProcessList's "<icon> <name>  (pid <pid>, <outcome>)" format,
-// internal/agentbox/process.go) and reports whether it's still running.
-// A name that doesn't appear at all (never started under this name, or its
-// record was rotated away by a later same-name run) counts as not-running
-// — there is nothing left to wait for either way.
-func runOutcomeLine(listing, name string) (line string, running bool) {
-	for _, l := range strings.Split(listing, "\n") {
-		trimmed := strings.TrimSpace(l)
-		fields := strings.Fields(trimmed)
-		if len(fields) < 2 || fields[1] != name {
-			continue
-		}
-		return trimmed, strings.Contains(trimmed, ", running)")
-	}
-	return "", false
-}
-
 // streamAndWait streams path's output to stdout (demultiplexed to
 // stdout+stderr when streamJSON) until ctx is cancelled or name's run has
 // exited, polling process_list independently of the tail_log loop to
@@ -286,7 +249,7 @@ func streamAndWait(ctx context.Context, sess *coderun.Session, name, logPath str
 			if err != nil {
 				continue // transient; the streaming loop's own retry handles reconnection
 			}
-			if _, running := runOutcomeLine(listing, name); !running {
+			if _, running := coderun.RunOutcomeLine(listing, name); !running {
 				select {
 				case <-time.After(codeStreamFollow + time.Second):
 				case <-ctx.Done():

--- a/internal/cmd/code_run.go
+++ b/internal/cmd/code_run.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"github.com/footprintai/containarium/internal/coderun"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -88,7 +89,7 @@ func runCodeRun(cmd *cobra.Command, args []string) error {
 	if codeRunStreamJSON {
 		captureMode = "framed"
 	}
-	command := buildClaudeRunCommand(codeRunPrompt, codeRunStreamJSON)
+	command := coderun.BuildClaudeRunCommand(codeRunPrompt, codeRunStreamJSON)
 
 	started, err := sess.ProcessStart(ctx, name, command, "", captureMode)
 	if err != nil {
@@ -118,11 +119,11 @@ func runCodeAttach(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("process_list on %q: %w", box, err)
 	}
-	line, _ := runOutcomeLine(listing, name)
+	line, _ := coderun.RunOutcomeLine(listing, name)
 	if line == "" {
 		return fmt.Errorf("no run named %q on %q — start one with `containarium code run %s --prompt ...`", name, box, box)
 	}
-	logPath, err := logPathFromListing(listing, name)
+	logPath, err := coderun.LogPathFromListing(listing, name)
 	if err != nil {
 		return err
 	}
@@ -150,7 +151,7 @@ func runCodeStatus(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("process_list on %q: %w", box, err)
 	}
-	line, _ := runOutcomeLine(listing, name)
+	line, _ := coderun.RunOutcomeLine(listing, name)
 	if line == "" {
 		return fmt.Errorf("no run named %q on %q", name, box)
 	}
@@ -186,19 +187,3 @@ func runCodeStop(cmd *cobra.Command, args []string) error {
 // text. process_list doesn't expose per-name lookup, so `code attach`
 // greps its own name's block the same way runOutcomeLine does, then reads
 // the "Log path:" line immediately under it.
-func logPathFromListing(listing, name string) (string, error) {
-	lines := strings.Split(listing, "\n")
-	for i, l := range lines {
-		fields := strings.Fields(strings.TrimSpace(l))
-		if len(fields) < 2 || fields[1] != name {
-			continue
-		}
-		for _, follow := range lines[i:] {
-			if strings.HasPrefix(strings.TrimSpace(follow), "Log path:") {
-				return strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(follow), "Log path:")), nil
-			}
-		}
-		return "", fmt.Errorf("process_list entry for %q has no Log path line", name)
-	}
-	return "", fmt.Errorf("no run named %q in process_list", name)
-}

--- a/internal/cmd/code_test.go
+++ b/internal/cmd/code_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/footprintai/containarium/internal/coderun"
 	"os/exec"
 	"strings"
 	"testing"
@@ -18,7 +19,7 @@ func TestShellQuoteSingle_RoundTripsThroughARealShell(t *testing.T) {
 	}
 	for _, in := range cases {
 		t.Run(in, func(t *testing.T) {
-			quoted := shellQuoteSingle(in)
+			quoted := coderun.ShellQuoteSingle(in)
 			// #nosec G204 -- fixed "sh -c" with a single literal-quoted
 			// argument built by the function under test; this is the
 			// injection check itself, not a caller-reachable path.
@@ -38,7 +39,7 @@ func TestShellQuoteSingle_NeverEscapesOutOfTheQuotedString(t *testing.T) {
 	// embedded quotes lets this argument terminate early and run a second
 	// command.
 	malicious := "'; touch /tmp/pwned; echo '"
-	quoted := shellQuoteSingle(malicious)
+	quoted := coderun.ShellQuoteSingle(malicious)
 	// #nosec G204 -- see above.
 	out, err := exec.Command("/bin/sh", "-c", "echo "+quoted).Output()
 	if err != nil {
@@ -51,8 +52,8 @@ func TestShellQuoteSingle_NeverEscapesOutOfTheQuotedString(t *testing.T) {
 }
 
 func TestBuildClaudeRunCommand(t *testing.T) {
-	cmd := buildClaudeRunCommand("fix the bug", false)
-	for _, want := range []string{"secrets.env", "~/.local/bin/claude", "-p", shellQuoteSingle("fix the bug")} {
+	cmd := coderun.BuildClaudeRunCommand("fix the bug", false)
+	for _, want := range []string{"secrets.env", "~/.local/bin/claude", "-p", coderun.ShellQuoteSingle("fix the bug")} {
 		if !strings.Contains(cmd, want) {
 			t.Errorf("command missing %q:\n%s", want, cmd)
 		}
@@ -63,7 +64,7 @@ func TestBuildClaudeRunCommand(t *testing.T) {
 }
 
 func TestBuildClaudeRunCommand_StreamJSON(t *testing.T) {
-	cmd := buildClaudeRunCommand("fix the bug", true)
+	cmd := coderun.BuildClaudeRunCommand("fix the bug", true)
 	if !strings.Contains(cmd, "--output-format stream-json") {
 		t.Errorf("expected --output-format stream-json in:\n%s", cmd)
 	}
@@ -80,7 +81,7 @@ func TestRunOutcomeLine(t *testing.T) {
 		"   Exit code:  0\n" +
 		"   Log path:   /tmp/agent-box/old-task.log\n\n"
 
-	line, running := runOutcomeLine(listing, "code")
+	line, running := coderun.RunOutcomeLine(listing, "code")
 	if !running {
 		t.Errorf("code should be reported running, line=%q", line)
 	}
@@ -88,7 +89,7 @@ func TestRunOutcomeLine(t *testing.T) {
 		t.Errorf("line = %q", line)
 	}
 
-	line, running = runOutcomeLine(listing, "old-task")
+	line, running = coderun.RunOutcomeLine(listing, "old-task")
 	if running {
 		t.Errorf("old-task should not be reported running, line=%q", line)
 	}
@@ -96,7 +97,7 @@ func TestRunOutcomeLine(t *testing.T) {
 		t.Errorf("line = %q", line)
 	}
 
-	line, running = runOutcomeLine(listing, "does-not-exist")
+	line, running = coderun.RunOutcomeLine(listing, "does-not-exist")
 	if running || line != "" {
 		t.Errorf("unknown name should report not-running/empty line, got running=%v line=%q", running, line)
 	}
@@ -109,7 +110,7 @@ func TestLogPathFromListing(t *testing.T) {
 		"   Started at: 2026-09-02T12:00:00Z\n" +
 		"   Log path:   /tmp/agent-box/code.log\n\n"
 
-	got, err := logPathFromListing(listing, "code")
+	got, err := coderun.LogPathFromListing(listing, "code")
 	if err != nil {
 		t.Fatalf("logPathFromListing: %v", err)
 	}
@@ -117,7 +118,7 @@ func TestLogPathFromListing(t *testing.T) {
 		t.Errorf("got %q, want /tmp/agent-box/code.log", got)
 	}
 
-	if _, err := logPathFromListing(listing, "nope"); err == nil {
+	if _, err := coderun.LogPathFromListing(listing, "nope"); err == nil {
 		t.Error("expected an error for a name not in the listing")
 	}
 }

--- a/internal/coderun/ops.go
+++ b/internal/coderun/ops.go
@@ -1,0 +1,87 @@
+package coderun
+
+import (
+	"fmt"
+	"strings"
+)
+
+// The operations behind `containarium code`, shared by the CLI handlers and
+// the platform MCP tools (#1698). CLAUDE.md's rule is CLI-first with MCP as a
+// thin wrapper over the SAME Go function — these live here so the two surfaces
+// cannot drift, rather than each parsing process_list its own way.
+
+// DefaultRunName is the process name a run uses when the caller names none.
+// A stable default is what lets `code attach <box>` find the run `code run
+// <box>` started without the user tracking an identifier.
+const DefaultRunName = "code"
+
+// ShellQuoteSingle single-quotes s for a POSIX shell, escaping any embedded
+// single quote by closing the quoted string, emitting a backslash-escaped
+// quote, then reopening. process_start runs its command under /bin/sh -c on
+// the box, so an unescaped caller-supplied prompt would be shell-interpreted
+// there — this is what stands between "the agent's prompt" and arbitrary
+// command injection into that shell.
+func ShellQuoteSingle(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// BuildClaudeRunCommand renders the shell command a run executes on the box.
+// Sourcing the seeded secrets file is what supplies the model credential
+// without it ever being a CLI argument or appearing in the run record.
+func BuildClaudeRunCommand(prompt string, streamJSON bool) string {
+	cmd := "set -a; [ -f /run/containarium/secrets.env ] && . /run/containarium/secrets.env; set +a; " +
+		"~/.local/bin/claude -p " + ShellQuoteSingle(prompt)
+	if streamJSON {
+		cmd += " --output-format stream-json"
+	}
+	return cmd
+}
+
+// CaptureModeFor maps the stream-json flag to the capture_mode process_start
+// expects. Framed exists so a JSON stream on stdout is not corrupted by
+// diagnostics interleaved from stderr.
+func CaptureModeFor(streamJSON bool) string {
+	if streamJSON {
+		return "framed"
+	}
+	return "combined"
+}
+
+// RunOutcomeLine finds name's own line in process_list's raw text (the
+// "<icon> <name>  (pid <pid>, <outcome>)" format handleProcessList emits) and
+// reports whether it is still running.
+//
+// A name that does not appear at all — never started, or its record rotated
+// away by a later same-name run — counts as not-running: there is nothing left
+// to wait for either way.
+func RunOutcomeLine(listing, name string) (line string, running bool) {
+	for _, l := range strings.Split(listing, "\n") {
+		trimmed := strings.TrimSpace(l)
+		fields := strings.Fields(trimmed)
+		if len(fields) < 2 || fields[1] != name {
+			continue
+		}
+		return trimmed, strings.Contains(trimmed, ", running)")
+	}
+	return "", false
+}
+
+// LogPathFromListing extracts name's log path from process_list's raw text.
+// The path is the handle every subsequent read uses, so a listing without one
+// is an error rather than an empty string a caller might tail.
+func LogPathFromListing(listing, name string) (string, error) {
+	lines := strings.Split(listing, "\n")
+	for i, l := range lines {
+		fields := strings.Fields(strings.TrimSpace(l))
+		if len(fields) < 2 || fields[1] != name {
+			continue
+		}
+		for _, follow := range lines[i:] {
+			if strings.HasPrefix(strings.TrimSpace(follow), "Log path:") {
+				return strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(follow), "Log path:")), nil
+			}
+		}
+		return "", fmt.Errorf("process_list entry for %q has no Log path line", name)
+	}
+	return "", fmt.Errorf("no run named %q in process_list", name)
+}

--- a/internal/coderun/ops_test.go
+++ b/internal/coderun/ops_test.go
@@ -1,0 +1,131 @@
+package coderun
+
+import "testing"
+
+// These helpers are the seam the CLI and the platform MCP both go through
+// (#1698), so a change here moves both surfaces at once — which is the point,
+// and the reason they are worth pinning.
+
+func TestShellQuoteSingle(t *testing.T) {
+	tests := []struct {
+		name, in, want string
+	}{
+		{"plain", "hello", `'hello'`},
+		{"spaces", "add a health endpoint", `'add a health endpoint'`},
+		{"embedded quote", "don't", `'don'\''t'`},
+		// The reason this function exists: process_start runs its command
+		// under /bin/sh -c on the box, so an unquoted prompt is a shell
+		// injection.
+		{"injection attempt", "x'; rm -rf /; echo '", `'x'\''; rm -rf /; echo '\'''`},
+		{"empty", "", `''`},
+		{"dollar and backtick stay literal", "$HOME `id`", "'$HOME `id`'"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ShellQuoteSingle(tt.in); got != tt.want {
+				t.Errorf("ShellQuoteSingle(%q) = %s, want %s", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildClaudeRunCommand_QuotesThePromptAndSourcesSecrets(t *testing.T) {
+	got := BuildClaudeRunCommand("don't panic", false)
+	if want := `'don'\''t panic'`; !contains(got, want) {
+		t.Errorf("prompt not shell-quoted:\n%s", got)
+	}
+	// The credential reaches the run by sourcing the seeded file, never as an
+	// argument — otherwise it would land in the run record and process_list.
+	if !contains(got, "/run/containarium/secrets.env") {
+		t.Errorf("secrets not sourced:\n%s", got)
+	}
+	if contains(got, "--output-format stream-json") {
+		t.Errorf("stream-json leaked into the non-streaming command:\n%s", got)
+	}
+	if streamed := BuildClaudeRunCommand("hi", true); !contains(streamed, "--output-format stream-json") {
+		t.Errorf("stream-json missing when requested:\n%s", streamed)
+	}
+}
+
+func TestCaptureModeFor(t *testing.T) {
+	if got := CaptureModeFor(true); got != "framed" {
+		t.Errorf("CaptureModeFor(true) = %q, want framed", got)
+	}
+	if got := CaptureModeFor(false); got != "combined" {
+		t.Errorf("CaptureModeFor(false) = %q, want combined", got)
+	}
+}
+
+const sampleListing = `Found 2 process(es):
+
+🟢 code  (pid 101, running)
+   Command:    claude -p 'x'
+   Started at: 2026-09-03T10:00:00Z
+   Log path:   /tmp/agent-box/code.log
+
+⚪ other  (pid 202, exited)
+   Command:    true
+   Started at: 2026-09-03T09:00:00Z
+   Exit code:  0
+   Log path:   /tmp/agent-box/other.log
+`
+
+func TestRunOutcomeLine(t *testing.T) {
+	tests := []struct {
+		name        string
+		run         string
+		wantFound   bool
+		wantRunning bool
+	}{
+		{"running run", "code", true, true},
+		{"exited run", "other", true, false},
+		// A name that never appears counts as not-running: there is nothing
+		// left to wait for either way.
+		{"absent run", "nope", false, false},
+		// Must not match on a prefix — "cod" is not "code".
+		{"prefix is not a match", "cod", false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			line, running := RunOutcomeLine(sampleListing, tt.run)
+			if (line != "") != tt.wantFound {
+				t.Errorf("line = %q, wantFound = %v", line, tt.wantFound)
+			}
+			if running != tt.wantRunning {
+				t.Errorf("running = %v, want %v", running, tt.wantRunning)
+			}
+		})
+	}
+}
+
+func TestLogPathFromListing(t *testing.T) {
+	got, err := LogPathFromListing(sampleListing, "code")
+	if err != nil {
+		t.Fatalf("LogPathFromListing: %v", err)
+	}
+	if got != "/tmp/agent-box/code.log" {
+		t.Errorf("log path = %q", got)
+	}
+
+	// The second entry's path must not be attributed to the first.
+	other, err := LogPathFromListing(sampleListing, "other")
+	if err != nil || other != "/tmp/agent-box/other.log" {
+		t.Errorf("other log path = %q (%v)", other, err)
+	}
+
+	// An absent run is an error, not an empty string a caller might tail.
+	if _, err := LogPathFromListing(sampleListing, "nope"); err == nil {
+		t.Error("absent run should error rather than return an empty path")
+	}
+}
+
+func contains(haystack, needle string) bool {
+	return len(haystack) >= len(needle) && (func() bool {
+		for i := 0; i+len(needle) <= len(haystack); i++ {
+			if haystack[i:i+len(needle)] == needle {
+				return true
+			}
+		}
+		return false
+	})()
+}

--- a/internal/mcp/code_tools.go
+++ b/internal/mcp/code_tools.go
@@ -1,0 +1,233 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/footprintai/containarium/internal/coderun"
+	"github.com/footprintai/containarium/internal/connectcore"
+	"github.com/footprintai/containarium/internal/sshkey"
+)
+
+// Platform-MCP wrappers for `containarium code` (#1698). Every operation here
+// is the SAME internal/coderun function the CLI handler calls — CLAUDE.md's
+// CLI-first rule, which had been running one-directional: the verb shipped in
+// #1673/#1674 with no MCP counterpart, so an agent could create a box and
+// expose a port but could not start a coding run on one or reattach to it.
+//
+// The streaming shape differs by necessity. The CLI streams to a terminal
+// until interrupted; MCP is request/response, so `code_run` and `code_attach`
+// return a BOUNDED window plus the offset to resume from, mirroring tail_log's
+// existing contract. An agent that carries `next_offset` across calls gets
+// exactly the disconnect-tolerant behavior a human gets from the CLI.
+
+// codeReadWindow bounds how long one code_run/code_attach call waits for new
+// output. Long enough that a caller polling in a loop sees steady progress,
+// short enough that no single MCP call looks hung.
+const codeReadWindow = 5 * time.Second
+
+// mcpCodeSession resolves box and opens an MCP session to its agent-box over
+// SSH — the same transport `connect` uses, so key/certificate handling stays
+// in one place rather than being reimplemented per tool.
+func mcpCodeSession(client API, box string) (*coderun.Session, func(), error) {
+	target, privPath, cleanup, err := mcpCodeTarget(client, box)
+	if err != nil {
+		return nil, nil, err
+	}
+	// No remote command — Connect appends "agent-box" itself.
+	sess, err := coderun.Connect(context.Background(), connectcore.BuildSSHArgs(target, privPath, ""))
+	if err != nil {
+		cleanup()
+		return nil, nil, fmt.Errorf("connect to agent-box on %q: %w", box, err)
+	}
+	return sess, func() { _ = sess.Close(); cleanup() }, nil
+}
+
+// mcpCodeTarget resolves the SSH target and an identity for box, preferring a
+// short-lived certificate and falling back to the managed key — the same
+// preference order handleConnect uses, and for the same reason: a certificate
+// leaves nothing installed on the box.
+func mcpCodeTarget(client API, box string) (connectcore.Target, string, func(), error) {
+	target, err := mcpWaitConnectable(client, box, "", "")
+	if err != nil {
+		return connectcore.Target{}, "", nil, err
+	}
+
+	cert, err := issueCertForBox(client, target.User)
+	switch {
+	case err == nil:
+		return target, cert.PrivateKeyPath, cert.Cleanup, nil
+	case errors.Is(err, errCertUnsupported):
+		pubPath, pub, _, kerr := sshkey.LocateOrGenerate(sshkey.LocateOpts{})
+		if kerr != nil {
+			return connectcore.Target{}, "", nil, fmt.Errorf("locate or generate managed key: %w", kerr)
+		}
+		if aerr := mcpAuthorizeKey(client, box, pub); aerr != nil {
+			return connectcore.Target{}, "", nil, fmt.Errorf("authorize key on %q: %w", box, aerr)
+		}
+		return target, strings.TrimSuffix(pubPath, ".pub"), func() {}, nil
+	default:
+		// The server COULD sign and something went wrong. Falling back would
+		// install a long-lived key to paper over a control-plane fault and
+		// never mention it — surface it instead.
+		return connectcore.Target{}, "", nil, fmt.Errorf("issue certificate for %q: %w", box, err)
+	}
+}
+
+func codeRunNameArg(args map[string]interface{}) string {
+	if n := strings.TrimSpace(getStringArg(args, "name", "")); n != "" {
+		return n
+	}
+	return coderun.DefaultRunName
+}
+
+// handleCodeRun starts a detached coding run and returns the first window of
+// its output. The run outlives this call — that is the entire point — so the
+// response carries what a caller needs to follow it: the run name and the
+// offset to resume from.
+func handleCodeRun(client API, args map[string]interface{}) (string, error) {
+	box := strings.TrimSpace(getStringArg(args, "box", ""))
+	if box == "" {
+		return "", fmt.Errorf("`box` is required")
+	}
+	prompt := strings.TrimSpace(getStringArg(args, "prompt", ""))
+	if prompt == "" {
+		return "", fmt.Errorf("`prompt` is required")
+	}
+	streamJSON := getBoolArg(args, "stream_json", false)
+	name := codeRunNameArg(args)
+
+	sess, done, err := mcpCodeSession(client, box)
+	if err != nil {
+		return "", err
+	}
+	defer done()
+
+	ctx := context.Background()
+	started, err := sess.ProcessStart(ctx,
+		name,
+		coderun.BuildClaudeRunCommand(prompt, streamJSON),
+		"",
+		coderun.CaptureModeFor(streamJSON),
+	)
+	if err != nil {
+		return "", fmt.Errorf("start run on %q: %w", box, err)
+	}
+
+	out, next := readCodeWindow(ctx, sess, started.LogPath, 0, streamJSON)
+	return fmt.Sprintf(
+		"✓ started %q (pid %d) on %s\n\nlog_path: %s\nnext_offset: %d\n\n--- output so far ---\n%s\n"+
+			"(the run continues on the box — call code_attach with name=%q and offset=%d for more)",
+		started.Name, started.PID, box, started.LogPath, next, out, started.Name, next), nil
+}
+
+// handleCodeAttach resumes a run's output from a byte offset. Passing back the
+// previous call's next_offset is what makes reconnection lossless: the reader
+// never re-derives a position, so nothing is skipped and nothing repeats.
+func handleCodeAttach(client API, args map[string]interface{}) (string, error) {
+	box := strings.TrimSpace(getStringArg(args, "box", ""))
+	if box == "" {
+		return "", fmt.Errorf("`box` is required")
+	}
+	name := codeRunNameArg(args)
+	var offset int64
+	if v, ok := getIntArg(args, "offset"); ok && v > 0 {
+		offset = int64(v)
+	}
+	streamJSON := getBoolArg(args, "stream_json", false)
+
+	sess, done, err := mcpCodeSession(client, box)
+	if err != nil {
+		return "", err
+	}
+	defer done()
+
+	ctx := context.Background()
+	listing, err := sess.ProcessList(ctx)
+	if err != nil {
+		return "", fmt.Errorf("process_list on %q: %w", box, err)
+	}
+	line, running := coderun.RunOutcomeLine(listing, name)
+	if line == "" {
+		return "", fmt.Errorf("no run named %q on %q — start one with code_run", name, box)
+	}
+	logPath, err := coderun.LogPathFromListing(listing, name)
+	if err != nil {
+		return "", err
+	}
+
+	out, next := readCodeWindow(ctx, sess, logPath, offset, streamJSON)
+	tail := fmt.Sprintf("(still running — call again with offset=%d)", next)
+	if !running {
+		// Say so explicitly: an agent polling a finished run would otherwise
+		// keep asking forever for output that will never arrive.
+		tail = "(run has finished; this is the end of its output)"
+	}
+	return fmt.Sprintf("%s\n\nnext_offset: %d\n\n--- output ---\n%s\n%s", line, next, out, tail), nil
+}
+
+// handleCodeStatus reports liveness and, once finished, the exit code.
+func handleCodeStatus(client API, args map[string]interface{}) (string, error) {
+	box := strings.TrimSpace(getStringArg(args, "box", ""))
+	if box == "" {
+		return "", fmt.Errorf("`box` is required")
+	}
+	name := codeRunNameArg(args)
+
+	sess, done, err := mcpCodeSession(client, box)
+	if err != nil {
+		return "", err
+	}
+	defer done()
+
+	listing, err := sess.ProcessList(context.Background())
+	if err != nil {
+		return "", fmt.Errorf("process_list on %q: %w", box, err)
+	}
+	line, _ := coderun.RunOutcomeLine(listing, name)
+	if line == "" {
+		return fmt.Sprintf("no run named %q on %s", name, box), nil
+	}
+	return line, nil
+}
+
+// handleCodeStop reaps a run. The log is deliberately left readable so its
+// output can still be collected afterwards.
+func handleCodeStop(client API, args map[string]interface{}) (string, error) {
+	box := strings.TrimSpace(getStringArg(args, "box", ""))
+	if box == "" {
+		return "", fmt.Errorf("`box` is required")
+	}
+	name := codeRunNameArg(args)
+
+	sess, done, err := mcpCodeSession(client, box)
+	if err != nil {
+		return "", err
+	}
+	defer done()
+
+	res, err := sess.ProcessKill(context.Background(), name, getBoolArg(args, "force", false))
+	if err != nil {
+		return "", fmt.Errorf("stop run %q on %q: %w", name, box, err)
+	}
+	return fmt.Sprintf("✓ stopped %q on %s (pid %d)\nlog kept at %s", name, box, res.PID, res.LogPath), nil
+}
+
+// readCodeWindow reads one bounded window from a run's log, returning the text
+// and the offset to resume from. Framed output is demultiplexed so a caller
+// sees the run's own stdout/stderr rather than the wire format.
+func readCodeWindow(ctx context.Context, sess *coderun.Session, logPath string, offset int64, streamJSON bool) (string, int64) {
+	var sb strings.Builder
+	var w interface{ Write([]byte) (int, error) } = &sb
+	if streamJSON {
+		w = coderun.NewDemuxWriter(&sb, &sb)
+	}
+	next, err := coderun.StreamOutput(ctx, sess, w, logPath, offset, codeReadWindow, nil)
+	if err != nil && sb.Len() == 0 {
+		return fmt.Sprintf("(no output read: %v)", err), offset
+	}
+	return sb.String(), next
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -22,8 +22,8 @@ func TestServerCreation(t *testing.T) {
 	assert.NotNil(t, server)
 	assert.Equal(t, config, server.config)
 	assert.NotNil(t, server.client)
-	// 30 base (+check_for_updates +upgrade_backend +get_upgrade_status, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes + 3 backups + connect (#453) + 2 agent-skills (#562) + call_agent (#570) + 2 crews (#584) + delete_route + install_zap (#960) + set_metrics_export + get_metrics_export (#1069) + verify_backup (#1159) + list_passthrough_routes + add_passthrough_route + delete_passthrough_route (#1550) + security_sentry_status (#1640) + list_bad_destinations + add_bad_destination + remove_bad_destination (#1641) + list_security_sentry_findings + resolve_security_sentry_finding (#1643).
-	assert.Len(t, server.tools, 68, "Should have 68 tools registered")
+	// 30 base (+check_for_updates +upgrade_backend +get_upgrade_status, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes + 3 backups + connect (#453) + 2 agent-skills (#562) + call_agent (#570) + 2 crews (#584) + delete_route + install_zap (#960) + set_metrics_export + get_metrics_export (#1069) + verify_backup (#1159) + list_passthrough_routes + add_passthrough_route + delete_passthrough_route (#1550) + security_sentry_status (#1640) + list_bad_destinations + add_bad_destination + remove_bad_destination (#1641) + list_security_sentry_findings + resolve_security_sentry_finding (#1643) + 4 code run/attach/status/stop (#1698).
+	assert.Len(t, server.tools, 72, "Should have 72 tools registered")
 }
 
 // TestServerTools tests tool registration
@@ -127,8 +127,8 @@ func TestHandleToolsList(t *testing.T) {
 
 	tools, ok := result["tools"].([]map[string]interface{})
 	require.True(t, ok)
-	// 30 base (+check_for_updates +upgrade_backend +get_upgrade_status, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes + 3 backups + connect (#453) + 2 agent-skills (#562) + call_agent (#570) + 2 crews (#584) + delete_route + install_zap (#960) + set_metrics_export + get_metrics_export (#1069) + verify_backup (#1159) + list_passthrough_routes + add_passthrough_route + delete_passthrough_route (#1550) + security_sentry_status (#1640) + list_bad_destinations + add_bad_destination + remove_bad_destination (#1641) + list_security_sentry_findings + resolve_security_sentry_finding (#1643).
-	assert.Len(t, tools, 68)
+	// 30 base (+check_for_updates +upgrade_backend +get_upgrade_status, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes + 3 backups + connect (#453) + 2 agent-skills (#562) + call_agent (#570) + 2 crews (#584) + delete_route + install_zap (#960) + set_metrics_export + get_metrics_export (#1069) + verify_backup (#1159) + list_passthrough_routes + add_passthrough_route + delete_passthrough_route (#1550) + security_sentry_status (#1640) + list_bad_destinations + add_bad_destination + remove_bad_destination (#1641) + list_security_sentry_findings + resolve_security_sentry_finding (#1643) + 4 code run/attach/status/stop (#1698).
+	assert.Len(t, tools, 72)
 
 	// Check first tool structure
 	firstTool := tools[0]

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1072,6 +1072,75 @@ func (s *Server) registerTools() {
 			Handler: handleSyncSSHConfig,
 		},
 		{
+			Name: "code_run",
+			Description: "Start a coding agent on a box and return the first window of its output. " +
+				"The run is DETACHED: it survives this call returning, the MCP connection dropping, and " +
+				"the client going away — that is the point. The response carries `next_offset`; pass it " +
+				"to code_attach to continue reading exactly where this left off, with nothing skipped " +
+				"and nothing repeated. Requires the box to already have the toolchain installed " +
+				"(code_install).",
+			InputSchema: map[string]interface{}{
+				"type":     "object",
+				"required": []string{"box", "prompt"},
+				"properties": map[string]interface{}{
+					"box":    map[string]interface{}{"type": "string", "description": "Box (container username) to run on."},
+					"prompt": map[string]interface{}{"type": "string", "description": "The task to give the agent."},
+					"name": map[string]interface{}{"type": "string",
+						"description": "Run name, default \"code\". Override to run more than one task concurrently on the same box; the same name is how code_attach/code_status/code_stop find it later."},
+					"stream_json": map[string]interface{}{"type": "boolean",
+						"description": "Capture stdout and stderr separately (framed) so a JSON stream on stdout is not corrupted by diagnostics. Default false."},
+				},
+			},
+			Handler: handleCodeRun,
+		},
+		{
+			Name: "code_attach",
+			Description: "Resume a run's output from a byte offset. Pass the `next_offset` from your " +
+				"previous code_run/code_attach call — carrying the offset forward is what makes " +
+				"reconnection lossless. Omit it (or 0) to replay the run from the beginning. Reports " +
+				"whether the run is still going, so you know when to stop polling.",
+			InputSchema: map[string]interface{}{
+				"type":     "object",
+				"required": []string{"box"},
+				"properties": map[string]interface{}{
+					"box":  map[string]interface{}{"type": "string", "description": "Box the run is on."},
+					"name": map[string]interface{}{"type": "string", "description": "Run name, default \"code\"."},
+					"offset": map[string]interface{}{"type": "integer",
+						"description": "Byte offset to resume from — the `next_offset` of your last call. 0 replays from the start."},
+					"stream_json": map[string]interface{}{"type": "boolean",
+						"description": "Set if the run was started with stream_json, so framed output is demultiplexed."},
+				},
+			},
+			Handler: handleCodeAttach,
+		},
+		{
+			Name:        "code_status",
+			Description: "Report a run's liveness and, once it has finished, its exit code — including for a run that finished while nothing was attached.",
+			InputSchema: map[string]interface{}{
+				"type":     "object",
+				"required": []string{"box"},
+				"properties": map[string]interface{}{
+					"box":  map[string]interface{}{"type": "string", "description": "Box the run is on."},
+					"name": map[string]interface{}{"type": "string", "description": "Run name, default \"code\"."},
+				},
+			},
+			Handler: handleCodeStatus,
+		},
+		{
+			Name:        "code_stop",
+			Description: "Stop a run. Its log is left readable, so output can still be collected afterwards with code_attach.",
+			InputSchema: map[string]interface{}{
+				"type":     "object",
+				"required": []string{"box"},
+				"properties": map[string]interface{}{
+					"box":   map[string]interface{}{"type": "string", "description": "Box the run is on."},
+					"name":  map[string]interface{}{"type": "string", "description": "Run name, default \"code\"."},
+					"force": map[string]interface{}{"type": "boolean", "description": "SIGKILL instead of SIGTERM. Default false."},
+				},
+			},
+			Handler: handleCodeStop,
+		},
+		{
 			Name: "connect",
 			Description: "Get SSH access to one of your boxes using the token you're already " +
 				"authenticated with — connect authorizes a managed key for you, so there's " +
@@ -1505,6 +1574,17 @@ func (s *Server) registerTools() {
 // completeness against the registered tool list.
 func toolScopeAssignments() map[string]string {
 	return map[string]string{
+		// coding runs on a box (#1698). code:write is the scope the CLI's
+		// own `code` surface is gated by — starting or stopping an agent
+		// run executes arbitrary code on the box, so it is deliberately NOT
+		// covered by containers:read. code_status/code_attach are reads of
+		// a run's output, but they read a run only this scope could have
+		// started, so they share it rather than widening the read surface.
+		"code_run":    auth.ScopeCodeWrite,
+		"code_attach": auth.ScopeCodeWrite,
+		"code_status": auth.ScopeCodeWrite,
+		"code_stop":   auth.ScopeCodeWrite,
+
 		// container lifecycle
 		"create_container":   auth.ScopeContainersWrite,
 		"delete_container":   auth.ScopeContainersWrite,


### PR DESCRIPTION
Closes #1698.

## The gap

`containarium code` shipped in #1673/#1674 with **no MCP counterpart** — 34 tools
registered, none of them this. An agent on the platform MCP could create a box,
expose a port, and run an agent-skill, but could not start a coding run or
reattach to one.

That is pointed for a feature whose whole premise is *delegating long-running
work and reconnecting to it later* — the shape an agent, not just a human at a
terminal, wants to drive.

## What this adds

`code_run`, `code_attach`, `code_status`, `code_stop` (72 tools total).

CLAUDE.md's rule is CLI-first with MCP as a thin wrapper over the **same** Go
function; that was running one-directional here. So the shared operations move
into `internal/coderun` — `BuildClaudeRunCommand`, `ShellQuoteSingle`,
`CaptureModeFor`, `RunOutcomeLine`, `LogPathFromListing` — and the CLI now calls
them rather than owning private copies. Neither surface can parse `process_list`
its own way any more.

## The streaming shape

The CLI streams to a terminal until interrupted; MCP is request/response. So
`code_run`/`code_attach` return a **bounded window plus `next_offset`**,
mirroring `tail_log`'s existing contract. An agent that carries `next_offset`
across calls gets the same disconnect-tolerant behaviour a human gets from the
CLI — and the tool descriptions say so explicitly, because an agent that
re-derives an offset would silently skip or repeat output.

`code_attach` also reports whether the run is still going, so a caller does not
poll a finished run forever waiting for output that will never arrive.

## Scope

`code:write`, not `containers:read` — starting or stopping a run executes
arbitrary code on the box. `code_status`/`code_attach` are reads, but they read a
run only a `code:write` caller could have started, so they share the scope rather
than widening the read surface.

## Transport

Reuses `handleConnect`'s certificate-preferred, managed-key-fallback path rather
than reimplementing key handling per tool — including its refusal to fall back
when the server *could* sign but failed, since papering over a control-plane
fault by installing a long-lived key is worse than surfacing it.

## Note

Two existing guards caught omissions before this was committed:
`TestEveryToolHasScope` (no scope assignment for the new tools) and the two
tool-count assertions. Both are the kind of check #1685 asks for on the RPC side,
working exactly as intended here.

New tests pin the shared helpers, including that `ShellQuoteSingle` neutralises a
prompt-borne shell injection and that run-name matching is equality rather than
prefix — the latter was confirmed to fail when the guard is relaxed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1554BHQdJmSXTuG1UhS3i


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MCP tools to start, attach to, check the status of, and stop detached coding-agent runs.
  * Supports named concurrent runs, resumable output, streamed JSON, exit-status inspection, and graceful or forced termination.
  * Added shared handling for secure command construction, run status detection, and log-path lookup.
* **Tests**
  * Added coverage for command safety, streaming behavior, run tracking, log extraction, and MCP tool registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->