### PR TITLE
feat(app-hosting): verify the DNS-01 provider credential against its own API

### DIFF
--- a/internal/app/dns_provider_verify.go
+++ b/internal/app/dns_provider_verify.go
@@ -23,7 +23,7 @@ import (
 // cloudflareTokenVerifyURL is Cloudflare's token-introspection endpoint — the
 // credential's own issuer confirms whether it's even accepted. A var, not a
 // const, so tests can point it at a fake server instead of the real API.
-var cloudflareTokenVerifyURL = "https://api.cloudflare.com/client/v4/user/tokens/verify"
+var cloudflareTokenVerifyURL = "https://api.cloudflare.com/client/v4/user/tokens/verify" // #nosec G101 -- a public API endpoint URL, not a credential value
 
 // resolvedProviderField returns the DNS-01 provider config's `field` value
 // with a `{env.VAR}` placeholder substituted from envVars (empty if that

--- a/internal/app/dns_provider_verify.go
+++ b/internal/app/dns_provider_verify.go
@@ -1,0 +1,106 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// #1739 — split out of #1597 once #1738 fixed the more foundational half (the
+// credential never reaching Caddy's process environment at all). A
+// credential can be present, non-empty, and correctly propagated (#1738) and
+// still be revoked, expired, or simply wrong — this authenticates it against
+// the provider's own API before any DNS-01 challenge is ever attempted.
+//
+// Only cloudflare has a verifier today, matching DNSChallengeFromEnv's own
+// cloudflare-specific defaulting. Any other provider name is a deliberate
+// no-op (see VerifyDNSProviderCredential) rather than a hard requirement —
+// verification is a nice-to-have layered on top of #1738's propagation fix,
+// not something every caddy-dns provider needs before this is useful.
+
+// cloudflareTokenVerifyURL is Cloudflare's token-introspection endpoint — the
+// credential's own issuer confirms whether it's even accepted. A var, not a
+// const, so tests can point it at a fake server instead of the real API.
+var cloudflareTokenVerifyURL = "https://api.cloudflare.com/client/v4/user/tokens/verify"
+
+// resolvedProviderField returns the DNS-01 provider config's `field` value
+// with a `{env.VAR}` placeholder substituted from envVars (empty if that
+// variable didn't resolve — already reported by caddyDNSProviderEnv's
+// missing-credential check). A literal, non-placeholder value — an operator
+// can set an explicit token via CONTAINARIUM_ACME_DNS_PROVIDER_CONFIG
+// instead of a placeholder — is returned as-is.
+func resolvedProviderField(dns *CaddyACMEChallenges, field string, envVars map[string]string) string {
+	if dns == nil || dns.DNS == nil {
+		return ""
+	}
+	v, ok := dns.DNS.Provider[field]
+	if !ok {
+		return ""
+	}
+	s, ok := v.(string)
+	if !ok {
+		return ""
+	}
+	if m := envPlaceholderPattern.FindStringSubmatch(s); m != nil {
+		return envVars[m[1]]
+	}
+	return s
+}
+
+// VerifyDNSProviderCredential authenticates the resolved DNS-01 credential
+// for `provider` against the provider's own API, using `envVars` (as
+// resolved by caddyDNSProviderEnv in internal/server) to fill in any
+// `{env.VAR}` placeholder.
+//
+// attempted is false when there's no built-in verifier for this provider
+// name, or nothing resolved to check — distinct from a verified-but-invalid
+// credential (attempted=true, err!=nil): "not verified" isn't "rejected".
+func VerifyDNSProviderCredential(ctx context.Context, provider string, envVars map[string]string) (attempted bool, err error) {
+	switch provider {
+	case "cloudflare":
+		token := resolvedProviderField(DNSChallengeFromEnv(), "api_token", envVars)
+		if token == "" {
+			return false, nil
+		}
+		return true, verifyCloudflareToken(ctx, token)
+	default:
+		return false, nil
+	}
+}
+
+// verifyCloudflareToken calls Cloudflare's token-verify endpoint. Returns
+// nil only when Cloudflare itself confirms the token is active.
+func verifyCloudflareToken(ctx context.Context, token string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, cloudflareTokenVerifyURL, nil)
+	if err != nil {
+		return fmt.Errorf("building token-verify request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("token-verify request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		Success bool `json:"success"`
+		Errors  []struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return fmt.Errorf("decoding token-verify response (status %d): %w", resp.StatusCode, err)
+	}
+	if result.Success {
+		return nil
+	}
+	if len(result.Errors) > 0 {
+		return fmt.Errorf("token rejected: %s (code %d)", result.Errors[0].Message, result.Errors[0].Code)
+	}
+	return fmt.Errorf("token rejected (HTTP %d)", resp.StatusCode)
+}

--- a/internal/app/dns_provider_verify_test.go
+++ b/internal/app/dns_provider_verify_test.go
@@ -1,0 +1,161 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// #1739 — a credential can be present, non-empty, and correctly propagated
+// to Caddy (#1738) and still be revoked, expired, or simply wrong. These
+// tests exercise the verifier against a fake Cloudflare server, never the
+// real API.
+
+func TestResolvedProviderField(t *testing.T) {
+	t.Run("nil challenge → empty", func(t *testing.T) {
+		if got := resolvedProviderField(nil, "api_token", nil); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+
+	t.Run("placeholder resolved from envVars", func(t *testing.T) {
+		dns := &CaddyACMEChallenges{DNS: &CaddyDNSChallenge{Provider: map[string]interface{}{
+			"name": "cloudflare", "api_token": "{env.CF_API_TOKEN}",
+		}}}
+		got := resolvedProviderField(dns, "api_token", map[string]string{"CF_API_TOKEN": "real-token"})
+		if got != "real-token" {
+			t.Errorf("got %q, want real-token", got)
+		}
+	})
+
+	t.Run("placeholder with nothing resolved → empty", func(t *testing.T) {
+		dns := &CaddyACMEChallenges{DNS: &CaddyDNSChallenge{Provider: map[string]interface{}{
+			"api_token": "{env.CF_API_TOKEN}",
+		}}}
+		got := resolvedProviderField(dns, "api_token", map[string]string{})
+		if got != "" {
+			t.Errorf("got %q, want empty — CF_API_TOKEN never resolved", got)
+		}
+	})
+
+	t.Run("literal (non-placeholder) value returned as-is", func(t *testing.T) {
+		dns := &CaddyACMEChallenges{DNS: &CaddyDNSChallenge{Provider: map[string]interface{}{
+			"api_token": "literal-token-set-via-json-config",
+		}}}
+		got := resolvedProviderField(dns, "api_token", nil)
+		if got != "literal-token-set-via-json-config" {
+			t.Errorf("got %q, want the literal value unchanged", got)
+		}
+	})
+
+	t.Run("field not present → empty", func(t *testing.T) {
+		dns := &CaddyACMEChallenges{DNS: &CaddyDNSChallenge{Provider: map[string]interface{}{"name": "cloudflare"}}}
+		if got := resolvedProviderField(dns, "api_token", nil); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+}
+
+// fakeCloudflareVerify returns an httptest.Server standing in for
+// Cloudflare's /user/tokens/verify — asserts the Bearer header carries
+// exactly the token under test and responds with the given success/error
+// shape.
+func fakeCloudflareVerify(t *testing.T, wantToken string, success bool, errCode int, errMsg string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got := r.Header.Get("Authorization")
+		if got != "Bearer "+wantToken {
+			t.Errorf("Authorization header = %q, want Bearer %s", got, wantToken)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		resp := struct {
+			Success bool `json:"success"`
+			Errors  []struct {
+				Code    int    `json:"code"`
+				Message string `json:"message"`
+			} `json:"errors"`
+		}{Success: success}
+		if !success {
+			resp.Errors = append(resp.Errors, struct {
+				Code    int    `json:"code"`
+				Message string `json:"message"`
+			}{Code: errCode, Message: errMsg})
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func withFakeCloudflareURL(t *testing.T, url string) {
+	t.Helper()
+	original := cloudflareTokenVerifyURL
+	cloudflareTokenVerifyURL = url
+	t.Cleanup(func() { cloudflareTokenVerifyURL = original })
+}
+
+func TestVerifyDNSProviderCredential_CloudflareAccepted(t *testing.T) {
+	srv := fakeCloudflareVerify(t, "good-token", true, 0, "")
+	withFakeCloudflareURL(t, srv.URL)
+	t.Setenv("CONTAINARIUM_ACME_DNS_PROVIDER", "cloudflare")
+	t.Setenv("CONTAINARIUM_ACME_DNS_PROVIDER_CONFIG", "")
+
+	attempted, err := VerifyDNSProviderCredential(context.Background(), "cloudflare",
+		map[string]string{"CF_API_TOKEN": "good-token"})
+	if !attempted {
+		t.Fatal("attempted = false, want true — a cloudflare verifier exists")
+	}
+	if err != nil {
+		t.Errorf("err = %v, want nil for an accepted token", err)
+	}
+}
+
+func TestVerifyDNSProviderCredential_CloudflareRejected(t *testing.T) {
+	srv := fakeCloudflareVerify(t, "bad-token", false, 1000, "Invalid API Token")
+	withFakeCloudflareURL(t, srv.URL)
+	t.Setenv("CONTAINARIUM_ACME_DNS_PROVIDER", "cloudflare")
+	t.Setenv("CONTAINARIUM_ACME_DNS_PROVIDER_CONFIG", "")
+
+	attempted, err := VerifyDNSProviderCredential(context.Background(), "cloudflare",
+		map[string]string{"CF_API_TOKEN": "bad-token"})
+	if !attempted {
+		t.Fatal("attempted = false, want true")
+	}
+	if err == nil {
+		t.Fatal("err = nil, want a rejection error")
+	}
+	if !strings.Contains(err.Error(), "Invalid API Token") {
+		t.Errorf("err = %v, want it to carry cloudflare's own message", err)
+	}
+}
+
+func TestVerifyDNSProviderCredential_NothingResolvedIsNotAttempted(t *testing.T) {
+	// #1738 already reports this case (missing credential) — the verifier
+	// must not ALSO fire a network call against an empty token.
+	t.Setenv("CONTAINARIUM_ACME_DNS_PROVIDER", "cloudflare")
+	t.Setenv("CONTAINARIUM_ACME_DNS_PROVIDER_CONFIG", "")
+
+	attempted, err := VerifyDNSProviderCredential(context.Background(), "cloudflare", map[string]string{})
+	if attempted {
+		t.Error("attempted = true, want false — nothing resolved to verify")
+	}
+	if err != nil {
+		t.Errorf("err = %v, want nil", err)
+	}
+}
+
+func TestVerifyDNSProviderCredential_UnknownProviderIsNotAttempted(t *testing.T) {
+	// route53 (and every other caddy-dns provider without a built-in
+	// verifier) degrades gracefully — not attempted, not an error.
+	attempted, err := VerifyDNSProviderCredential(context.Background(), "route53",
+		map[string]string{"AWS_ACCESS_KEY_ID": "whatever"})
+	if attempted {
+		t.Error("attempted = true, want false — no verifier registered for route53")
+	}
+	if err != nil {
+		t.Errorf("err = %v, want nil", err)
+	}
+}

--- a/internal/server/core_services.go
+++ b/internal/server/core_services.go
@@ -556,8 +556,7 @@ func (cs *CoreServices) setupCaddy(ctx context.Context, baseDomain string) error
 	// Create systemd service for Caddy. Injects one Environment= line per
 	// DNS-01 provider credential Caddy needs to expand from ITS OWN process
 	// environment — see caddyServiceUnit (#1597).
-	present, missing := caddyDNSProviderEnv()
-	logMissingDNSProviderCredentials(missing)
+	present := resolveDNSProviderCredential()
 	systemdUnit := caddyServiceUnit(present)
 	if err := cs.incusClient.WriteFile(CoreCaddyContainer, "/etc/systemd/system/caddy.service", []byte(systemdUnit), "0644"); err != nil {
 		return fmt.Errorf("failed to write caddy service: %w", err)
@@ -620,6 +619,54 @@ func logMissingDNSProviderCredentials(missing []string) {
 	}
 }
 
+// verifyDNSProviderCredentialFn is a var, not a plain call, so tests that
+// exercise reconcileCaddyDNSEnv's propagation/reconcile logic (unrelated to
+// verification) can stub it out — without this seam every such test would
+// make a real network call to whatever provider API a test token happens to
+// name, which is slow, flaky, and points at a live third party.
+var verifyDNSProviderCredentialFn = verifyDNSProviderCredential
+
+// verifyDNSProviderCredential authenticates the resolved DNS-01 credential
+// against its own provider's API (#1739) — a credential can be present,
+// non-empty, and correctly propagated (#1738) and still be revoked,
+// expired, or simply wrong. Non-fatal, same as the presence check: an
+// ERROR log on rejection, an INFO note when no built-in verifier exists for
+// this provider, and — per #1739's own acceptance criterion — nothing at
+// all when the credential is confirmed valid.
+func verifyDNSProviderCredential(present map[string]string) {
+	provider := app.DNSProviderFromEnv()
+	if provider == "" || len(present) == 0 {
+		return // no DNS-01 configured, or nothing resolved to check (#1738 already reported that)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	attempted, err := app.VerifyDNSProviderCredential(ctx, provider, present)
+	if !attempted {
+		log.Printf("INFO: no built-in credential verification for DNS-01 provider %q — presence and "+
+			"propagation to Caddy were confirmed (#1738), but validity against the provider's own API "+
+			"is unchecked (#1739)", provider)
+		return
+	}
+	if err != nil {
+		log.Printf("ERROR: DNS-01 provider %q rejected its configured credential: %v — wildcard/DNS-01 "+
+			"certificate issuance will fail until this is fixed (#1739)", provider, err)
+	}
+}
+
+// resolveDNSProviderCredential resolves the DNS-01 provider's {env.VAR}
+// placeholders against the daemon's own environment, reports any that are
+// missing (#1738), and — for a provider with a built-in verifier — checks
+// the resolved credential is actually accepted (#1739). Returns the
+// resolved map for the caller to inject into Caddy's systemd environment.
+// Shared by setupCaddy (first provisioning) and reconcileCaddyDNSEnv (every
+// subsequent daemon start) so both paths get the same checks.
+func resolveDNSProviderCredential() map[string]string {
+	present, missing := caddyDNSProviderEnv()
+	logMissingDNSProviderCredentials(missing)
+	verifyDNSProviderCredentialFn(present)
+	return present
+}
+
 // caddyServiceUnit renders the containarium-core-caddy systemd unit, adding
 // one Environment= line per resolved DNS-01 provider credential so Caddy's
 // own process can actually expand the {env.VAR} placeholders the daemon's
@@ -671,9 +718,7 @@ WantedBy=multi-user.target
 // common case, every daemon startup, is a ReadFile and a string compare.
 // Called from both of EnsureCaddy's "container already exists" paths.
 func (cs *CoreServices) reconcileCaddyDNSEnv() {
-	present, missing := caddyDNSProviderEnv()
-	logMissingDNSProviderCredentials(missing)
-
+	present := resolveDNSProviderCredential()
 	desired := caddyServiceUnit(present)
 	if current, err := cs.incusClient.ReadFile(CoreCaddyContainer, "/etc/systemd/system/caddy.service"); err == nil && string(current) == desired {
 		return

--- a/internal/server/core_services_caddy_dns_test.go
+++ b/internal/server/core_services_caddy_dns_test.go
@@ -135,7 +135,20 @@ func (b *fakeCaddyDNSBackend) Exec(_ string, command []string) error {
 	return b.execErr
 }
 
+// stubDNSProviderVerification disables the (real, network-calling)
+// credential verifier for the duration of a test. These reconcile tests
+// exercise propagation/reconcile logic — whether a fake test token happens
+// to be accepted by a live third-party API is #1739's own concern, covered
+// by internal/app's tests against a fake server, not this package's.
+func stubDNSProviderVerification(t *testing.T) {
+	t.Helper()
+	original := verifyDNSProviderCredentialFn
+	verifyDNSProviderCredentialFn = func(map[string]string) {}
+	t.Cleanup(func() { verifyDNSProviderCredentialFn = original })
+}
+
 func TestReconcileCaddyDNSEnv_NoOpWhenAlreadyInSync(t *testing.T) {
+	stubDNSProviderVerification(t)
 	t.Setenv("CONTAINARIUM_ACME_DNS_PROVIDER", "cloudflare")
 	t.Setenv("CONTAINARIUM_ACME_DNS_PROVIDER_CONFIG", "")
 	t.Setenv("CF_API_TOKEN", "real-token-value")
@@ -156,6 +169,7 @@ func TestReconcileCaddyDNSEnv_NoOpWhenAlreadyInSync(t *testing.T) {
 }
 
 func TestReconcileCaddyDNSEnv_WritesAndRestartsWhenCredentialAppears(t *testing.T) {
+	stubDNSProviderVerification(t)
 	// The exact #1597 scenario: an operator sets CONTAINARIUM_ACME_DNS_PROVIDER
 	// (and the credential) on an ALREADY-provisioned host — setupCaddy already
 	// ran once, long ago, with no DNS-01 configured at all.
@@ -193,6 +207,7 @@ func TestReconcileCaddyDNSEnv_WritesAndRestartsWhenCredentialAppears(t *testing.
 // partial/corrupt state), and this is the visibility #1597 asks for even
 // when there is nothing to write yet.
 func TestReconcileCaddyDNSEnv_LogsAndDoesNotWriteWhenCredentialUnset(t *testing.T) {
+	stubDNSProviderVerification(t)
 	t.Setenv("CONTAINARIUM_ACME_DNS_PROVIDER", "cloudflare")
 	t.Setenv("CONTAINARIUM_ACME_DNS_PROVIDER_CONFIG", "")
 	t.Setenv("CF_API_TOKEN", "")
@@ -212,5 +227,50 @@ func TestReconcileCaddyDNSEnv_LogsAndDoesNotWriteWhenCredentialUnset(t *testing.
 	}
 	if len(backend.execCalls) != 0 {
 		t.Errorf("Exec was called though nothing changed: %v", backend.execCalls)
+	}
+}
+
+// #1739 — resolveDNSProviderCredential (used by both setupCaddy and
+// reconcileCaddyDNSEnv) must hand the resolved credential map to the
+// verifier, and only when something actually resolved.
+func TestResolveDNSProviderCredential_CallsVerifierWithResolvedCredential(t *testing.T) {
+	t.Setenv("CONTAINARIUM_ACME_DNS_PROVIDER", "cloudflare")
+	t.Setenv("CONTAINARIUM_ACME_DNS_PROVIDER_CONFIG", "")
+	t.Setenv("CF_API_TOKEN", "a-real-looking-token")
+
+	var gotCalls []map[string]string
+	original := verifyDNSProviderCredentialFn
+	verifyDNSProviderCredentialFn = func(present map[string]string) { gotCalls = append(gotCalls, present) }
+	t.Cleanup(func() { verifyDNSProviderCredentialFn = original })
+
+	got := resolveDNSProviderCredential()
+
+	if len(gotCalls) != 1 {
+		t.Fatalf("verifier called %d times, want 1", len(gotCalls))
+	}
+	if gotCalls[0]["CF_API_TOKEN"] != "a-real-looking-token" {
+		t.Errorf("verifier called with %v, want CF_API_TOKEN=a-real-looking-token", gotCalls[0])
+	}
+	if got["CF_API_TOKEN"] != "a-real-looking-token" {
+		t.Errorf("resolveDNSProviderCredential returned %v", got)
+	}
+}
+
+// resolveDNSProviderCredential always calls through to the verifier — it's
+// verifyDNSProviderCredential's own job to no-op on an empty/unconfigured
+// case (covered directly by internal/app's tests) rather than duplicating
+// that decision here.
+func TestResolveDNSProviderCredential_CallsVerifierEvenWithNothingResolved(t *testing.T) {
+	t.Setenv("CONTAINARIUM_ACME_DNS_PROVIDER", "")
+
+	var gotCalls []map[string]string
+	original := verifyDNSProviderCredentialFn
+	verifyDNSProviderCredentialFn = func(present map[string]string) { gotCalls = append(gotCalls, present) }
+	t.Cleanup(func() { verifyDNSProviderCredentialFn = original })
+
+	resolveDNSProviderCredential()
+
+	if len(gotCalls) != 1 || len(gotCalls[0]) != 0 {
+		t.Errorf("verifier calls = %v, want exactly one call with an empty map", gotCalls)
 	}
 }


### PR DESCRIPTION
## What

Partial progress on #1739 — covers the "credential valid" acceptance criterion; zone coverage is left for a follow-up (see below). This PR is standalone-mergeable and doesn't need to wait on that.

## Why

#1738 fixed the DNS-01 credential never reaching Caddy's process environment at all, and added a presence check. Neither catches a credential that IS present, non-empty, and correctly propagated — and still revoked, expired, or simply wrong. The daemon and Caddy both start clean either way, and DNS-01 fails per-issuance with a message that reads like a token-scope problem, not "the token itself is bad."

## What changed

- `app.VerifyDNSProviderCredential` (new, `internal/app/dns_provider_verify.go`): for cloudflare, calls `GET /user/tokens/verify` with the resolved token as a Bearer header. Any other `caddy-dns` provider name degrades to "not attempted" — per the issue's own framing, verification is additive on top of #1738, not a new hard requirement.
- Wired into `core_services.go`'s `resolveDNSProviderCredential` — the one helper `setupCaddy` (first provisioning) and `reconcileCaddyDNSEnv` (every subsequent daemon start, #1738) both already call to resolve the credential. So a revoked token gets caught on the next daemon restart, not just at first setup.
- Non-fatal: `ERROR` log on rejection, `INFO` note when no verifier exists for the configured provider, **nothing at all on success** — matching the issue's explicit "a fully valid credential produces no noise" acceptance criterion.

## A test-hygiene fix along the way

Wiring verification into `resolveDNSProviderCredential` meant `core_services_caddy_dns_test.go`'s existing reconcile tests — written before this PR, using made-up tokens like `"freshly-configured-token"` — started making **real network calls to Cloudflare's actual API** (I caught this because the tests went from ~0.00s to ~0.5s and logged a genuine "Invalid request headers" response from `api.cloudflare.com`). Fixed by making the verifier a package-level var (`verifyDNSProviderCredentialFn`) so those tests can stub it out; the real Cloudflare-calling logic is exercised only by `internal/app`'s own tests, against a fake `httptest.Server`.

## Deferred

Zone coverage (enumerate the token's zones, warn per TLS subject not covered) needs the live subject list, which lives in `internal/app.ProxyManager` — a different package than `core_services.go`, and not stable at pure daemon-startup/reconcile time the way the credential resolution is. Left as the remaining half of #1739's own acceptance criteria rather than folding a second, architecturally distinct check into this PR.

## Test plan

- [x] `internal/app/dns_provider_verify_test.go` (new): accepted/rejected against a fake Cloudflare server, "nothing resolved → not attempted", "unknown provider → not attempted", plus placeholder-resolution edge cases in `resolvedProviderField`
- [x] `internal/server/core_services_caddy_dns_test.go`: existing reconcile tests now stub verification (no more live network calls — confirmed by test duration dropping back to ~0.00s); new tests confirm `resolveDNSProviderCredential` calls the verifier with the correctly-resolved map
- [x] `go build ./...`, `go test ./internal/server/... ./internal/app/...`, `go vet`, `gofmt -l`, `golangci-lint run` — all clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FHECHYsrFnSfXrqv94BZRc

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic verification of Cloudflare DNS credentials before use.
  - Supports credentials provided directly or through environment-variable references.
  - Applies verification during initial setup and subsequent configuration updates.
  - Reports missing, unresolved, rejected, or invalid credentials.

- **Bug Fixes**
  - Standardized DNS credential handling across setup and reconciliation workflows.
  - Unsupported providers continue without verification.
  - Invalid credentials are no longer silently accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->