### PR TITLE
feat(tokens): delegate roles as well as scopes, intersected (#1708)

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -9847,6 +9847,13 @@
           "type": "string",
           "format": "int64",
           "description": "Lifetime in seconds. 0 uses the daemon's default access-token\nexpiry; values above the daemon's maximum are capped rather\nthan rejected, so a caller asking for too long gets a shorter\ntoken instead of a failure."
+        },
+        "roles": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Roles requested for the minted token. INTERSECTED with the\ncaller's own roles, never unioned — the same rule scopes follow.\n\nUnlike scopes, empty means NO ROLES, not \"inherit the caller's\".\nThe two differ because their absent-claim semantics are opposite:\nan absent scopes claim reads as unrestricted, so an empty scope\ngrant is dangerous and the daemon refuses it; an absent roles\nclaim reads as no roles at all (HasRole simply finds nothing), so\nempty is already the safe state. Given that, silently inheriting\nadmin would be the only way to get this wrong, so a caller that\nneeds a role has to say so.\n\nA token with no roles can still act for its own subject —\nAuthorizeTenant's self-access path does not consult roles — but\ncannot reach admin-gated RPCs or another tenant's resources."
         }
       },
       "description": "ExchangeDelegatedTokenRequest asks for a token acting for `subject`."
@@ -9869,6 +9876,13 @@
             "type": "string"
           },
           "description": "The scopes actually granted, after intersection. Returned\nexplicitly because they may be NARROWER than requested, and a\ncaller that assumes otherwise would fail later with a\nconfusing permission error instead of here."
+        },
+        "grantedRoles": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The roles actually granted, after intersection. Empty is a normal\nand safe result: such a token still acts for its own subject, it\njust cannot reach admin-gated RPCs or other tenants."
         }
       }
     },

--- a/internal/auth/delegation.go
+++ b/internal/auth/delegation.go
@@ -1,6 +1,9 @@
 package auth
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // Actor is the RFC 8693 "act" (actor) claim: the principal that actually
 // dispatched a token's mint, distinct from the token's own subject, when the
@@ -62,4 +65,45 @@ func RootActor(a *Actor) string {
 		a = a.Act
 	}
 	return a.Subject
+}
+
+// IntersectRoles returns the roles common to caller and requested.
+//
+// Deliberately NOT IntersectScopes with a different argument name. That
+// function treats a nil caller as "no ceiling" and passes the requested set
+// through unchanged, which is right for scopes — an absent scopes claim means
+// unrestricted — and catastrophically wrong for roles, where it would let a
+// caller holding no roles at all mint an admin token.
+//
+// Roles fail closed at every step here: no wildcard, and an empty result is a
+// normal outcome rather than something to widen. HasRole finds nothing in an
+// empty list, so a token minted with no roles simply cannot reach anything
+// gated on one.
+//
+// Returns a non-nil empty slice rather than nil so callers can range over it
+// without a check.
+func IntersectRoles(caller, requested []string) []string {
+	out := make([]string, 0, len(requested))
+	if len(caller) == 0 || len(requested) == 0 {
+		return out
+	}
+	held := make(map[string]struct{}, len(caller))
+	for _, r := range caller {
+		held[strings.TrimSpace(r)] = struct{}{}
+	}
+	seen := make(map[string]struct{}, len(requested))
+	for _, r := range requested {
+		r = strings.TrimSpace(r)
+		if r == "" {
+			continue
+		}
+		if _, dup := seen[r]; dup {
+			continue
+		}
+		if _, ok := held[r]; ok {
+			seen[r] = struct{}{}
+			out = append(out, r)
+		}
+	}
+	return out
 }

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -905,34 +905,36 @@ func (c *HTTPClient) RevokeToken(jti, reason, expiresAt string) (string, error) 
 // Returns the token, its real expiry (read from the token's own exp claim
 // by the daemon, so it is safe to cache against), and the scopes actually
 // granted — which may be narrower than those requested.
