### PR TITLE
feat(tokens): mint a token acting for another subject (cloud#1427)

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -6063,6 +6063,41 @@
         ]
       }
     },
+    "/v1/tokens/delegate": {
+      "post": {
+        "summary": "Mint a token acting for another subject",
+        "description": "Exchanges the caller's credential for a token whose subject is `subject` and whose `act` chain records the caller. Granted scopes are the intersection of the caller's own scopes with those requested — an exchange can never widen authority. Requires the `tokens:delegate` scope, on a token that carries an explicit scopes claim — an unscoped token is rejected here even when strict-scope enforcement is off, because the caller's scopes are the ceiling being applied.",
+        "operationId": "TokensService_ExchangeDelegatedToken",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ExchangeDelegatedTokenResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "ExchangeDelegatedTokenRequest asks for a token acting for `subject`.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ExchangeDelegatedTokenRequest"
+            }
+          }
+        ],
+        "tags": [
+          "Tokens"
+        ]
+      }
+    },
     "/v1/tokens/refresh": {
       "post": {
         "summary": "Exchange a refresh token for a new (access, refresh) pair",
@@ -9793,6 +9828,49 @@
         }
       },
       "description": "Evidence bundles the flow and deny records that triggered a finding.\nCapped by the store to the most recent entries — see FindingStore."
