### PR TITLE
docs(security): route vulnerability reports to security@containarium.dev

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,8 +10,21 @@ or pull request that describes the vulnerability.**
 
 - **Preferred:** GitHub's private vulnerability reporting at
   <https://github.com/FootprintAI/Containarium/security/advisories/new>.
-- **Email:** `devops@footprint-ai.com` (use the subject prefix
-  `[security]` and include `Containarium` so it's routed correctly).
+- **Email:** `security@containarium.dev` — a dedicated address, so a
+  report is never missed in a general-purpose inbox and never depends on
+  one person being available. No subject prefix needed; everything sent
+  there is triaged as a security report.
+
+### This applies to us too
+
+The rule above is not only for external reporters. A vulnerability found by
+a maintainer, an internal audit, or an automated sweep goes through the same
+private channel — **this repository is public, so an issue describing an
+unguarded code path is a disclosure regardless of who opened it**, and it is
+a disclosure that lands before a fix is released rather than after.
+
+File the tracking issue once a fix has shipped, describing what changed
+rather than what was reachable.
 
 In your report, please include:
 


### PR DESCRIPTION
Two changes to `SECURITY.md`.

## The reporting address

`devops@footprint-ai.com` → **`security@containarium.dev`**, a dedicated mailbox rather than a general-purpose one. A report is then not missed among ordinary traffic and does not depend on one person being available. The subject-prefix instruction goes away with it — everything sent to that address is triaged as a security report.

GitHub's private vulnerability reporting stays listed as the preferred route.

## The policy now says it binds maintainers too

This is the part worth reviewing.

The existing text already said *"Do not open a public issue, discussion, or pull request that describes the vulnerability."* It read as advice to outside reporters, and in practice it did not hold internally:

| issue | what it published |
| --- | --- |
| #1716 | named four RPCs that took an arbitrary username with no auth guard, and what each let you do to another tenant's box |
| #1717 | named the two handlers that mutated the fleet blocklist ungated, and noted removal silently disables a detection rule |
| #1718 | tabulated nine ungated RPCs and exactly what each disclosed |

All three were opened as **public issues on this public repository, before any fix was released**. Each is a working description of how to reach an unguarded path, published during the window where it was still reachable.

The added section says plainly that a finding from a maintainer, an internal audit, or an automated sweep goes through the same private channel, because the repository being public makes it a disclosure regardless of who opened it — and that the tracking issue is filed once the fix has shipped, describing what changed rather than what was reachable.

## Not addressed here

Whether to retroactively do anything about #1716/#1717/#1718 — redact, or leave them since the fixes are now merged on `main`. Worth a decision, but it is an operational call rather than a docs change, and I did not want to make it unilaterally.

Those fixes are also **merged but not released**: v0.73.0 was tagged before them, so the described paths are still open on the deployed fleet while the public issues describing them remain up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1554BHQdJmSXTuG1UhS3i

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the security contact to a dedicated email address.
  - Simplified vulnerability reporting requirements by removing mandatory subject prefixes and project names.
  - Clarified private reporting expectations and post-release tracking practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->