### PR TITLE
fix(secrets): default new secrets to file delivery instead of env

### DIFF
--- a/docs/integrations/pi.md
+++ b/docs/integrations/pi.md
@@ -121,9 +121,12 @@ refresh` pushes the current store to a running box without a restart.
 `/run/containarium/secrets.env` (tmpfs); `--delivery file` writes one file per
 secret at `/run/secrets/<NAME>` if you'd rather read them individually.
 
-### Why not the default `env` delivery
+### Why not `env` delivery
 
-The default (`--delivery env`) stamps `environment.<NAME>=<value>` on the LXC.
+`--delivery env` stamps `environment.<NAME>=<value>` on the LXC (no longer
+the default since #1604, but still fully supported and worth naming
+explicitly here since it's the one delivery mode that looks like it should
+work for an SSH session and doesn't).
 That reaches container-start processes and nested docker/compose apps — but
 **not an SSH shell session**, which is where pi runs. The login path rebuilds
 the environment from scratch (`sshd` → the box's login wrapper → `su -` →

--- a/docs/security/SECRETS-ENV-VAR-RISK.md
+++ b/docs/security/SECRETS-ENV-VAR-RISK.md
@@ -1,20 +1,34 @@
 # Container Env-Var Introspection Risk (Audit C-MED-4)
 
-This is a design note about how Containarium currently delivers tenant
-secrets into containers, the risk that comes with it, and the
-tmpfs-mount alternative we plan to offer as opt-in.
+This is a design note about how Containarium delivers tenant secrets
+into containers, the risk that comes with the env-var path, and the
+tmpfs-mount (`file` delivery) alternative that closes it.
 
-## Today: env-var stamping
+## Today: file delivery is the default; env-var stamping remains available (#1604)
 
-`internal/server/secrets_server.go:stampSecretsOnLXC` calls
-`incus config set environment.<NAME>=<value>` for every secret a tenant
-owns. The values land in the LXC's Incus config; on the next container
-start (or `RefreshSecrets` call) they become environment variables of
-the container's init process (`PID 1`) and inherit into every child
+A `SetSecret` with no delivery specified now gets `file` — the
+tmpfs-mount path described below — rather than env-var stamping.
+Existing rows keep whatever mode they were written with; nothing is
+migrated retroactively, and a value rotation that doesn't repeat an
+explicit `--delivery` preserves the row's current mode rather than
+silently reclassifying it.
+
+`env` remains fully supported and selectable via
+`containarium secrets set <user> <NAME> <value> --delivery env` — some
+apps only read `os.Getenv` and nothing else, and this document's risk
+analysis of that path is unchanged; it's just no longer what a caller
+gets without asking for it.
+
+When `env` delivery is in effect, `internal/server/secrets_server.go:stampSecretsOnLXC`
+calls `incus config set environment.<NAME>=<value>` for that secret.
+The value lands in the LXC's Incus config; on the next container start
+(or `RefreshSecrets` call) it becomes an environment variable of the
+container's init process (`PID 1`) and inherits into every child
 process via `execve(2)`.
 
-The app code reads them as `os.Getenv("OPENAI_API_KEY")` or whatever's
-idiomatic in its language — convenient, language-agnostic, no SDK.
+The app code reads it as `os.Getenv("OPENAI_API_KEY")` or whatever's
+idiomatic in its language — convenient, language-agnostic, no SDK, and
+the reason `env` remains available rather than being removed.
 
 ## What "in env" means in practice
 
@@ -94,7 +108,7 @@ the tmpfs alternative:
    `containarium secret set` (which versions in place) means an
    exposed secret has a bounded blast radius.
 
-## Future: tmpfs-mount alternative (planned, not yet implemented)
+## The tmpfs-mount alternative (`file` delivery — shipped, now the default)
 
 The cleanest mitigation is to stop putting secrets in env entirely:
 
@@ -119,18 +133,18 @@ Costs:
   support `<SECRET>_FILE` env-var conventions (Postgres password,
   Vault sidecars, Docker Compose secrets) work with no code change —
   set `PGPASSWORD_FILE=/run/secrets/PGPASSWORD` instead of
-  `PGPASSWORD=…`.
-- Operator UX: a second toggle on `containarium secret set`
-  (`--delivery=env|file`, opt-in to file mode).
+  `PGPASSWORD=…`. Apps that only read `os.Getenv` need
+  `--delivery env` instead — see the "Today" section above.
 - One more code path on the daemon (mount management, file rotation
   on `RefreshSecrets`).
 
-The plan is to offer this as **opt-in alongside** the env-var path,
-not as a replacement. Operators choose per-tenant or per-secret. The
-default stays env-stamping for backwards compatibility; new
-deployments are encouraged to use file mode for high-risk values.
+This ships **alongside** the env-var path, not as a replacement —
+`env` stays fully supported and selectable per-tenant or per-secret via
+`--delivery env`. It's the default (#1604) rather than opt-in, because
+the risk this section describes applies whether or not an operator
+knew to ask for the alternative.
 
-### Status: shipped through Phase B-2
+### Status: shipped through Phase B-2, default flipped in #1604
 
 - **Phase A** (PR #274): the `delivery` field is plumbed
   through proto / Store / CLI. Operators can set it via

--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -266,9 +266,14 @@ func runSecretsList(cmd *cobra.Command, args []string) error {
 		fmt.Printf("(no secrets for %s)\n", username)
 		return nil
 	}
-	fmt.Printf("%-32s %-8s %s\n", "NAME", "VERSION", "UPDATED")
+	// #1604 — delivery mode was already on SecretMetadata but never
+	// surfaced here, so an operator had no way to see which of their
+	// secrets are still in the env (Incus-config-visible) mode short of
+	// reading the daemon's own database.
+	fmt.Printf("%-32s %-8s %-9s %s\n", "NAME", "VERSION", "DELIVERY", "UPDATED")
 	for _, row := range list {
-		fmt.Printf("%-32s %-8d %s\n", row.GetName(), row.GetVersion(), strings.TrimSuffix(row.GetUpdatedAt(), "Z"))
+		fmt.Printf("%-32s %-8d %-9s %s\n", row.GetName(), row.GetVersion(),
+			secretDeliveryLabel(row.GetDeliveryMode()), strings.TrimSuffix(row.GetUpdatedAt(), "Z"))
 	}
 	return nil
 }

--- a/internal/secrets/store.go
+++ b/internal/secrets/store.go
@@ -26,8 +26,8 @@ type SecretMetadata struct {
 	CreatedAt time.Time
 	UpdatedAt time.Time
 
-	// Phase 4.3 — delivery mode. "env" (default) or "file".
-	// Phase A lands the field; Phase B switches the stamping
+	// Phase 4.3 — delivery mode: "env", "file" (default since #1604), or
+	// "compose". Phase A lands the field; Phase B switches the stamping
 	// path to honor it. See docs/security/SECRETS-ENV-VAR-RISK.md.
 	Delivery string
 }
@@ -46,9 +46,9 @@ const (
 	DeliveryCompose = "compose"
 )
 
-// ValidateDelivery returns nil for "" (defaults to env at the storage
-// layer), "env", "file", or "compose". Anything else is caller-error
-// and rejected at the API boundary.
+// ValidateDelivery returns nil for "" (defaults to file at the storage
+// layer — #1604), "env", "file", or "compose". Anything else is
+// caller-error and rejected at the API boundary.
 func ValidateDelivery(mode string) error {
 	switch mode {
 	case "", DeliveryEnv, DeliveryFile, DeliveryCompose:
@@ -282,8 +282,8 @@ func (s *Store) initSchema(ctx context.Context) error {
 // populated. Otherwise it writes a legacy row exactly as before
 // Phase 4.1 — wrapped_dek and kek_id stay NULL.
 //
-// `delivery` (Phase 4.3) is one of "" (defaults to env on storage),
-// "env", "file". Validated at the API boundary; invalid values
+// `delivery` (Phase 4.3) is one of "" (defaults to file on storage — #1604),
+// "env", "file", "compose". Validated at the API boundary; invalid values
 // reject before any DB work.
 func (s *Store) Set(ctx context.Context, username, name, value, delivery string) (*SecretMetadata, error) {
 	if username == "" {
@@ -303,11 +303,30 @@ func (s *Store) Set(ctx context.Context, username, name, value, delivery string)
 	if err := ValidateValueForDelivery(delivery, value); err != nil {
 		return nil, err
 	}
-	// Storage layer normalizes "" → "env" so the column is
-	// always populated. Lets future migration code rely on
-	// the field being non-empty.
-	if delivery == "" {
-		delivery = DeliveryEnv
+	// explicit is the caller's ORIGINAL argument, empty or not — kept
+	// separate from the resolved value below so a value rotation that
+	// doesn't repeat its delivery choice can be told apart, in SQL, from
+	// one that does. Losing that distinction would mean any rotation of
+	// an existing env secret that omits --delivery silently reclassifies
+	// it as file the moment this default flips — the app reading
+	// os.Getenv would stop seeing the new value with no error anywhere,
+	// exactly the kind of silent, persisted config loss #1671 already
+	// burned this codebase on for a different field.
+	explicit := delivery
+	// Storage layer normalizes "" → "file" for a genuinely NEW row so the
+	// column is always populated. #1604: env was the unspecified default
+	// for a secret any same-container process can read via
+	// /proc/<pid>/environ, AND the one Incus itself prints in cleartext
+	// (`incus config show`) — a deployment fully migrated to envelope
+	// encryption at rest could still leak every secret through this
+	// path, because the two never interacted. file (0440 root:<tenant>
+	// on tmpfs, absent from the Incus config entirely) closes both, and
+	// is the default an operator gets without having to know to ask for
+	// it. env remains fully supported and selectable via --delivery for
+	// apps that only read os.Getenv.
+	resolved := delivery
+	if resolved == "" {
+		resolved = DeliveryFile
 	}
 
 	nonce, ct, wrappedDEK, kekID, err := s.encryptForStorage(ctx, username, name, []byte(value))
@@ -319,6 +338,12 @@ func (s *Store) Set(ctx context.Context, username, name, value, delivery string)
 	// rotate in a single round-trip. The version bumps on every
 	// rotation; the row's created_at stays as the original
 	// (set-once-ever timestamp), updated_at moves to NOW().
+	//
+	// delivery's CASE: an unspecified ($8 = '') rotation preserves
+	// whatever the row already had — only an EXPLICIT delivery argument
+	// changes an existing row's mode. A brand-new row (the INSERT branch,
+	// no conflict) always gets `resolved`, which is `explicit` when given
+	// or file otherwise.
 	const q = `
 		INSERT INTO secrets (username, name, nonce, ciphertext, wrapped_dek, kek_id, delivery, version)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, 1)
