### PR TITLE
chore(release): v0.72.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,59 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.72.0] - 2026-09-04
+
+### Added
+
+- **Mint a token that acts FOR another subject** — `POST /v1/tokens/delegate`,
+  `containarium token delegate` (containarium-cloud#1427). A service that
+  fronts this API for end users presents its own credential on every call, so
+  #1676's rule that an agent token is bounded by the caller's scopes binds
+  nothing when that caller is a shared service account, and #1678's audit
+  `actor` records the service rather than the person who asked.
+
+  `act` is a JWT claim and never a header (#1677), so the fronting service
+  cannot fix this itself: it holds no signing key, and handing it one would let
+  it mint any identity at all. It asks the daemon to mint instead.
+
+  Three invariants make that safe. Granted scopes are the **intersection** of
+  the caller's with those requested, so an exchange can only narrow authority.
+  `act` is built server-side from the authenticated caller and **wraps** the
+  caller's existing chain, so a multi-hop delegation nests rather than
+  flattening and `RootActor` still resolves to the human furthest from the
+  leaf. And it is gated on a new `tokens:delegate` scope, deliberately not
+  `tokens:write` — managing your own tokens and acting as another person are
+  different capabilities.
+
+  Unlike every other RPC, this one fails **closed** on a token carrying no
+  scopes claim, whatever `CONTAINARIUM_STRICT_SCOPES` is set to. Elsewhere that
+  claim is optional for backward compatibility (#1679) and safely so, because
+  the token's own authority still bounds a read or a mutation. Here the
+  caller's scopes *are* the ceiling being applied, and an absent claim would
+  mean no ceiling.
+
+### Fixed
+
+- **Sentinel logged a bind failure on every tunnel connect and reconnect**
+  (#1710, #1711). Any non-primary backend advertising the sentinel's HTTPS port
+  tried to open a per-spot loopback listener there, which the ConnMux's
+  wildcard listener on that port makes impossible. The exemption existed but
+  only covered tunnel-promoted primaries. HTTPS for every backend already
+  routes through `DialTunnel()` via the SNI router, so the listener was
+  dead-on-arrival in all cases; the exemption now covers every backend, and the
+  sentinel's configured `--https-port` is threaded through instead of relying
+  on a promoted primary's `PublicPort` matching it by coincidence.
+
+### Internal
+
+- **A release tag whose changelog and version constant disagree with it now
+  fails** (#1705). Two documented conventions that nothing enforced, each of
+  which had already failed silently three times: a `CHANGELOG.md` missing the
+  release it ships, and `pkg/version/version.go` left stale — 0.68, 0.69 and
+  0.70 all shipped with the constant reading 0.67.0. Both are one grep. A
+  failure here costs a re-tag; not checking costs a published release that
+  misrepresents itself, which cannot be taken back.
+
 ## [0.71.0] - 2026-09-04
 
 ### Added

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,7 +11,7 @@ var (
 	// ldflags (`make build-release VERSION=<tag>` in .github/workflows/release.yml),
 	// so the tag is the source of truth; keep this constant in sync as the
 	// fallback for plain `make build` / `go build`.
-	Version = "0.71.0"
+	Version = "0.72.0"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
Release prep for v0.72.0. Three commits since v0.71.0.

## Contents

**Added** — delegated-token minting: `POST /v1/tokens/delegate`, `containarium token delegate`, and a new `tokens:delegate` scope (#1708, for containarium-cloud#1427). Lets a fronting service trade its own credential for one that acts for an end user, so audit rows name the person and scope checks bind against something real.

**Fixed** — the sentinel logged a bind failure on every tunnel connect and reconnect (#1710, #1711). The per-spot loopback listener on the ConnMux HTTPS port was dead-on-arrival for every backend, not just the promoted primaries the old exemption covered.

**Internal** — the release gate from #1705, which this very release is the first to be checked by.

## Gate check

Ran the workflow's own logic locally before tagging:

```
PASS: changelog section has 39 lines
PASS: version constant = 0.72.0
```

Both files it checks are updated here: `CHANGELOG.md` gains a `## [0.72.0]` section, and `pkg/version/version.go` moves 0.71.0 → 0.72.0. That constant had been stale for three consecutive releases before the gate existed.

## Test plan

- [x] `go build ./...` and the auth/server suites green
- [x] Release-gate logic run locally against this tree

Tag goes on this commit once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1554BHQdJmSXTuG1UhS3i

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added delegated token minting through the API and `containarium token delegate` command.
  - Supports scoped authorization, nested delegation chains, and fail-closed handling when scope claims are missing.

- **Bug Fixes**
  - Improved Sentinel bind-failure logging and configuration.
  - Strengthened release validation to ensure changelog and version consistency.

- **Documentation**
  - Added the v0.72.0 changelog entry with details on delegated token workflows.

- **Release**
  - Updated the application version to v0.72.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->