+    },
+    "ExchangeDelegatedTokenRequest": {
+      "type": "object",
+      "properties": {
+        "subject": {
+          "type": "string",
+          "description": "The subject the minted token represents — the end user the\ncaller is acting for. Required: an empty subject would mint\nan unattributed token, which is the state this endpoint\nexists to eliminate."
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Scopes requested for the minted token. INTERSECTED with the\ncaller's own scopes, never unioned. Empty requests the\ncaller's own scope set (still bounded by it)."
+        },
+        "expiresInSeconds": {
+          "type": "string",
+          "format": "int64",
+          "description": "Lifetime in seconds. 0 uses the daemon's default access-token\nexpiry; values above the daemon's maximum are capped rather\nthan rejected, so a caller asking for too long gets a shorter\ntoken instead of a failure."
+        }
+      },
+      "description": "ExchangeDelegatedTokenRequest asks for a token acting for `subject`."
+    },
+    "ExchangeDelegatedTokenResponse": {
+      "type": "object",
+      "properties": {
+        "token": {
+          "type": "string",
+          "description": "The minted access token."
+        },
+        "expiresAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "When it expires, so a caller can cache it rather than\nexchanging on every request — the round trip this endpoint\nadds is meant to be amortized per (subject, TTL)."
+        },
+        "grantedScopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The scopes actually granted, after intersection. Returned\nexplicitly because they may be NARROWER than requested, and a\ncaller that assumes otherwise would fail later with a\nconfusing permission error instead of here."
+        }
+      }
     },
     "ExecInSandboxBody": {
       "type": "object",

--- a/internal/auth/scopes.go
+++ b/internal/auth/scopes.go
@@ -84,6 +84,15 @@ const (
 	// without `tokens:write` can't revoke either.
 	ScopeTokensWrite = "tokens:write"
 
+	// tokens:delegate — mint a token that acts FOR another subject
+	// (ExchangeDelegatedToken, containarium-cloud#1427). Deliberately
+	// SEPARATE from tokens:write: managing your own tokens and acting as
+	// someone else are different capabilities, and the second is the one
+	// that puts a name in an audit row. A service that fronts this API for
+	// end users needs exactly this and nothing else from the tokens
+	// surface, so it should be grantable on its own.
+	ScopeTokensDelegate = "tokens:delegate"
+
 	// agent skills (AgentSkillService). `agents:read` lists/inspects the
 	// skill catalog; `agents:run` provisions a skill's box and runs a task.
 	// A skill's OWN token is minted with only the scopes the skill declares
@@ -146,7 +155,7 @@ var AllScopes = []string{
 	ScopeAlertsRead, ScopeAlertsWrite,
 	ScopeTrafficRead,
 	ScopeCodeWrite, ScopeSSHWrite,
-	ScopeTokensWrite,
+	ScopeTokensWrite, ScopeTokensDelegate,
 	ScopeAgentsRead, ScopeAgentsRun, ScopeAgentsCall,
 	ScopeCrewsRead, ScopeCrewsRun,
 	ScopeClustersRead, ScopeClustersWrite, ScopeClustersScale,

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -897,6 +897,52 @@ func (c *HTTPClient) RevokeToken(jti, reason, expiresAt string) (string, error) 
 	return result.Message, nil
 }
 
+// ExchangeDelegatedToken trades this client's own credential for a token
+// that acts FOR `subject` (containarium-cloud#1427). The caller must hold
+// the tokens:delegate scope, and the returned token can never carry more
+// scopes than the caller already had.
+//
+// Returns the token, its real expiry (read from the token's own exp claim
+// by the daemon, so it is safe to cache against), and the scopes actually
+// granted — which may be narrower than those requested.
+func (c *HTTPClient) ExchangeDelegatedToken(subject string, scopes []string, expiresIn time.Duration) (string, time.Time, []string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	body, err := json.Marshal(exchangeDelegatedTokenRequest{
+		Subject:          subject,
+		Scopes:           scopes,
+		ExpiresInSeconds: int64(expiresIn / time.Second),
+	})
+	if err != nil {
+		return "", time.Time{}, nil, fmt.Errorf("marshal request: %w", err)
+	}
+	resp, err := c.doRequest(ctx, http.MethodPost, "/v1/tokens/delegate", body)
+	if err != nil {
+		return "", time.Time{}, nil, fmt.Errorf("exchange delegated token: %w", err)
+	}
+	defer drainClose(resp)
+	b, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return "", time.Time{}, nil, parseErr(b, resp.StatusCode, "exchange delegated token")
+	}
+	// protojson renders google.protobuf.Timestamp as an RFC3339 string.
+	var result struct {
+		Token         string   `json:"token"`
+		ExpiresAt     string   `json:"expiresAt"`
+		GrantedScopes []string `json:"grantedScopes"`
+	}
+	if err := json.Unmarshal(b, &result); err != nil {
+		return "", time.Time{}, nil, fmt.Errorf("decode delegate response: %w", err)
+	}
+	var expiresAt time.Time
+	if result.ExpiresAt != "" {
+		// A malformed timestamp is not fatal: the token itself is usable and
+		// carries its own exp. The caller loses only the ability to cache.
+		expiresAt, _ = time.Parse(time.RFC3339, result.ExpiresAt)
+	}
+	return result.Token, expiresAt, result.GrantedScopes, nil
+}
+
 // SetSecret creates or updates a tenant secret via HTTP.
 // `delivery` is one of "" (server normalizes to env), "env",
 // or "file" (Phase 4.3 — Phase A lands the field; Phase B

--- a/internal/client/http_requests.go
+++ b/internal/client/http_requests.go
@@ -185,6 +185,21 @@ type revokeTokenRequest struct {
 	ExpiresAt string `json:"expires_at,omitempty"`
 }
 
+// exchangeDelegatedTokenRequest is POST /v1/tokens/delegate
+// (containarium-cloud#1427).
+//
+// Note what is NOT here: an `act` field. The delegation chain is built by
+// the daemon from the caller's own authenticated token, never asserted by
+// the client — a request that could name its own actor would let any
+// holder of this scope forge the audit trail (#1677).
+type exchangeDelegatedTokenRequest struct {
+	Subject string `json:"subject"`
+	// Empty means "everything the caller itself holds". Either way the
+	// daemon intersects with the caller's scopes, so this can only narrow.
+	Scopes           []string `json:"scopes,omitempty"`
+	ExpiresInSeconds int64    `json:"expires_in_seconds,omitempty"`
+}
+
 // startEgressProxyRequest is POST /v1/network/egress-proxy (#808).
 type startEgressProxyRequest struct {
 	ContainerName string `json:"containerName"`

--- a/internal/cmd/token.go
+++ b/internal/cmd/token.go
@@ -30,6 +30,12 @@ var (
 	refreshTokenIn   string
 	refreshTokenFile string
 
+	// `token delegate` flags (containarium-cloud#1427)
+	delegateSubject   string
+	delegateScopes    []string
+	delegateExpiry    string
+	delegateRawOutput bool
+
 	// `token list-revoked` flags
 	listRevokedLimit          int32
 	listRevokedIncludeExpired bool
@@ -178,6 +184,47 @@ Admin role + tokens:write scope required.`,
 	RunE: runTokenListRevoked,
 }
 
+// tokenDelegateCmd implements `containarium token delegate`
+// (containarium-cloud#1427) — trade your own credential for one that acts
+// FOR someone else.
+var tokenDelegateCmd = &cobra.Command{
+	Use:   "delegate",
+	Short: "Exchange your token for one acting on behalf of another subject",
+	Long: `Trade the credential you already hold for a short-lived token minted
+for another subject, with your identity recorded as the actor.
+
+This exists for a service that fronts the API for end users. Such a
+service presents its own service account on every call, so audit rows
+name the service rather than the person, and a scope check against the
+service account bounds nothing. Rather than hand that service a signing
+key — which would let it mint any identity at all — it asks the daemon
+to mint, and the daemon records the delegation itself.
+
+Two limits are enforced server-side and cannot be argued with:
+
+  - The granted scopes are the intersection of yours with those you
+    request. This exchange can only narrow authority, never widen it.
+  - The actor is taken from your authenticated token, never from the
+    request. You cannot name someone else as the delegator.
+
+Requires the tokens:delegate scope — deliberately distinct from
+tokens:write, because managing your own tokens and acting as another
+person are different capabilities.`,
+	Example: `  # Act for a user, inheriting every scope you hold
+  containarium token delegate --subject alice@example.com \
+    --server $S --token $T
+
+  # Narrow it further than your own token, and shorten the life
+  containarium token delegate --subject alice@example.com \
+    --scopes containers:read --expiry 5m \
+    --server $S --token $T
+
+  # For scripting: emit only the token
+  DELEGATED=$(containarium token delegate --subject alice@example.com \
+    --raw --server $S --token $T)`,
+	RunE: runTokenDelegate,
+}
+
 // tokenUnscopedReportCmd implements `containarium token
 // unscoped-report` (#1679) — the measurement to check before
 // arming CONTAINARIUM_STRICT_SCOPES.
@@ -201,6 +248,13 @@ func init() {
 	tokenCmd.AddCommand(tokenRefreshCmd)
 	tokenCmd.AddCommand(tokenListRevokedCmd)
 	tokenCmd.AddCommand(tokenUnscopedReportCmd)
+	tokenCmd.AddCommand(tokenDelegateCmd)
+
+	tokenDelegateCmd.Flags().StringVar(&delegateSubject, "subject", "", "Subject to act on behalf of (required)")
+	_ = tokenDelegateCmd.MarkFlagRequired("subject")
+	tokenDelegateCmd.Flags().StringSliceVar(&delegateScopes, "scopes", nil, "Scopes to request (comma-separated). Omit to inherit your own; the server intersects either way, so this can only narrow.")
+	tokenDelegateCmd.Flags().StringVar(&delegateExpiry, "expiry", "", "Lifetime of the delegated token (e.g. 5m, 1h). Empty = the daemon's access-token default.")
+	tokenDelegateCmd.Flags().BoolVar(&delegateRawOutput, "raw", false, "Output only the raw token (for scripting)")
 
 	tokenRefreshCmd.Flags().StringVar(&refreshTokenIn, "refresh-token", "", "Refresh token to exchange (mutually exclusive with --refresh-token-file)")
 	tokenRefreshCmd.Flags().StringVar(&refreshTokenFile, "refresh-token-file", "", "Path to file containing the refresh token (mode 0600 recommended)")
@@ -390,6 +444,73 @@ func runTokenRefresh(cmd *cobra.Command, args []string) error {
 	if refreshExp > 0 {
 		fmt.Printf("  Refresh expires: %s\n", time.Unix(refreshExp, 0).Format(time.RFC3339))
 	}
+	fmt.Printf("\n═══════════════════════════════════════════════════════════════\n\n")
+	return nil
+}
+
+// runTokenDelegate POSTs to /v1/tokens/delegate. Every safety decision —
+// scope intersection, actor construction, TTL capping — belongs to the
+// daemon; this handler only carries the request and reports what came back.
+func runTokenDelegate(cmd *cobra.Command, args []string) error {
+	if serverAddr == "" {
+		return fmt.Errorf("--server is required (the daemon holds the signing key, not the CLI)")
+	}
+	if authToken == "" {
+		return fmt.Errorf("--token is required (the delegated token is minted on ITS authority)")
+	}
+	subject := strings.TrimSpace(delegateSubject)
+	if subject == "" {
+		return fmt.Errorf("--subject is required")
+	}
+
+	var expiresIn time.Duration
+	if delegateExpiry != "" {
+		d, err := time.ParseDuration(delegateExpiry)
+		if err != nil {
+			return fmt.Errorf("invalid --expiry %q: %w", delegateExpiry, err)
+		}
+		if d <= 0 {
+			return fmt.Errorf("--expiry must be positive (a delegated token is deliberately short-lived)")
+		}
+		expiresIn = d
+	}
+
+	httpClient, err := client.NewHTTPClient(serverAddr, authToken)
+	if err != nil {
+		return fmt.Errorf("create http client: %w", err)
+	}
+	defer func() { _ = httpClient.Close() }()
+
+	token, expiresAt, granted, err := httpClient.ExchangeDelegatedToken(subject, delegateScopes, expiresIn)
+	if err != nil {
+		return err
+	}
+
+	if delegateRawOutput {
+		fmt.Println(token)
+		return nil
+	}
+
+	fmt.Printf("\n═══════════════════════════════════════════════════════════════\n")
+	fmt.Printf("  Delegated token minted\n")
+	fmt.Printf("═══════════════════════════════════════════════════════════════\n\n")
+	fmt.Printf("Acting for:  %s\n", subject)
+	if !expiresAt.IsZero() {
+		fmt.Printf("Expires:     %s\n", expiresAt.Format(time.RFC3339))
+	}
+	// Print what was GRANTED, not what was asked for. The two differ whenever
+	// the request exceeded the caller's own authority, and a silent narrowing
+	// is exactly the kind of surprise that shows up later as a confusing 403.
+	if len(granted) == 0 {
+		fmt.Printf("Scopes:      (none recorded — inherits the daemon's unscoped default)\n")
+	} else {
+		fmt.Printf("Scopes:      %s\n", strings.Join(granted, ", "))
+	}
+	if len(delegateScopes) > 0 && len(granted) < len(delegateScopes) {
+		fmt.Printf("\nNote: fewer scopes granted than requested — your own token does not\n")
+		fmt.Printf("carry the rest. The exchange narrows; it never widens.\n")
+	}
+	fmt.Printf("\nToken (use as Authorization: Bearer):\n%s\n", token)
 	fmt.Printf("\n═══════════════════════════════════════════════════════════════\n\n")
 	return nil
 }

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -1566,7 +1566,7 @@ skipAppHosting:
 				// for operator revocation via CLI / MCP.
 				tokensServer := NewTokensServer(tokenManager, revStore, 0)
 				pb.RegisterTokensServiceServer(grpcServer, tokensServer)
-				log.Printf("TokensService registered (POST /v1/tokens/revoke)")
+				log.Printf("TokensService registered (POST /v1/tokens/revoke, /v1/tokens/delegate)")
 			}
 		}
 	}

--- a/internal/server/tokens_delegate_test.go
+++ b/internal/server/tokens_delegate_test.go
@@ -1,0 +1,221 @@
+package server
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/footprintai/containarium/internal/auth"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// ExchangeDelegatedToken exists to let a fronting service act for a user
+// without holding a signing key (containarium-cloud#1427). Its safety rests
+// entirely on two invariants, so those are what these tests pin.
+
+func delegateTestServer(t *testing.T) *TokensServer {
+	t.Helper()
+	tm, err := auth.NewTokenManager(delegateTestSecret, "containarium-test")
+	if err != nil {
+		t.Fatalf("NewTokenManager: %v", err)
+	}
+	return NewTokensServer(tm, nil, 0)
+}
+
+const delegateTestSecret = "test-secret-for-delegation-tests-0123456789"
+
+// callerCtx builds an authenticated caller carrying both a scopes claim and
+// an act chain — the shape the gateway annotator produces in production. The
+// two ContextWithTestSubject* helpers each write a full metadata set, so the
+// scopes pair is merged onto the act-bearing context rather than layered by a
+// second constructor call, which would drop the act.
+func callerCtx(username string, scopes []string, act *auth.Actor) context.Context {
+	ctx := auth.ContextWithTestSubjectAct(context.Background(), username, []string{"admin"}, act)
+	if scopes == nil {
+		return ctx
+	}
+	md, _ := metadata.FromIncomingContext(ctx)
+	md = md.Copy()
+	md.Set(auth.MDKeyScopes, strings.Join(scopes, ","))
+	return metadata.NewIncomingContext(ctx, md)
+}
+
+// THE invariant: an exchange can never produce more authority than the caller
+// already holds. Without it this endpoint is #1676's escalation reopened.
+func TestExchangeDelegatedToken_CannotWidenAuthority(t *testing.T) {
+	s := delegateTestServer(t)
+	ctx := callerCtx("cloud-daemon",
+		[]string{auth.ScopeTokensDelegate, auth.ScopeContainersRead},
+		nil)
+
+	resp, err := s.ExchangeDelegatedToken(ctx, &pb.ExchangeDelegatedTokenRequest{
+		Subject: "alice@example.com",
+		// Asking for far more than the caller holds.
+		Scopes: []string{auth.ScopeContainersRead, auth.ScopeSecretsRead, auth.ScopeContainersWrite},
+	})
+	if err != nil {
+		t.Fatalf("exchange: %v", err)
+	}
+
+	for _, s := range resp.GetGrantedScopes() {
+		if s == auth.ScopeSecretsRead || s == auth.ScopeContainersWrite {
+			t.Fatalf("granted %q — the caller does not hold it; the exchange widened authority", s)
+		}
+	}
+	if len(resp.GetGrantedScopes()) != 1 || resp.GetGrantedScopes()[0] != auth.ScopeContainersRead {
+		t.Errorf("granted = %v, want only containers:read", resp.GetGrantedScopes())
+	}
+}
+
+// act must come from the authenticated context, never from the request — the
+// rule #1677 states. A caller that could name its own actor could forge the
+// audit trail.
+func TestExchangeDelegatedToken_ActIsServerSetAndNests(t *testing.T) {
+	s := delegateTestServer(t)
+	// The caller itself already acts for someone: a two-hop chain.
+	existing := &auth.Actor{Subject: "human@example.com"}
+	ctx := callerCtx("cloud-daemon", []string{auth.ScopeTokensDelegate}, existing)
+
+	resp, err := s.ExchangeDelegatedToken(ctx, &pb.ExchangeDelegatedTokenRequest{
+		Subject: "alice@example.com",
+	})
+	if err != nil {
+		t.Fatalf("exchange: %v", err)
+	}
+
+	tm, _ := auth.NewTokenManager(delegateTestSecret, "containarium-test")
+	claims, err := tm.ValidateToken(resp.GetToken())
+	if err != nil {
+		t.Fatalf("minted token does not validate: %v", err)
+	}
+	if claims.Username != "alice@example.com" {
+		t.Errorf("subject = %q, want the delegated-for user", claims.Username)
+	}
+	if claims.Act == nil {
+		t.Fatal("no act chain — the delegation path was not recorded")
+	}
+	if claims.Act.Subject != "cloud-daemon" {
+		t.Errorf("act.sub = %q, want the authenticated caller", claims.Act.Subject)
+	}
+	// The caller's own chain must be WRAPPED, not dropped: RootActor is what
+	// #1678's audit `actor` column resolves to, and flattening here would
+	// lose the human furthest from the leaf.
+	if got := auth.RootActor(claims.Act); got != "human@example.com" {
+		t.Errorf("RootActor = %q, want the original human — the chain was flattened", got)
+	}
+}
+
+func TestExchangeDelegatedToken_RequiresDelegateScope(t *testing.T) {
+	s := delegateTestServer(t)
+	// tokens:write is deliberately NOT enough: managing your own tokens and
+	// acting as someone else are different capabilities.
+	ctx := callerCtx("cloud-daemon", []string{auth.ScopeTokensWrite}, nil)
+
+	_, err := s.ExchangeDelegatedToken(ctx, &pb.ExchangeDelegatedTokenRequest{Subject: "alice@example.com"})
+	if err == nil {
+		t.Fatal("tokens:write alone must not permit acting as another subject")
+	}
+	if got := status.Code(err); got != codes.PermissionDenied {
+		t.Errorf("code = %v, want PermissionDenied", got)
+	}
+}
+
+func TestExchangeDelegatedToken_RejectsEmptySubject(t *testing.T) {
+	s := delegateTestServer(t)
+	ctx := callerCtx("cloud-daemon", []string{auth.ScopeTokensDelegate}, nil)
+
+	// An empty subject would mint an unattributed token — the state this
+	// endpoint exists to remove, so it must not silently fall back.
+	_, err := s.ExchangeDelegatedToken(ctx, &pb.ExchangeDelegatedTokenRequest{Subject: "  "})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("err = %v, want InvalidArgument for an empty subject", err)
+	}
+}
+
+func TestExchangeDelegatedToken_RejectsAnOverlongChain(t *testing.T) {
+	s := delegateTestServer(t)
+	// Build a chain already at the maximum; one more hop must be refused
+	// rather than truncated — truncation drops the human furthest from the
+	// leaf, which is the one an auditor needs.
+	var deep *auth.Actor
+	for i := 0; i < auth.MaxActDepth; i++ {
+		deep = &auth.Actor{Subject: "hop", Act: deep}
+	}
+	ctx := callerCtx("cloud-daemon", []string{auth.ScopeTokensDelegate}, deep)
+
+	_, err := s.ExchangeDelegatedToken(ctx, &pb.ExchangeDelegatedTokenRequest{Subject: "alice@example.com"})
+	if err == nil {
+		t.Fatal("a chain past MaxActDepth must be refused, not silently truncated")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "depth") {
+		t.Errorf("err = %v, want a depth violation", err)
+	}
+}
+
+func TestExchangeDelegatedToken_ReportsExpiry(t *testing.T) {
+	s := delegateTestServer(t)
+	ctx := callerCtx("cloud-daemon", []string{auth.ScopeTokensDelegate}, nil)
+
+	resp, err := s.ExchangeDelegatedToken(ctx, &pb.ExchangeDelegatedTokenRequest{
+		Subject:          "alice@example.com",
+		ExpiresInSeconds: 300,
+	})
+	if err != nil {
+		t.Fatalf("exchange: %v", err)
+	}
+	// The caller is meant to cache by this, so it has to be present and sane
+	// — the round trip is only acceptable if it can be amortized.
+	if resp.GetExpiresAt() == nil {
+		t.Fatal("no expires_at — a caller cannot cache without it")
+	}
+	if d := time.Until(resp.GetExpiresAt().AsTime()); d <= 0 || d > 6*time.Minute {
+		t.Errorf("expires in %v, want ~5 minutes", d)
+	}
+}
+
+// The fail-open scope default (#1679) must NOT reach this endpoint. Everywhere
+// else a token with no scopes claim is tolerated for backward compatibility;
+// here the caller's scope set IS the ceiling, and IntersectScopes reads a nil
+// caller as unbounded — so tolerating it would grant any scope asked for.
+func TestExchangeDelegatedToken_RefusesAnUnscopedCaller(t *testing.T) {
+	s := delegateTestServer(t)
+	// nil scopes = no scopes claim at all, the pre-1.7 token shape.
+	ctx := callerCtx("legacy-service", nil, nil)
+
+	resp, err := s.ExchangeDelegatedToken(ctx, &pb.ExchangeDelegatedTokenRequest{
+		Subject: "alice@example.com",
+		Scopes:  []string{auth.ScopeSecretsRead, auth.ScopeContainersWrite},
+	})
+	if err == nil {
+		t.Fatalf("an unscoped caller was granted %v — the exchange has no ceiling to apply",
+			resp.GetGrantedScopes())
+	}
+	if got := status.Code(err); got != codes.PermissionDenied {
+		t.Errorf("code = %v, want PermissionDenied", got)
+	}
+}
+
+// An explicit empty scope list is a different thing from an absent claim: the
+// caller holds nothing, so it can delegate nothing. It must not be mistaken
+// for "unscoped" and handed the requested set.
+func TestExchangeDelegatedToken_ExplicitlyEmptyScopesGrantNothing(t *testing.T) {
+	s := delegateTestServer(t)
+	ctx := callerCtx("cloud-daemon", []string{auth.ScopeTokensDelegate}, nil)
+
+	resp, err := s.ExchangeDelegatedToken(ctx, &pb.ExchangeDelegatedTokenRequest{
+		Subject: "alice@example.com",
+		Scopes:  []string{auth.ScopeSecretsRead},
+	})
+	if err != nil {
+		t.Fatalf("exchange: %v", err)
+	}
+	// tokens:delegate is the only scope held, and it was not requested.
+	if len(resp.GetGrantedScopes()) != 0 {
+		t.Errorf("granted = %v, want nothing — the caller holds none of what it asked for",
+			resp.GetGrantedScopes())
+	}
+}

