### PR TITLE
fix(tokens): an exchange granting nothing minted an UNRESTRICTED token (#1708)

### DIFF
--- a/internal/server/tokens_delegate_test.go
+++ b/internal/server/tokens_delegate_test.go
@@ -199,23 +199,80 @@ func TestExchangeDelegatedToken_RefusesAnUnscopedCaller(t *testing.T) {
 	}
 }
 
-// An explicit empty scope list is a different thing from an absent claim: the
-// caller holds nothing, so it can delegate nothing. It must not be mistaken
-// for "unscoped" and handed the requested set.
-func TestExchangeDelegatedToken_ExplicitlyEmptyScopesGrantNothing(t *testing.T) {
+// An exchange that would grant nothing must REFUSE, not mint.
+//
+// This test replaces one that asserted on resp.GetGrantedScopes() and passed
+// while the endpoint was handing out unrestricted tokens. The response field
+// said "granted nothing" and was telling the truth; the token attached to it
+// carried no scopes claim, which HasScope reads as no restriction at all. The
+// assertion was on the wrong object — the report rather than the credential.
+//
+// So this asserts on what the caller actually receives, and the sibling below
+// proves the failure the old test missed.
+func TestExchangeDelegatedToken_RefusesAnExchangeThatWouldGrantNothing(t *testing.T) {
 	s := delegateTestServer(t)
+	// tokens:delegate is the only scope held, and it is not what is requested.
 	ctx := callerCtx("cloud-daemon", []string{auth.ScopeTokensDelegate}, nil)
 
 	resp, err := s.ExchangeDelegatedToken(ctx, &pb.ExchangeDelegatedTokenRequest{
 		Subject: "alice@example.com",
 		Scopes:  []string{auth.ScopeSecretsRead},
 	})
-	if err != nil {
-		t.Fatalf("exchange: %v", err)
+	if err == nil {
+		t.Fatalf("minted a token for an empty grant (scopes=%v); a token with no scopes "+
+			"claim is UNRESTRICTED, not powerless", resp.GetGrantedScopes())
 	}
-	// tokens:delegate is the only scope held, and it was not requested.
-	if len(resp.GetGrantedScopes()) != 0 {
-		t.Errorf("granted = %v, want nothing — the caller holds none of what it asked for",
-			resp.GetGrantedScopes())
+	if got := status.Code(err); got != codes.PermissionDenied {
+		t.Errorf("code = %v, want PermissionDenied", got)
+	}
+}
+
+// The regression itself, asserted on the minted TOKEN rather than the response.
+// Every token this endpoint hands out must carry a non-empty scopes claim,
+// because an absent claim is unrestricted — so "granted nothing" and "granted
+// everything" are the same bytes on the wire.
+func TestExchangeDelegatedToken_NeverMintsAnUnrestrictedToken(t *testing.T) {
+	tm, err := auth.NewTokenManager(delegateTestSecret, "containarium-test")
+	if err != nil {
+		t.Fatalf("NewTokenManager: %v", err)
+	}
+	s := NewTokensServer(tm, nil, 0)
+
+	cases := []struct {
+		name         string
+		callerScopes []string
+		requested    []string
+	}{
+		{"asks for what it does not hold", []string{auth.ScopeTokensDelegate}, []string{auth.ScopeSecretsRead}},
+		{"asks for nothing at all", []string{auth.ScopeTokensDelegate, auth.ScopeContainersRead}, nil},
+		{"partial overlap", []string{auth.ScopeTokensDelegate, auth.ScopeContainersRead},
+			[]string{auth.ScopeContainersRead, auth.ScopeSecretsWrite}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := callerCtx("cloud-daemon", c.callerScopes, nil)
+			resp, err := s.ExchangeDelegatedToken(ctx, &pb.ExchangeDelegatedTokenRequest{
+				Subject: "alice@example.com",
+				Scopes:  c.requested,
+			})
+			if err != nil {
+				return // refused outright, which is a correct outcome here
+			}
+			claims, verr := tm.ValidateToken(resp.GetToken())
+			if verr != nil {
+				t.Fatalf("minted token does not validate: %v", verr)
+			}
+			if len(claims.Scopes) == 0 {
+				t.Fatalf("minted a token whose scopes claim is empty/absent — every "+
+					"RequireScope will pass on it. response said granted=%v",
+					resp.GetGrantedScopes())
+			}
+			// And it must never exceed what the caller held.
+			for _, got := range claims.Scopes {
+				if !auth.HasExplicitScope(c.callerScopes, got) {
+					t.Errorf("token carries %q, which the caller does not hold", got)
+				}
+			}
+		})
 	}
 }

--- a/internal/server/tokens_server.go
+++ b/internal/server/tokens_server.go
@@ -350,6 +350,28 @@ func (s *TokensServer) ExchangeDelegatedToken(ctx context.Context, req *pb.Excha
 		granted = callerScopes
 	}
 
+	// An empty intersection must NOT mint. This is the trap in the claim
+	// shape: HasScope treats an ABSENT scopes claim as unrestricted, and
+	// generate() omits the claim when it is handed zero scopes. So a token
+	// minted from an empty grant is not powerless — it is unlimited, which is
+	// the precise inversion of what the caller asked for and what the response
+	// would report.
+	//
+	// Concretely, before this check: a caller holding only tokens:delegate
+	// requests secrets:read, the intersection correctly yields nothing, the
+	// response honestly says granted_scopes=[], and the token it hands back
+	// passes RequireScope for every scope in the system.
+	//
+	// There is no way to express "no authority" in this claim, so refusing is
+	// the only correct answer. It also loses nothing: a token that genuinely
+	// carried zero scopes could not be used for anything.
+	if len(granted) == 0 {
+		return nil, status.Error(codes.PermissionDenied,
+			"the requested scopes intersect none of the caller's own, so this exchange "+
+				"would grant nothing; a token carrying no scopes claim reads as UNRESTRICTED "+
+				"rather than powerless, so it is refused instead of minted")
+	}
+
 	// A caller asking for longer than the daemon permits gets a shorter
 	// token, not a failure: generate() caps it internally, and failing here
 	// would make a working exchange depend on the client knowing the


### PR DESCRIPTION
**Security fix. Shipped in v0.72.0 this morning and currently deployed on all seven fleet hosts.**

## The bug

`ExchangeDelegatedToken` computed the scope intersection correctly, reported it honestly, and then handed back a token that ignored it.

The trap is the claim shape. `HasScope` treats an **absent** scopes claim as "no restriction", and `generate()` omits the claim entirely when handed zero scopes. So an empty grant does not mint a powerless token. It mints an unlimited one.

Verified against the shipped code — caller holds only `tokens:delegate`, requests `secrets:read`:

```
response granted_scopes = [] (len=0)
TOKEN scopes claim = [] (nil=true)
RequireScope(secrets:read)  -> nil   ALLOWED
RequireScope(secrets:write) -> nil   ALLOWED
```

Ask for scopes you do not hold, receive a token that can do anything. That is the escalation #1676 closed, reopened by the endpoint I added to close it on the cloud path.

## The fix

An exchange that would grant nothing is refused rather than minted. There is no way to express "no authority" in this claim, so refusing is the only correct answer — and nothing is lost, since a token genuinely carrying zero scopes could not be used for anything.

## Why the tests missed it

`TestExchangeDelegatedToken_ExplicitlyEmptyScopesGrantNothing` asserted on `resp.GetGrantedScopes()`. That field was **correct** — it said `[]`, and it was telling the truth. The assertion was simply on the wrong object: the report rather than the credential.

Replaced with two tests that look at the minted token:

- `RefusesAnExchangeThatWouldGrantNothing` — the endpoint must error.
- `NeverMintsAnUnrestrictedToken` — a table over three overlap shapes (none, empty request, partial) that fails if any mints a token with an empty scopes claim, and separately fails if any scope exceeds what the caller held.

Both verified to fail with the guard removed:

```
--- FAIL: RefusesAnExchangeThatWouldGrantNothing
    minted a token for an empty grant (scopes=[]); a token with no scopes claim is UNRESTRICTED, not powerless
--- FAIL: NeverMintsAnUnrestrictedToken/asks_for_what_it_does_not_hold
```

## How it was found

By probing what a delegated token can actually do — `RequireRole`, `AuthorizeTenant`, `RequireScope` against the real guards — rather than trusting the response fields, while starting the cloud half of `containarium-cloud#1427`.

That probe also surfaced a **separate** gap, not fixed here: the minted token carries `roles=[]`, so it fails every `RequireRole(admin)` handler and every cross-tenant `AuthorizeTenant`. That blocks the cloud half and needs its own change; filing separately rather than widening this fix.

## Exposure

Reaching this required holding `tokens:delegate`, which is granted deliberately and, in practice, only to the cloud control plane — and the control plane does not call the endpoint yet. So the window is small. It still warrants a release rather than riding to the next one.

## Test plan

- [x] `go test ./internal/server/ ./internal/auth/` green
- [x] Both new guards sabotage-verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1554BHQdJmSXTuG1UhS3i

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Delegated-token exchanges are now rejected when requested scopes do not overlap with the caller’s authorized scopes.
  * Prevents issuance of unscoped tokens that could be interpreted as unrestricted access.
  * Ensures issued delegated tokens contain only explicitly authorized, non-empty scopes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->