### PR TITLE
security(release): route github.ref_name through env in the two remaining run blocks (#1602)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,9 +192,19 @@ jobs:
 
       - name: Create release notes
         id: release_notes
+        env:
+          # Untrusted: a tag name may contain shell metacharacters (#1602).
+          # The heredoc below stays quoted (<< 'EOF') deliberately — the
+          # body has literal backticks (markdown code spans) that an
+          # UNQUOTED heredoc would hand to the shell as command
+          # substitutions. So github.ref_name can't be expanded into the
+          # heredoc at all, quoted or not; it's substituted via bash
+          # parameter expansion AFTER the file is written instead, which
+          # never re-parses the value as syntax.
+          RELEASE_REF: ${{ github.ref_name }}
         run: |
           cat > release_notes.md << 'EOF'
-          ## Containarium ${{ github.ref_name }}
+          ## Containarium __RELEASE_REF__
 
           The open-source, self-hostable, agent-native sandbox.
 
@@ -219,23 +229,23 @@ jobs:
           ```bash
           # containarium CLI / daemon (Linux x86_64 example)
           curl -L -o /usr/local/bin/containarium \
-            https://github.com/footprintai/containarium/releases/download/${{ github.ref_name }}/containarium-linux-amd64
+            https://github.com/footprintai/containarium/releases/download/__RELEASE_REF__/containarium-linux-amd64
           chmod +x /usr/local/bin/containarium
 
           # Windows: client-only CLI (create/list/ssh/… against a remote daemon;
           # the daemon/sentinel/tunnel subcommands are Linux/macOS only)
           # PowerShell:
           #   curl.exe -L -o containarium.exe `
-          #     https://github.com/footprintai/containarium/releases/download/${{ github.ref_name }}/containarium-windows-amd64.exe
+          #     https://github.com/footprintai/containarium/releases/download/__RELEASE_REF__/containarium-windows-amd64.exe
 
           # platform MCP (your laptop, e.g. macOS arm64)
           curl -L -o /usr/local/bin/mcp-server \
-            https://github.com/footprintai/containarium/releases/download/${{ github.ref_name }}/mcp-server-darwin-arm64
+            https://github.com/footprintai/containarium/releases/download/__RELEASE_REF__/mcp-server-darwin-arm64
           chmod +x /usr/local/bin/mcp-server
 
           # agent-box (drop into your container image, Linux x86_64)
           curl -L -o /usr/local/bin/agent-box \
-            https://github.com/footprintai/containarium/releases/download/${{ github.ref_name }}/agent-box-linux-amd64
+            https://github.com/footprintai/containarium/releases/download/__RELEASE_REF__/agent-box-linux-amd64
           chmod +x /usr/local/bin/agent-box
           ```
 
@@ -274,6 +284,15 @@ jobs:
 
           See [README.md](https://github.com/footprintai/containarium#quick-start) for the full agent-native walkthrough.
           EOF
+
+          # Fill in the tag now that the file is written. Bash parameter
+          # expansion, not sed: sed would re-parse RELEASE_REF's content
+          # against its own delimiter/escape rules, reopening exactly the
+          # injection the quoted heredoc above was written to avoid. This
+          # substitutes the value as a literal string, full stop.
+          notes="$(cat release_notes.md)"
+          notes="${notes//__RELEASE_REF__/$RELEASE_REF}"
+          printf '%s\n' "$notes" > release_notes.md
 
           # Changelog first, boilerplate under it — a reader wants to know
           # what changed before they read install instructions (#1600).
@@ -430,9 +449,15 @@ jobs:
         run: make sidecar-build-otel || true
 
       - name: Assemble bundle tarball
+        env:
+          # Untrusted: a tag name may contain shell metacharacters (#1602).
+          # Routing it through env and a quoted reference makes the shell
+          # treat it as one opaque argv word to `make`, never re-parsed as
+          # command syntax — matches "Apply release notes" above.
+          RELEASE_REF: ${{ github.ref_name }}
         run: |
           make build-bundle \
-            BUNDLE_VERSION=${{ github.ref_name }} \
+            BUNDLE_VERSION="$RELEASE_REF" \
             BUNDLE_OS=${{ matrix.target.os }} \
             BUNDLE_ARCH=${{ matrix.target.arch }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -449,17 +449,25 @@ jobs:
         run: make sidecar-build-otel || true
 
       - name: Assemble bundle tarball
+        # Untrusted: a tag name may contain shell metacharacters (#1602).
+        # Deliberately NOT `make build-bundle BUNDLE_VERSION="$RELEASE_REF"`:
+        # that target's recipe (Makefile) does `echo "... $(BUNDLE_VERSION)
+        # ..."`, and GNU Make expands $(...) in a command-line-overridden
+        # variable wherever a recipe dereferences it — a tag like
+        # `v$(shell ...)` would have Make itself execute the shell function,
+        # a second injection layer underneath the one env/quoting above
+        # already closes at the GitHub Actions shell level. Calling the
+        # script directly (what the Makefile target does internally anyway)
+        # gives it the value as a real env var, read with bash parameter
+        # expansion only — never passed through Make's own macro expansion.
         env:
-          # Untrusted: a tag name may contain shell metacharacters (#1602).
-          # Routing it through env and a quoted reference makes the shell
-          # treat it as one opaque argv word to `make`, never re-parsed as
-          # command syntax — matches "Apply release notes" above.
           RELEASE_REF: ${{ github.ref_name }}
         run: |
-          make build-bundle \
-            BUNDLE_VERSION="$RELEASE_REF" \
-            BUNDLE_OS=${{ matrix.target.os }} \
-            BUNDLE_ARCH=${{ matrix.target.arch }}
+          chmod +x scripts/bundle/build-bundle.sh
+          VERSION="$RELEASE_REF" \
+            OS="${{ matrix.target.os }}" \
+            ARCH="${{ matrix.target.arch }}" \
+            ./scripts/bundle/build-bundle.sh
 
       - name: List bundle outputs
         run: ls -lh dist/


### PR DESCRIPTION
## Why

Two pre-existing script-injection surfaces predating #1601's fix (which
closed a third instance, in `Generate changelog`): `Create release notes`
(`build-and-release`) and `Assemble bundle tarball` (`build-bundle`) both
interpolated `${{ github.ref_name }}` directly into a `run:` block. Git
permits shell metacharacters in tag names, and GitHub Actions splices
`${{ }}` into the script **textually before the shell parses it**.

