### PR TITLE
fix(security): guard two ungated write paths (#1716, #1717)

### DIFF
--- a/internal/server/authguard_writepath_test.go
+++ b/internal/server/authguard_writepath_test.go
@@ -1,0 +1,124 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/footprintai/containarium/internal/auth"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// #1716 and #1717: two write paths that reached real state with no
+// authorization guard at all. These assert the denial, not the happy path —
+// the happy path was never broken, and a test that only proves the guard lets
+// the right caller through would still pass with the guard removed.
+
+// scopedTenantCtx is tenantCtx (rbac_phase_1_4_tenant_test.go) plus a scopes
+// claim — these guards check scope AND tenancy, so both have to be set.
+func scopedTenantCtx(username string, scopes ...string) context.Context {
+	return auth.ContextWithTestSubjectScopes(context.Background(), username, []string{"user"}, scopes)
+}
+
+// #1716. The username is request input naming whose box gets touched. Before
+// the fix, any caller could pass any username: Enable/Disable mutated state
+// inside another tenant's box, and Discover/Status read it.
+func TestComposeAutostart_RefusesAnotherTenantsBox(t *testing.T) {
+	s := &ComposeAutostartServer{}
+	// alice is authenticated, correctly scoped, and targets bob's box.
+	ctx := scopedTenantCtx("alice", auth.ScopeContainersRead, auth.ScopeContainersWrite)
+
+	calls := map[string]func() error{
+		"Discover": func() error {
+			_, err := s.Discover(ctx, &pb.DiscoverRequest{Username: "bob"})
+			return err
+		},
+		"Enable": func() error {
+			_, err := s.Enable(ctx, &pb.EnableRequest{Username: "bob"})
+			return err
+		},
+		"Disable": func() error {
+			_, err := s.Disable(ctx, &pb.DisableRequest{Username: "bob"})
+			return err
+		},
+		"Status": func() error {
+			_, err := s.Status(ctx, &pb.StatusRequest{Username: "bob"})
+			return err
+		},
+	}
+	for name, call := range calls {
+		t.Run(name, func(t *testing.T) {
+			err := call()
+			if err == nil {
+				t.Fatalf("%s reached bob's box for a caller authenticated as alice", name)
+			}
+			if got := status.Code(err); got != codes.PermissionDenied {
+				t.Errorf("code = %v, want PermissionDenied (got %v)", got, err)
+			}
+		})
+	}
+}
+
+// Scope alone must not be enough, and neither must tenancy alone. A caller
+// acting on its OWN box still needs the right scope — otherwise a read-only
+// token could flip autostart.
+func TestComposeAutostart_ReadScopeCannotMutateOwnBox(t *testing.T) {
+	s := &ComposeAutostartServer{}
+	ctx := scopedTenantCtx("alice", auth.ScopeContainersRead) // read only
+
+	if _, err := s.Enable(ctx, &pb.EnableRequest{Username: "alice"}); err == nil {
+		t.Error("a containers:read token enabled autostart on its own box")
+	} else if got := status.Code(err); got != codes.PermissionDenied {
+		t.Errorf("Enable: code = %v, want PermissionDenied", got)
+	}
+	if _, err := s.Disable(ctx, &pb.DisableRequest{Username: "alice"}); err == nil {
+		t.Error("a containers:read token disabled autostart on its own box")
+	}
+}
+
+// An entirely unauthenticated caller must not reach any of them.
+func TestComposeAutostart_RefusesUnauthenticated(t *testing.T) {
+	s := &ComposeAutostartServer{}
+	if _, err := s.Enable(context.Background(), &pb.EnableRequest{Username: "alice"}); err == nil {
+		t.Fatal("an unauthenticated caller enabled autostart")
+	}
+}
+
+// #1717. The bad-destination blocklist is a fleet-wide detection control.
+// Removing an entry silently disables a rule, which is why this is gated on
+// the admin role and not only a scope.
+func TestBadDestination_MutationRequiresAdmin(t *testing.T) {
+	s := &ThreatDetectionServer{}
+	// Correctly scoped, but not an admin.
+	ctx := scopedTenantCtx("alice", auth.ScopeSecurityWrite)
+
+	if _, err := s.AddBadDestination(ctx, &pb.AddBadDestinationRequest{Cidr: "10.0.0.0/8"}); err == nil {
+		t.Error("a non-admin added a fleet-wide blocklist entry")
+	} else if got := status.Code(err); got != codes.PermissionDenied {
+		t.Errorf("Add: code = %v, want PermissionDenied", got)
+	}
+	if _, err := s.RemoveBadDestination(ctx, &pb.RemoveBadDestinationRequest{Cidr: "10.0.0.0/8"}); err == nil {
+		t.Error("a non-admin removed a fleet-wide blocklist entry — this silently disables a detection rule")
+	} else if got := status.Code(err); got != codes.PermissionDenied {
+		t.Errorf("Remove: code = %v, want PermissionDenied", got)
+	}
+}
+
+// ...and the admin role alone is not enough either: the scope is still required.
+func TestBadDestination_AdminStillNeedsTheScope(t *testing.T) {
+	s := &ThreatDetectionServer{}
+	ctx := auth.ContextWithTestSubjectScopes(context.Background(), "ops",
+		[]string{auth.RoleAdmin}, []string{auth.ScopeSecurityRead})
+
+	if _, err := s.RemoveBadDestination(ctx, &pb.RemoveBadDestinationRequest{Cidr: "10.0.0.0/8"}); err == nil {
+		t.Error("an admin holding only security:read mutated the blocklist")
+	}
+}
+
+func TestBadDestination_RefusesUnauthenticated(t *testing.T) {
+	s := &ThreatDetectionServer{}
+	if _, err := s.AddBadDestination(context.Background(), &pb.AddBadDestinationRequest{Cidr: "10.0.0.0/8"}); err == nil {
+		t.Fatal("an unauthenticated caller mutated the blocklist")
+	}
+}

--- a/internal/server/compose_autostart_server.go
+++ b/internal/server/compose_autostart_server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"github.com/footprintai/containarium/internal/auth"
 	"math"
 	"strconv"
 
@@ -99,7 +100,18 @@ func (s *ComposeAutostartServer) execAgentBoxCompose(username, verb string, args
 
 // ---- Discover ------------------------------------------------------
 
-func (s *ComposeAutostartServer) Discover(_ context.Context, req *pb.DiscoverRequest) (*pb.DiscoverResponse, error) {
+// Discover reads another box's filesystem, so it is tenant-scoped despite
+// being read-only: the compose stacks on a tenant's box are that tenant's
+// business (#1716).
+func (s *ComposeAutostartServer) Discover(ctx context.Context, req *pb.DiscoverRequest) (*pb.DiscoverResponse, error) {
+	if err := auth.RequireScope(ctx, auth.ScopeContainersRead); err != nil {
+		return nil, err
+	}
+	// The username is REQUEST input and names whose box is touched, so it
+	// must be checked against the authenticated caller — not trusted.
+	if err := auth.AuthorizeTenant(ctx, req.GetUsername()); err != nil {
+		return nil, err
+	}
 	args := []string{}
 	if req.GetRoot() != "" {
 		args = append(args, "--root", req.GetRoot())
@@ -135,7 +147,18 @@ func (s *ComposeAutostartServer) Discover(_ context.Context, req *pb.DiscoverReq
 
 // ---- Enable --------------------------------------------------------
 
-func (s *ComposeAutostartServer) Enable(_ context.Context, req *pb.EnableRequest) (*pb.EnableResponse, error) {
+// Enable mutates state INSIDE a tenant's box (#1716). Before this guard any
+// caller reaching the gRPC surface could pass an arbitrary username and turn
+// compose autostart on in someone else's box.
+func (s *ComposeAutostartServer) Enable(ctx context.Context, req *pb.EnableRequest) (*pb.EnableResponse, error) {
+	if err := auth.RequireScope(ctx, auth.ScopeContainersWrite); err != nil {
+		return nil, err
+	}
+	// The username is REQUEST input and names whose box is touched, so it
+	// must be checked against the authenticated caller — not trusted.
+	if err := auth.AuthorizeTenant(ctx, req.GetUsername()); err != nil {
+		return nil, err
+	}
 	if req.GetDir() == "" {
 		return nil, status.Error(codes.InvalidArgument, "dir is required")
 	}
@@ -170,7 +193,18 @@ func (s *ComposeAutostartServer) Enable(_ context.Context, req *pb.EnableRequest
 
 // ---- Disable -------------------------------------------------------
 
-func (s *ComposeAutostartServer) Disable(_ context.Context, req *pb.DisableRequest) (*pb.DisableResponse, error) {
+// Disable mutates state inside a tenant's box (#1716). Removing autostart
+// from another tenant's stack is the more damaging direction: it is silent
+// until their services fail to come back after a reboot.
+func (s *ComposeAutostartServer) Disable(ctx context.Context, req *pb.DisableRequest) (*pb.DisableResponse, error) {
+	if err := auth.RequireScope(ctx, auth.ScopeContainersWrite); err != nil {
+		return nil, err
+	}
+	// The username is REQUEST input and names whose box is touched, so it
+	// must be checked against the authenticated caller — not trusted.
+	if err := auth.AuthorizeTenant(ctx, req.GetUsername()); err != nil {
+		return nil, err
+	}
 	if req.GetDir() == "" {
 		return nil, status.Error(codes.InvalidArgument, "dir is required")
 	}
@@ -200,7 +234,17 @@ func (s *ComposeAutostartServer) Disable(_ context.Context, req *pb.DisableReque
 
 // ---- Status --------------------------------------------------------
 
-func (s *ComposeAutostartServer) Status(_ context.Context, req *pb.StatusRequest) (*pb.StatusResponse, error) {
+// Status reports another box's compose state, so it is tenant-scoped for the
+// same reason as Discover (#1716).
+func (s *ComposeAutostartServer) Status(ctx context.Context, req *pb.StatusRequest) (*pb.StatusResponse, error) {
+	if err := auth.RequireScope(ctx, auth.ScopeContainersRead); err != nil {
+		return nil, err
+	}
+	// The username is REQUEST input and names whose box is touched, so it
+	// must be checked against the authenticated caller — not trusted.
+	if err := auth.AuthorizeTenant(ctx, req.GetUsername()); err != nil {
+		return nil, err
+	}
 	if req.GetDir() == "" {
 		return nil, status.Error(codes.InvalidArgument, "dir is required")
 	}

--- a/internal/server/compose_autostart_server_test.go
+++ b/internal/server/compose_autostart_server_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"errors"
+	"github.com/footprintai/containarium/internal/auth"
 	"strings"
 	"testing"
 
@@ -32,9 +33,29 @@ func (f *fakeExecer) ExecWithOutput(containerName string, command []string) (str
 	return f.stdout, f.stderr, f.err
 }
 
+// These handlers gained tenant + scope guards in #1716, so every call needs an
+// authenticated context. composeCallerCtx is alice acting on her OWN box with
+// both scopes — the authorized case, so these tests keep exercising the
+// command-building behaviour they were written for rather than the new gate.
+// The gate itself is tested separately in authguard_writepath_test.go.
+func composeCallerCtx() context.Context {
+	return auth.ContextWithTestSubjectScopes(context.Background(), "alice",
+		[]string{"user"}, []string{auth.ScopeContainersRead, auth.ScopeContainersWrite})
+}
+
+// composeAdminCtx reaches argument validation for requests that deliberately
+// carry no username. Auth runs BEFORE validation on purpose (the convention
+// SetTenantKMSKey states: an under-privileged caller must not get to probe
+// argument handling), so a blank username would otherwise be refused by the
+// tenant check before the validation under test ever runs.
+func composeAdminCtx() context.Context {
+	return auth.ContextWithTestSubjectScopes(context.Background(), "ops",
+		[]string{auth.RoleAdmin}, []string{auth.ScopeContainersRead, auth.ScopeContainersWrite})
+}
+
 func TestExecAgentBox_BlankUsername_InvalidArg(t *testing.T) {
 	s := NewComposeAutostartServer(&fakeExecer{})
-	_, err := s.Discover(context.Background(), &pb.DiscoverRequest{})
+	_, err := s.Discover(composeAdminCtx(), &pb.DiscoverRequest{})
 	if status.Code(err) != codes.InvalidArgument {
 		t.Errorf("code = %v, want InvalidArgument; err = %v", status.Code(err), err)
 	}
@@ -43,7 +64,7 @@ func TestExecAgentBox_BlankUsername_InvalidArg(t *testing.T) {
 func TestExecAgentBox_TransportError_Internal(t *testing.T) {
 	f := &fakeExecer{err: errors.New("ssh connection refused"), stderr: "no route to host"}
 	s := NewComposeAutostartServer(f)
-	_, err := s.Status(context.Background(), &pb.StatusRequest{Username: "alice", Dir: "/srv"})
+	_, err := s.Status(composeCallerCtx(), &pb.StatusRequest{Username: "alice", Dir: "/srv"})
 	if status.Code(err) != codes.Internal {
 		t.Errorf("code = %v, want Internal", status.Code(err))
 	}
@@ -55,7 +76,7 @@ func TestExecAgentBox_TransportError_Internal(t *testing.T) {
 func TestExecAgentBox_MalformedEnvelope_Internal(t *testing.T) {
 	f := &fakeExecer{stdout: "not json {{"}
 	s := NewComposeAutostartServer(f)
-	_, err := s.Status(context.Background(), &pb.StatusRequest{Username: "alice", Dir: "/srv"})
+	_, err := s.Status(composeCallerCtx(), &pb.StatusRequest{Username: "alice", Dir: "/srv"})
 	if status.Code(err) != codes.Internal {
 		t.Errorf("code = %v, want Internal (malformed envelope)", status.Code(err))
 	}
@@ -64,7 +85,7 @@ func TestExecAgentBox_MalformedEnvelope_Internal(t *testing.T) {
 func TestExecAgentBox_EnvelopeFalse_FailedPrecondition(t *testing.T) {
 	f := &fakeExecer{stdout: `{"ok":false,"error":"no compose runtime found on PATH"}`}
 	s := NewComposeAutostartServer(f)
-	_, err := s.Status(context.Background(), &pb.StatusRequest{Username: "alice", Dir: "/srv"})
+	_, err := s.Status(composeCallerCtx(), &pb.StatusRequest{Username: "alice", Dir: "/srv"})
 	if status.Code(err) != codes.FailedPrecondition {
 		t.Errorf("code = %v, want FailedPrecondition", status.Code(err))
 	}
@@ -76,7 +97,7 @@ func TestExecAgentBox_EnvelopeFalse_FailedPrecondition(t *testing.T) {
 func TestDiscover_BuildsCommandFromRequest(t *testing.T) {
 	f := &fakeExecer{stdout: `{"ok":true,"result":{"stacks":[]}}`}
 	s := NewComposeAutostartServer(f)
-	_, err := s.Discover(context.Background(), &pb.DiscoverRequest{
+	_, err := s.Discover(composeCallerCtx(), &pb.DiscoverRequest{
 		Username: "alice",
 		Root:     "/home/alice",
 		MaxDepth: 4,
@@ -104,7 +125,7 @@ func TestDiscover_BuildsCommandFromRequest(t *testing.T) {
 func TestDiscover_OmitsZeroValuedFlags(t *testing.T) {
 	f := &fakeExecer{stdout: `{"ok":true,"result":{"stacks":[]}}`}
 	s := NewComposeAutostartServer(f)
-	_, err := s.Discover(context.Background(), &pb.DiscoverRequest{
+	_, err := s.Discover(composeCallerCtx(), &pb.DiscoverRequest{
 		Username: "alice",
 	})
 	if err != nil {
@@ -118,7 +139,7 @@ func TestDiscover_OmitsZeroValuedFlags(t *testing.T) {
 
 func TestEnable_RequiresDir(t *testing.T) {
 	s := NewComposeAutostartServer(&fakeExecer{})
-	_, err := s.Enable(context.Background(), &pb.EnableRequest{Username: "alice"})
+	_, err := s.Enable(composeCallerCtx(), &pb.EnableRequest{Username: "alice"})
 	if status.Code(err) != codes.InvalidArgument {
 		t.Errorf("code = %v, want InvalidArgument", status.Code(err))
 	}
@@ -127,7 +148,7 @@ func TestEnable_RequiresDir(t *testing.T) {
 func TestEnable_ForceFlagPropagates(t *testing.T) {
 	f := &fakeExecer{stdout: `{"ok":true,"result":{"unit":"u","dir":"/d","compose_bin":"podman compose","already":false}}`}
 	s := NewComposeAutostartServer(f)
-	_, err := s.Enable(context.Background(), &pb.EnableRequest{
+	_, err := s.Enable(composeCallerCtx(), &pb.EnableRequest{
 		Username: "alice",
 		Dir:      "/srv/app",
 		Force:    true,
@@ -153,7 +174,7 @@ func TestEnable_MapsResultIntoProto(t *testing.T) {
 		}
 	}`}
 	s := NewComposeAutostartServer(f)
-	resp, err := s.Enable(context.Background(), &pb.EnableRequest{Username: "alice", Dir: "/srv/app"})
+	resp, err := s.Enable(composeCallerCtx(), &pb.EnableRequest{Username: "alice", Dir: "/srv/app"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -186,7 +207,7 @@ func TestStatus_MapsComposeStackFields(t *testing.T) {
 		}
 	}`}
 	s := NewComposeAutostartServer(f)
-	resp, err := s.Status(context.Background(), &pb.StatusRequest{Username: "alice", Dir: "/srv/app"})
+	resp, err := s.Status(composeCallerCtx(), &pb.StatusRequest{Username: "alice", Dir: "/srv/app"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -215,7 +236,7 @@ func TestDiscover_MapsStacksInOrder(t *testing.T) {
 		}
 	}`}
 	s := NewComposeAutostartServer(f)
-	resp, err := s.Discover(context.Background(), &pb.DiscoverRequest{Username: "alice"})
+	resp, err := s.Discover(composeCallerCtx(), &pb.DiscoverRequest{Username: "alice"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/server/threatdetect_server.go
+++ b/internal/server/threatdetect_server.go
@@ -168,6 +168,21 @@ func (s *ThreatDetectionServer) ListBadDestinations(ctx context.Context, _ *pb.L
 // and (when a DaemonConfigStore is configured) persisted across restarts —
 // no daemon rebuild required.
 func (s *ThreatDetectionServer) AddBadDestination(ctx context.Context, req *pb.AddBadDestinationRequest) (*pb.AddBadDestinationResponse, error) {
+	// Platform-wide security control, so BOTH gates (#1717). security:write
+	// matches this file's own neighbours (ListFindings/ResolveFinding); the
+	// admin role is the additional one, because unlike a finding this is not
+	// tenant data — the blocklist protects the whole fleet, and a scoped
+	// non-admin token has no business editing it.
+	//
+	// Removing an entry is the dangerous direction: adding a bad CIDR is a
+	// nuisance a tenant would notice immediately, while deleting one silently
+	// disables a detection rule and nothing looks wrong afterwards.
+	if err := auth.RequireScope(ctx, auth.ScopeSecurityWrite); err != nil {
+		return nil, err
+	}
+	if err := auth.RequireRole(ctx, auth.RoleAdmin); err != nil {
+		return nil, err
+	}
 	if s.badDestRule == nil {
 		return nil, status.Errorf(codes.Unavailable, "bad-destination rule not available")
 	}
@@ -186,6 +201,21 @@ func (s *ThreatDetectionServer) AddBadDestination(ctx context.Context, req *pb.A
 // RemoveBadDestination removes a previously operator-added entry. Baseline
 // entries cannot be removed — see BadDestinationRule.RemoveDestination.
 func (s *ThreatDetectionServer) RemoveBadDestination(ctx context.Context, req *pb.RemoveBadDestinationRequest) (*pb.RemoveBadDestinationResponse, error) {
+	// Platform-wide security control, so BOTH gates (#1717). security:write
+	// matches this file's own neighbours (ListFindings/ResolveFinding); the
+	// admin role is the additional one, because unlike a finding this is not
+	// tenant data — the blocklist protects the whole fleet, and a scoped
+	// non-admin token has no business editing it.
+	//
+	// Removing an entry is the dangerous direction: adding a bad CIDR is a
+	// nuisance a tenant would notice immediately, while deleting one silently
+	// disables a detection rule and nothing looks wrong afterwards.
+	if err := auth.RequireScope(ctx, auth.ScopeSecurityWrite); err != nil {
+		return nil, err
+	}
+	if err := auth.RequireRole(ctx, auth.RoleAdmin); err != nil {
+		return nil, err
+	}
 	if s.badDestRule == nil {
 		return nil, status.Errorf(codes.Unavailable, "bad-destination rule not available")
 	}

--- a/internal/server/threatdetect_server_test.go
+++ b/internal/server/threatdetect_server_test.go
@@ -83,6 +83,15 @@ func TestListBadDestinations_NoRule_ReturnsUnavailable(t *testing.T) {
 	}
 }
 
+// The bad-destination blocklist is fleet-wide, so mutating it now requires the
+// admin role AND security:write (#1717). These tests exercise the round-trip
+// behaviour, not the gate — the gate has its own tests in
+// authguard_writepath_test.go.
+func badDestAdminCtx() context.Context {
+	return auth.ContextWithTestSubjectScopes(context.Background(), "ops",
+		[]string{auth.RoleAdmin}, []string{auth.ScopeSecurityWrite})
+}
+
 func TestAddThenListBadDestination(t *testing.T) {
 	s := NewThreatDetectionServer(nil, false, false, "")
 	rule, err := threatdetect.NewBadDestinationRule(context.Background(), nil)
@@ -91,7 +100,7 @@ func TestAddThenListBadDestination(t *testing.T) {
 	}
 	s.SetBadDestinationRule(rule)
 
-	addResp, err := s.AddBadDestination(context.Background(), &pb.AddBadDestinationRequest{Cidr: "192.0.2.55/32", Label: "test entry"})
+	addResp, err := s.AddBadDestination(badDestAdminCtx(), &pb.AddBadDestinationRequest{Cidr: "192.0.2.55/32", Label: "test entry"})
 	if err != nil {
 		t.Fatalf("AddBadDestination: %v", err)
 	}
@@ -122,7 +131,7 @@ func TestAddBadDestination_MissingCidr(t *testing.T) {
 	}
 	s.SetBadDestinationRule(rule)
 
-	if _, err := s.AddBadDestination(context.Background(), &pb.AddBadDestinationRequest{Label: "no cidr"}); err == nil {
+	if _, err := s.AddBadDestination(badDestAdminCtx(), &pb.AddBadDestinationRequest{Label: "no cidr"}); err == nil {
 		t.Fatal("AddBadDestination with no cidr should error, got nil")
 	}
 }
@@ -135,7 +144,7 @@ func TestRemoveBadDestination_NotFound(t *testing.T) {
 	}
 	s.SetBadDestinationRule(rule)
 
-	if _, err := s.RemoveBadDestination(context.Background(), &pb.RemoveBadDestinationRequest{Cidr: "192.0.2.99/32"}); err == nil {
+	if _, err := s.RemoveBadDestination(badDestAdminCtx(), &pb.RemoveBadDestinationRequest{Cidr: "192.0.2.99/32"}); err == nil {
 		t.Fatal("RemoveBadDestination on a never-added entry should error, got nil")
 	}
 }
@@ -148,10 +157,10 @@ func TestRemoveBadDestination_RoundTrip(t *testing.T) {
 	}
 	s.SetBadDestinationRule(rule)
 
-	if _, err := s.AddBadDestination(context.Background(), &pb.AddBadDestinationRequest{Cidr: "192.0.2.55/32", Label: "temp"}); err != nil {
+	if _, err := s.AddBadDestination(badDestAdminCtx(), &pb.AddBadDestinationRequest{Cidr: "192.0.2.55/32", Label: "temp"}); err != nil {
 		t.Fatalf("AddBadDestination: %v", err)
 	}
-	if _, err := s.RemoveBadDestination(context.Background(), &pb.RemoveBadDestinationRequest{Cidr: "192.0.2.55/32"}); err != nil {
+	if _, err := s.RemoveBadDestination(badDestAdminCtx(), &pb.RemoveBadDestinationRequest{Cidr: "192.0.2.55/32"}); err != nil {
 		t.Fatalf("RemoveBadDestination: %v", err)
 	}
 	listResp, err := s.ListBadDestinations(context.Background(), &pb.ListBadDestinationsRequest{})


### PR DESCRIPTION
Closes #1716 and #1717. Both handlers reached real state with **no authorization call of any kind**.

## #1716 — ComposeAutostartService: cross-tenant box mutation

All four handlers took `_ context.Context`. That is the tell — they could not have checked anything. Each then passed `req.GetUsername()` straight to `execAgentBoxCompose`, which execs into that tenant's box.

Any caller reaching the gRPC surface could name **any** tenant and enable or disable compose autostart inside their box, or read what stacks they run.

| RPC | scope | tenant check |
| --- | --- | --- |
| `Discover` | `containers:read` | yes |
| `Status` | `containers:read` | yes |
| `Enable` | `containers:write` | yes |
| `Disable` | `containers:write` | yes |

`Discover` and `Status` are tenant-scoped despite being read-only: what a tenant runs on their own box is their business.

`Disable` is the direction worth naming — removing autostart from someone else's stack is silent until their services fail to come back after a reboot.

## #1717 — ThreatDetectionService: fleet-wide blocklist

`AddBadDestination` / `RemoveBadDestination` mutate the eBPF bad-destination blocklist. This is platform config, not tenant data, so it takes **both** `security:write` (matching `ListFindings`/`ResolveFinding` in the same file) **and** the admin role.

Adding a bad CIDR is a nuisance somebody notices. **Removing** one quietly disables a detection rule and nothing looks wrong afterwards.

## Auth before validation

Both follow the convention `SetTenantKMSKey` states explicitly: an under-privileged caller must not get to probe argument handling.

## Tests assert the denial, not the happy path

A test that only proves the right caller gets through still passes with the guard removed. Verified by removing each guard in turn:

- Without the tenant check, the compose handlers **run through to `execAgentBoxCompose` with the other tenant's username** and panic on the nil execer. That panic is itself the proof the call reached real execution rather than being denied.
- Without the role check, a non-admin holding `security:write` mutates the fleet blocklist.

Also asserted: read scope cannot mutate your own box, admin alone without the scope cannot touch the blocklist, and unauthenticated is refused everywhere.

## Collateral, handled

Existing tests for both services called the handlers with `context.Background()` and began failing — correctly, since that is now unauthorized. They carry an authorized context and keep testing the command-building behaviour they were written for. The blank-username validation test needs an **admin** context specifically, because auth now runs first and would otherwise refuse before the validation under test is reached.

## One correction to the issues

Both cite `internal/server/authcoverage_test.go` / `TestEveryRPCHasAuthGuard` as the audit that found them, and say to remove entries from its `authExemptions`. **That file does not exist**, and #1685 is still open. So there is no exemption list to update yet, and nothing currently stops a third handler shipping ungated.

## Not in this PR

- #1718's nine read-only RPCs — lower severity, separate change
- #1685's coverage test — the systematic fix; without it this class recurs

## Test plan

- [x] `go build ./... && go vet ./internal/...` clean
- [x] `internal/server` and `internal/auth` green
- [x] Each guard sabotage-verified

Pre-existing darwin-only agentbox socket-path failures reproduce on clean main and are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1554BHQdJmSXTuG1UhS3i

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Added authentication and tenant authorization to Compose autostart operations.
  - Compose discovery and status checks require container-read access; enabling and disabling autostart require container-write access.
  - Restricted threat-detection blocklist changes to authenticated administrators with security-write access.
  - Unauthorized requests now return permission-denied responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->