@@ -328,14 +353,16 @@ func (s *Store) Set(ctx context.Context, username, name, value, delivery string)
 			ciphertext  = EXCLUDED.ciphertext,
 			wrapped_dek = EXCLUDED.wrapped_dek,
 			kek_id      = EXCLUDED.kek_id,
-			delivery    = EXCLUDED.delivery,
+			delivery    = CASE WHEN $8 = '' THEN secrets.delivery ELSE EXCLUDED.delivery END,
 			version     = secrets.version + 1,
 			updated_at  = NOW()
-		RETURNING version, created_at, updated_at;
+		RETURNING version, created_at, updated_at, delivery;
 	`
 	var version int32
 	var createdAt, updatedAt time.Time
-	if err := s.pool.QueryRow(ctx, q, username, name, nonce, ct, wrappedDEK, kekID, delivery).Scan(&version, &createdAt, &updatedAt); err != nil {
+	var finalDelivery string
+	if err := s.pool.QueryRow(ctx, q, username, name, nonce, ct, wrappedDEK, kekID, resolved, explicit).
+		Scan(&version, &createdAt, &updatedAt, &finalDelivery); err != nil {
 		return nil, fmt.Errorf("upsert secret: %w", err)
 	}
 	return &SecretMetadata{
@@ -344,7 +371,7 @@ func (s *Store) Set(ctx context.Context, username, name, value, delivery string)
 		Version:   version,
 		CreatedAt: createdAt,
 		UpdatedAt: updatedAt,
-		Delivery:  delivery,
+		Delivery:  finalDelivery,
 	}, nil
 }
 

--- a/internal/secrets/store_test.go
+++ b/internal/secrets/store_test.go
@@ -120,6 +120,79 @@ func TestSecretsStore_Roundtrip(t *testing.T) {
 	}
 }
 
+// #1604 — env was the unspecified default: any process in the same
+// container that can read /proc/<pid>/environ sees every secret, and Incus
+// itself prints it in cleartext (`incus config show`). file closes both and
+// is now what a caller gets without asking for it by name; env stays fully
+// supported and selectable via an explicit delivery argument.
+func TestSecretsStore_DeliveryDefaultsToFile(t *testing.T) {
+	dsn := os.Getenv("CONTAINARIUM_TEST_DSN")
+	if dsn == "" {
+		t.Skip("set CONTAINARIUM_TEST_DSN to run this against Postgres (the store-integration lane does)")
+	}
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect Postgres: %v", err)
+	}
+	defer pool.Close()
+
+	key := make([]byte, corecrypto.MasterKeySize)
+	for i := range key {
+		key[i] = byte(i)
+	}
+	cipher, err := corecrypto.NewCipher(key)
+	if err != nil {
+		t.Fatalf("NewCipher: %v", err)
+	}
+	store, err := NewStore(ctx, pool, cipher)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	const user = "store-delivery-default-test-user"
+	_, _ = pool.Exec(ctx, "DELETE FROM secrets WHERE username = $1", user)
+
+	t.Run("unspecified delivery becomes file", func(t *testing.T) {
+		meta, err := store.Set(ctx, user, "UNSPECIFIED_DELIVERY", "v1", "")
+		if err != nil {
+			t.Fatalf("Set: %v", err)
+		}
+		if meta.Delivery != DeliveryFile {
+			t.Errorf("Delivery = %q, want %q (#1604's new default)", meta.Delivery, DeliveryFile)
+		}
+	})
+
+	t.Run("explicit env is still honored, not upgraded to file", func(t *testing.T) {
+		meta, err := store.Set(ctx, user, "EXPLICIT_ENV", "v1", DeliveryEnv)
+		if err != nil {
+			t.Fatalf("Set: %v", err)
+		}
+		if meta.Delivery != DeliveryEnv {
+			t.Errorf("Delivery = %q, want %q — an explicit choice must not be overridden", meta.Delivery, DeliveryEnv)
+		}
+	})
+
+	t.Run("a rotation with unspecified delivery keeps the row's existing mode, not the new default", func(t *testing.T) {
+		// Set (env) then rotate the value without repeating the delivery
+		// argument — the same shape a caller upgrading nothing but the
+		// value would use. Silently flipping delivery on an unrelated
+		// value rotation would be exactly the kind of surprise #1671
+		// (issuer replacement) already burned this codebase on once.
+		if _, err := store.Set(ctx, user, "ROTATED_ENV", "v1", DeliveryEnv); err != nil {
+			t.Fatalf("initial Set: %v", err)
+		}
+		meta, err := store.Set(ctx, user, "ROTATED_ENV", "v2", "")
+		if err != nil {
+			t.Fatalf("rotation Set: %v", err)
+		}
+		if meta.Delivery != DeliveryEnv {
+			t.Errorf("Delivery after rotation = %q, want %q preserved from the original Set", meta.Delivery, DeliveryEnv)
+		}
+	})
+}
+
 func TestSecretsStore_NilArgsRejected(t *testing.T) {
 	ctx := context.Background()
 	key := make([]byte, corecrypto.MasterKeySize)

--- a/internal/server/secrets_delivery.go
+++ b/internal/server/secrets_delivery.go
@@ -17,9 +17,11 @@ import (
 // both representations.
 
 // deliveryToProto maps a storage delivery string onto the enum. An empty
-// string means "unset" at the storage layer, which the store normalizes to
-// env — so it maps to ENV rather than UNSPECIFIED, keeping the enum a
-// faithful view of what will actually happen.
+// string only occurs on a legacy row predating the delivery column
+// (#1604's new default, file, is always written explicitly for anything
+// set since) — those rows were actually stamped as env, so "" maps to ENV
+// rather than UNSPECIFIED, keeping the enum a faithful view of what
+// already happened rather than what a fresh Set would do today.
 func deliveryToProto(s string) pb.SecretDelivery {
 	switch s {
 	case secrets.DeliveryFile:


### PR DESCRIPTION
## What

Closes #1604. `SECRET_DELIVERY_ENV` was the unspecified default for tenant secrets — unless an operator passed `--delivery file`, every secret was stamped as `environment.<NAME>=<value>` on the LXC. Both consequences are already documented in `docs/security/SECRETS-ENV-VAR-RISK.md` (audit C-MED-4): same-container `/proc/<pid>/environ` introspection, and `incus config show` printing the value in cleartext regardless of how thoroughly the secret is protected at rest.

The `file` delivery mode (0440 `root:<tenant>` on tmpfs, absent from the Incus config entirely) already shipped through Phase B-2 and fixes both — it was just opt-in and invisible unless an operator knew to ask for it.

## What changed

- `Store.Set`'s `""` fallback now resolves to `file` instead of `env`. `env` remains fully supported and selectable via `--delivery env`; existing rows are untouched.
- `secrets list` now shows a `DELIVERY` column — `SecretMetadata` already carried the field, nothing surfaced it, so an operator had no way to see which secrets were still in `env` short of reading the daemon's own database.
- `docs/security/SECRETS-ENV-VAR-RISK.md`'s "Today" section rewritten to not describe `env` as the default (per the issue's own acceptance criterion), and a "planned, not yet implemented" heading that was already stale (Phase B-2 had shipped) now says so.
- `docs/integrations/pi.md`'s "why not the default env delivery" section updated similarly.

## A sharper bug found while implementing the flip

The `INSERT ... ON CONFLICT DO UPDATE` unconditionally wrote `delivery = EXCLUDED.delivery`. That means a value **rotation** that doesn't repeat its original `--delivery` choice — the ordinary shape of `containarium secrets set alice DB_PASSWORD newvalue`, rotating a password without thinking about delivery mode — would have silently reclassified an existing `env` secret as `file` the moment this default changed. The app reading `os.Getenv` would stop seeing the rotated value with no error anywhere; the daemon and Caddy-adjacent logs would show nothing.

Same class of silent, persisted config loss as #1671 (issuer replacement destroying fields on repair) — caught here by writing a test for exactly this rotation shape *before* trusting the naive one-line flip. Fixed with a SQL `CASE`: an unspecified (`$8 = ''`) rotation now preserves whatever the row already had; only an **explicit** `--delivery` argument changes an existing row's mode. A brand-new row still gets the new default.

## Test plan

- [x] `internal/secrets/store_test.go` (DSN-gated, runs in the "stores against a real Postgres" CI lane): unspecified delivery → `file`; explicit `env` still honored, not upgraded; **a rotation with unspecified delivery preserves the row's existing mode, not the new default** (the bug above, verified to actually reproduce against the pre-fix `EXCLUDED.delivery` unconditional overwrite before I added the `CASE`)
- [x] Existing `internal/secrets` / `internal/server` delivery tests (`TestValidateDelivery`, `TestDeliveryToProto`, `TestResolveDelivery`, etc.) all still pass unchanged — none of them assumed a specific default, so none needed updating
- [x] `go build ./...`, `go test ./internal/secrets/... ./internal/server/... ./internal/cmd/...`, `go vet`, `gofmt -l`, `golangci-lint run` — all clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FHECHYsrFnSfXrqv94BZRc

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New secrets now use file delivery by default.
  * Secret listings now show each secret’s delivery mode: file, environment, or compose.
  * Rotating a secret without specifying delivery preserves its existing delivery mode.
  * Compose delivery is supported for secrets.

* **Documentation**
  * Updated integration and security documentation to explain file delivery, explicit environment-delivery opt-in, and associated risks.
  * Clarified behavior for existing secrets and legacy delivery settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->