## Assemble bundle tarball

Straightforward fix, matching the already-fixed `Apply release notes`
step: `env: RELEASE_REF: ${{ github.ref_name }}`, then
`BUNDLE_VERSION="$RELEASE_REF"` instead of the raw interpolation.

## Create release notes — a different fix, on purpose

The value appears 4× inside a `cat > file << 'EOF'` heredoc. The delimiter
is already quoted (why this one was lower-severity than the other in the
issue) — which is also exactly why the "assign to env, reference inside
the heredoc" fix does **not** work here: switching to an **unquoted**
heredoc so `$RELEASE_REF` would expand would *also* make the shell
command-substitute every backtick already in the release notes body
(markdown code spans: `` `containarium` ``, `` `mcp-server` ``, `` `shell_exec` ``,
etc. — the body has many). That trade would be worse than the bug.

Kept the heredoc quoted (so none of that literal content is touched),
replaced each `${{ github.ref_name }}` with a `__RELEASE_REF__` placeholder,
and substituted it in **after** the file is written — via bash parameter
expansion (`${notes//__RELEASE_REF__/$RELEASE_REF}`), not `sed`. `sed`
would re-parse the value's content against its own delimiter/escape
rules, reopening a narrower version of the same injection class this is
meant to close.

## Verification

- **zizmor** (the tool the issue cites) flags 6 `template-injection`
  findings on `main`'s version of this file, all on `github.ref_name` in
  these two run blocks. **Zero** after this fix.
- Manually simulated a tag value containing `"; $(touch ...); echo "`
  through the actual heredoc+substitution logic locally — confirmed the
  payload lands as inert literal text, no command executes.
- `bash -n` on the modified block; `python3 -c "import yaml; ..."` on the
  full file.

The three other `with:`-block usages of `github.ref_name` (`tag_name:`,
`name:`, `files:` on `softprops/action-gh-release`) are untouched — action
inputs aren't a shell-run context, so a crafted tag there becomes YAML
string content, not executable syntax. Out of this issue's stated scope
(which names exactly two run blocks), and not the injection class zizmor
or the issue are about.

## Test plan

- [x] `bash -n` on the modified run-block bodies
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] `zizmor` before/after: 6 `template-injection` findings on `github.ref_name` → 0
- [x] Simulated-payload test proving the substitution never re-executes the value

Closes #1602

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHECHYsrFnSfXrqv94BZRc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved release automation so version tags are applied consistently across release notes, download links, and bundled release artifacts.
  - Release packages and associated references now use the correct release identifier, helping ensure published downloads point to matching artifacts.
  - Bundle assembly now applies the selected version, operating system, and architecture consistently across generated release packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->