### PR TITLE
fix(sentinel): skip per-spot loopback listener for the ConnMux HTTPS port on every backend

### DIFF
--- a/internal/cmd/sentinel.go
+++ b/internal/cmd/sentinel.go
@@ -276,7 +276,7 @@ func runSentinel(cmd *cobra.Command, args []string) error {
 				return polErr
 			}
 			loadPersistedTunnelTokens(tunnelPolicy)
-			tunnelServer := sentinel.NewTunnelServer("", tunnelPolicy, registry)
+			tunnelServer := sentinel.NewTunnelServer("", tunnelPolicy, registry, sentinelHTTPSPort)
 			tunnelServer.OnConnect = manager.OnTunnelConnect
 			tunnelServer.OnDisconnect = manager.OnTunnelDisconnect
 			manager.SetTunnelRegistry(registry)
@@ -365,7 +365,7 @@ func runSentinel(cmd *cobra.Command, args []string) error {
 			return polErr
 		}
 		loadPersistedTunnelTokens(tunnelPolicy)
-		tunnelServer := sentinel.NewTunnelServer("", tunnelPolicy, registry)
+		tunnelServer := sentinel.NewTunnelServer("", tunnelPolicy, registry, sentinelHTTPSPort)
 		tunnelServer.OnConnect = manager.OnTunnelConnect
 		tunnelServer.OnDisconnect = manager.OnTunnelDisconnect
 		manager.SetTunnelRegistry(registry)

