### PR TITLE
fix(app-hosting): repair DNS-01 issuers in place instead of replacing them

### DIFF
--- a/internal/app/proxy.go
+++ b/internal/app/proxy.go
@@ -344,8 +344,8 @@ func (p *ProxyManager) RemoveTLSSubject(domain string) error {
 	return nil
 }
 
-// ensureDNSIssuers gives a policy's issuers the configured DNS-01 challenge
-// config, reporting whether it changed anything.
+// ensureDNSIssuers gives a policy's ACME issuers the configured DNS-01
+// challenge config, reporting whether it changed anything.
 //
 // Wildcard subjects (`*.example.com`) can ONLY be issued via DNS-01 —
 // HTTP-01 and TLS-ALPN-01 categorically cannot solve them. A policy created
@@ -353,17 +353,46 @@ func (p *ProxyManager) RemoveTLSSubject(domain string) error {
 // wildcard to it produces a subject Caddy never attempts: no certificate, no
 // error, nothing in the log to notice (#1066).
 //
-// A no-op when DNS-01 isn't configured (nothing to add) or when every issuer
-// already carries it, so this is safe to call on every provision.
+// Repairs issuers in place — attaching `challenges.dns` to each ACME issuer
+// that lacks it — rather than replacing the array. The previous wholesale
+// `policy.Issuers = issuersFor(...)` silently discarded any per-issuer field
+// issuersFor doesn't itself reproduce: external_account (EAB), Module was
+// always overwritten to "acme", CA became Let's Encrypt for anything but
+// (#1671). Only reachable via a hand-edited policy today (ProxyManager is
+// the only in-tree writer), but the loss was permanent — persisted back to
+// Caddy on the very next reconcile tick.
+//
+// A non-ACME issuer (Module != "acme", e.g. "internal") is left completely
+// alone: it categorically cannot solve DNS-01, and attaching the challenge
+// config anyway is meaningless for an internal CA and would misrepresent an
+// issuer that was deliberately kept off public ACME.
+//
+// A no-op when DNS-01 isn't configured (nothing to add), when the policy has
+// no issuers at all to repair, or when every ACME issuer already carries it
+// — so this is safe to call on every provision.
 func (p *ProxyManager) ensureDNSIssuers(policy *CaddyTLSAutomationPolicy) bool {
 	if p.dnsChallenge == nil {
 		return false
 	}
-	if len(policy.Issuers) > 0 && policyHasDNSChallenge(*policy) {
+	if len(policy.Issuers) == 0 {
+		policy.Issuers = issuersFor(p.dnsChallenge)
+		return true
+	}
+	if policyHasDNSChallenge(*policy) {
 		return false
 	}
-	policy.Issuers = issuersFor(p.dnsChallenge)
-	return true
+	changed := false
+	for i := range policy.Issuers {
+		issuer := &policy.Issuers[i]
+		if issuer.Module != "acme" {
+			continue
+		}
+		if issuer.Challenges == nil || issuer.Challenges.DNS == nil {
+			issuer.Challenges = p.dnsChallenge
+			changed = true
+		}
+	}
+	return changed
 }
 
 // ensureIssuerEmail gives a policy's issuers the configured ACME contact
@@ -435,12 +464,18 @@ func (p *ProxyManager) dropUnregisterableZeroSSL(policy *CaddyTLSAutomationPolic
 	return true
 }
 
-// policyHasDNSChallenge reports whether EVERY issuer can solve DNS-01.
+// policyHasDNSChallenge reports whether EVERY ACME issuer can solve DNS-01.
 //
 // Every, not any: Caddy tries issuers in order, and one that cannot solve the
 // challenge is a failed attempt for the wildcard rather than a skipped one.
+// A non-ACME issuer (Module != "acme") is exempt — it can never solve DNS-01
+// and ensureDNSIssuers deliberately leaves it untouched (#1671), so its
+// absence of `challenges` isn't a gap this function should report.
 func policyHasDNSChallenge(policy CaddyTLSAutomationPolicy) bool {
 	for _, issuer := range policy.Issuers {
+		if issuer.Module != "acme" {
+			continue
+		}
 		if issuer.Challenges == nil || issuer.Challenges.DNS == nil {
 			return false
 		}

--- a/internal/app/proxy_tls_dns_issuers_test.go
+++ b/internal/app/proxy_tls_dns_issuers_test.go
@@ -184,3 +184,110 @@ func TestPolicyHasDNSChallengeRequiresEveryIssuer(t *testing.T) {
 		t.Error("a policy where every issuer solves DNS-01 was reported as not covered")
 	}
 }
+
+// #1671 — ensureDNSIssuers used to replace policy.Issuers wholesale, which
+// silently discarded any field issuersFor doesn't itself reproduce:
+// external_account (EAB), trusted_roots_pem_files, a non-default CA, and the
+// issuer count itself. These tests exercise ensureDNSIssuers directly so the
+// assertions are about specific fields, not just "the policy still works".
+
+// newTestProxyManagerWithDNS returns a ProxyManager configured with a DNS-01
+// challenge and nothing else — ensureDNSIssuers never touches the network,
+// so the fake-Caddy-server machinery the rest of this file uses isn't needed.
+func newTestProxyManagerWithDNS() *ProxyManager {
+	return NewProxyManager("http://unused.invalid", "example.com").WithDNSChallenge(testDNSChallenge())
+}
+
+func TestEnsureDNSIssuers_PreservesExternalAccountKey(t *testing.T) {
+	p := newTestProxyManagerWithDNS()
+	issuer := NewACMEIssuer()
+	issuer.CA = "https://acme.zerossl.com/v2/DV90"
+	issuer.ExternalAccountKey = "kid:hmac-base64"
+	policy := &CaddyTLSAutomationPolicy{Issuers: []CaddyTLSIssuer{issuer}}
+
+	if !p.ensureDNSIssuers(policy) {
+		t.Fatal("ensureDNSIssuers reported no change, but the issuer had no DNS-01 challenge")
+	}
+	if policy.Issuers[0].ExternalAccountKey != "kid:hmac-base64" {
+		t.Errorf("ExternalAccountKey = %q, want it preserved — EAB ties issuance to a paid/authorised "+
+			"ACME account and losing it silently breaks the next issuance against that CA",
+			policy.Issuers[0].ExternalAccountKey)
+	}
+	if policy.Issuers[0].CA != "https://acme.zerossl.com/v2/DV90" {
+		t.Errorf("CA = %q, want the hand-set CA preserved", policy.Issuers[0].CA)
+	}
+	assertAllIssuersSolveDNS(t, *policy)
+}
+
+func TestEnsureDNSIssuers_PreservesTrustedRootsPEMFiles(t *testing.T) {
+	p := newTestProxyManagerWithDNS()
+	issuer := NewACMEIssuer()
+	issuer.CA = "https://private-ca.example.internal/acme/directory"
+	issuer.TrustedRootsPEMFiles = []string{"/etc/containarium/private-ca-root.pem"}
+	policy := &CaddyTLSAutomationPolicy{Issuers: []CaddyTLSIssuer{issuer}}
+
+	p.ensureDNSIssuers(policy)
+
+	got := policy.Issuers[0].TrustedRootsPEMFiles
+	if len(got) != 1 || got[0] != "/etc/containarium/private-ca-root.pem" {
+		t.Errorf("TrustedRootsPEMFiles = %v, want [/etc/containarium/private-ca-root.pem] preserved — "+
+			"a private CA's issuer is unusable without its trust root", got)
+	}
+}
+
+func TestEnsureDNSIssuers_PreservesIssuerCount(t *testing.T) {
+	p := newTestProxyManagerWithDNS()
+	custom := NewACMEIssuer()
+	custom.CA = "https://private-ca.example.internal/acme/directory"
+	policy := &CaddyTLSAutomationPolicy{
+		Issuers: []CaddyTLSIssuer{NewACMEIssuer(), NewZeroSSLIssuer(), custom},
+	}
+
+	p.ensureDNSIssuers(policy)
+
+	if len(policy.Issuers) != 3 {
+		t.Fatalf("got %d issuers, want 3 preserved (a three-issuer policy silently becoming one or two "+
+			"is the #1671 bug)", len(policy.Issuers))
+	}
+	assertAllIssuersSolveDNS(t, *policy)
+}
+
+// A non-ACME issuer (e.g. Caddy's own "internal" CA, kept deliberately off
+// public ACME) must be left completely alone — attaching challenges.dns to
+// it is meaningless, and replacing it would attempt public issuance for a
+// subject someone explicitly kept internal-only.
+func TestEnsureDNSIssuers_LeavesNonACMEIssuerAlone(t *testing.T) {
+	p := newTestProxyManagerWithDNS()
+	internal := CaddyTLSIssuer{Module: "internal"}
+	policy := &CaddyTLSAutomationPolicy{
+		Issuers: []CaddyTLSIssuer{internal, NewACMEIssuer()},
+	}
+
+	if !p.ensureDNSIssuers(policy) {
+		t.Fatal("ensureDNSIssuers reported no change, but the acme issuer had no DNS-01 challenge")
+	}
+
+	if policy.Issuers[0].Module != "internal" || policy.Issuers[0].Challenges != nil {
+		t.Errorf("the internal issuer was modified: %+v, want it untouched", policy.Issuers[0])
+	}
+	if policy.Issuers[1].Challenges == nil || policy.Issuers[1].Challenges.DNS == nil {
+		t.Error("the acme issuer did not get a DNS-01 challenge attached")
+	}
+
+	// Idempotent: a second call must not report a change — the internal
+	// issuer permanently lacks challenges by design, so the outer guard
+	// must not mistake that for "still needs repair" forever.
+	if p.ensureDNSIssuers(policy) {
+		t.Error("ensureDNSIssuers reported a change on a policy already fully repaired")
+	}
+}
+
+func TestEnsureDNSIssuers_NoOpWhenAllACMEIssuersAlreadySolveDNS(t *testing.T) {
+	p := newTestProxyManagerWithDNS()
+	policy := &CaddyTLSAutomationPolicy{
+		Issuers: []CaddyTLSIssuer{{Module: "internal"}, issuersFor(testDNSChallenge())[0]},
+	}
+	if p.ensureDNSIssuers(policy) {
+		t.Error("ensureDNSIssuers reported a change though the only ACME issuer already solves DNS-01")
+	}
+}


### PR DESCRIPTION
## What

Closes #1671. `ensureDNSIssuers` replaced a policy's whole `issuers` array whenever DNS-01 needed adding — so any per-issuer field `issuersFor` doesn't itself reproduce was silently discarded and, since the reconciler `PATCH`es the result straight back to Caddy, the loss was permanent.

| Field | Before this fix |
| --- | --- |
| `Module` | always overwritten to `"acme"` |
| `CA` | became Let's Encrypt (or ZeroSSL) for anything else |
| `Email` | only from `CONTAINARIUM_ACME_EMAIL`; a hand-set address was lost |
| `ExternalAccountKey` (EAB) | always lost |
| `TrustedRootsPEMFiles` | always lost |
| issuer count | could shrink (a 3-issuer policy → 1 or 2) |

The trigger is exactly the state every policy is in before DNS-01 gets configured — the case the function exists to repair — so this fires on the very next reconcile tick after DNS-01 is turned on.

## Fix

Same pattern `ensureIssuerEmail` already established for the identical problem with contact addresses (#1616): repair in place. For each issuer already on the policy, attach `challenges.dns` if it's missing and leave everything else untouched. Only fall back to `issuersFor` (building a fresh array) when the policy has zero issuers to begin with — nothing to repair.

A non-ACME issuer (`Module != "acme"`, e.g. Caddy's own `"internal"`) is left completely alone, per the issue's own framing: attaching a DNS-01 challenge to it is meaningless, and replacing it would attempt public issuance for a subject someone deliberately kept off public ACME. `policyHasDNSChallenge`'s "every issuer" check now scopes to ACME issuers too, so a policy mixing an internal issuer with fully-repaired ACME issuers correctly reads as covered (not re-entering the repair loop forever).

## Test plan

New tests in `internal/app/proxy_tls_dns_issuers_test.go`, calling `ensureDNSIssuers` directly (it never touches the network):

- [x] `TestEnsureDNSIssuers_PreservesExternalAccountKey` — EAB and a hand-set CA both survive
- [x] `TestEnsureDNSIssuers_PreservesTrustedRootsPEMFiles`
- [x] `TestEnsureDNSIssuers_PreservesIssuerCount` — a 3-issuer policy stays 3
- [x] `TestEnsureDNSIssuers_LeavesNonACMEIssuerAlone` — an `"internal"` issuer is untouched, and the fix is idempotent (no false "still needs repair" on the next call)
- [x] `TestEnsureDNSIssuers_NoOpWhenAllACMEIssuersAlreadySolveDNS`

Confirmed each new test genuinely fails against the pre-fix code (stashed the fix, reran — 4 failures + a panic, all matching the bug as described) before restoring it.

- [x] Full existing suite in `internal/app` still green (the #1066/#1616 tests this file already had)
- [x] `go build ./...`, `go vet`, `golangci-lint run ./internal/app/...` — clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FHECHYsrFnSfXrqv94BZRc

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - DNS challenge configuration now preserves existing issuer settings.
  - DNS-01 challenges are applied only to ACME issuers; other issuer types remain unchanged.
  - Existing DNS-01 configurations are not duplicated or modified unnecessarily.
  - Empty issuer configurations are handled safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->