### PR TITLE
chore(release): v0.73.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.73.0] - 2026-09-04
+
+### Security
+
+- **An exchange granting nothing minted an UNRESTRICTED token** (#1713).
+  `ExchangeDelegatedToken` computed the scope intersection correctly, reported
+  it honestly, and then handed back a token that ignored it.
+
+  The trap is the claim shape. `HasScope` treats an **absent** scopes claim as
+  "no restriction", and the generator omits the claim entirely when handed zero
+  scopes. So an empty grant does not mint a powerless token — it mints an
+  unlimited one. A caller holding only `tokens:delegate` could request
+  `secrets:read`, be correctly granted nothing, and receive a token that passes
+  `RequireScope` for every scope in the system.
+
+  That is the escalation #1676 closed, reopened by the endpoint added in
+  v0.72.0 to close it on the cloud path. An exchange that would grant nothing
+  is now refused rather than minted: there is no way to express "no authority"
+  in this claim, and a token genuinely carrying zero scopes could not be used
+  for anything anyway.
+
+  Reaching it required holding `tokens:delegate`, which is granted deliberately
+  and in practice only to the cloud control plane — which does not call the
+  endpoint yet. The window was one release.
+
+  The test that should have caught it asserted on the response's
+  `granted_scopes` field, which was correct and said `[]`. The assertion was on
+  the report rather than the credential. It is replaced by tests that inspect
+  the minted token.
+
+### Added
+
+- **Delegated tokens carry roles, intersected with the caller's** (#1714).
+  A delegated token was minted with no roles at all, so it failed every one of
+  the 111 handlers gated on `RequireRole(admin)` and every cross-tenant
+  `AuthorizeTenant` path. The scope half worked; without roles the token could
+  not do the job the endpoint exists for.
+
+  Roles now follow the same rule as scopes — intersected with the caller's,
+  never unioned — with one deliberate difference. An absent **scopes** claim
+  reads as unrestricted, which is why an empty scope grant is refused. An
+  absent **roles** claim reads as no roles at all, so empty is already the safe
+  state; the only way to get roles wrong would be to inherit admin silently.
+  An empty roles request therefore grants none, and a caller that needs a role
+  names it.
+
+  `IntersectRoles` is deliberately not `IntersectScopes` with different
+  arguments: that function treats a nil caller as "no ceiling", which is right
+  for scopes and would let a caller holding **no roles** mint an admin token.
+  The two agree on every case where the caller holds something, so only a
+  role-less caller distinguishes them — and there is a test for exactly that.
+
+  `containarium token delegate` gains `--roles`.
+
 ## [0.72.0] - 2026-09-04
 
 ### Added

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,7 +11,7 @@ var (
 	// ldflags (`make build-release VERSION=<tag>` in .github/workflows/release.yml),
 	// so the tag is the source of truth; keep this constant in sync as the
 	// fallback for plain `make build` / `go build`.
-	Version = "0.72.0"
+	Version = "0.73.0"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
Two commits since v0.72.0, and one of them is a live security fix.

## Contents

**Security — #1713.** `ExchangeDelegatedToken` computed the scope intersection correctly, reported it honestly, then handed back a token that ignored it. An absent scopes claim reads as *unrestricted*, and the generator omits the claim when given zero scopes — so an empty grant minted an unlimited token rather than a powerless one.

That escalation is **currently live in v0.72.0 on all seven fleet hosts**. Exposure is small: it requires holding `tokens:delegate`, which in practice only the control plane has, and the control plane does not call the endpoint yet. The window is one release, and this closes it.

**Added — #1714.** Delegated tokens now carry roles, intersected with the caller's. Without them a delegated token fails all 111 `RequireRole(admin)` handlers and every cross-tenant path, which blocks `containarium-cloud#1427`'s CP half.

## Gate check

```
PASS: changelog body 39 lines
PASS: constant = 0.73.0
```

## Test plan

- [x] `go build ./...` clean
- [x] `internal/server` and `internal/auth` green
- [x] Release-gate logic run locally against this tree

Tag goes on this commit once merged, then fleet deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1554BHQdJmSXTuG1UhS3i

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Delegated tokens now support role intersection for more controlled access.
  - Added the `containarium token delegate --roles` option for specifying delegated roles.

- **Security**
  - Delegated-token exchanges that grant no scopes are refused, preventing unrestricted tokens.

- **Chores**
  - Updated the application version to 0.73.0.
  - Added release notes for version 0.73.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->