--- a/internal/server/tokens_server.go
+++ b/internal/server/tokens_server.go
@@ -3,12 +3,14 @@ package server
 import (
 	"context"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/footprintai/containarium/internal/auth"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // Phase 1.2 follow-up — TokensService implementation. Pairs
@@ -265,4 +267,126 @@ func (s *TokensServer) GetUnscopedTokenReport(ctx context.Context, _ *pb.GetUnsc
 		resp.Since = report.Since.UTC().Format(time.RFC3339)
 	}
 	return resp, nil
+}
+
+// ExchangeDelegatedToken mints a token acting FOR another subject, on the
+// authority of the caller's own credential (containarium-cloud#1427).
+//
+// A service that fronts this API for end users — the cloud control plane is
+// the case that motivated it — presents its own service credential on every
+// call. #1676 bounds an agent token by the caller's scopes, but when the
+// caller is a shared service account that bound means nothing, and #1678's
+// audit `actor` records the service rather than the person. `act` is a JWT
+// claim and never a header (#1677), so the fronting service cannot assert it:
+// it holds no signing key, and giving it one would let it mint any identity.
+// It asks this daemon to mint instead.
+//
+// Two invariants make that safe, and they are the same two RunAgentSkill's
+// own delegated mint relies on:
+//
+//   - Granted scopes are the INTERSECTION of the caller's with those
+//     requested. An exchange can never widen authority — without this the
+//     endpoint is exactly the escalation primitive #1676 closed, reopened
+//     under a new name.
+//   - `act` is built server-side from the authenticated caller, wrapping the
+//     caller's own chain, so the delegation path is recorded rather than
+//     claimed.
+func (s *TokensServer) ExchangeDelegatedToken(ctx context.Context, req *pb.ExchangeDelegatedTokenRequest) (*pb.ExchangeDelegatedTokenResponse, error) {
+	// tokens:delegate, not tokens:write — acting as another subject is a
+	// distinct capability from managing your own tokens.
+	if err := auth.RequireScope(ctx, auth.ScopeTokensDelegate); err != nil {
+		return nil, err
+	}
+
+	// This endpoint FAILS CLOSED on an unscoped token, regardless of
+	// CONTAINARIUM_STRICT_SCOPES. Everywhere else a missing scopes claim is
+	// tolerated (#1679) so that tokens minted before scopes existed keep
+	// working; that tolerance is safe for a handler that merely reads or
+	// mutates, because the token's own authority still bounds the blast
+	// radius.
+	//
+	// It is NOT safe here. The ceiling below is the caller's scope set, and
+	// IntersectScopes treats a nil caller as unbounded — so an unscoped
+	// caller could ask for, and be granted, any scope in the system. That
+	// makes this endpoint the escalation primitive #1676 closed, reopened
+	// under a new name, with the fail-open as its trigger.
+	//
+	// The usual reason to fail open does not apply: this RPC is new, so
+	// there is no population of legacy callers to preserve. A fronting
+	// service must present a scoped credential — which is what
+	// containarium-cloud#1428 is separately doing to the cloud's own
+	// service token.
+	callerScopes, scopesPresent := auth.ScopesFromGRPCContext(ctx)
+	if !scopesPresent {
+		return nil, status.Error(codes.PermissionDenied,
+			"delegation requires a token carrying an explicit scopes claim: "+
+				"the granted set is bounded by the caller's own scopes, and an "+
+				"unscoped token has no bound to apply")
+	}
+
+	subject := strings.TrimSpace(req.GetSubject())
+	if subject == "" {
+		// An empty subject would mint an unattributed token — the exact
+		// state this endpoint exists to eliminate, so it is an error
+		// rather than a silent fallback to the caller's own identity.
+		return nil, status.Error(codes.InvalidArgument, "subject is required")
+	}
+
+	caller, _, ok := auth.SubjectFromGRPCContext(ctx)
+	if !ok || caller == "" {
+		return nil, status.Error(codes.Unauthenticated, "no authenticated subject in request context")
+	}
+
+	// The caller becomes the actor, wrapping whatever chain it already
+	// carries, so a multi-hop delegation nests instead of flattening. Never
+	// taken from the request — that is #1677's rule.
+	callerAct, _ := auth.ActFromGRPCContext(ctx)
+	act := &auth.Actor{Subject: caller, Act: callerAct}
+
+	granted := auth.IntersectScopes(callerScopes, req.GetScopes())
+	if len(req.GetScopes()) == 0 {
+		// No explicit request means "whatever I have" — still the caller's
+		// own set, never wider.
+		granted = callerScopes
+	}
+
+	// A caller asking for longer than the daemon permits gets a shorter
+	// token, not a failure: generate() caps it internally, and failing here
+	// would make a working exchange depend on the client knowing the
+	// daemon's configured maximum.
+	//
+	// An unspecified TTL is an access-token lifetime, NOT the daemon
+	// maximum. Passing 0 straight through would mint the longest-lived
+	// token the daemon allows for the least specific request — the wrong
+	// default for a credential handed to a fronting service.
+	ttl := auth.DefaultAccessTokenExpiry
+	if secs := req.GetExpiresInSeconds(); secs > 0 {
+		ttl = time.Duration(secs) * time.Second
+	}
+
+	token, err := s.tokenManager.GenerateDelegatedToken(subject, nil, ttl, act, granted...)
+	if err != nil {
+		// Depth violations are a client-correctable conflict (the chain is
+		// too long), not a server fault — surface them as such.
+		if strings.Contains(err.Error(), "delegation chain depth") {
+			return nil, status.Errorf(codes.FailedPrecondition, "mint delegated token: %v", err)
+		}
+		return nil, status.Errorf(codes.Internal, "mint delegated token: %v", err)
+	}
+
+	// Report the token's OWN exp rather than recomputing the deadline here.
+	// The manager caps a too-long TTL silently, so a locally derived
+	// timestamp can claim a validity the token does not have — and the
+	// caller caches against this value, so it would keep presenting a token
+	// the daemon already rejects.
+	claims, err := s.tokenManager.ValidateToken(token)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "minted token failed self-validation: %v", err)
+	}
+
+	return &pb.ExchangeDelegatedTokenResponse{
+		Token:         token,
+		ExpiresAt:     timestamppb.New(claims.ExpiresAt.Time),
+		GrantedScopes: granted,
+	}, nil
 }

