### PR TITLE
fix(security): require read authority on nine ungated read-only RPCs (#1718)

### DIFF
--- a/internal/server/alert_server.go
+++ b/internal/server/alert_server.go
@@ -268,6 +268,11 @@ func (s *ContainerServer) DeleteAlertRule(ctx context.Context, req *pb.DeleteAle
 
 // GetAlertingInfo returns alerting system status
 func (s *ContainerServer) GetAlertingInfo(ctx context.Context, req *pb.GetAlertingInfoRequest) (*pb.GetAlertingInfoResponse, error) {
+	// Reports alerting health, the masked webhook URL and whether a webhook
+	// secret is configured. alerts:read matches this file's own convention (#1718).
+	if err := auth.RequireScope(ctx, auth.ScopeAlertsRead); err != nil {
+		return nil, err
+	}
 	resp := &pb.GetAlertingInfoResponse{
 		Enabled: s.alertStore != nil,
 	}
@@ -349,6 +354,11 @@ func maskURL(rawURL string) string {
 
 // ListDefaultAlertRules returns the built-in default alert rules
 func (s *ContainerServer) ListDefaultAlertRules(ctx context.Context, req *pb.ListDefaultAlertRulesRequest) (*pb.ListDefaultAlertRulesResponse, error) {
+	// Static rule catalog, gated on the same read scope as the rest of this
+	// file rather than left open (#1718).
+	if err := auth.RequireScope(ctx, auth.ScopeAlertsRead); err != nil {
+		return nil, err
+	}
 	rules, err := parseDefaultAlertRules()
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to parse default rules: %v", err)

--- a/internal/server/authguard_readpath_test.go
+++ b/internal/server/authguard_readpath_test.go
@@ -1,0 +1,86 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/footprintai/containarium/internal/auth"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// #1718: nine read-only RPCs returned static or platform-wide config with no
+// authorization call at all. None are per-tenant, so the fix is a read scope
+// rather than a tenant check — but "close to public already" is not the same
+// as "reachable with no token authority", which is what they were.
+//
+// The reconnaissance value is the point: an unauthenticated caller could learn
+// which security tooling is enabled, whether an alerting webhook is
+// configured, and what the threat blocklist watches for.
+
+// wrongScopeCtx is authenticated and genuinely scoped — it just holds the
+// wrong scope. That is the realistic "least-privilege token without this
+// authority" case, and the one these guards must deny.
+//
+// NOT an empty scope set: an empty claim currently collapses to the same
+// (nil, false) as an absent one and is therefore treated as UNRESTRICTED, so a
+// test written that way would pass whether or not the guard existed. That
+// collapse contradicts ScopesFromGRPCContext's own doc comment and is filed
+// separately; it is not what #1718 is about.
+func wrongScopeCtx() context.Context {
+	return auth.ContextWithTestSubjectScopes(context.Background(), "nobody",
+		[]string{"user"}, []string{auth.ScopeBackupsRead})
+}
+
+func TestReadOnlyRPCs_RequireSomeReadAuthority(t *testing.T) {
+	cs := &ContainerServer{}
+	td := &ThreatDetectionServer{}
+
+	cases := []struct {
+		name string
+		call func(context.Context) error
+	}{
+		{"ContainerService.ListStacks", func(c context.Context) error {
+			_, err := cs.ListStacks(c, &pb.ListStacksRequest{})
+			return err
+		}},
+		{"ContainerService.GetMonitoringInfo", func(c context.Context) error {
+			_, err := cs.GetMonitoringInfo(c, &pb.GetMonitoringInfoRequest{})
+			return err
+		}},
+		{"ContainerService.GetAlertingInfo", func(c context.Context) error {
+			_, err := cs.GetAlertingInfo(c, &pb.GetAlertingInfoRequest{})
+			return err
+		}},
+		{"ContainerService.ListDefaultAlertRules", func(c context.Context) error {
+			_, err := cs.ListDefaultAlertRules(c, &pb.ListDefaultAlertRulesRequest{})
+			return err
+		}},
+		{"ThreatDetectionService.GetSentryStatus", func(c context.Context) error {
+			_, err := td.GetSentryStatus(c, &pb.GetSentryStatusRequest{})
+			return err
+		}},
+		{"ThreatDetectionService.ListBadDestinations", func(c context.Context) error {
+			_, err := td.ListBadDestinations(c, &pb.ListBadDestinationsRequest{})
+			return err
+		}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name+"/unauthenticated", func(t *testing.T) {
+			if err := c.call(context.Background()); err == nil {
+				t.Fatal("returned data to a caller with no authenticated subject")
+			}
+		})
+		t.Run(c.name+"/authenticated-wrong-scope", func(t *testing.T) {
+			err := c.call(wrongScopeCtx())
+			if err == nil {
+				t.Fatal("returned data to a caller holding only an unrelated scope")
+			}
+			if got := status.Code(err); got != codes.PermissionDenied {
+				t.Errorf("code = %v, want PermissionDenied (%v)", got, err)
+			}
+		})
+	}
+}

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -1928,6 +1928,12 @@ func (s *ContainerServer) InstallStack(ctx context.Context, req *pb.InstallStack
 // parameter schemas. The web UI uses this to render the Create Container
 // dialog's stack dropdown and any dynamically-shown parameter inputs.
 func (s *ContainerServer) ListStacks(ctx context.Context, req *pb.ListStacksRequest) (*pb.ListStacksResponse, error) {
+	// Static built-in stack catalog, but still behind a read scope (#1718):
+	// before this, any caller reaching the surface got it with no token authority
+	// at all.
+	if err := auth.RequireScope(ctx, auth.ScopeContainersRead); err != nil {
+		return nil, err
+	}
 	mgr := stacks.GetDefault()
 	all := mgr.GetAllStacks()
 
@@ -4221,6 +4227,11 @@ func (s *ContainerServer) SetMonitoringURLs(victoriaMetricsURL, grafanaURL strin
 
 // GetMonitoringInfo returns monitoring configuration (Grafana/VictoriaMetrics URLs)
 func (s *ContainerServer) GetMonitoringInfo(ctx context.Context, req *pb.GetMonitoringInfoRequest) (*pb.GetMonitoringInfoResponse, error) {
+	// Discloses the Grafana/VictoriaMetrics endpoints and whether monitoring is
+	// on — reconnaissance value, so it needs some read authority (#1718).
+	if err := auth.RequireScope(ctx, auth.ScopeContainersRead); err != nil {
+		return nil, err
+	}
 	return &pb.GetMonitoringInfoResponse{
 		Enabled:            s.victoriaMetricsURL != "",
 		GrafanaUrl:         s.grafanaURL,

--- a/internal/server/network_server.go
+++ b/internal/server/network_server.go
@@ -1010,6 +1010,11 @@ func (s *NetworkServer) GetNetworkTopology(ctx context.Context, req *pb.GetNetwo
 
 // ListACLPresets lists available firewall presets
 func (s *NetworkServer) ListACLPresets(ctx context.Context, req *pb.ListACLPresetsRequest) (*pb.ListACLPresetsResponse, error) {
+	// Static ACL preset list. routes:read is what every other read in this file
+	// uses (#1718).
+	if err := auth.RequireScope(ctx, auth.ScopeRoutesRead); err != nil {
+		return nil, err
+	}
 	presets := []*pb.ACLPresetInfo{
 		{
 			Preset:      pb.ACLPreset_ACL_PRESET_FULL_ISOLATION,

--- a/internal/server/pentest_server.go
+++ b/internal/server/pentest_server.go
@@ -241,6 +241,11 @@ func (s *PentestServer) SuppressPentestFinding(ctx context.Context, req *pb.Supp
 // availability + module names, no tenant or finding data.
 // Any authenticated user can discover whether scanning is on.
 func (s *PentestServer) GetPentestConfig(ctx context.Context, req *pb.GetPentestConfigRequest) (*pb.GetPentestConfigResponse, error) {
+	// Reveals whether pentesting is enabled, its interval, and which scanners are
+	// available — precisely the reconnaissance #1718 is about.
+	if err := auth.RequireScope(ctx, auth.ScopeSecurityRead); err != nil {
+		return nil, err
+	}
 	config := &pb.PentestConfig{
 		Enabled: s.manager != nil,
 	}

--- a/internal/server/threatdetect_server.go
+++ b/internal/server/threatdetect_server.go
@@ -101,6 +101,11 @@ func (s *ThreatDetectionServer) SetUnavailable(reason string) {
 // backend that can't detect anything — DISABLED and UNAVAILABLE are
 // distinct, explicit states from OK/DEGRADED (design doc).
 func (s *ThreatDetectionServer) GetSentryStatus(ctx context.Context, _ *pb.GetSentryStatusRequest) (*pb.GetSentryStatusResponse, error) {
+	// Reveals whether the eBPF threat sentry is enabled and, if not, why —
+	// telling an attacker which detection is off (#1718).
+	if err := auth.RequireScope(ctx, auth.ScopeSecurityRead); err != nil {
+		return nil, err
+	}
 	s.mu.Lock()
 	ebpfAvailable, unavailableReason := s.ebpfAvailable, s.unavailableReason
 	s.mu.Unlock()
@@ -153,6 +158,11 @@ func (s *ThreatDetectionServer) GetSentryStatus(ctx context.Context, _ *pb.GetSe
 // known-bad-destination list the bad-destination rule (#1641) matches
 // against.
 func (s *ThreatDetectionServer) ListBadDestinations(ctx context.Context, _ *pb.ListBadDestinationsRequest) (*pb.ListBadDestinationsResponse, error) {
+	// The blocklist's current entries. Reading is far less damaging than the
+	// mutations gated in #1717, but it still shows what is being watched for.
+	if err := auth.RequireScope(ctx, auth.ScopeSecurityRead); err != nil {
+		return nil, err
+	}
 	if s.badDestRule == nil {
 		return nil, status.Errorf(codes.Unavailable, "bad-destination rule not available")
 	}

--- a/internal/server/threatdetect_server_test.go
+++ b/internal/server/threatdetect_server_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestGetSentryStatus_Disabled(t *testing.T) {
 	s := NewThreatDetectionServer(nil, false, false, "")
-	resp, err := s.GetSentryStatus(context.Background(), &pb.GetSentryStatusRequest{})
+	resp, err := s.GetSentryStatus(secReadCtx(), &pb.GetSentryStatusRequest{})
 	if err != nil {
 		t.Fatalf("GetSentryStatus: %v", err)
 	}
@@ -32,7 +32,7 @@ func TestGetSentryStatus_Disabled(t *testing.T) {
 // never silently "no findings" — the #1640 acceptance criterion.
 func TestGetSentryStatus_UnavailableWithoutEBPF(t *testing.T) {
 	s := NewThreatDetectionServer(nil, true, false, "eBPF object not loaded (set CONTAINARIUM_NETWORK_POLICY_BPF_OBJECT)")
-	resp, err := s.GetSentryStatus(context.Background(), &pb.GetSentryStatusRequest{})
+	resp, err := s.GetSentryStatus(secReadCtx(), &pb.GetSentryStatusRequest{})
 	if err != nil {
 		t.Fatalf("GetSentryStatus: %v", err)
 	}
@@ -47,7 +47,7 @@ func TestGetSentryStatus_UnavailableWithoutEBPF(t *testing.T) {
 func TestGetSentryStatus_Degraded(t *testing.T) {
 	engine := threatdetect.NewEngine(&fakeFindingSink{}, "backend-1", true /* degraded */, nil, nil)
 	s := NewThreatDetectionServer(engine, true, true, "")
-	resp, err := s.GetSentryStatus(context.Background(), &pb.GetSentryStatusRequest{})
+	resp, err := s.GetSentryStatus(secReadCtx(), &pb.GetSentryStatusRequest{})
 	if err != nil {
 		t.Fatalf("GetSentryStatus: %v", err)
 	}
@@ -64,7 +64,7 @@ func TestGetSentryStatus_OKWithRuleHealth(t *testing.T) {
 	engine.Register(&fakeRule{id: pb.ThreatRuleId_THREAT_RULE_ID_BAD_DESTINATION})
 	s := NewThreatDetectionServer(engine, true, true, "")
 
-	resp, err := s.GetSentryStatus(context.Background(), &pb.GetSentryStatusRequest{})
+	resp, err := s.GetSentryStatus(secReadCtx(), &pb.GetSentryStatusRequest{})
 	if err != nil {
 		t.Fatalf("GetSentryStatus: %v", err)
 	}
@@ -78,7 +78,7 @@ func TestGetSentryStatus_OKWithRuleHealth(t *testing.T) {
 
 func TestListBadDestinations_NoRule_ReturnsUnavailable(t *testing.T) {
 	s := NewThreatDetectionServer(nil, false, false, "")
-	if _, err := s.ListBadDestinations(context.Background(), &pb.ListBadDestinationsRequest{}); err == nil {
+	if _, err := s.ListBadDestinations(secReadCtx(), &pb.ListBadDestinationsRequest{}); err == nil {
 		t.Fatal("ListBadDestinations with no rule wired should error, got nil")
 	}
 }
@@ -87,6 +87,12 @@ func TestListBadDestinations_NoRule_ReturnsUnavailable(t *testing.T) {
 // admin role AND security:write (#1717). These tests exercise the round-trip
 // behaviour, not the gate — the gate has its own tests in
 // authguard_writepath_test.go.
+// GetSentryStatus and ListBadDestinations gained security:read in #1718.
+func secReadCtx() context.Context {
+	return auth.ContextWithTestSubjectScopes(context.Background(), "ops",
+		[]string{"user"}, []string{auth.ScopeSecurityRead})
+}
+
 func badDestAdminCtx() context.Context {
 	return auth.ContextWithTestSubjectScopes(context.Background(), "ops",
 		[]string{auth.RoleAdmin}, []string{auth.ScopeSecurityWrite})
@@ -108,7 +114,7 @@ func TestAddThenListBadDestination(t *testing.T) {
 		t.Errorf("AddBadDestination entry = %+v, want cidr=192.0.2.55/32 source=operator", addResp.GetEntry())
 	}
 
-	listResp, err := s.ListBadDestinations(context.Background(), &pb.ListBadDestinationsRequest{})
+	listResp, err := s.ListBadDestinations(secReadCtx(), &pb.ListBadDestinationsRequest{})
 	if err != nil {
 		t.Fatalf("ListBadDestinations: %v", err)
 	}
@@ -163,7 +169,7 @@ func TestRemoveBadDestination_RoundTrip(t *testing.T) {
 	if _, err := s.RemoveBadDestination(badDestAdminCtx(), &pb.RemoveBadDestinationRequest{Cidr: "192.0.2.55/32"}); err != nil {
 		t.Fatalf("RemoveBadDestination: %v", err)
 	}
-	listResp, err := s.ListBadDestinations(context.Background(), &pb.ListBadDestinationsRequest{})
+	listResp, err := s.ListBadDestinations(secReadCtx(), &pb.ListBadDestinationsRequest{})
 	if err != nil {
 		t.Fatalf("ListBadDestinations: %v", err)
 	}

--- a/internal/server/zap_server.go
+++ b/internal/server/zap_server.go
@@ -177,6 +177,10 @@ func (s *ZapServer) SuppressZapAlert(ctx context.Context, req *pb.SuppressZapAle
 // Any authenticated user can call it to discover whether
 // scanning is enabled.
 func (s *ZapServer) GetZapConfig(ctx context.Context, req *pb.GetZapConfigRequest) (*pb.GetZapConfigResponse, error) {
+	// Reveals whether ZAP scanning is enabled and available (#1718).
+	if err := auth.RequireScope(ctx, auth.ScopeSecurityRead); err != nil {
+		return nil, err
+	}
 	config := &pb.ZapConfig{
 		Enabled: s.manager != nil,
 	}


### PR DESCRIPTION
Closes #1718. Stacks on #1720.

Nine handlers returned static or platform-wide config with **no authorization call at all** — reachable by any caller who got to the gRPC surface, whatever their token carried.

## Scope per file convention, not one blanket choice

| scope | RPCs |
| --- | --- |
| `containers:read` | `ListStacks`, `GetMonitoringInfo` |
| `alerts:read` | `GetAlertingInfo`, `ListDefaultAlertRules` |
| `routes:read` | `ListACLPresets` |
| `security:read` | `GetPentestConfig`, `GetZapConfig`, `GetSentryStatus`, `ListBadDestinations` |

Each matches what its own file already uses for reads, so nothing here invents a new convention.

## What actually leaked

Several are close to public already — a catalog of built-in stacks, static ACL presets. The ones that matter disclose **which security tooling is enabled and configured**: whether pentesting and ZAP run and with which scanners, whether the eBPF sentry is up and if not why, whether an alerting webhook secret exists, and what the threat blocklist watches for.

That is reconnaissance, and it was available without holding any scope.

## A separate bug found while testing this

An **explicitly empty** scopes claim collapses to the same `(nil, false)` as an absent one, and is therefore treated as unrestricted:

```
nil (claim absent)   -> present=false  RequireScope=ALLOWED
explicitly empty     -> present=false  RequireScope=ALLOWED
unrelated scope held -> present=true   RequireScope=denied
```

`ScopesFromGRPCContext`'s own doc comment promises the opposite:

> Returns (nil, false) when the claim wasn't carried — distinct from (empty, true) which would mean an explicit empty grant.

The distinction is documented but not implemented. Filing separately — it is not what this issue is about, and it is the same family as the empty-grant trap in #1713 and cloud#1428.

**It does shape the tests here.** My first version asserted with an empty scope set and failed against a correct implementation, because such a caller is treated as unrestricted — that test would have passed whether or not the guard existed. The tests now use a caller holding an *unrelated* scope: genuinely authenticated, genuinely scoped, just not for this. That is the realistic least-privilege case and the one that must be denied.

Verified by removing two guards in turn; three subtests fail each time.

## Collateral, handled

Existing `GetSentryStatus` and `ListBadDestinations` tests called the handlers with `context.Background()` and now carry a `security:read` context.

## Test plan

- [x] `go build ./... && go vet ./internal/server/` clean
- [x] `internal/server` green
- [x] Two guards sabotage-verified
- [x] Both unauthenticated and wrong-scope callers asserted denied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1554BHQdJmSXTuG1UhS3i

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added scope-based authorization to alerting, container, network, pentest, threat-detection, and security configuration endpoints.
  * Restricted container operations to authorized tenants.
  * Required elevated permissions for threat-detection blocklist changes.

* **Tests**
  * Added coverage for unauthenticated access, insufficient scopes, tenant isolation, and administrative requirements across read and write operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->