### PR TITLE
ci(security): run the Makefile variable-injection regression test

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -95,6 +95,16 @@ jobs:
           fi
           echo "govulncheck passed (the scan ran; any remaining vulns have no upstream fix)"
 
+  makefile-var-safety:
+    name: Makefile variable injection (#1732)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Run test-makefile-var-safety.sh
+        run: ./scripts/test-makefile-var-safety.sh
+
   trivy:
     name: Dependency Scan (Trivy)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Wires `scripts/test-makefile-var-safety.sh` into `security.yml` as its own CI job.

## Context

Closes #1732. The actual fix — freezing `VERSION`/`GIT_COMMIT`/`BUILD_TIME`/`BUNDLE_VERSION`/`BUNDLE_OS`/`BUNDLE_ARCH` against Make's own `$(shell ...)` re-expansion, and reading them back in every recipe via shell `${VAR}` instead of Make's `$(VAR)` — plus the regression test script itself, already landed on `main` as part of the v0.74.0 release commit (#1733). That happened before this piece could go out as its own reviewed PR (a concurrent session's release-cut swept up in-progress uncommitted work in this shared checkout). This PR adds the one thing that didn't make it across: CI enforcement, so a future Makefile change can't reopen the class without a red build.

## What the underlying fix closes (already on `main`, for reviewers' context)

- Any of the six variables above set via `make ... VAR=value` (or inherited from the environment) is normally a recursively-expanded Make macro, not inert data. A recipe that dereferences it lets Make itself evaluate a `$(shell ...)` hidden inside the value — and Make auto-exports every command-line-set variable into every recipe's shell environment even when that recipe never references it, so this was exploitable with zero direct reference anywhere in the Makefile.
- Verified locally before the fix: `make build VERSION='$(shell touch /tmp/pwned)'` created `/tmp/pwned`; so did setting any of the other five variables against a target that never mentions them.
- After the fix: the same payloads (Make-level `$(shell ...)`, shell-level `$(...)`, and backticks) are all inert across all six variables, while `make build VERSION=1.2.3` still embeds the real value via `-ldflags` — verified end-to-end against a real `mcp-server` build with `strings` on the resulting binary.

## Test plan

- [x] `./scripts/test-makefile-var-safety.sh` passes locally (19/19)
- [x] New `makefile-var-safety` job added to `security.yml`, runs the same script on every PR
- [x] `make build-mcp VERSION=9.9.9-embedtest` still embeds the version correctly (checked via `strings`)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FHECHYsrFnSfXrqv94BZRc

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated security check to detect potentially unsafe Makefile variable injection during repository validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->