--- a/pkg/pb/containarium/v1/tokens.pb.go
+++ b/pkg/pb/containarium/v1/tokens.pb.go
@@ -11,6 +11,7 @@ import (
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
@@ -581,11 +582,151 @@ func (x *GetUnscopedTokenReportResponse) GetStrictModeEnabled() bool {
 	return false
 }
 
+// ExchangeDelegatedTokenRequest asks for a token acting for `subject`.
+type ExchangeDelegatedTokenRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The subject the minted token represents — the end user the
+	// caller is acting for. Required: an empty subject would mint
+	// an unattributed token, which is the state this endpoint
+	// exists to eliminate.
+	Subject string `protobuf:"bytes,1,opt,name=subject,proto3" json:"subject,omitempty"`
+	// Scopes requested for the minted token. INTERSECTED with the
+	// caller's own scopes, never unioned. Empty requests the
+	// caller's own scope set (still bounded by it).
+	Scopes []string `protobuf:"bytes,2,rep,name=scopes,proto3" json:"scopes,omitempty"`
+	// Lifetime in seconds. 0 uses the daemon's default access-token
+	// expiry; values above the daemon's maximum are capped rather
+	// than rejected, so a caller asking for too long gets a shorter
+	// token instead of a failure.
+	ExpiresInSeconds int64 `protobuf:"varint,3,opt,name=expires_in_seconds,json=expiresInSeconds,proto3" json:"expires_in_seconds,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *ExchangeDelegatedTokenRequest) Reset() {
+	*x = ExchangeDelegatedTokenRequest{}
+	mi := &file_containarium_v1_tokens_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ExchangeDelegatedTokenRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ExchangeDelegatedTokenRequest) ProtoMessage() {}
+
+func (x *ExchangeDelegatedTokenRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_tokens_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ExchangeDelegatedTokenRequest.ProtoReflect.Descriptor instead.
+func (*ExchangeDelegatedTokenRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_tokens_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *ExchangeDelegatedTokenRequest) GetSubject() string {
+	if x != nil {
+		return x.Subject
+	}
+	return ""
+}
+
+func (x *ExchangeDelegatedTokenRequest) GetScopes() []string {
+	if x != nil {
+		return x.Scopes
+	}
+	return nil
+}
+
+func (x *ExchangeDelegatedTokenRequest) GetExpiresInSeconds() int64 {
+	if x != nil {
+		return x.ExpiresInSeconds
+	}
+	return 0
+}
+
+type ExchangeDelegatedTokenResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The minted access token.
+	Token string `protobuf:"bytes,1,opt,name=token,proto3" json:"token,omitempty"`
+	// When it expires, so a caller can cache it rather than
+	// exchanging on every request — the round trip this endpoint
+	// adds is meant to be amortized per (subject, TTL).
+	ExpiresAt *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=expires_at,json=expiresAt,proto3" json:"expires_at,omitempty"`
+	// The scopes actually granted, after intersection. Returned
+	// explicitly because they may be NARROWER than requested, and a
+	// caller that assumes otherwise would fail later with a
+	// confusing permission error instead of here.
+	GrantedScopes []string `protobuf:"bytes,3,rep,name=granted_scopes,json=grantedScopes,proto3" json:"granted_scopes,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ExchangeDelegatedTokenResponse) Reset() {
+	*x = ExchangeDelegatedTokenResponse{}
+	mi := &file_containarium_v1_tokens_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ExchangeDelegatedTokenResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ExchangeDelegatedTokenResponse) ProtoMessage() {}
+
+func (x *ExchangeDelegatedTokenResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_tokens_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ExchangeDelegatedTokenResponse.ProtoReflect.Descriptor instead.
+func (*ExchangeDelegatedTokenResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_tokens_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *ExchangeDelegatedTokenResponse) GetToken() string {
+	if x != nil {
+		return x.Token
+	}
+	return ""
+}
+
+func (x *ExchangeDelegatedTokenResponse) GetExpiresAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.ExpiresAt
+	}
+	return nil
+}
+
+func (x *ExchangeDelegatedTokenResponse) GetGrantedScopes() []string {
+	if x != nil {
+		return x.GrantedScopes
+	}
+	return nil
+}
+
 var File_containarium_v1_tokens_proto protoreflect.FileDescriptor
 
 const file_containarium_v1_tokens_proto_rawDesc = "" +
 	"\n" +
-	"\x1ccontainarium/v1/tokens.proto\x12\x0fcontainarium.v1\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto\"]\n" +
+	"\x1ccontainarium/v1/tokens.proto\x12\x0fcontainarium.v1\x1a\x1cgoogle/api/annotations.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a.protoc-gen-openapiv2/options/annotations.proto\"]\n" +
 	"\x12RevokeTokenRequest\x12\x10\n" +
 	"\x03jti\x18\x01 \x01(\tR\x03jti\x12\x16\n" +
 	"\x06reason\x18\x02 \x01(\tR\x06reason\x12\x1d\n" +
@@ -620,10 +761,21 @@ const file_containarium_v1_tokens_proto_rawDesc = "" +
 	"\x1eGetUnscopedTokenReportResponse\x12.\n" +
 	"\x13unscoped_call_count\x18\x01 \x01(\x03R\x11unscopedCallCount\x12\x14\n" +
 	"\x05since\x18\x02 \x01(\tR\x05since\x12.\n" +
-	"\x13strict_mode_enabled\x18\x03 \x01(\bR\x11strictModeEnabled2\xb7\x0e\n" +
+	"\x13strict_mode_enabled\x18\x03 \x01(\bR\x11strictModeEnabled\"\x7f\n" +
+	"\x1dExchangeDelegatedTokenRequest\x12\x18\n" +
+	"\asubject\x18\x01 \x01(\tR\asubject\x12\x16\n" +
+	"\x06scopes\x18\x02 \x03(\tR\x06scopes\x12,\n" +
+	"\x12expires_in_seconds\x18\x03 \x01(\x03R\x10expiresInSeconds\"\x98\x01\n" +
+	"\x1eExchangeDelegatedTokenResponse\x12\x14\n" +
+	"\x05token\x18\x01 \x01(\tR\x05token\x129\n" +
+	"\n" +
+	"expires_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\texpiresAt\x12%\n" +
+	"\x0egranted_scopes\x18\x03 \x03(\tR\rgrantedScopes2\xe1\x13\n" +
 	"\rTokensService\x12\x85\x03\n" +
 	"\vRevokeToken\x12#.containarium.v1.RevokeTokenRequest\x1a$.containarium.v1.RevokeTokenResponse\"\xaa\x02\x92A\x8a\x02\n" +
-	"\x06Tokens\x12\x17Revoke a JWT by its jti\x1a\xe6\x01Adds the token's jti to the revocation list. The token will be rejected on the next request that tries to use it. Admin-only. Idempotent — revoking an already-revoked jti is a no-op (the original revocation reason is preserved).\x82\xd3\xe4\x93\x02\x16:\x01*\"\x11/v1/tokens/revoke\x12\xf0\x03\n" +
+	"\x06Tokens\x12\x17Revoke a JWT by its jti\x1a\xe6\x01Adds the token's jti to the revocation list. The token will be rejected on the next request that tries to use it. Admin-only. Idempotent — revoking an already-revoked jti is a no-op (the original revocation reason is preserved).\x82\xd3\xe4\x93\x02\x16:\x01*\"\x11/v1/tokens/revoke\x12\xa7\x05\n" +
+	"\x16ExchangeDelegatedToken\x12..containarium.v1.ExchangeDelegatedTokenRequest\x1a/.containarium.v1.ExchangeDelegatedTokenResponse\"\xab\x04\x92A\x89\x04\n" +
+	"\x06Tokens\x12'Mint a token acting for another subject\x1a\xd5\x03Exchanges the caller's credential for a token whose subject is `subject` and whose `act` chain records the caller. Granted scopes are the intersection of the caller's own scopes with those requested — an exchange can never widen authority. Requires the `tokens:delegate` scope, on a token that carries an explicit scopes claim — an unscoped token is rejected here even when strict-scope enforcement is off, because the caller's scopes are the ceiling being applied.\x82\xd3\xe4\x93\x02\x18:\x01*\"\x13/v1/tokens/delegate\x12\xf0\x03\n" +
 	"\fRefreshToken\x12$.containarium.v1.RefreshTokenRequest\x1a%.containarium.v1.RefreshTokenResponse\"\x92\x03\x92A\xf1\x02\n" +
 	"\x06Tokens\x129Exchange a refresh token for a new (access, refresh) pair\x1a\xab\x02Validates the refresh token (signature + exp + tt='refresh' + not revoked), mints a new short-lived access token, mints a new long-lived refresh token, and revokes the input refresh token's jti. Refresh tokens are single-use; the new refresh token must be stored by the client for the next exchange.\x82\xd3\xe4\x93\x02\x17:\x01*\"\x12/v1/tokens/refresh\x12\xf2\x02\n" +
 	"\x11ListRevokedTokens\x12).containarium.v1.ListRevokedTokensRequest\x1a*.containarium.v1.ListRevokedTokensResponse\"\x85\x02\x92A\xe7\x01\n" +
@@ -643,7 +795,7 @@ func file_containarium_v1_tokens_proto_rawDescGZIP() []byte {
 	return file_containarium_v1_tokens_proto_rawDescData
 }
 
-var file_containarium_v1_tokens_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_containarium_v1_tokens_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
 var file_containarium_v1_tokens_proto_goTypes = []any{
 	(*RevokeTokenRequest)(nil),             // 0: containarium.v1.RevokeTokenRequest
 	(*RevokeTokenResponse)(nil),            // 1: containarium.v1.RevokeTokenResponse
@@ -654,22 +806,28 @@ var file_containarium_v1_tokens_proto_goTypes = []any{
 	(*ListRevokedTokensResponse)(nil),      // 6: containarium.v1.ListRevokedTokensResponse
 	(*GetUnscopedTokenReportRequest)(nil),  // 7: containarium.v1.GetUnscopedTokenReportRequest
 	(*GetUnscopedTokenReportResponse)(nil), // 8: containarium.v1.GetUnscopedTokenReportResponse
+	(*ExchangeDelegatedTokenRequest)(nil),  // 9: containarium.v1.ExchangeDelegatedTokenRequest
+	(*ExchangeDelegatedTokenResponse)(nil), // 10: containarium.v1.ExchangeDelegatedTokenResponse
+	(*timestamppb.Timestamp)(nil),          // 11: google.protobuf.Timestamp
 }
 var file_containarium_v1_tokens_proto_depIdxs = []int32{
-	4, // 0: containarium.v1.ListRevokedTokensResponse.revocations:type_name -> containarium.v1.Revocation
-	0, // 1: containarium.v1.TokensService.RevokeToken:input_type -> containarium.v1.RevokeTokenRequest
-	2, // 2: containarium.v1.TokensService.RefreshToken:input_type -> containarium.v1.RefreshTokenRequest
-	5, // 3: containarium.v1.TokensService.ListRevokedTokens:input_type -> containarium.v1.ListRevokedTokensRequest
-	7, // 4: containarium.v1.TokensService.GetUnscopedTokenReport:input_type -> containarium.v1.GetUnscopedTokenReportRequest
-	1, // 5: containarium.v1.TokensService.RevokeToken:output_type -> containarium.v1.RevokeTokenResponse
-	3, // 6: containarium.v1.TokensService.RefreshToken:output_type -> containarium.v1.RefreshTokenResponse
-	6, // 7: containarium.v1.TokensService.ListRevokedTokens:output_type -> containarium.v1.ListRevokedTokensResponse
-	8, // 8: containarium.v1.TokensService.GetUnscopedTokenReport:output_type -> containarium.v1.GetUnscopedTokenReportResponse
-	5, // [5:9] is the sub-list for method output_type
-	1, // [1:5] is the sub-list for method input_type
-	1, // [1:1] is the sub-list for extension type_name
-	1, // [1:1] is the sub-list for extension extendee
-	0, // [0:1] is the sub-list for field type_name
+	4,  // 0: containarium.v1.ListRevokedTokensResponse.revocations:type_name -> containarium.v1.Revocation
+	11, // 1: containarium.v1.ExchangeDelegatedTokenResponse.expires_at:type_name -> google.protobuf.Timestamp
+	0,  // 2: containarium.v1.TokensService.RevokeToken:input_type -> containarium.v1.RevokeTokenRequest
+	9,  // 3: containarium.v1.TokensService.ExchangeDelegatedToken:input_type -> containarium.v1.ExchangeDelegatedTokenRequest
+	2,  // 4: containarium.v1.TokensService.RefreshToken:input_type -> containarium.v1.RefreshTokenRequest
+	5,  // 5: containarium.v1.TokensService.ListRevokedTokens:input_type -> containarium.v1.ListRevokedTokensRequest
+	7,  // 6: containarium.v1.TokensService.GetUnscopedTokenReport:input_type -> containarium.v1.GetUnscopedTokenReportRequest
+	1,  // 7: containarium.v1.TokensService.RevokeToken:output_type -> containarium.v1.RevokeTokenResponse
+	10, // 8: containarium.v1.TokensService.ExchangeDelegatedToken:output_type -> containarium.v1.ExchangeDelegatedTokenResponse
+	3,  // 9: containarium.v1.TokensService.RefreshToken:output_type -> containarium.v1.RefreshTokenResponse
+	6,  // 10: containarium.v1.TokensService.ListRevokedTokens:output_type -> containarium.v1.ListRevokedTokensResponse
+	8,  // 11: containarium.v1.TokensService.GetUnscopedTokenReport:output_type -> containarium.v1.GetUnscopedTokenReportResponse
+	7,  // [7:12] is the sub-list for method output_type
+	2,  // [2:7] is the sub-list for method input_type
+	2,  // [2:2] is the sub-list for extension type_name
+	2,  // [2:2] is the sub-list for extension extendee
+	0,  // [0:2] is the sub-list for field type_name
 }
 
 func init() { file_containarium_v1_tokens_proto_init() }
@@ -683,7 +841,7 @@ func file_containarium_v1_tokens_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_v1_tokens_proto_rawDesc), len(file_containarium_v1_tokens_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   9,
+			NumMessages:   11,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/pb/containarium/v1/tokens.pb.gw.go
+++ b/pkg/pb/containarium/v1/tokens.pb.gw.go
@@ -62,6 +62,33 @@ func local_request_TokensService_RevokeToken_0(ctx context.Context, marshaler ru
 	return msg, metadata, err
 }
 
+func request_TokensService_ExchangeDelegatedToken_0(ctx context.Context, marshaler runtime.Marshaler, client TokensServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ExchangeDelegatedTokenRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.ExchangeDelegatedToken(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_TokensService_ExchangeDelegatedToken_0(ctx context.Context, marshaler runtime.Marshaler, server TokensServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ExchangeDelegatedTokenRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.ExchangeDelegatedToken(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_TokensService_RefreshToken_0(ctx context.Context, marshaler runtime.Marshaler, client TokensServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq RefreshTokenRequest
@@ -170,6 +197,26 @@ func RegisterTokensServiceHandlerServer(ctx context.Context, mux *runtime.ServeM
 			return
 		}
 		forward_TokensService_RevokeToken_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_TokensService_ExchangeDelegatedToken_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.TokensService/ExchangeDelegatedToken", runtime.WithHTTPPathPattern("/v1/tokens/delegate"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_TokensService_ExchangeDelegatedToken_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_TokensService_ExchangeDelegatedToken_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 	mux.Handle(http.MethodPost, pattern_TokensService_RefreshToken_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
@@ -288,6 +335,23 @@ func RegisterTokensServiceHandlerClient(ctx context.Context, mux *runtime.ServeM
 		}
 		forward_TokensService_RevokeToken_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_TokensService_ExchangeDelegatedToken_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.TokensService/ExchangeDelegatedToken", runtime.WithHTTPPathPattern("/v1/tokens/delegate"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_TokensService_ExchangeDelegatedToken_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_TokensService_ExchangeDelegatedToken_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_TokensService_RefreshToken_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -344,6 +408,7 @@ func RegisterTokensServiceHandlerClient(ctx context.Context, mux *runtime.ServeM
 
 var (
 	pattern_TokensService_RevokeToken_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "tokens", "revoke"}, ""))
+	pattern_TokensService_ExchangeDelegatedToken_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "tokens", "delegate"}, ""))
 	pattern_TokensService_RefreshToken_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "tokens", "refresh"}, ""))
 	pattern_TokensService_ListRevokedTokens_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "tokens", "revoked"}, ""))
 	pattern_TokensService_GetUnscopedTokenReport_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "tokens", "unscoped-report"}, ""))
@@ -351,6 +416,7 @@ var (
 
 var (
 	forward_TokensService_RevokeToken_0            = runtime.ForwardResponseMessage
+	forward_TokensService_ExchangeDelegatedToken_0 = runtime.ForwardResponseMessage
 	forward_TokensService_RefreshToken_0           = runtime.ForwardResponseMessage
 	forward_TokensService_ListRevokedTokens_0      = runtime.ForwardResponseMessage
 	forward_TokensService_GetUnscopedTokenReport_0 = runtime.ForwardResponseMessage

--- a/pkg/pb/containarium/v1/tokens_grpc.pb.go
+++ b/pkg/pb/containarium/v1/tokens_grpc.pb.go
@@ -20,6 +20,7 @@ const _ = grpc.SupportPackageIsVersion9
 
 const (
 	TokensService_RevokeToken_FullMethodName            = "/containarium.v1.TokensService/RevokeToken"
+	TokensService_ExchangeDelegatedToken_FullMethodName = "/containarium.v1.TokensService/ExchangeDelegatedToken"
 	TokensService_RefreshToken_FullMethodName           = "/containarium.v1.TokensService/RefreshToken"
 	TokensService_ListRevokedTokens_FullMethodName      = "/containarium.v1.TokensService/ListRevokedTokens"
 	TokensService_GetUnscopedTokenReport_FullMethodName = "/containarium.v1.TokensService/GetUnscopedTokenReport"
@@ -40,6 +41,45 @@ type TokensServiceClient interface {
 	// taking effect on the next authenticated request that
 	// names it. Idempotent — repeated revokes are safe.
 	RevokeToken(ctx context.Context, in *RevokeTokenRequest, opts ...grpc.CallOption) (*RevokeTokenResponse, error)
+	// ExchangeDelegatedToken mints a token that acts FOR another
+	// subject, on the authority of the caller's own credential
+	// (containarium-cloud#1427).
+	//
+	// The problem it solves: a service that fronts this API on
+	// behalf of end users — the cloud control plane is the case
+	// that motivated it — presents its own service credential on
+	// every call. #1676 bounds an agent token by the CALLER's
+	// scopes, but when the caller is a shared service account
+	// that bound is meaningless, and #1678's audit `actor` column
+	// records the service, not the person. `act` is deliberately
+	// a JWT claim and never a header (#1677: set only by the
+	// minting server from an authenticated context), so the
+	// fronting service cannot assert it — it has no signing key,
+	// and giving it one would let it mint any identity.
+	//
+	// So it asks this daemon to mint instead. Two invariants make
+	// that safe, mirroring RunAgentSkill's own delegated mint:
+	//
+	//   - The minted token's scopes are the INTERSECTION of the
+	//     caller's scopes with those requested, so an exchange can
+	//     never produce more authority than the caller already
+	//     holds. Without this the endpoint would be precisely the
+	//     escalation primitive #1676 closed.
+	//   - `act` is built server-side from the authenticated
+	//     caller, wrapping the caller's own chain, so the delegation
+	//     path is recorded rather than claimed.
+	//
+	// Gated on `tokens:delegate` — a distinct scope, not
+	// `tokens:write`: acting as another subject is a different and
+	// more dangerous capability than managing your own tokens.
+	//
+	// Unlike every other RPC, this one FAILS CLOSED on a token that
+	// carries no scopes claim at all, whatever
+	// CONTAINARIUM_STRICT_SCOPES is set to. Elsewhere that claim is
+	// optional for backward compatibility (#1679); here the
+	// caller's scopes ARE the ceiling, so an absent claim would
+	// mean no ceiling. A caller must present a scoped credential.
+	ExchangeDelegatedToken(ctx context.Context, in *ExchangeDelegatedTokenRequest, opts ...grpc.CallOption) (*ExchangeDelegatedTokenResponse, error)
 	// RefreshToken exchanges a valid refresh token for a new
 	// (access, refresh) pair. The prior refresh token's jti is
 	// revoked on success — refresh tokens are SINGLE-USE.
@@ -74,6 +114,16 @@ func (c *tokensServiceClient) RevokeToken(ctx context.Context, in *RevokeTokenRe
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(RevokeTokenResponse)
 	err := c.cc.Invoke(ctx, TokensService_RevokeToken_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *tokensServiceClient) ExchangeDelegatedToken(ctx context.Context, in *ExchangeDelegatedTokenRequest, opts ...grpc.CallOption) (*ExchangeDelegatedTokenResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ExchangeDelegatedTokenResponse)
+	err := c.cc.Invoke(ctx, TokensService_ExchangeDelegatedToken_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -125,6 +175,45 @@ type TokensServiceServer interface {
 	// taking effect on the next authenticated request that
 	// names it. Idempotent — repeated revokes are safe.
 	RevokeToken(context.Context, *RevokeTokenRequest) (*RevokeTokenResponse, error)
+	// ExchangeDelegatedToken mints a token that acts FOR another
+	// subject, on the authority of the caller's own credential
+	// (containarium-cloud#1427).
+	//
+	// The problem it solves: a service that fronts this API on
+	// behalf of end users — the cloud control plane is the case
+	// that motivated it — presents its own service credential on
+	// every call. #1676 bounds an agent token by the CALLER's
+	// scopes, but when the caller is a shared service account
+	// that bound is meaningless, and #1678's audit `actor` column
+	// records the service, not the person. `act` is deliberately
+	// a JWT claim and never a header (#1677: set only by the
+	// minting server from an authenticated context), so the
+	// fronting service cannot assert it — it has no signing key,
+	// and giving it one would let it mint any identity.
+	//
+	// So it asks this daemon to mint instead. Two invariants make
+	// that safe, mirroring RunAgentSkill's own delegated mint:
+	//
+	//   - The minted token's scopes are the INTERSECTION of the
+	//     caller's scopes with those requested, so an exchange can
+	//     never produce more authority than the caller already
+	//     holds. Without this the endpoint would be precisely the
+	//     escalation primitive #1676 closed.
+	//   - `act` is built server-side from the authenticated
+	//     caller, wrapping the caller's own chain, so the delegation
+	//     path is recorded rather than claimed.
+	//
+	// Gated on `tokens:delegate` — a distinct scope, not
+	// `tokens:write`: acting as another subject is a different and
+	// more dangerous capability than managing your own tokens.
+	//
+	// Unlike every other RPC, this one FAILS CLOSED on a token that
+	// carries no scopes claim at all, whatever
+	// CONTAINARIUM_STRICT_SCOPES is set to. Elsewhere that claim is
+	// optional for backward compatibility (#1679); here the
+	// caller's scopes ARE the ceiling, so an absent claim would
+	// mean no ceiling. A caller must present a scoped credential.
+	ExchangeDelegatedToken(context.Context, *ExchangeDelegatedTokenRequest) (*ExchangeDelegatedTokenResponse, error)
 	// RefreshToken exchanges a valid refresh token for a new
 	// (access, refresh) pair. The prior refresh token's jti is
 	// revoked on success — refresh tokens are SINGLE-USE.
@@ -157,6 +246,9 @@ type UnimplementedTokensServiceServer struct{}
 
 func (UnimplementedTokensServiceServer) RevokeToken(context.Context, *RevokeTokenRequest) (*RevokeTokenResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RevokeToken not implemented")
+}
+func (UnimplementedTokensServiceServer) ExchangeDelegatedToken(context.Context, *ExchangeDelegatedTokenRequest) (*ExchangeDelegatedTokenResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ExchangeDelegatedToken not implemented")
 }
 func (UnimplementedTokensServiceServer) RefreshToken(context.Context, *RefreshTokenRequest) (*RefreshTokenResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RefreshToken not implemented")
@@ -202,6 +294,24 @@ func _TokensService_RevokeToken_Handler(srv interface{}, ctx context.Context, de
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(TokensServiceServer).RevokeToken(ctx, req.(*RevokeTokenRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _TokensService_ExchangeDelegatedToken_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ExchangeDelegatedTokenRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TokensServiceServer).ExchangeDelegatedToken(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: TokensService_ExchangeDelegatedToken_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TokensServiceServer).ExchangeDelegatedToken(ctx, req.(*ExchangeDelegatedTokenRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -270,6 +380,10 @@ var TokensService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "RevokeToken",
 			Handler:    _TokensService_RevokeToken_Handler,
+		},
+		{
+			MethodName: "ExchangeDelegatedToken",
+			Handler:    _TokensService_ExchangeDelegatedToken_Handler,
 		},
 		{
 			MethodName: "RefreshToken",

--- a/proto/containarium/v1/tokens.proto
+++ b/proto/containarium/v1/tokens.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package containarium.v1;
 
 import "google/api/annotations.proto";
+import "google/protobuf/timestamp.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
 
 option go_package = "github.com/footprintai/containarium/pkg/pb/containarium/v1;containariumv1";
@@ -161,6 +162,56 @@ service TokensService {
     };
   }
 
+  // ExchangeDelegatedToken mints a token that acts FOR another
+  // subject, on the authority of the caller's own credential
+  // (containarium-cloud#1427).
+  //
+  // The problem it solves: a service that fronts this API on
+  // behalf of end users — the cloud control plane is the case
+  // that motivated it — presents its own service credential on
+  // every call. #1676 bounds an agent token by the CALLER's
+  // scopes, but when the caller is a shared service account
+  // that bound is meaningless, and #1678's audit `actor` column
+  // records the service, not the person. `act` is deliberately
+  // a JWT claim and never a header (#1677: set only by the
+  // minting server from an authenticated context), so the
+  // fronting service cannot assert it — it has no signing key,
+  // and giving it one would let it mint any identity.
+  //
+  // So it asks this daemon to mint instead. Two invariants make
+  // that safe, mirroring RunAgentSkill's own delegated mint:
+  //
+  //   * The minted token's scopes are the INTERSECTION of the
+  //     caller's scopes with those requested, so an exchange can
+  //     never produce more authority than the caller already
+  //     holds. Without this the endpoint would be precisely the
+  //     escalation primitive #1676 closed.
+  //   * `act` is built server-side from the authenticated
+  //     caller, wrapping the caller's own chain, so the delegation
+  //     path is recorded rather than claimed.
+  //
+  // Gated on `tokens:delegate` — a distinct scope, not
+  // `tokens:write`: acting as another subject is a different and
+  // more dangerous capability than managing your own tokens.
+  //
+  // Unlike every other RPC, this one FAILS CLOSED on a token that
+  // carries no scopes claim at all, whatever
+  // CONTAINARIUM_STRICT_SCOPES is set to. Elsewhere that claim is
+  // optional for backward compatibility (#1679); here the
+  // caller's scopes ARE the ceiling, so an absent claim would
+  // mean no ceiling. A caller must present a scoped credential.
+  rpc ExchangeDelegatedToken(ExchangeDelegatedTokenRequest) returns (ExchangeDelegatedTokenResponse) {
+    option (google.api.http) = {
+      post: "/v1/tokens/delegate"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Mint a token acting for another subject";
+      description: "Exchanges the caller's credential for a token whose subject is `subject` and whose `act` chain records the caller. Granted scopes are the intersection of the caller's own scopes with those requested — an exchange can never widen authority. Requires the `tokens:delegate` scope, on a token that carries an explicit scopes claim — an unscoped token is rejected here even when strict-scope enforcement is off, because the caller's scopes are the ceiling being applied.";
+      tags: "Tokens";
+    };
+  }
+
   // RefreshToken exchanges a valid refresh token for a new
   // (access, refresh) pair. The prior refresh token's jti is
   // revoked on success — refresh tokens are SINGLE-USE.
@@ -211,4 +262,40 @@ service TokensService {
       tags: "Tokens";
     };
   }
+}
+
+// ExchangeDelegatedTokenRequest asks for a token acting for `subject`.
+message ExchangeDelegatedTokenRequest {
+  // The subject the minted token represents — the end user the
+  // caller is acting for. Required: an empty subject would mint
+  // an unattributed token, which is the state this endpoint
+  // exists to eliminate.
+  string subject = 1;
+
+  // Scopes requested for the minted token. INTERSECTED with the
+  // caller's own scopes, never unioned. Empty requests the
+  // caller's own scope set (still bounded by it).
+  repeated string scopes = 2;
+
+  // Lifetime in seconds. 0 uses the daemon's default access-token
+  // expiry; values above the daemon's maximum are capped rather
+  // than rejected, so a caller asking for too long gets a shorter
+  // token instead of a failure.
+  int64 expires_in_seconds = 3;
+}
+
+message ExchangeDelegatedTokenResponse {
+  // The minted access token.
+  string token = 1;
+
+  // When it expires, so a caller can cache it rather than
+  // exchanging on every request — the round trip this endpoint
+  // adds is meant to be amortized per (subject, TTL).
+  google.protobuf.Timestamp expires_at = 2;
+
+  // The scopes actually granted, after intersection. Returned
+  // explicitly because they may be NARROWER than requested, and a
+  // caller that assumes otherwise would fail later with a
+  // confusing permission error instead of here.
+  repeated string granted_scopes = 3;
 }


### PR DESCRIPTION
## Why

A service that fronts this API for end users presents its own service credential on every call. Two consequences:

- #1676's rule that an agent token is bounded by the caller's scopes binds nothing when the caller is a shared service account.
- #1678's audit `actor` column records the service rather than the person who asked.

`act` is a JWT claim and never a header (#1677) — set only by the minting server from an authenticated context. The fronting service cannot fix this itself: it holds no signing key, and handing it one would let it mint any identity at all. So it asks the daemon to mint instead.

This is the OSS half of containarium-cloud#1427. The cloud half calls the new RPC and caches per (subject, TTL).

## What

- `ExchangeDelegatedToken` RPC → `POST /v1/tokens/delegate` (proto-first; gateway shim and swagger regenerated)
- `containarium token delegate` CLI subcommand
- `HTTPClient.ExchangeDelegatedToken` typed client method
- New scope `tokens:delegate`

## The invariants

Three, each pinned by a test that was **proven to fail** when its guard is removed:

| Guard removed | Test that catches it |
| --- | --- |
| intersection dropped | `CannotWidenAuthority` — granted `secrets:read` the caller never held |
| act chain flattened | `ActIsServerSetAndNests` + `RejectsAnOverlongChain` |
| `tokens:write` accepted | `RequiresDelegateScope` |

- **Granted scopes are the intersection** of the caller's with those requested. An exchange can only narrow authority. Without this the endpoint is the escalation primitive #1676 closed, under a new name.
- **`act` is built from the authenticated caller and wraps the caller's own chain**, so multi-hop delegation nests rather than flattening. `RootActor` still resolves to the human furthest from the leaf, which is what an auditor needs.
- **Gated on `tokens:delegate`**, deliberately not `tokens:write`. Managing your own tokens and acting as another person are different capabilities.

## One deliberate departure from #1679

This endpoint fails **closed** on a token carrying no scopes claim, regardless of `CONTAINARIUM_STRICT_SCOPES`.

Everywhere else that claim is optional for backward compatibility, and safely so — the token's own authority still bounds a read or a mutation. Here the caller's scopes *are* the ceiling, and `IntersectScopes` reads a nil caller as unbounded. Tolerating an absent claim would hand out whatever was asked for.

The usual reason to fail open does not apply: the RPC is new, so there is no legacy caller population to preserve. Practically this means containarium-cloud#1428 (scoping the driver token) must land before the cloud can use this.

## Note on expiry

The response reports the token's own `exp` claim rather than a locally recomputed deadline. The manager caps an over-long TTL silently, so a derived timestamp can promise validity the token does not have — and the caller caches against that value.

## Test plan

- [x] `go test ./internal/server/ ./internal/auth/ ./internal/client/ ./internal/cmd/` green
- [x] Each of the three guards sabotaged in turn; the corresponding test fails
- [x] `containarium token delegate --help` renders
- [x] Gateway route and swagger entry confirmed present after `make proto`
- [x] `/v1/tokens/delegate` is absent from the middleware public-path allowlist, so it is authenticated

Pre-existing `internal/agentbox` failures on darwin (unix socket path length) reproduce on a clean tree and are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1554BHQdJmSXTuG1UhS3i

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added delegated token exchange through the REST and service APIs.
  - Added the `token delegate` command to create short-lived tokens for another subject.
  - Supports requested scopes, optional expiration, raw token output, and reporting of granted scopes and expiry.
- **Security**
  - Delegated tokens require delegation permission.
  - Granted scopes cannot exceed the caller’s authorized scopes.
  - Delegation chains and maximum depth are enforced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->