-func (c *HTTPClient) ExchangeDelegatedToken(subject string, scopes []string, expiresIn time.Duration) (string, time.Time, []string, error) {
+func (c *HTTPClient) ExchangeDelegatedToken(subject string, scopes, roles []string, expiresIn time.Duration) (string, time.Time, []string, []string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	body, err := json.Marshal(exchangeDelegatedTokenRequest{
 		Subject:          subject,
 		Scopes:           scopes,
+		Roles:            roles,
 		ExpiresInSeconds: int64(expiresIn / time.Second),
 	})
 	if err != nil {
-		return "", time.Time{}, nil, fmt.Errorf("marshal request: %w", err)
+		return "", time.Time{}, nil, nil, fmt.Errorf("marshal request: %w", err)
 	}
 	resp, err := c.doRequest(ctx, http.MethodPost, "/v1/tokens/delegate", body)
 	if err != nil {
-		return "", time.Time{}, nil, fmt.Errorf("exchange delegated token: %w", err)
+		return "", time.Time{}, nil, nil, fmt.Errorf("exchange delegated token: %w", err)
 	}
 	defer drainClose(resp)
 	b, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode >= 400 {
-		return "", time.Time{}, nil, parseErr(b, resp.StatusCode, "exchange delegated token")
+		return "", time.Time{}, nil, nil, parseErr(b, resp.StatusCode, "exchange delegated token")
 	}
 	// protojson renders google.protobuf.Timestamp as an RFC3339 string.
 	var result struct {
 		Token         string   `json:"token"`
 		ExpiresAt     string   `json:"expiresAt"`
 		GrantedScopes []string `json:"grantedScopes"`
+		GrantedRoles  []string `json:"grantedRoles"`
 	}
 	if err := json.Unmarshal(b, &result); err != nil {
-		return "", time.Time{}, nil, fmt.Errorf("decode delegate response: %w", err)
+		return "", time.Time{}, nil, nil, fmt.Errorf("decode delegate response: %w", err)
 	}
 	var expiresAt time.Time
 	if result.ExpiresAt != "" {
@@ -940,7 +942,7 @@ func (c *HTTPClient) ExchangeDelegatedToken(subject string, scopes []string, exp
 		// carries its own exp. The caller loses only the ability to cache.
 		expiresAt, _ = time.Parse(time.RFC3339, result.ExpiresAt)
 	}
-	return result.Token, expiresAt, result.GrantedScopes, nil
+	return result.Token, expiresAt, result.GrantedScopes, result.GrantedRoles, nil
 }
 
 // SetSecret creates or updates a tenant secret via HTTP.

--- a/internal/client/http_requests.go
+++ b/internal/client/http_requests.go
@@ -198,6 +198,10 @@ type exchangeDelegatedTokenRequest struct {
 	// daemon intersects with the caller's scopes, so this can only narrow.
 	Scopes           []string `json:"scopes,omitempty"`
 	ExpiresInSeconds int64    `json:"expires_in_seconds,omitempty"`
+	// Roles requested. Intersected with the caller's, and — unlike scopes —
+	// empty means none rather than "inherit mine". A token with no roles can
+	// still act for its own subject but cannot reach admin-gated RPCs.
+	Roles []string `json:"roles,omitempty"`
 }
 
 // startEgressProxyRequest is POST /v1/network/egress-proxy (#808).

--- a/internal/cmd/token.go
+++ b/internal/cmd/token.go
@@ -33,6 +33,7 @@ var (
 	// `token delegate` flags (containarium-cloud#1427)
 	delegateSubject   string
 	delegateScopes    []string
+	delegateRoles     []string
 	delegateExpiry    string
 	delegateRawOutput bool
 
@@ -253,6 +254,7 @@ func init() {
 	tokenDelegateCmd.Flags().StringVar(&delegateSubject, "subject", "", "Subject to act on behalf of (required)")
 	_ = tokenDelegateCmd.MarkFlagRequired("subject")
 	tokenDelegateCmd.Flags().StringSliceVar(&delegateScopes, "scopes", nil, "Scopes to request (comma-separated). Omit to inherit your own; the server intersects either way, so this can only narrow.")
+	tokenDelegateCmd.Flags().StringSliceVar(&delegateRoles, "roles", nil, "Roles to request (comma-separated, e.g. admin). Intersected with your own. UNLIKE --scopes, omitting this grants NO roles rather than inheriting yours: a role-less token can act for its subject but cannot reach admin-gated RPCs or other tenants.")
 	tokenDelegateCmd.Flags().StringVar(&delegateExpiry, "expiry", "", "Lifetime of the delegated token (e.g. 5m, 1h). Empty = the daemon's access-token default.")
 	tokenDelegateCmd.Flags().BoolVar(&delegateRawOutput, "raw", false, "Output only the raw token (for scripting)")
 
@@ -481,7 +483,7 @@ func runTokenDelegate(cmd *cobra.Command, args []string) error {
 	}
 	defer func() { _ = httpClient.Close() }()
 
-	token, expiresAt, granted, err := httpClient.ExchangeDelegatedToken(subject, delegateScopes, expiresIn)
+	token, expiresAt, granted, grantedRoles, err := httpClient.ExchangeDelegatedToken(subject, delegateScopes, delegateRoles, expiresIn)
 	if err != nil {
 		return err
 	}
@@ -501,10 +503,17 @@ func runTokenDelegate(cmd *cobra.Command, args []string) error {
 	// Print what was GRANTED, not what was asked for. The two differ whenever
 	// the request exceeded the caller's own authority, and a silent narrowing
 	// is exactly the kind of surprise that shows up later as a confusing 403.
-	if len(granted) == 0 {
-		fmt.Printf("Scopes:      (none recorded — inherits the daemon's unscoped default)\n")
+	fmt.Printf("Scopes:      %s\n", strings.Join(granted, ", "))
+	// Printed even when empty, because empty is the normal result and its
+	// meaning is not obvious: the token can act for its own subject but
+	// cannot reach admin-gated RPCs or another tenant's resources.
+	if len(grantedRoles) == 0 {
+		fmt.Printf("Roles:       (none — acts for its own subject only)\n")
 	} else {
-		fmt.Printf("Scopes:      %s\n", strings.Join(granted, ", "))
+		fmt.Printf("Roles:       %s\n", strings.Join(grantedRoles, ", "))
+	}
+	if len(delegateRoles) > 0 && len(grantedRoles) < len(delegateRoles) {
+		fmt.Printf("\nNote: fewer roles granted than requested — you do not hold the rest.\n")
 	}
 	if len(delegateScopes) > 0 && len(granted) < len(delegateScopes) {
 		fmt.Printf("\nNote: fewer scopes granted than requested — your own token does not\n")

--- a/internal/server/tokens_delegate_test.go
+++ b/internal/server/tokens_delegate_test.go
@@ -276,3 +276,152 @@ func TestExchangeDelegatedToken_NeverMintsAnUnrestrictedToken(t *testing.T) {
 		})
 	}
 }
+
+// Roles follow the same rule as scopes — intersected with the caller's, never
+// unioned — but with the opposite empty-state default, because the two claims
+// mean opposite things when absent.
+
+func TestExchangeDelegatedToken_RolesAreIntersectedNotUnioned(t *testing.T) {
+	tm, err := auth.NewTokenManager(delegateTestSecret, "containarium-test")
+	if err != nil {
+		t.Fatalf("NewTokenManager: %v", err)
+	}
+	s := NewTokensServer(tm, nil, 0)
+
+	// The caller is a plain user. It asks for admin anyway.
+	ctx := auth.ContextWithTestSubjectAct(context.Background(), "cloud-daemon",
+		[]string{"user"}, nil)
+	md, _ := metadata.FromIncomingContext(ctx)
+	md = md.Copy()
+	md.Set(auth.MDKeyScopes, auth.ScopeTokensDelegate+","+auth.ScopeContainersRead)
+	ctx = metadata.NewIncomingContext(context.Background(), md)
+
+	resp, err := s.ExchangeDelegatedToken(ctx, &pb.ExchangeDelegatedTokenRequest{
+		Subject: "alice@example.com",
+		Scopes:  []string{auth.ScopeContainersRead},
+		Roles:   []string{auth.RoleAdmin},
+	})
+	if err != nil {
+		t.Fatalf("exchange: %v", err)
+	}
+	for _, r := range resp.GetGrantedRoles() {
+		if r == auth.RoleAdmin {
+			t.Fatal("granted admin to a caller that holds only the user role — roles were unioned, not intersected")
+		}
+	}
+	claims, err := tm.ValidateToken(resp.GetToken())
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if auth.HasRole(claims.Roles, auth.RoleAdmin) {
+		t.Fatalf("minted token carries admin; roles=%v", claims.Roles)
+	}
+}
+
+// The whole point of the roles field: an admin caller can pass admin through,
+// so the cloud driver's calls reach admin-gated RPCs and cross-tenant paths.
+// Without this the delegated token is useless for its actual purpose.
+func TestExchangeDelegatedToken_AdminCallerCanDelegateAdmin(t *testing.T) {
+	tm, err := auth.NewTokenManager(delegateTestSecret, "containarium-test")
+	if err != nil {
+		t.Fatalf("NewTokenManager: %v", err)
+	}
+	s := NewTokensServer(tm, nil, 0)
+	ctx := callerCtx("cloud-region-driver", []string{auth.ScopeWildcard}, nil)
+
+	resp, err := s.ExchangeDelegatedToken(ctx, &pb.ExchangeDelegatedTokenRequest{
+		Subject: "tenant-alice",
+		Scopes:  []string{auth.ScopeContainersRead, auth.ScopeContainersWrite},
+		Roles:   []string{auth.RoleAdmin},
+	})
+	if err != nil {
+		t.Fatalf("exchange: %v", err)
+	}
+	claims, err := tm.ValidateToken(resp.GetToken())
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if !auth.HasRole(claims.Roles, auth.RoleAdmin) {
+		t.Fatalf("admin was not delegated; roles=%v — cross-tenant and admin-gated RPCs stay unreachable", claims.Roles)
+	}
+	// And it must still be bounded by scopes, which is what makes carrying
+	// admin acceptable at all.
+	pctx := auth.ContextWithTestSubjectScopes(context.Background(),
+		claims.Username, claims.Roles, claims.Scopes)
+	if err := auth.RequireScope(pctx, auth.ScopeSecretsRead); err == nil {
+		t.Error("an admin-carrying delegated token reached a scope it was not granted")
+	}
+}
+
+// Absent roles must mean NO roles. If this ever inherits the caller's, every
+// delegated token silently becomes admin — the roles-shaped version of the
+// empty-scope bug above.
+func TestExchangeDelegatedToken_NoRolesRequestedMeansNoRoles(t *testing.T) {
+	tm, _ := auth.NewTokenManager(delegateTestSecret, "containarium-test")
+	s := NewTokensServer(tm, nil, 0)
+	ctx := callerCtx("cloud-region-driver", []string{auth.ScopeWildcard}, nil)
+
+	resp, err := s.ExchangeDelegatedToken(ctx, &pb.ExchangeDelegatedTokenRequest{
+		Subject: "tenant-alice",
+		Scopes:  []string{auth.ScopeContainersRead},
+	})
+	if err != nil {
+		t.Fatalf("exchange: %v", err)
+	}
+	claims, _ := tm.ValidateToken(resp.GetToken())
+	if len(claims.Roles) != 0 {
+		t.Fatalf("roles = %v, want none — a caller that did not ask for a role must not get one", claims.Roles)
+	}
+	// Such a token is still useful: it can act for its own subject.
+	pctx := auth.ContextWithTestSubjectScopes(context.Background(),
+		claims.Username, claims.Roles, claims.Scopes)
+	if err := auth.AuthorizeTenant(pctx, "tenant-alice"); err != nil {
+		t.Errorf("role-less token cannot act for its own subject: %v", err)
+	}
+	if err := auth.AuthorizeTenant(pctx, "tenant-bob"); err == nil {
+		t.Error("role-less token reached another tenant")
+	}
+}
+
+// The reuse trap, pinned. IntersectScopes treats a nil caller as "no ceiling"
+// and returns the requested set unchanged — correct for scopes, where an
+// absent claim means unrestricted. Applied to roles it means a caller holding
+// NO roles can mint an admin token, which is the whole escalation this
+// endpoint is supposed to prevent.
+//
+// The two functions agree on every case where the caller holds something, so a
+// test with a role-holding caller passes either way. This one does not.
+func TestExchangeDelegatedToken_RolelessCallerCannotMintARole(t *testing.T) {
+	tm, err := auth.NewTokenManager(delegateTestSecret, "containarium-test")
+	if err != nil {
+		t.Fatalf("NewTokenManager: %v", err)
+	}
+	s := NewTokensServer(tm, nil, 0)
+
+	// Authenticated and scoped, but holding no roles whatsoever.
+	md := metadata.Pairs(
+		auth.MDKeyUsername, "roleless-service",
+		auth.MDKeyRoles, "",
+		auth.MDKeyScopes, auth.ScopeTokensDelegate+","+auth.ScopeContainersRead,
+	)
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+
+	resp, err := s.ExchangeDelegatedToken(ctx, &pb.ExchangeDelegatedTokenRequest{
+		Subject: "tenant-alice",
+		Scopes:  []string{auth.ScopeContainersRead},
+		Roles:   []string{auth.RoleAdmin},
+	})
+	if err != nil {
+		return // refusing outright is also correct
+	}
+	if len(resp.GetGrantedRoles()) != 0 {
+		t.Fatalf("granted %v to a caller holding no roles at all", resp.GetGrantedRoles())
+	}
+	claims, verr := tm.ValidateToken(resp.GetToken())
+	if verr != nil {
+		t.Fatalf("validate: %v", verr)
+	}
+	if auth.HasRole(claims.Roles, auth.RoleAdmin) {
+		t.Fatalf("a caller with no roles minted an admin token; roles=%v", claims.Roles)
+	}
+}

--- a/internal/server/tokens_server.go
+++ b/internal/server/tokens_server.go
@@ -332,7 +332,7 @@ func (s *TokensServer) ExchangeDelegatedToken(ctx context.Context, req *pb.Excha
 		return nil, status.Error(codes.InvalidArgument, "subject is required")
 	}
 
-	caller, _, ok := auth.SubjectFromGRPCContext(ctx)
+	caller, callerRoles, ok := auth.SubjectFromGRPCContext(ctx)
 	if !ok || caller == "" {
 		return nil, status.Error(codes.Unauthenticated, "no authenticated subject in request context")
 	}
@@ -386,7 +386,21 @@ func (s *TokensServer) ExchangeDelegatedToken(ctx context.Context, req *pb.Excha
 		ttl = time.Duration(secs) * time.Second
 	}
 
-	token, err := s.tokenManager.GenerateDelegatedToken(subject, nil, ttl, act, granted...)
+	// Roles, on the same rule as scopes: intersected with the caller's own,
+	// never unioned. IntersectRoles rather than IntersectScopes deliberately —
+	// the latter treats a nil caller as "no ceiling", which is right for
+	// scopes and would let a role-less caller mint an admin token here.
+	//
+	// An empty request yields no roles, and that is the intended default
+	// rather than an oversight. The two claims' absent-state semantics are
+	// opposite: an absent scopes claim reads as unrestricted (hence the
+	// refusal above), while an absent roles claim reads as no roles at all.
+	// Since empty is already the safe state for roles, the only way to get
+	// this wrong would be to inherit admin silently, so a caller that needs a
+	// role has to name it.
+	grantedRoles := auth.IntersectRoles(callerRoles, req.GetRoles())
+
+	token, err := s.tokenManager.GenerateDelegatedToken(subject, grantedRoles, ttl, act, granted...)
 	if err != nil {
 		// Depth violations are a client-correctable conflict (the chain is
 		// too long), not a server fault — surface them as such.
@@ -410,5 +424,6 @@ func (s *TokensServer) ExchangeDelegatedToken(ctx context.Context, req *pb.Excha
 		Token:         token,
 		ExpiresAt:     timestamppb.New(claims.ExpiresAt.Time),
 		GrantedScopes: granted,
+		GrantedRoles:  grantedRoles,
 	}, nil
 }

--- a/pkg/pb/containarium/v1/tokens.pb.go
+++ b/pkg/pb/containarium/v1/tokens.pb.go
@@ -599,8 +599,24 @@ type ExchangeDelegatedTokenRequest struct {
 	// than rejected, so a caller asking for too long gets a shorter
 	// token instead of a failure.
 	ExpiresInSeconds int64 `protobuf:"varint,3,opt,name=expires_in_seconds,json=expiresInSeconds,proto3" json:"expires_in_seconds,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// Roles requested for the minted token. INTERSECTED with the
+	// caller's own roles, never unioned — the same rule scopes follow.
+	//
+	// Unlike scopes, empty means NO ROLES, not "inherit the caller's".
+	// The two differ because their absent-claim semantics are opposite:
+	// an absent scopes claim reads as unrestricted, so an empty scope
+	// grant is dangerous and the daemon refuses it; an absent roles
+	// claim reads as no roles at all (HasRole simply finds nothing), so
+	// empty is already the safe state. Given that, silently inheriting
+	// admin would be the only way to get this wrong, so a caller that
+	// needs a role has to say so.
+	//
+	// A token with no roles can still act for its own subject —
+	// AuthorizeTenant's self-access path does not consult roles — but
+	// cannot reach admin-gated RPCs or another tenant's resources.
+	Roles         []string `protobuf:"bytes,4,rep,name=roles,proto3" json:"roles,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ExchangeDelegatedTokenRequest) Reset() {
@@ -654,6 +670,13 @@ func (x *ExchangeDelegatedTokenRequest) GetExpiresInSeconds() int64 {
 	return 0
 }
 
+func (x *ExchangeDelegatedTokenRequest) GetRoles() []string {
+	if x != nil {
+		return x.Roles
+	}
+	return nil
+}
+
 type ExchangeDelegatedTokenResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The minted access token.
@@ -667,6 +690,10 @@ type ExchangeDelegatedTokenResponse struct {
 	// caller that assumes otherwise would fail later with a
 	// confusing permission error instead of here.
 	GrantedScopes []string `protobuf:"bytes,3,rep,name=granted_scopes,json=grantedScopes,proto3" json:"granted_scopes,omitempty"`
+	// The roles actually granted, after intersection. Empty is a normal
+	// and safe result: such a token still acts for its own subject, it
+	// just cannot reach admin-gated RPCs or other tenants.
+	GrantedRoles  []string `protobuf:"bytes,4,rep,name=granted_roles,json=grantedRoles,proto3" json:"granted_roles,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -722,6 +749,13 @@ func (x *ExchangeDelegatedTokenResponse) GetGrantedScopes() []string {
 	return nil
 }
 
+func (x *ExchangeDelegatedTokenResponse) GetGrantedRoles() []string {
+	if x != nil {
+		return x.GrantedRoles
+	}
+	return nil
+}
+
 var File_containarium_v1_tokens_proto protoreflect.FileDescriptor
 
 const file_containarium_v1_tokens_proto_rawDesc = "" +
@@ -761,16 +795,18 @@ const file_containarium_v1_tokens_proto_rawDesc = "" +
 	"\x1eGetUnscopedTokenReportResponse\x12.\n" +
 	"\x13unscoped_call_count\x18\x01 \x01(\x03R\x11unscopedCallCount\x12\x14\n" +
 	"\x05since\x18\x02 \x01(\tR\x05since\x12.\n" +
-	"\x13strict_mode_enabled\x18\x03 \x01(\bR\x11strictModeEnabled\"\x7f\n" +
+	"\x13strict_mode_enabled\x18\x03 \x01(\bR\x11strictModeEnabled\"\x95\x01\n" +
 	"\x1dExchangeDelegatedTokenRequest\x12\x18\n" +
 	"\asubject\x18\x01 \x01(\tR\asubject\x12\x16\n" +
 	"\x06scopes\x18\x02 \x03(\tR\x06scopes\x12,\n" +
-	"\x12expires_in_seconds\x18\x03 \x01(\x03R\x10expiresInSeconds\"\x98\x01\n" +
+	"\x12expires_in_seconds\x18\x03 \x01(\x03R\x10expiresInSeconds\x12\x14\n" +
+	"\x05roles\x18\x04 \x03(\tR\x05roles\"\xbd\x01\n" +
 	"\x1eExchangeDelegatedTokenResponse\x12\x14\n" +
 	"\x05token\x18\x01 \x01(\tR\x05token\x129\n" +
 	"\n" +
 	"expires_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\texpiresAt\x12%\n" +
-	"\x0egranted_scopes\x18\x03 \x03(\tR\rgrantedScopes2\xe1\x13\n" +
+	"\x0egranted_scopes\x18\x03 \x03(\tR\rgrantedScopes\x12#\n" +
+	"\rgranted_roles\x18\x04 \x03(\tR\fgrantedRoles2\xe1\x13\n" +
 	"\rTokensService\x12\x85\x03\n" +
 	"\vRevokeToken\x12#.containarium.v1.RevokeTokenRequest\x1a$.containarium.v1.RevokeTokenResponse\"\xaa\x02\x92A\x8a\x02\n" +
 	"\x06Tokens\x12\x17Revoke a JWT by its jti\x1a\xe6\x01Adds the token's jti to the revocation list. The token will be rejected on the next request that tries to use it. Admin-only. Idempotent — revoking an already-revoked jti is a no-op (the original revocation reason is preserved).\x82\xd3\xe4\x93\x02\x16:\x01*\"\x11/v1/tokens/revoke\x12\xa7\x05\n" +

--- a/proto/containarium/v1/tokens.proto
+++ b/proto/containarium/v1/tokens.proto
@@ -282,6 +282,23 @@ message ExchangeDelegatedTokenRequest {
   // than rejected, so a caller asking for too long gets a shorter
   // token instead of a failure.
   int64 expires_in_seconds = 3;
+
+  // Roles requested for the minted token. INTERSECTED with the
+  // caller's own roles, never unioned — the same rule scopes follow.
+  //
+  // Unlike scopes, empty means NO ROLES, not "inherit the caller's".
+  // The two differ because their absent-claim semantics are opposite:
+  // an absent scopes claim reads as unrestricted, so an empty scope
+  // grant is dangerous and the daemon refuses it; an absent roles
+  // claim reads as no roles at all (HasRole simply finds nothing), so
+  // empty is already the safe state. Given that, silently inheriting
+  // admin would be the only way to get this wrong, so a caller that
+  // needs a role has to say so.
+  //
+  // A token with no roles can still act for its own subject —
+  // AuthorizeTenant's self-access path does not consult roles — but
+  // cannot reach admin-gated RPCs or another tenant's resources.
+  repeated string roles = 4;
 }
 
 message ExchangeDelegatedTokenResponse {
@@ -298,4 +315,9 @@ message ExchangeDelegatedTokenResponse {
   // caller that assumes otherwise would fail later with a
   // confusing permission error instead of here.
   repeated string granted_scopes = 3;
+
+  // The roles actually granted, after intersection. Empty is a normal
+  // and safe result: such a token still acts for its own subject, it
+  // just cannot reach admin-gated RPCs or other tenants.
+  repeated string granted_roles = 4;
 }


### PR DESCRIPTION
Unblocks the CP half of `containarium-cloud#1427`. Stacks on #1713.

## The gap

A delegated token was minted with `roles=nil`. Probed against the real guards rather than reasoned about:

```
minted: username="tenant-alice" roles=[] scopes=[containers:read containers:write]

RequireRole(admin)            -> PermissionDenied
AuthorizeTenant(self)         -> ok
AuthorizeTenant(other)        -> PermissionDenied
RequireScope(containers:read) -> ok
RequireScope(secrets:read)    -> PermissionDenied
```

The scope half was already correct and is exactly what #1427 wants. But **111 handlers** gate on `RequireRole(admin)` or `AuthorizeTenant`'s cross-tenant path, and a role-less token fails all of them. The cloud driver needs both, so the CP half could not be built on this.

## The rule, and one deliberate asymmetry

Roles are now intersected with the caller's, never unioned — the same rule scopes follow. With one difference, because the two claims mean **opposite things when absent**:

| claim | absent means | so an empty grant is |
| --- | --- | --- |
| scopes | unrestricted | dangerous — refused outright (#1713) |
| roles | no roles at all | already safe — the correct default |

So an empty `roles` request grants none, and a caller that needs a role names it. Silently inheriting admin would be the only way to get this wrong.

## Why `IntersectRoles` and not `IntersectScopes`

`IntersectScopes` treats a **nil caller as "no ceiling"** and returns the requested set unchanged. That is right for scopes, where an absent claim means unrestricted. Applied to roles it means a caller holding **no roles** can mint an admin token — the escalation this endpoint exists to prevent.

The two functions agree on every case where the caller holds something, so a test with a role-holding caller passes either way. `RolelessCallerCannotMintARole` is the one that does not, and it fails when the functions are swapped:

```
--- FAIL: TestExchangeDelegatedToken_RolelessCallerCannotMintARole
    granted [admin] to a caller holding no roles at all
```

I only found that because the first sabotage run came back clean and the absence of a failure was itself suspicious.

## Guards, all sabotage-verified

| guard | test |
| --- | --- |
| roles intersected, not unioned | `RolesAreIntersectedNotUnioned` |
| admin caller can pass admin through, still bounded by scopes | `AdminCallerCanDelegateAdmin` |
| no request means no roles | `NoRolesRequestedMeansNoRoles` |
| role-less caller cannot mint a role | `RolelessCallerCannotMintARole` |

## Test plan

- [x] `go build ./... && go vet ./internal/...` clean
- [x] `internal/server`, `internal/auth`, `internal/client`, `internal/cmd` green
- [x] `containarium token delegate --roles` renders, with the asymmetry stated in the flag help
- [x] proto regenerated; swagger in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1554BHQdJmSXTuG1UhS3i

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delegated tokens support requesting specific roles.
  * Token responses show the roles actually granted.
  * Added a `--roles` option to the token delegation command.
  * Delegated roles are limited to those held by the caller; omitted roles result in a role-less token.
* **Security**
  * Delegated tokens remain constrained by scopes and tenant authorization.
  * Exchanges that would grant no scopes are rejected.
  * Delegated tokens cannot gain unrestricted access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->