### PR TITLE
feat(audit): anchor the hash chain's root outside the database (#1706)

### DIFF
--- a/docs/security/OPERATOR-SECURITY-RUNBOOK.md
+++ b/docs/security/OPERATOR-SECURITY-RUNBOOK.md
@@ -1164,6 +1164,39 @@ If the chain is broken:
 3. Restore the table from the most recent verified backup (the
    chain root from the backup is the authoritative "good" state).
 
+### The gap `audit verify` alone cannot close
+
+`audit verify` only proves internal consistency. Someone with
+Postgres write access can edit a row and then correctly recompute
+every `row_hash` after it — the chain that produces is internally
+consistent by construction, so `audit verify` reports "intact" even
+though a row was rewritten.
+
+The daemon closes this by periodically publishing the chain's
+current tip to a local file Postgres has no access to
+(`CONTAINARIUM_AUDIT_ANCHOR_PATH`, default
+`/var/lib/containarium/audit-anchors.jsonl`; cadence
+`CONTAINARIUM_AUDIT_ANCHOR_INTERVAL`, default 15m). Run:
+
+```bash
+containarium audit verify-anchor
+```
+
+This re-reads the row at the last anchored checkpoint from the
+database and compares it against the anchored value — catching
+exactly the rewrite-and-recompute case `audit verify` cannot — and
+also re-runs internal consistency for everything logged since that
+checkpoint. A rewrite of a row anchored less than one anchoring
+interval ago is undetectable until the next anchor publishes a
+checkpoint past it; that window is inherent to periodic anchoring,
+not a bug.
+
+The anchor file itself is only as trustworthy as the host's
+filesystem permissions — it defends against a Postgres-privileged
+attacker, not a host-root one who could edit both. Back it up
+off-host (it's a plain append-only JSON-lines file) for anything
+stronger.
+
 ---
 
 ## References

--- a/internal/audit/anchor.go
+++ b/internal/audit/anchor.go
@@ -1,0 +1,300 @@
+package audit
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// #1706 — anchoring the hash chain's root outside the database.
+//
+// hash_chain.go's own doc comment already named the gap: "Append-only
+// forensics (push the chain root to an external sink periodically) detects
+// deletions on top of this; that's tracked separately." This is that.
+//
+// The chain (hash_chain.go) is tamper-evident against an application-level
+// attacker: editing a row breaks VerifyChain from that point forward. It is
+// SILENT against a privileged one — an operator with Postgres write access
+// can rewrite a row and recompute every hash after it, and internal
+// consistency alone can't tell the difference between "untouched" and
+// "tampered, then correctly recomputed." The only thing that can tell the
+// difference is a copy of an old hash value held somewhere the rewriter
+// doesn't control. That's what RootSink is for.
+//
+// Design choice: the default sink (FileSink) is a local append-only file,
+// not an object-store upload or a co-signed timestamp (the issue's other
+// two suggested shapes). It satisfies the THREAT MODEL AS STATED — "an
+// operator with write access to Postgres" — since a Postgres credential
+// grants no access to the daemon host's filesystem. It does not defend
+// against a full host-root attacker (who could edit both); that is a
+// materially larger threat model than #1706 asks for, and the RootSink
+// interface is the seam a stronger backend (object-store-with-versioning,
+// a remote co-signed timestamp service) would slot into without changing
+// anything else — AnchorManager and VerifyChainAgainstAnchor talk to the
+// interface, not the file.
+
+// RootSink durably records the hash chain's current tip. Implementations
+// MUST reject a call whose checkpoint was already published with a
+// DIFFERENT root — accepting one would let a second, conflicting write
+// silently replace the first, defeating the entire point of anchoring.
+// Republishing the SAME (checkpoint, root) pair is a safe no-op.
+type RootSink interface {
+	// PublishRoot records that as of audit-log row id `checkpoint`, the
+	// chain's row_hash was `root`.
+	PublishRoot(ctx context.Context, checkpoint int64, root string) error
+	// LastPublished returns the most recently published (checkpoint,
+	// root), or ok=false if nothing has ever been published.
+	LastPublished(ctx context.Context) (checkpoint int64, root string, ok bool, err error)
+}
+
+// ErrAnchorConflict is returned by PublishRoot when checkpoint was already
+// published with a different root than the one now being published.
+var ErrAnchorConflict = errors.New("audit: checkpoint already anchored with a different root")
+
+// anchorRecord is FileSink's on-disk line shape: one JSON object per line,
+// append-only. AnchoredAt is informational only (not part of what's
+// verified) — it lets an operator eyeball how stale the last anchor is
+// without decoding a hash.
+type anchorRecord struct {
+	Checkpoint int64  `json:"checkpoint"`
+	Root       string `json:"root"`
+	AnchoredAt string `json:"anchored_at"`
+}
+
+// FileSink is the default RootSink: an append-only local file, opened
+// O_APPEND for every write so a partial write from a crash can only ever
+// truncate the LAST line, never corrupt an earlier one. Read side skips a
+// trailing line that doesn't parse, rather than treating it as evidence the
+// whole file is compromised (see lastPublishedLocked).
+type FileSink struct {
+	path string
+	mu   sync.Mutex
+}
+
+// NewFileSink builds a FileSink at path, creating its parent directory
+// (0750) if needed. Does not create or touch the file itself — an absent
+// file is a legitimate "never anchored yet" state (LastPublished reports
+// ok=false), not an error.
+func NewFileSink(path string) (*FileSink, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, fmt.Errorf("audit: anchor file path required")
+	}
+	if dir := filepath.Dir(path); dir != "." {
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			return nil, fmt.Errorf("audit: create anchor directory %q: %w", dir, err)
+		}
+	}
+	return &FileSink{path: path}, nil
+}
+
+func (f *FileSink) PublishRoot(_ context.Context, checkpoint int64, root string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	lastCheckpoint, lastRoot, ok, err := f.lastPublishedLocked()
+	if err != nil {
+		return err
+	}
+	if ok {
+		switch {
+		case checkpoint < lastCheckpoint:
+			return fmt.Errorf("audit: refusing to anchor checkpoint %d, older than the last anchored checkpoint %d",
+				checkpoint, lastCheckpoint)
+		case checkpoint == lastCheckpoint:
+			if root == lastRoot {
+				return nil // idempotent — nothing to do
+			}
+			return fmt.Errorf("%w: checkpoint=%d", ErrAnchorConflict, checkpoint)
+		}
+	}
+
+	rec := anchorRecord{Checkpoint: checkpoint, Root: root, AnchoredAt: time.Now().UTC().Format(time.RFC3339Nano)}
+	line, err := json.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("audit: marshal anchor record: %w", err)
+	}
+	fh, err := os.OpenFile(f.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("audit: open anchor file: %w", err)
+	}
+	defer func() { _ = fh.Close() }()
+	if _, err := fh.Write(append(line, '\n')); err != nil {
+		return fmt.Errorf("audit: append anchor record: %w", err)
+	}
+	return nil
+}
+
+func (f *FileSink) LastPublished(_ context.Context) (int64, string, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.lastPublishedLocked()
+}
+
+// lastPublishedLocked scans every line for the last one that parses as a
+// valid anchorRecord. A truncated or corrupt trailing line — the only shape
+// of damage an O_APPEND-only writer can produce from a crash mid-write — is
+// skipped rather than failing the whole read: the write before it is still
+// the authoritative last-known-good anchor, and losing that on a truncated
+// tail would be strictly worse than ignoring one bad line.
+func (f *FileSink) lastPublishedLocked() (int64, string, bool, error) {
+	data, err := os.ReadFile(f.path)
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, "", false, nil
+	}
+	if err != nil {
+		return 0, "", false, fmt.Errorf("audit: read anchor file: %w", err)
+	}
+	lines := strings.Split(string(data), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+		var rec anchorRecord
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			continue
+		}
+		return rec.Checkpoint, rec.Root, true, nil
+	}
+	return 0, "", false, nil
+}
+
+// ChainStore is the narrow slice of *Store the anchor manager needs, kept
+// as an interface so unit tests fake it without a real Postgres — mirrors
+// internal/ttlsweeper's IncusClient/Deleter seams.
+type ChainStore interface {
+	MaxRowID(ctx context.Context) (int64, error)
+	RowHashAt(ctx context.Context, id int64) (hash string, found bool, err error)
+}
+
+// DefaultAnchorInterval is the tick cadence. This IS the exposure window
+// the issue asks to have "stated and bounded": a privileged rewrite of a
+// row anchored less than one interval ago is undetectable by
+// VerifyChainAgainstAnchor until the NEXT tick publishes a newer
+// checkpoint past it. 15 minutes bounds that window without anchoring on
+// every single audit-log write, which would turn every write into two.
+const DefaultAnchorInterval = 15 * time.Minute
+
+// AnchorOptions bundles the optional knobs. Production callers should pass
+// zero values to get DefaultAnchorInterval and time.Now.
+type AnchorOptions struct {
+	Interval time.Duration
+	Clock    func() time.Time
+}
+
+// AnchorManager owns the tick loop that keeps a RootSink current. One
+// Manager per daemon, alongside the other ticker managers (ttlsweeper,
+// autosleep) — same Start(ctx)/Stop() lifecycle.
+type AnchorManager struct {
+	store ChainStore
+	sink  RootSink
+
+	interval time.Duration
+	clock    func() time.Time
+
+	stopCh   chan struct{}
+	done     chan struct{}
+	stopOnce sync.Once
+
+	// lastCheckpoint short-circuits a tick when nothing new has been
+	// logged since the last successful publish. Touched only from the
+	// single run goroutine's tick, so it needs no lock (mirrors
+	// ttlsweeper.Manager.failures).
+	lastCheckpoint int64
+}
+
+// NewAnchorManager constructs a manager. Neither store nor sink may be
+// nil — an anchor manager with nowhere to read from or write to has
+// nothing useful to do, and silently degrading would hide a wiring bug in
+// daemon startup (same rationale as ttlsweeper.NewManager's panics).
+func NewAnchorManager(store ChainStore, sink RootSink, opts AnchorOptions) *AnchorManager {
+	if store == nil {
+		panic("audit: nil ChainStore")
+	}
+	if sink == nil {
+		panic("audit: nil RootSink")
+	}
+	if opts.Interval <= 0 {
+		opts.Interval = DefaultAnchorInterval
+	}
+	if opts.Clock == nil {
+		opts.Clock = time.Now
+	}
+	return &AnchorManager{
+		store:    store,
+		sink:     sink,
+		interval: opts.Interval,
+		clock:    opts.Clock,
+		stopCh:   make(chan struct{}),
+		done:     make(chan struct{}),
+	}
+}
+
+// Start spawns the tick loop. Returns immediately.
+func (m *AnchorManager) Start(ctx context.Context) {
+	go m.run(ctx)
+	log.Printf("[audit-anchor] ticker started (interval=%s) — a privileged rewrite is undetectable only within this window", m.interval)
+}
+
+// Stop signals the loop to exit and waits for it to finish. Idempotent.
+func (m *AnchorManager) Stop() {
+	m.stopOnce.Do(func() { close(m.stopCh) })
+	<-m.done
+}
+
+func (m *AnchorManager) run(ctx context.Context) {
+	defer close(m.done)
+	t := time.NewTicker(m.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-m.stopCh:
+			return
+		case <-t.C:
+			m.tick(ctx)
+		}
+	}
+}
+
+// tick publishes a new anchor at the chain's current tail, if the tail has
+// advanced since the last successful publish. Every failure is logged
+// loud and the loop continues — per #1706's "anchor failures are loud,"
+// not "anchor failures are fatal": losing tamper-evidence against a
+// privileged rewrite is bad, but taking the daemon down over a full disk
+// is worse.
+func (m *AnchorManager) tick(ctx context.Context) {
+	id, err := m.store.MaxRowID(ctx)
+	if err != nil {
+		log.Printf("[audit-anchor] ERROR: read max row id: %v — anchor NOT updated, tamper-evidence against a privileged rewrite is degraded until the next successful tick", err)
+		return
+	}
+	if id == 0 || id == m.lastCheckpoint {
+		return // empty chain, or nothing new since the last anchor
+	}
+	root, found, err := m.store.RowHashAt(ctx, id)
+	if err != nil {
+		log.Printf("[audit-anchor] ERROR: read row hash at checkpoint %d: %v", id, err)
+		return
+	}
+	if !found {
+		// The row MaxRowID just reported no longer exists — a concurrent
+		// delete raced us, or the table was truncated. Anchoring a
+		// nonexistent checkpoint would be worse than not anchoring at all.
+		log.Printf("[audit-anchor] ERROR: checkpoint %d reported by MaxRowID no longer exists in audit_logs", id)
+		return
+	}
+	if err := m.sink.PublishRoot(ctx, id, root); err != nil {
+		log.Printf("[audit-anchor] ERROR: publish anchor at checkpoint %d: %v — tamper-evidence against a privileged rewrite is degraded until this succeeds", id, err)
+		return
+	}
+	m.lastCheckpoint = id
+}