--- a/internal/sentinel/tunnel_integration_test.go
+++ b/internal/sentinel/tunnel_integration_test.go
@@ -91,7 +91,7 @@ func TestTunnelIntegration(t *testing.T) {
 	defer func() { _ = connMux.Close() }()
 
 	registry := NewTunnelRegistry()
-	tunnelServer := NewTunnelServer("", policyAny(token), registry)
+	tunnelServer := NewTunnelServer("", policyAny(token), registry, 0)
 
 	// These callbacks run on the tunnel server's own goroutines, which
 	// OUTLIVE this function: a session closing after the test returns still

--- a/internal/sentinel/tunnel_reregister_test.go
+++ b/internal/sentinel/tunnel_reregister_test.go
@@ -177,7 +177,7 @@ func TestMonitorSessionIgnoresSupersededGeneration(t *testing.T) {
 	stubLoopbackAliases(t)
 
 	registry := NewTunnelRegistry()
-	ts := NewTunnelServer("127.0.0.1:0", NewTokenPolicy(), registry)
+	ts := NewTunnelServer("127.0.0.1:0", NewTokenPolicy(), registry, 0)
 	closeProxiesOnCleanup(t, ts)
 
 	var mu sync.Mutex
@@ -258,7 +258,7 @@ func TestMonitorSessionCleansUpCurrentGeneration(t *testing.T) {
 	stubLoopbackAliases(t)
 
 	registry := NewTunnelRegistry()
-	ts := NewTunnelServer("127.0.0.1:0", NewTokenPolicy(), registry)
+	ts := NewTunnelServer("127.0.0.1:0", NewTokenPolicy(), registry, 0)
 	closeProxiesOnCleanup(t, ts)
 
 	disconnected := make(chan string, 1)
@@ -309,7 +309,7 @@ func TestStartProxiesRefusesToClobberANewerGeneration(t *testing.T) {
 	stubLoopbackAliases(t)
 
 	registry := NewTunnelRegistry()
-	ts := NewTunnelServer("127.0.0.1:0", NewTokenPolicy(), registry)
+	ts := NewTunnelServer("127.0.0.1:0", NewTokenPolicy(), registry, 0)
 	closeProxiesOnCleanup(t, ts)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/sentinel/tunnel_server.go
+++ b/internal/sentinel/tunnel_server.go
@@ -21,6 +21,12 @@ type TunnelServer struct {
 	policy     *TokenPolicy
 	registry   *TunnelRegistry
 
+	// httpsPort is the sentinel's own ConnMux HTTPS port (the maintenance/SNI
+	// listener's wildcard bind). No spot ever gets a loopback listener for
+	// it — see loopbackPortsFor. Zero disables the exclusion (e.g. in tests
+	// that don't run a ConnMux).
+	httpsPort int
+
 	// Callbacks for Manager integration
 	OnConnect    func(spot *TunnelSpot)
 	OnDisconnect func(spot *TunnelSpot)
@@ -46,12 +52,16 @@ type proxySet struct {
 //
 //	policy := NewTokenPolicy()
 //	policy.Allow(token, "*")
-//	srv := NewTunnelServer(addr, policy, registry)
-func NewTunnelServer(listenAddr string, policy *TokenPolicy, registry *TunnelRegistry) *TunnelServer {
+//	srv := NewTunnelServer(addr, policy, registry, httpsPort)
+//
+// httpsPort is the sentinel's own ConnMux HTTPS port; pass 0 if this
+// TunnelServer never runs alongside a ConnMux (e.g. in a test).
+func NewTunnelServer(listenAddr string, policy *TokenPolicy, registry *TunnelRegistry, httpsPort int) *TunnelServer {
 	return &TunnelServer{
 		listenAddr: listenAddr,
 		policy:     policy,
 		registry:   registry,
+		httpsPort:  httpsPort,
 		proxies:    make(map[string]proxySet),
 	}
 }
@@ -160,25 +170,18 @@ func (ts *TunnelServer) handleConnection(ctx context.Context, conn net.Conn) {
 
 	log.Printf("[tunnel-server] spot %q authenticated, assigned %s, ports %v", hs.SpotID, localIP, hs.Ports)
 
-	// Start local TCP proxy listeners for each port. Skip the public
-	// port for tunnel-promoted primaries — the sentinel's own ConnMux
-	// owns it, and the SNI router uses TunnelRegistry.DialTunnel() to
-	// stream bytes via yamux instead.
+	// Start local TCP proxy listeners for each port. Skip the sentinel's own
+	// HTTPS ConnMux port for every backend, not just tunnel-promoted
+	// primaries — the ConnMux always holds a wildcard bind on it, so a
+	// per-spot loopback listener there can never succeed, and the SNI router
+	// already reaches every backend's HTTPS traffic via
+	// TunnelRegistry.DialTunnel() instead (#1710). Also skip a promoted
+	// primary's PublicPort in case it differs from the ConnMux's port.
 	externalPort := 0
 	if spot := ts.registry.Get(hs.SpotID); spot != nil {
 		externalPort = spot.ExternalPort
 	}
-	loopbackPorts := hs.Ports
-	if hs.PublicHostname != "" && hs.PublicPort != 0 {
-		filtered := make([]int, 0, len(hs.Ports))
-		for _, p := range hs.Ports {
-			if p == hs.PublicPort {
-				continue
-			}
-			filtered = append(filtered, p)
-		}
-		loopbackPorts = filtered
-	}
+	loopbackPorts := loopbackPortsFor(hs.Ports, ts.httpsPort, hs.PublicPort)
 	ts.startProxies(ctx, hs.SpotID, gen, localIP, externalPort, loopbackPorts, session)
 
 	// Notify manager
@@ -191,6 +194,25 @@ func (ts *TunnelServer) handleConnection(ctx context.Context, conn net.Conn) {
 	// keeps this cleanup from firing against a LATER registration of the same
 	// spot (#769).
 	go ts.monitorSession(hs.SpotID, gen, session)
+}
+
+// loopbackPortsFor returns the subset of ports that should get a per-spot
+// loopback proxy listener, excluding the sentinel's own ConnMux HTTPS port
+// (httpsPort) and, if set, a promoted primary's PublicPort. Neither ever
+// needs a per-spot listener: the ConnMux holds a wildcard bind on its port,
+// so a per-spot listener there can never succeed, and HTTPS traffic to every
+// backend (promoted primary or not) already reaches it via
+// TunnelRegistry.DialTunnel() through the SNI router instead (#1710).
+// httpsPort/publicPort of 0 disable the corresponding exclusion.
+func loopbackPortsFor(ports []int, httpsPort, publicPort int) []int {
+	filtered := make([]int, 0, len(ports))
+	for _, p := range ports {
+		if p == httpsPort || (publicPort != 0 && p == publicPort) {
+			continue
+		}
+		filtered = append(filtered, p)
+	}
+	return filtered
 }
 
 // startProxies opens a local TCP listener on localIP:port for each port.

--- a/internal/sentinel/tunnel_server_test.go
+++ b/internal/sentinel/tunnel_server_test.go
@@ -1,0 +1,57 @@
+package sentinel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoopbackPortsFor(t *testing.T) {
+	tests := []struct {
+		name       string
+		ports      []int
+		httpsPort  int
+		publicPort int
+		want       []int
+	}{
+		{
+			name:      "non-primary backend still excludes the sentinel's own https port",
+			ports:     []int{22, 8080, 443},
+			httpsPort: 443,
+			want:      []int{22, 8080},
+		},
+		{
+			name:       "promoted primary excludes its public port too",
+			ports:      []int{22, 8080, 443},
+			httpsPort:  443,
+			publicPort: 443,
+			want:       []int{22, 8080},
+		},
+		{
+			name:       "public port distinct from the https port is excluded on top of it",
+			ports:      []int{22, 8080, 443, 9443},
+			httpsPort:  443,
+			publicPort: 9443,
+			want:       []int{22, 8080},
+		},
+		{
+			name:      "no https port configured filters nothing",
+			ports:     []int{22, 8080, 443},
+			httpsPort: 0,
+			want:      []int{22, 8080, 443},
+		},
+		{
+			name:      "port not present is a no-op",
+			ports:     []int{22, 8080},
+			httpsPort: 443,
+			want:      []int{22, 8080},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := loopbackPortsFor(tt.ports, tt.httpsPort, tt.publicPort)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/sentinel/tunnel_test.go
+++ b/internal/sentinel/tunnel_test.go
@@ -122,7 +122,7 @@ func TestTunnelEndToEnd(t *testing.T) {
 
 	// 2. Start tunnel server
 	registry := NewTunnelRegistry()
-	server := NewTunnelServer(fmt.Sprintf("127.0.0.1:%d", tunnelPort), policyAny(token), registry)
+	server := NewTunnelServer(fmt.Sprintf("127.0.0.1:%d", tunnelPort), policyAny(token), registry, 0)
 
 	connectCh := make(chan *TunnelSpot, 1)
 	server.OnConnect = func(spot *TunnelSpot) {
@@ -191,7 +191,7 @@ func TestTunnelWrongToken(t *testing.T) {
 
 	tunnelPort := freePort(t)
 	registry := NewTunnelRegistry()
-	server := NewTunnelServer(fmt.Sprintf("127.0.0.1:%d", tunnelPort), policyAny("correct-token"), registry)
+	server := NewTunnelServer(fmt.Sprintf("127.0.0.1:%d", tunnelPort), policyAny("correct-token"), registry, 0)
 
 	go func() { _ = server.Run(ctx) }()
 	time.Sleep(100 * time.Millisecond)
@@ -324,7 +324,7 @@ func TestConnMuxWithTunnelClient(t *testing.T) {
 
 	// Start tunnel server on the mux's tunnel listener
 	registry := NewTunnelRegistry()
-	tunnelServer := NewTunnelServer("", policyAny(token), registry)
+	tunnelServer := NewTunnelServer("", policyAny(token), registry, 0)
 	connectCh := make(chan *TunnelSpot, 1)
 	tunnelServer.OnConnect = func(spot *TunnelSpot) {
 		connectCh <- spot


### PR DESCRIPTION
## Summary

- Every non-primary tunnel backend logged a bind failure for its per-spot loopback listener on the sentinel's HTTPS port, on every connect/reconnect — the ConnMux's wildcard bind on that port makes any other listener there impossible, for any backend.
- The existing exemption for this only covered tunnel-promoted primaries. HTTPS traffic for every backend already routes through `TunnelRegistry.DialTunnel()` via the SNI router regardless of promotion, so the listener was dead-on-arrival for all non-primary backends — harmless, but noisy, log spam on every reconnect that could bury a real bind conflict.
- Extracted the filter into a small pure helper (`loopbackPortsFor`) and applied it to every backend, and threaded the sentinel's actual configured `--https-port` through to `TunnelServer` instead of relying on a promoted primary's `PublicPort` happening to match it.

Fixes #1710

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/sentinel/... ./internal/cmd/...`
- [x] `golangci-lint run ./internal/sentinel/... ./internal/cmd/...` — 0 issues
- [x] New unit test `TestLoopbackPortsFor` (5 cases: non-primary excludes the ConnMux port, promoted primary excludes both its port and a distinct public port, `httpsPort=0` disables the exclusion, and a no-op case)
- [x] Full `internal/sentinel` + `internal/cmd` suites pass, including the existing end-to-end `TestTunnelIntegration/https_via_connmux`, confirming HTTPS-via-ConnMux dispatch is unaffected by removing the dead-path listener

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHECHYsrFnSfXrqv94BZRc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tunnel proxy setup to prevent routing traffic through the sentinel’s HTTPS port.
  * Prevented promoted primary public ports from being incorrectly selected for proxying.
* **Tests**
  * Added coverage for port exclusion scenarios, including configured, shared, distinct, and unavailable ports.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->