--- a/internal/audit/anchor_test.go
+++ b/internal/audit/anchor_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 )
@@ -197,7 +198,15 @@ func (f *fakeChainStore) RowHashAt(_ context.Context, id int64) (string, bool, e
 	return h, ok, nil
 }
 
+// fakeSink is deliberately mutex-protected, not just a plain slice: unlike
+// every other test in this file, TestAnchorManager_StartStop reads it from
+// a SEPARATE goroutine than the one Start spawns to write it, and CI's race
+// detector caught exactly that the first time this went unprotected — a
+// real bug in the test, not a false alarm, since a live AnchorManager's
+// tick goroutine and anything polling its sink genuinely do race without
+// synchronization of their own.
 type fakeSink struct {
+	mu        sync.Mutex
 	published []struct {
 		checkpoint int64
 		root       string
@@ -206,6 +215,8 @@ type fakeSink struct {
 }
 
 func (f *fakeSink) PublishRoot(_ context.Context, checkpoint int64, root string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if f.publishErr != nil {
 		return f.publishErr
 	}
@@ -217,11 +228,23 @@ func (f *fakeSink) PublishRoot(_ context.Context, checkpoint int64, root string)
 }
 
 func (f *fakeSink) LastPublished(context.Context) (int64, string, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if len(f.published) == 0 {
 		return 0, "", false, nil
 	}
 	last := f.published[len(f.published)-1]
 	return last.checkpoint, last.root, true, nil
+}
+
+// Count and At are the synchronized accessors tests use — direct field
+// access on .published from more than one goroutine is exactly the bug
+// above; single-goroutine tests may still index .published directly since
+// nothing else touches it concurrently there.
+func (f *fakeSink) Count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.published)
 }
 
 func TestAnchorManager_PublishesNewCheckpoint(t *testing.T) {
@@ -310,7 +333,7 @@ func TestAnchorManager_StartStop(t *testing.T) {
 	m.Start(ctx)
 	go func() {
 		for i := 0; i < 50; i++ {
-			if len(sink.published) > 0 {
+			if sink.Count() > 0 {
 				fired <- struct{}{}
 				return
 			}

--- a/internal/audit/anchor_test.go
+++ b/internal/audit/anchor_test.go
@@ -1,0 +1,327 @@
+package audit
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// #1706: the hash chain's root never leaves the database, so a Postgres-
+// privileged operator can rewrite a row and recompute the chain forward
+// undetectably. FileSink is the default external sink — an append-only
+// file outside Postgres's reach — and AnchorManager is the periodic loop
+// that keeps it current.
+
+func tempSink(t *testing.T) *FileSink {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "anchors.jsonl")
+	s, err := NewFileSink(path)
+	if err != nil {
+		t.Fatalf("NewFileSink: %v", err)
+	}
+	return s
+}
+
+func TestFileSink_EmptyFileNotPublished(t *testing.T) {
+	s := tempSink(t)
+	_, _, ok, err := s.LastPublished(context.Background())
+	if err != nil {
+		t.Fatalf("LastPublished: %v", err)
+	}
+	if ok {
+		t.Fatal("ok = true for a sink that was never published to")
+	}
+}
+
+func TestFileSink_PublishAndLastPublished(t *testing.T) {
+	s := tempSink(t)
+	ctx := context.Background()
+	if err := s.PublishRoot(ctx, 10, "hash-at-10"); err != nil {
+		t.Fatalf("PublishRoot: %v", err)
+	}
+	cp, root, ok, err := s.LastPublished(ctx)
+	if err != nil {
+		t.Fatalf("LastPublished: %v", err)
+	}
+	if !ok || cp != 10 || root != "hash-at-10" {
+		t.Fatalf("LastPublished = (%d, %q, %v), want (10, %q, true)", cp, root, ok, "hash-at-10")
+	}
+}
+
+func TestFileSink_AdvancesAcrossMultiplePublishes(t *testing.T) {
+	s := tempSink(t)
+	ctx := context.Background()
+	if err := s.PublishRoot(ctx, 10, "hash-at-10"); err != nil {
+		t.Fatalf("first publish: %v", err)
+	}
+	if err := s.PublishRoot(ctx, 20, "hash-at-20"); err != nil {
+		t.Fatalf("second publish: %v", err)
+	}
+	cp, root, ok, err := s.LastPublished(ctx)
+	if err != nil || !ok || cp != 20 || root != "hash-at-20" {
+		t.Fatalf("LastPublished = (%d, %q, %v, %v), want (20, %q, true, nil)", cp, root, ok, err, "hash-at-20")
+	}
+}
+
+// Republishing the exact same checkpoint+root is a no-op — the manager's
+// own "skip if nothing new" check should make this rare, but the sink
+// enforces it independently rather than trusting every future caller to
+// get that right.
+func TestFileSink_IdempotentRepublish(t *testing.T) {
+	s := tempSink(t)
+	ctx := context.Background()
+	if err := s.PublishRoot(ctx, 10, "hash-at-10"); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	if err := s.PublishRoot(ctx, 10, "hash-at-10"); err != nil {
+		t.Fatalf("idempotent republish should not error: %v", err)
+	}
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		t.Fatalf("read anchor file: %v", err)
+	}
+	if got := len(splitNonEmptyLines(string(data))); got != 1 {
+		t.Errorf("anchor file has %d lines, want 1 — a duplicate publish should not grow it", got)
+	}
+}
+
+// The whole point of anchoring: a checkpoint, once published, can never be
+// silently replaced by a different root. This is the guard that makes the
+// anchor trustworthy even if the daemon itself is later compromised and
+// tries to re-anchor over its own history.
+func TestFileSink_RejectsConflictingRoot(t *testing.T) {
+	s := tempSink(t)
+	ctx := context.Background()
+	if err := s.PublishRoot(ctx, 10, "hash-at-10"); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	err := s.PublishRoot(ctx, 10, "a-different-hash")
+	if err == nil {
+		t.Fatal("republishing checkpoint 10 with a different root succeeded — this defeats the anchor's purpose")
+	}
+	if !errors.Is(err, ErrAnchorConflict) {
+		t.Errorf("err = %v, want ErrAnchorConflict", err)
+	}
+	// The conflicting write must not have landed.
+	_, root, _, _ := s.LastPublished(ctx)
+	if root != "hash-at-10" {
+		t.Errorf("root = %q after a rejected conflicting publish, want the original", root)
+	}
+}
+
+func TestFileSink_RejectsOlderCheckpoint(t *testing.T) {
+	s := tempSink(t)
+	ctx := context.Background()
+	if err := s.PublishRoot(ctx, 20, "hash-at-20"); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	if err := s.PublishRoot(ctx, 10, "hash-at-10"); err == nil {
+		t.Fatal("publishing an older checkpoint after a newer one succeeded")
+	}
+}
+
+// An append-only file can end mid-write after a crash. The last COMPLETE
+// line is still the authoritative anchor; a truncated trailing line must
+// not be mistaken for corruption of the whole history.
+func TestFileSink_SkipsCorruptTrailingLine(t *testing.T) {
+	s := tempSink(t)
+	ctx := context.Background()
+	if err := s.PublishRoot(ctx, 10, "hash-at-10"); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	f, err := os.OpenFile(s.path, os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		t.Fatalf("open for corruption: %v", err)
+	}
+	if _, err := f.WriteString(`{"checkpoint":20,"root":"trunc`); err != nil {
+		t.Fatalf("write partial line: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	cp, root, ok, err := s.LastPublished(ctx)
+	if err != nil {
+		t.Fatalf("LastPublished: %v", err)
+	}
+	if !ok || cp != 10 || root != "hash-at-10" {
+		t.Fatalf("LastPublished = (%d, %q, %v), want the last GOOD record (10, %q, true)", cp, root, ok, "hash-at-10")
+	}
+}
+
+func splitNonEmptyLines(s string) []string {
+	var out []string
+	start := 0
+	for i, c := range s {
+		if c == '\n' {
+			if i > start {
+				out = append(out, s[start:i])
+			}
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		out = append(out, s[start:])
+	}
+	return out
+}
+
+// --- AnchorManager -----------------------------------------------------
+
+type fakeChainStore struct {
+	maxID     int64
+	hashes    map[int64]string
+	maxErr    error
+	hashErr   error
+	maxCalls  int
+	hashCalls int
+}
+
+func (f *fakeChainStore) MaxRowID(context.Context) (int64, error) {
+	f.maxCalls++
+	if f.maxErr != nil {
+		return 0, f.maxErr
+	}
+	return f.maxID, nil
+}
+
+func (f *fakeChainStore) RowHashAt(_ context.Context, id int64) (string, bool, error) {
+	f.hashCalls++
+	if f.hashErr != nil {
+		return "", false, f.hashErr
+	}
+	h, ok := f.hashes[id]
+	return h, ok, nil
+}
+
+type fakeSink struct {
+	published []struct {
+		checkpoint int64
+		root       string
+	}
+	publishErr error
+}
+
+func (f *fakeSink) PublishRoot(_ context.Context, checkpoint int64, root string) error {
+	if f.publishErr != nil {
+		return f.publishErr
+	}
+	f.published = append(f.published, struct {
+		checkpoint int64
+		root       string
+	}{checkpoint, root})
+	return nil
+}
+
+func (f *fakeSink) LastPublished(context.Context) (int64, string, bool, error) {
+	if len(f.published) == 0 {
+		return 0, "", false, nil
+	}
+	last := f.published[len(f.published)-1]
+	return last.checkpoint, last.root, true, nil
+}
+
+func TestAnchorManager_PublishesNewCheckpoint(t *testing.T) {
+	store := &fakeChainStore{maxID: 42, hashes: map[int64]string{42: "root-42"}}
+	sink := &fakeSink{}
+	m := NewAnchorManager(store, sink, AnchorOptions{})
+	m.tick(context.Background())
+
+	if len(sink.published) != 1 {
+		t.Fatalf("published %d times, want 1", len(sink.published))
+	}
+	if sink.published[0].checkpoint != 42 || sink.published[0].root != "root-42" {
+		t.Errorf("published %+v, want checkpoint=42 root=root-42", sink.published[0])
+	}
+}
+
+// The whole reason a tick is cheap between real anchors: no new rows means
+// nothing to publish, so no sink write and no wasted round trip.
+func TestAnchorManager_SkipsWhenNoNewRows(t *testing.T) {
+	store := &fakeChainStore{maxID: 42, hashes: map[int64]string{42: "root-42"}}
+	sink := &fakeSink{}
+	m := NewAnchorManager(store, sink, AnchorOptions{})
+	m.tick(context.Background())
+	m.tick(context.Background())
+	m.tick(context.Background())
+
+	if len(sink.published) != 1 {
+		t.Fatalf("published %d times across 3 ticks with no new rows, want 1", len(sink.published))
+	}
+}
+
+func TestAnchorManager_PublishesAgainAfterNewRows(t *testing.T) {
+	store := &fakeChainStore{maxID: 42, hashes: map[int64]string{42: "root-42", 50: "root-50"}}
+	sink := &fakeSink{}
+	m := NewAnchorManager(store, sink, AnchorOptions{})
+	m.tick(context.Background())
+	store.maxID = 50
+	m.tick(context.Background())
+
+	if len(sink.published) != 2 {
+		t.Fatalf("published %d times, want 2", len(sink.published))
+	}
+	if sink.published[1].checkpoint != 50 {
+		t.Errorf("second publish checkpoint = %d, want 50", sink.published[1].checkpoint)
+	}
+}
+
+// An empty chain (nothing logged yet) has nothing to anchor — checkpoint 0
+// isn't a real row and publishing it would be meaningless.
+func TestAnchorManager_SkipsEmptyChain(t *testing.T) {
+	store := &fakeChainStore{maxID: 0}
+	sink := &fakeSink{}
+	m := NewAnchorManager(store, sink, AnchorOptions{})
+	m.tick(context.Background())
+
+	if len(sink.published) != 0 {
+		t.Fatalf("published %d times against an empty chain, want 0", len(sink.published))
+	}
+}
+
+// A failed publish must not wedge the manager — the next tick tries again.
+// This is the "loud, not fatal" half of #1706's "anchor failures are loud."
+func TestAnchorManager_RetriesAfterSinkFailure(t *testing.T) {
+	store := &fakeChainStore{maxID: 42, hashes: map[int64]string{42: "root-42"}}
+	sink := &fakeSink{publishErr: errors.New("disk full")}
+	m := NewAnchorManager(store, sink, AnchorOptions{})
+	m.tick(context.Background())
+	if len(sink.published) != 0 {
+		t.Fatalf("published %d times despite the sink erroring, want 0", len(sink.published))
+	}
+
+	sink.publishErr = nil
+	m.tick(context.Background())
+	if len(sink.published) != 1 {
+		t.Fatalf("published %d times after the sink recovered, want 1 — the manager must retry, not give up permanently", len(sink.published))
+	}
+}
+
+func TestAnchorManager_StartStop(t *testing.T) {
+	store := &fakeChainStore{maxID: 1, hashes: map[int64]string{1: "root-1"}}
+	sink := &fakeSink{}
+	fired := make(chan struct{}, 1)
+	clock := time.Now
+	m := NewAnchorManager(store, sink, AnchorOptions{Interval: time.Millisecond, Clock: clock})
+	ctx, cancel := context.WithCancel(context.Background())
+	m.Start(ctx)
+	go func() {
+		for i := 0; i < 50; i++ {
+			if len(sink.published) > 0 {
+				fired <- struct{}{}
+				return
+			}
+			time.Sleep(2 * time.Millisecond)
+		}
+	}()
+	select {
+	case <-fired:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ticker never published within 2s")
+	}
+	cancel()
+	m.Stop()
+}

--- a/internal/audit/hash_chain.go
+++ b/internal/audit/hash_chain.go
@@ -22,9 +22,12 @@ import (
 // The chain doesn't prove the log is COMPLETE (an attacker could
 // delete the suffix of rows and leave the head intact), but it
 // proves nothing has been MODIFIED or INSERTED — which is the
-// threat audit C-MED-5+ flags. Append-only forensics (push the
-// chain root to an external sink periodically) detects deletions
-// on top of this; that's tracked separately.
+// threat audit C-MED-5+ flags. It also can't, by itself, catch a
+// privileged attacker who rewrites a row AND correctly recomputes
+// every hash after it — that produces a chain that IS internally
+// consistent. anchor.go closes that gap (#1706): the chain's tip is
+// periodically published to an external sink Postgres can't rewrite,
+// and VerifyChainAgainstAnchor checks against it.
 
 const (
 	// HashEmpty is the value used as the previous hash for the

--- a/internal/audit/store.go
+++ b/internal/audit/store.go
@@ -150,6 +150,11 @@ func (s *Store) initSchema(ctx context.Context) error {
 // locks.
 const auditChainLockKey int64 = 0x0A0D17C4A1
 
+// defaultVerifyBatch mirrors VerifyChainSinceID's own internal default
+// (limit<=0 -> 1000) — used by VerifyChainAgainstAnchor to advance fromID
+// across multiple calls the same way the CLI's runAuditVerify loops.
+const defaultVerifyBatch = 1000
+
 func (s *Store) Log(ctx context.Context, entry *AuditEntry) error {
 	ts := entry.Timestamp
 	if ts.IsZero() {
@@ -441,4 +446,100 @@ func (s *Store) Query(ctx context.Context, params QueryParams) ([]AuditEntry, in
 // Close closes the underlying connection pool
 func (s *Store) Close() {
 	s.pool.Close()
+}
+
+// RowHashAt returns the row_hash stored at audit-log row id, and whether
+// that row exists. found=false (rather than an error) is the expected,
+// meaningful outcome when the row has been deleted — a fact
+// VerifyChainAgainstAnchor treats as evidence of tampering, not a failure
+// to report as "unknown."
+func (s *Store) RowHashAt(ctx context.Context, id int64) (hash string, found bool, err error) {
+	err = s.pool.QueryRow(ctx, `SELECT row_hash FROM audit_logs WHERE id = $1`, id).Scan(&hash)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("audit: row hash at id=%d: %w", id, err)
+	}
+	return hash, true, nil
+}
+
+// AnchorVerifyResult is VerifyChainAgainstAnchor's outcome. Two independent
+// checks, because they catch two different attacks (#1706):
+//
+//   - AnchorRoot vs CurrentRoot: was the row AT the anchored checkpoint (or
+//     anything before it) rewritten since it was anchored? Internal chain
+//     consistency alone cannot see this — a rewrite followed by a correct
+//     recompute forward preserves internal consistency by construction.
+//     Only a hash held outside the database can catch it.
+//   - FirstBadAfterCheckpoint: is everything AFTER the checkpoint still
+//     internally consistent? A break here means tampering since the last
+//     anchor that was NOT (or not yet) followed by a correct recompute —
+//     the ordinary hash_chain.go case, just scoped to the post-anchor tail.
+type AnchorVerifyResult struct {
+	// Checkpoint is the anchored row id this result was checked against.
+	Checkpoint int64
+	// AnchorRoot is the externally-anchored hash at Checkpoint.
+	AnchorRoot string
+	// CurrentRoot is what's in the database at Checkpoint right now.
+	// Empty means the row no longer exists (deleted) — also a mismatch.
+	CurrentRoot string
+	// FirstBadAfterCheckpoint is VerifyChainSinceID's result for rows after
+	// Checkpoint: 0 if intact, otherwise the first bad row's id.
+	FirstBadAfterCheckpoint int64
+}
+
+// OK reports whether both halves of the result are clean.
+func (r AnchorVerifyResult) OK() bool {
+	return r.AnchorRoot == r.CurrentRoot && r.FirstBadAfterCheckpoint == 0
+}
+
+// ErrNoAnchor is returned by VerifyChainAgainstAnchor when sink has never
+// had a root published to it. Not a chain-integrity failure — there is
+// simply nothing yet to check against.
+var ErrNoAnchor = errors.New("audit: no anchor has been published yet")
+
+// VerifyChainAgainstAnchor checks the chain against the last root sink
+// published, catching a privileged rewrite-and-recompute that internal
+// consistency (VerifyChain / VerifyChainSinceID) cannot: see
+// AnchorVerifyResult's doc comment for why both checks are needed.
+func (s *Store) VerifyChainAgainstAnchor(ctx context.Context, sink RootSink) (AnchorVerifyResult, error) {
+	checkpoint, anchorRoot, ok, err := sink.LastPublished(ctx)
+	if err != nil {
+		return AnchorVerifyResult{}, fmt.Errorf("audit: read last anchor: %w", err)
+	}
+	if !ok {
+		return AnchorVerifyResult{}, ErrNoAnchor
+	}
+	currentRoot, _, err := s.RowHashAt(ctx, checkpoint)
+	if err != nil {
+		return AnchorVerifyResult{}, fmt.Errorf("audit: row hash at anchored checkpoint %d: %w", checkpoint, err)
+	}
+
+	// VerifyChainSinceID caps a single call at `limit` rows (default 1000)
+	// to keep memory bounded — the same reason runAuditVerify (CLI) loops
+	// rather than trusting one call to cover an arbitrary range. Mirrored
+	// here so a chain with many rows logged since the last anchor is still
+	// checked in full, not just its first 1000 post-checkpoint rows.
+	maxID, err := s.MaxRowID(ctx)
+	if err != nil {
+		return AnchorVerifyResult{}, fmt.Errorf("audit: max row id: %w", err)
+	}
+	var firstBad int64
+	for from := checkpoint; from < maxID; {
+		firstBad, err = s.VerifyChainSinceID(ctx, from, 0)
+		if err != nil {
+			return AnchorVerifyResult{}, fmt.Errorf("audit: verify chain since checkpoint %d: %w", checkpoint, err)
+		}
+		if firstBad != 0 {
+			break
+		}
+		from += defaultVerifyBatch
+	}
+	return AnchorVerifyResult{
+		Checkpoint:              checkpoint,
+		AnchorRoot:              anchorRoot,
+		CurrentRoot:             currentRoot,
+		FirstBadAfterCheckpoint: firstBad,
+	}, nil
 }

--- a/internal/audit/store_integration_test.go
+++ b/internal/audit/store_integration_test.go
@@ -18,11 +18,14 @@ package audit
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -163,5 +166,272 @@ func TestAuditChain_DeletedRowIsDetected(t *testing.T) {
 	if _, err := s.VerifyChainSinceID(ctx, 0, 1000); err == nil {
 		t.Fatal("removing an audit row left the chain verifying clean — an operator could delete " +
 			"the record of an action and nothing would show it")
+	}
+}
+
+// --- #1706: anchoring against a privileged rewrite ----------------------
+
+// rewriteAndRecomputeForward simulates the exact attack #1706 describes: an
+// operator with Postgres write access edits a row, then recomputes
+// row_hash/prev_hash forward through every row after it — exactly what
+// Log's own hashing logic would produce, so internal consistency
+// (VerifyChain/VerifyChainSinceID) cannot tell it apart from a row that was
+// never touched.
+func rewriteAndRecomputeForward(t *testing.T, s *Store, tamperID int64) {
+	t.Helper()
+	ctx := context.Background()
+
+	if _, err := s.pool.Exec(ctx,
+		`UPDATE audit_logs SET username = 'mallory' WHERE id = $1`, tamperID,
+	); err != nil {
+		t.Fatalf("tamper: %v", err)
+	}
+
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, timestamp, username, action, resource_type, resource_id,
+		       detail, source_ip, status_code, actor, delegation_chain,
+		       token_id, org_id, run_id, hash_version
+		FROM audit_logs WHERE id >= $1 ORDER BY id ASC
+	`, tamperID)
+	if err != nil {
+		t.Fatalf("read forward: %v", err)
+	}
+	type fwdRow struct {
+		id          int64
+		entry       AuditEntry
+		hashVersion int16
+	}
+	var toFix []fwdRow
+	for rows.Next() {
+		var r fwdRow
+		if err := rows.Scan(&r.id, &r.entry.Timestamp, &r.entry.Username, &r.entry.Action,
+			&r.entry.ResourceType, &r.entry.ResourceID, &r.entry.Detail, &r.entry.SourceIP,
+			&r.entry.StatusCode, &r.entry.Actor, &r.entry.DelegationChain, &r.entry.TokenID,
+			&r.entry.OrgID, &r.entry.RunID, &r.hashVersion); err != nil {
+			rows.Close()
+			t.Fatalf("scan forward row: %v", err)
+		}
+		toFix = append(toFix, r)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate forward rows: %v", err)
+	}
+
+	var prevHash string
+	err = s.pool.QueryRow(ctx,
+		`SELECT row_hash FROM audit_logs WHERE id < $1 ORDER BY id DESC LIMIT 1`, tamperID,
+	).Scan(&prevHash)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			prevHash = HashEmpty
+		} else {
+			t.Fatalf("read predecessor hash: %v", err)
+		}
+	}
+
+	for _, r := range toFix {
+		newHash, err := computeRowHash(&r.entry, prevHash, r.hashVersion)
+		if err != nil {
+			t.Fatalf("recompute hash for id=%d: %v", r.id, err)
+		}
+		if _, err := s.pool.Exec(ctx,
+			`UPDATE audit_logs SET row_hash = $1, prev_hash = $2 WHERE id = $3`,
+			newHash, prevHash, r.id,
+		); err != nil {
+			t.Fatalf("rewrite forward at id=%d: %v", r.id, err)
+		}
+		prevHash = newHash
+	}
+}
+
+func rowIDAtOffset(t *testing.T, s *Store, offset int) int64 {
+	t.Helper()
+	var id int64
+	if err := s.pool.QueryRow(context.Background(),
+		`SELECT id FROM audit_logs ORDER BY id ASC OFFSET $1 LIMIT 1`, offset,
+	).Scan(&id); err != nil {
+		t.Fatalf("row id at offset %d: %v", offset, err)
+	}
+	return id
+}
+
+func TestStore_RowHashAt(t *testing.T) {
+	ctx := context.Background()
+	s := auditTestStore(t)
+	logN(t, s, 3)
+
+	target := rowIDAtOffset(t, s, 1)
+	hash, found, err := s.RowHashAt(ctx, target)
+	if err != nil {
+		t.Fatalf("RowHashAt: %v", err)
+	}
+	if !found || hash == "" {
+		t.Fatalf("RowHashAt(%d) = (%q, %v), want a non-empty hash and found=true", target, hash, found)
+	}
+
+	_, found, err = s.RowHashAt(ctx, target+1_000_000)
+	if err != nil {
+		t.Fatalf("RowHashAt(missing): %v", err)
+	}
+	if found {
+		t.Error("found = true for a row id that was never inserted")
+	}
+}
+
+func TestVerifyChainAgainstAnchor_NoAnchorYet(t *testing.T) {
+	ctx := context.Background()
+	s := auditTestStore(t)
+	logN(t, s, 3)
+
+	sink, err := NewFileSink(filepath.Join(t.TempDir(), "anchors.jsonl"))
+	if err != nil {
+		t.Fatalf("NewFileSink: %v", err)
+	}
+	if _, err := s.VerifyChainAgainstAnchor(ctx, sink); !errors.Is(err, ErrNoAnchor) {
+		t.Fatalf("err = %v, want ErrNoAnchor", err)
+	}
+}
+
+func TestVerifyChainAgainstAnchor_CleanChainVerifiesOK(t *testing.T) {
+	ctx := context.Background()
+	s := auditTestStore(t)
+	logN(t, s, 10)
+
+	tail := rowIDAtOffset(t, s, 9)
+	tailHash, found, err := s.RowHashAt(ctx, tail)
+	if err != nil || !found {
+		t.Fatalf("RowHashAt(tail): found=%v err=%v", found, err)
+	}
+	sink, err := NewFileSink(filepath.Join(t.TempDir(), "anchors.jsonl"))
+	if err != nil {
+		t.Fatalf("NewFileSink: %v", err)
+	}
+	if err := sink.PublishRoot(ctx, tail, tailHash); err != nil {
+		t.Fatalf("PublishRoot: %v", err)
+	}
+
+	result, err := s.VerifyChainAgainstAnchor(ctx, sink)
+	if err != nil {
+		t.Fatalf("VerifyChainAgainstAnchor: %v", err)
+	}
+	if !result.OK() {
+		t.Errorf("result = %+v, want OK() true for an untampered chain", result)
+	}
+}
+
+// The money test: a privileged rewrite-and-recompute-forward is INVISIBLE
+// to internal-consistency verification (proving the premise of #1706), and
+// CAUGHT by anchor verification (proving the fix).
+func TestVerifyChainAgainstAnchor_DetectsRewriteRecomputedForward(t *testing.T) {
+	ctx := context.Background()
+	s := auditTestStore(t)
+	logN(t, s, 10)
+
+	tamperID := rowIDAtOffset(t, s, 2) // an early row, well before the tail
+	tail := rowIDAtOffset(t, s, 9)
+
+	tailHash, found, err := s.RowHashAt(ctx, tail)
+	if err != nil || !found {
+		t.Fatalf("RowHashAt(tail) before attack: found=%v err=%v", found, err)
+	}
+	sink, err := NewFileSink(filepath.Join(t.TempDir(), "anchors.jsonl"))
+	if err != nil {
+		t.Fatalf("NewFileSink: %v", err)
+	}
+	if err := sink.PublishRoot(ctx, tail, tailHash); err != nil {
+		t.Fatalf("PublishRoot: %v", err)
+	}
+
+	rewriteAndRecomputeForward(t, s, tamperID)
+
+	// Prove the premise: internal-only verification is fooled.
+	if firstBad, verr := s.VerifyChainSinceID(ctx, 0, 1000); verr != nil || firstBad != 0 {
+		t.Fatalf("internal verify caught the attack (firstBad=%d err=%v) — test setup is wrong, "+
+			"this must pass clean for the anchor check below to prove anything", firstBad, verr)
+	}
+
+	// Prove the fix: anchor verification is not fooled.
+	result, err := s.VerifyChainAgainstAnchor(ctx, sink)
+	if err != nil {
+		t.Fatalf("VerifyChainAgainstAnchor: %v", err)
+	}
+	if result.OK() {
+		t.Fatal("VerifyChainAgainstAnchor reported OK after a rewrite-and-recompute attack — " +
+			"this is the exact gap #1706 exists to close")
+	}
+	if result.AnchorRoot == result.CurrentRoot {
+		t.Errorf("AnchorRoot == CurrentRoot (%s) after tampering a row before the anchored checkpoint — want them to differ",
+			abbrev(result.AnchorRoot))
+	}
+}
+
+// Deleting the anchored row itself (not just editing it) is a variant of the
+// same attack, and must also be caught: RowHashAt reports found=false, which
+// VerifyChainAgainstAnchor surfaces as CurrentRoot="" — never equal to a
+// real anchored hash.
+func TestVerifyChainAgainstAnchor_DetectsDeletedCheckpoint(t *testing.T) {
+	ctx := context.Background()
+	s := auditTestStore(t)
+	logN(t, s, 5)
+
+	tail := rowIDAtOffset(t, s, 4)
+	tailHash, found, err := s.RowHashAt(ctx, tail)
+	if err != nil || !found {
+		t.Fatalf("RowHashAt(tail): found=%v err=%v", found, err)
+	}
+	sink, err := NewFileSink(filepath.Join(t.TempDir(), "anchors.jsonl"))
+	if err != nil {
+		t.Fatalf("NewFileSink: %v", err)
+	}
+	if err := sink.PublishRoot(ctx, tail, tailHash); err != nil {
+		t.Fatalf("PublishRoot: %v", err)
+	}
+
+	if _, err := s.pool.Exec(ctx, `DELETE FROM audit_logs WHERE id = $1`, tail); err != nil {
+		t.Fatalf("delete anchored row: %v", err)
+	}
+
+	result, err := s.VerifyChainAgainstAnchor(ctx, sink)
+	if err != nil {
+		t.Fatalf("VerifyChainAgainstAnchor: %v", err)
+	}
+	if result.OK() {
+		t.Fatal("VerifyChainAgainstAnchor reported OK after the anchored row was deleted")
+	}
+	if result.CurrentRoot != "" {
+		t.Errorf("CurrentRoot = %q, want empty (row no longer exists)", result.CurrentRoot)
+	}
+}
+
+// AnchorManager wired to the real store: proves the periodic loop actually
+// advances a real Postgres-backed chain's checkpoint, not just the fakes in
+// anchor_test.go.
+func TestAnchorManager_PublishesAgainstRealStore(t *testing.T) {
+	ctx := context.Background()
+	s := auditTestStore(t)
+	logN(t, s, 5)
+
+	sink, err := NewFileSink(filepath.Join(t.TempDir(), "anchors.jsonl"))
+	if err != nil {
+		t.Fatalf("NewFileSink: %v", err)
+	}
+	m := NewAnchorManager(s, sink, AnchorOptions{})
+	m.tick(ctx)
+
+	tail := rowIDAtOffset(t, s, 4)
+	cp, root, ok, err := sink.LastPublished(ctx)
+	if err != nil || !ok {
+		t.Fatalf("LastPublished: ok=%v err=%v", ok, err)
+	}
+	if cp != tail {
+		t.Errorf("published checkpoint = %d, want the chain tail %d", cp, tail)
+	}
+	wantHash, found, err := s.RowHashAt(ctx, tail)
+	if err != nil || !found {
+		t.Fatalf("RowHashAt(tail): found=%v err=%v", found, err)
+	}
+	if root != wantHash {
+		t.Errorf("published root = %s, want %s", abbrev(root), abbrev(wantHash))
 	}
 }

--- a/internal/cmd/audit.go
+++ b/internal/cmd/audit.go
@@ -4,6 +4,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -39,7 +40,16 @@ var (
 	// `audit verify` flags
 	auditVerifyFromID int64
 	auditVerifyBatch  int
+
+	// `audit verify-anchor` flags
+	auditAnchorPath string
 )
+
+// defaultAuditAnchorPath mirrors internal/server's constant of the same
+// name (#1706) — duplicated rather than imported so this CLI keeps its
+// stated direct-Postgres-only dependency shape rather than pulling in the
+// daemon package for one path string.
+const defaultAuditAnchorPath = "/var/lib/containarium/audit-anchors.jsonl"
 
 var auditCmd = &cobra.Command{
 	Use:   "audit",
@@ -86,10 +96,12 @@ the row was edited after insert OR a row was inserted
 between two existing rows.
 
 The chain doesn't prove the log is COMPLETE (an attacker
-could delete the suffix); it proves nothing has been
-MODIFIED or INSERTED. Append-only forensics (external
-sink for the chain root) catches deletion, tracked
-separately.
+with database access could rewrite a row and recompute every
+hash after it, or delete the tail outright — either preserves
+internal consistency). It proves nothing has been MODIFIED or
+INSERTED as long as nobody can also rewrite the rows after the
+edit. See 'audit verify-anchor' for the check that catches a
+privileged rewrite-and-recompute, which this command cannot.
 
 A clean verify reports "intact" and the highest ID seen.`,
 	Example: `  # Verify from the chain start
@@ -103,10 +115,50 @@ A clean verify reports "intact" and the highest ID seen.`,
 	RunE: runAuditVerify,
 }
 
+var auditVerifyAnchorCmd = &cobra.Command{
+	Use:   "verify-anchor",
+	Short: "Verify the audit chain against its last externally-anchored root",
+	Long: `'audit verify' proves internal consistency: every row's hash matches
+what its own fields (and the previous row's hash) compute to.
+It CANNOT catch an operator with Postgres write access who
+edits a row and then correctly recomputes every hash after it
+— that produces a chain that is internally consistent by
+construction, because the attacker used the same hashing rule
+the daemon does.
+
+This command closes that gap (#1706). The daemon periodically
+publishes the chain's current tip to an external file the
+database cannot rewrite (see CONTAINARIUM_AUDIT_ANCHOR_PATH /
+CONTAINARIUM_AUDIT_ANCHOR_INTERVAL on the daemon). This command
+re-reads the row at that anchored checkpoint from the database
+right now and compares: if it doesn't match what was anchored,
+that row (or an earlier one) was rewritten after anchoring — no
+matter how correctly the chain was recomputed forward. It also
+re-runs the ordinary internal-consistency check for everything
+AFTER the checkpoint, since a break there is a different failure
+(tampering since the last anchor) that comparing one hash value
+can't see.
+
+A privileged rewrite of a row anchored less than one anchoring
+interval ago is undetectable until the daemon's next anchor
+publishes a checkpoint past it — that window is inherent to
+periodic anchoring, not a bug in this check.`,
+	Example: `  # Default anchor path (same as the daemon's default)
+  containarium audit verify-anchor
+
+  # Non-default anchor location
+  containarium audit verify-anchor --anchor-path /mnt/forensics/audit-anchors.jsonl`,
+	RunE: runAuditVerifyAnchor,
+}
+
 func init() {
 	rootCmd.AddCommand(auditCmd)
 	auditCmd.AddCommand(auditQueryCmd)
 	auditCmd.AddCommand(auditVerifyCmd)
+	auditCmd.AddCommand(auditVerifyAnchorCmd)
+
+	auditVerifyAnchorCmd.Flags().StringVar(&auditAnchorPath, "anchor-path", "",
+		"Path to the anchor file (default: $CONTAINARIUM_AUDIT_ANCHOR_PATH, or the daemon's own default)")
 
 	auditQueryCmd.Flags().StringVar(&auditQueryUsername, "username", "", "Filter by username (exact match)")
 	auditQueryCmd.Flags().StringVar(&auditQueryAction, "action", "", "Filter by action (exact match, e.g. create_container)")
@@ -257,6 +309,59 @@ func runAuditVerify(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("\n  ✓ Audit-log chain intact (verified through id=%d)\n\n", maxID)
 	return nil
+}
+
+func runAuditVerifyAnchor(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+	store, cleanup, err := openAuditStore(ctx)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	path := auditAnchorPath
+	if path == "" {
+		path = os.Getenv("CONTAINARIUM_AUDIT_ANCHOR_PATH")
+	}
+	if path == "" {
+		path = defaultAuditAnchorPath
+	}
+	sink, err := audit.NewFileSink(path)
+	if err != nil {
+		return fmt.Errorf("open anchor sink %q: %w", path, err)
+	}
+
+	result, err := store.VerifyChainAgainstAnchor(ctx, sink)
+	if err != nil {
+		if errors.Is(err, audit.ErrNoAnchor) {
+			fmt.Printf("\n  ⚠ No anchor has been published yet at %s\n", path)
+			fmt.Println("    Either the daemon has not run long enough to anchor once, or")
+			fmt.Println("    CONTAINARIUM_AUDIT_ANCHOR_PATH doesn't match this daemon's setting.")
+			fmt.Println()
+			return nil
+		}
+		return fmt.Errorf("verify against anchor: %w", err)
+	}
+
+	if result.OK() {
+		fmt.Printf("\n  ✓ Chain matches its anchor at checkpoint id=%d\n\n", result.Checkpoint)
+		return nil
+	}
+
+	fmt.Fprintf(os.Stderr, "\n  ✗ Chain does NOT match its anchor at checkpoint id=%d\n\n", result.Checkpoint)
+	if result.AnchorRoot != result.CurrentRoot {
+		if result.CurrentRoot == "" {
+			fmt.Fprintf(os.Stderr, "  Row id=%d, which was anchored, no longer exists — it was deleted.\n", result.Checkpoint)
+		} else {
+			fmt.Fprintf(os.Stderr, "  Row id=%d's hash has changed since it was anchored — that row, or an earlier\n", result.Checkpoint)
+			fmt.Fprintf(os.Stderr, "  one, was rewritten after anchoring, even though 'audit verify' alone would not show it:\n")
+			fmt.Fprintf(os.Stderr, "  a rewrite followed by a correctly recomputed chain looks internally consistent.\n\n")
+		}
+	}
+	if result.FirstBadAfterCheckpoint != 0 {
+		fmt.Fprintf(os.Stderr, "  Additionally, internal consistency breaks at row id=%d (after the checkpoint).\n\n", result.FirstBadAfterCheckpoint)
+	}
+	return fmt.Errorf("chain does not match its anchor at checkpoint id=%d", result.Checkpoint)
 }
 
 // sanitizeDetailForCLI strips newlines from the detail

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -222,6 +222,7 @@ type DualServer struct {
 	securityServer           *SecurityServer
 	auditStore               *audit.Store
 	auditEventSubscriber     *audit.EventSubscriber
+	auditAnchorManager       *audit.AnchorManager // periodic hash-chain-root anchoring (#1706)
 	sshCollector             *audit.SSHCollector
 	revocationStore          *auth.PgRevocationStore // Phase 1.2 — kill-switch for issued JWTs
 	alertStore               *alert.Store
@@ -2267,6 +2268,13 @@ func (ds *DualServer) startIntegrityHeartbeat(ctx context.Context) {
 // traffic (design doc: 30s).
 const threatDetectSweepInterval = 30 * time.Second
 
+// defaultAuditAnchorPath is where the audit hash chain's periodic root
+// anchor lives (#1706). Overridable via CONTAINARIUM_AUDIT_ANCHOR_PATH.
+// Deliberately NOT under the same Postgres-managed state this anchors
+// against — see audit.RootSink's doc comment for why that separation is
+// the whole point.
+const defaultAuditAnchorPath = "/var/lib/containarium/audit-anchors.jsonl"
+
 // startThreatDetectSweep drives the threat-detection engine's time-window
 // rules on a fixed tick, separate from ctx so it can be stopped independent
 // of the daemon's own shutdown (Stop() cancels it via threatDetectSweepStop
@@ -2585,6 +2593,32 @@ func (ds *DualServer) Start(ctx context.Context) error {
 		log.Printf("[ttlsweeper] incus unavailable (%v); sweeping via the k8s box backend", err)
 	} else {
 		log.Printf("[ttlsweeper] incus client unavailable: %v (sweeper disabled)", err)
+	}
+
+	// Periodic audit hash-chain anchoring (#1706). Best-effort: an anchoring
+	// failure degrades tamper-evidence against a privileged rewrite, but must
+	// never block the daemon from starting or serving. Only runs when audit
+	// logging itself is enabled — there is no chain to anchor otherwise.
+	if ds.auditStore != nil {
+		anchorPath := os.Getenv("CONTAINARIUM_AUDIT_ANCHOR_PATH")
+		if anchorPath == "" {
+			anchorPath = defaultAuditAnchorPath
+		}
+		anchorSink, err := audit.NewFileSink(anchorPath)
+		if err != nil {
+			log.Printf("[audit-anchor] disabled: %v", err)
+		} else {
+			opts := audit.AnchorOptions{}
+			if raw := os.Getenv("CONTAINARIUM_AUDIT_ANCHOR_INTERVAL"); raw != "" {
+				if d, err := time.ParseDuration(raw); err == nil && d > 0 {
+					opts.Interval = d
+				} else {
+					log.Printf("[audit-anchor] CONTAINARIUM_AUDIT_ANCHOR_INTERVAL=%q invalid, using default %s", raw, audit.DefaultAnchorInterval)
+				}
+			}
+			ds.auditAnchorManager = audit.NewAnchorManager(ds.auditStore, anchorSink, opts)
+			ds.auditAnchorManager.Start(ctx)
+		}
 	}
 
 	// Sandbox TTL sweeper (#1488 Phase 4: "no sandbox leaks past
@@ -2953,6 +2987,9 @@ func (ds *DualServer) Start(ctx context.Context) error {
 		}
 		if ds.ttlSweeperManager != nil {
 			ds.ttlSweeperManager.Stop()
+		}
+		if ds.auditAnchorManager != nil {
+			ds.auditAnchorManager.Stop()
 		}
 		if ds.sandboxTTLSweeperManager != nil {
 			ds.sandboxTTLSweeperManager.Stop()


### PR DESCRIPTION
## Why

`internal/audit/hash_chain.go`'s own doc comment already named this gap:
the chain proves nothing was modified or inserted, but it can't
distinguish an untouched chain from one where a privileged operator with
Postgres write access rewrote a row **and correctly recomputed every hash
after it** — that produces a chain that's internally consistent by
construction. `VerifyChain`/`VerifyChainSinceID` alone cannot catch this;
only a hash value held somewhere the rewriter doesn't control can.

## What this adds

- **`internal/audit/anchor.go`**: `RootSink` interface + `FileSink`, the
  default implementation — an append-only local file outside Postgres's
  reach. Rejects republishing a checkpoint with a different root
  (`ErrAnchorConflict`); tolerates a truncated trailing line from a crash
  mid-write without losing the last good record.
- **`AnchorManager`**: a periodic ticker (mirrors `ttlsweeper`/`autosleep`'s
  `Start(ctx)/Stop()` shape exactly) that publishes the chain's current tip
  every interval (default 15m, `CONTAINARIUM_AUDIT_ANCHOR_INTERVAL`) when
  new rows have been logged since the last publish. Failures are loud
  (`log.Printf`) and non-fatal.
- **`Store.RowHashAt` + `Store.VerifyChainAgainstAnchor`**: the new
  verification mode. Compares the DB's *current* hash at the last anchored
  checkpoint against what was anchored (catches a rewrite at or before
  that checkpoint) and re-runs internal consistency for everything after
  it (catches tampering since the last anchor) — both checks are needed,
  they catch different attacks.
- **`containarium audit verify-anchor`** CLI command, alongside the
  existing `audit verify`, same direct-Postgres pattern.
- Wired into `dual_server.go`: best-effort, only when audit logging itself
  is enabled, started/stopped alongside the other ticker managers.

## Design choice: local file, not an object store or timestamp

The issue names two shapes ("an append-only object store with versioning,
or a co-signed timestamp"). Went with neither, by design: a local
append-only file satisfies the **threat model as stated** — "an operator
with write access to Postgres" — since a Postgres credential grants no
filesystem access, without requiring a cloud dependency this OSS daemon
doesn't otherwise have. It does not defend a full host-root attacker;
that's a materially larger threat model than #1706 asks for. `RootSink` is
the seam a stronger backend would slot into later without touching
`AnchorManager` or `VerifyChainAgainstAnchor`.

## Proof, not just unit tests

`TestVerifyChainAgainstAnchor_DetectsRewriteRecomputedForward` (real
Postgres integration test) is the money test: it performs the **exact**
attack #1706 describes — edit a row, then recompute `row_hash`/`prev_hash`
forward exactly as `Log()` would — asserts `VerifyChainSinceID` reports
the chain intact (proving the premise), then asserts
`VerifyChainAgainstAnchor` catches it (proving the fix).

Also manually verified end-to-end against a local ephemeral Postgres using
the built CLI binary:

\`\`\`
\$ containarium audit verify          # AFTER the simulated attack
  ✓ Audit-log chain intact (verified through id=5)      ← fooled, as expected

\$ containarium audit verify-anchor   # AFTER the same attack
  ✗ Chain does NOT match its anchor at checkpoint id=5   ← caught
\`\`\`

## Cadence and failure visibility (acceptance criteria)

- Cadence stated and bounded: \`DefaultAnchorInterval = 15 minutes\`,
  documented on the constant and in the CLI's \`--help\` text as the window
  within which a very recent rewrite is undetectable.
- Anchor failures are loud: every failure path in \`AnchorManager.tick\`
  logs via \`log.Printf\` with the concrete consequence spelled out,
  matching this codebase's existing loudness convention (no slog/metrics
  infra exists here yet — see \`ttlsweeper\`/\`autosleep\` for the same idiom).

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./internal/audit/... ./internal/cmd/... ./internal/server/...\` clean
- [x] \`go test -tags=integration ./internal/audit/...\` clean against a real
      local Postgres (15 tests, including the rewrite-and-recompute attack
      proof)
- [x] \`golangci-lint run\` on touched packages → 0 issues
- [x] Manual end-to-end CLI verification against a real ephemeral Postgres
      (see above)

Closes #1706

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHECHYsrFnSfXrqv94BZRc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added periodic audit-chain checkpoint anchoring to detect tampering, deletions, and rewritten records.
  * Added `audit verify-anchor` to compare stored checkpoints with audit data and validate subsequent entries.
  * Added configurable anchor file location and interval, with graceful handling of unavailable anchors or temporary failures.

* **Documentation**
  * Documented detection limits, verification windows, filesystem trust assumptions, and off-host backup recommendations.

* **Tests**
  * Added coverage for checkpoint publication, verification, recovery, ordering, and integrity-failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->