### PR TITLE
fix(server): close the CPU admission check-then-act race

### DIFF
--- a/docs/CPU-CAPACITY-ADMISSION.md
+++ b/docs/CPU-CAPACITY-ADMISSION.md
@@ -158,6 +158,21 @@ containarium daemon --placement-cpu-aware
 
 - **Local participation in ranking.** Today an in-pool healthy local backend
   still wins unconditionally; a future option could rank local alongside peers.
-- **Check-then-act race under concurrent operations.** Two concurrent
-  creates/resizes can each admit against a stale committed-cores snapshot and
-  jointly exceed the ceiling — see #1588.
+
+## Concurrent admission (#1588)
+
+Two concurrent creates/resizes admitting against the same host's committed
+cores could each read a stale (pre-mutation) snapshot and jointly exceed the
+ceiling — the check and the mutation weren't atomic with respect to each
+other. Closed by an in-memory reservation: an admitted request reserves its
+cores (`ContainerServer.cpuReservations`) for the duration of its caller's
+mutation, and every subsequent admission check on that host counts other
+tenants' outstanding reservations on top of the real committed total, not
+just the real total alone. The caller releases the reservation once its
+mutation concludes (success or failure) — `CreateContainer`, `ResizeContainer`,
+and the cluster reconciler's VM provisioning all do this.
+
+A reservation also expires on its own after `cpuReservationTTL` (10 minutes)
+as a safety net for a caller whose completion this package can't directly
+observe — the k8s Box-CR path hands off to the operator's own
+reconciliation and never calls release explicitly.

--- a/internal/server/cluster_reconciler.go
+++ b/internal/server/cluster_reconciler.go
@@ -31,8 +31,10 @@ type ClusterReconciler struct {
 	mgr   *clustercore.Manager
 
 	// admit is the CPU-admission seam (nil = no gate, unit tests).
-	// Refusals are recorded as events, never silent.
-	admit func(owner, cpu string) error
+	// Refusals are recorded as events, never silent. The returned release
+	// func (#1588) must be called once this reconciler's own provisioning
+	// attempt concludes — see admitSize.
+	admit func(owner, cpu string) (release func(), err error)
 
 	// publish allocates/records the external API endpoint for a
 	// cluster whose control plane is up; unpublish reverses it.
@@ -67,7 +69,9 @@ func NewClusterReconciler(store clusterstore.Store, mgr *clustercore.Manager) *C
 }
 
 // SetAdmission wires the CPU-admission gate.
-func (r *ClusterReconciler) SetAdmission(f func(owner, cpu string) error) { r.admit = f }
+func (r *ClusterReconciler) SetAdmission(f func(owner, cpu string) (release func(), err error)) {
+	r.admit = f
+}
 
 // SetVPADisabled turns off VPA deployment into new clusters.
 func (r *ClusterReconciler) SetVPADisabled(v bool) { r.vpaDisabled = v }
@@ -208,10 +212,12 @@ func (r *ClusterReconciler) reconcileCluster(ctx context.Context, c *clusterstor
 	for _, act := range actions {
 		switch act.Kind {
 		case clustercore.ActionCreateCP:
-			if err := r.admitSize(c, cpSize, "control-plane"); err != nil {
+			release, err := r.admitSize(c, cpSize, "control-plane")
+			if err != nil {
 				return nil // refusal recorded; retry next pass
 			}
 			cpIP, err := r.mgr.ProvisionCP(c.Owner, c.Name, iso, cpSize, r.controlPlaneSANs())
+			release() // #1588: release once the attempt concludes, success or failure
 			if err != nil {
 				return fmt.Errorf("provision control plane: %w", err)
 			}
@@ -224,14 +230,18 @@ func (r *ClusterReconciler) reconcileCluster(ctx context.Context, c *clusterstor
 
 		case clustercore.ActionCreateWorker:
 			g := groupByName[act.Group]
-			if err := r.admitSize(c, g, act.Group); err != nil {
+			release, err := r.admitSize(c, g, act.Group)
+			if err != nil {
 				return nil // refusal recorded; retry next pass
 			}
 			cpIP, err := r.mgr.CPIP(c.Owner, c.Name)
 			if err != nil {
+				release() // #1588: nothing to provision after all
 				return fmt.Errorf("control-plane IP: %w", err)
 			}
-			if err := r.mgr.ProvisionWorker(c.Owner, c.Name, iso, g, act.Name, cpIP); err != nil {
+			err = r.mgr.ProvisionWorker(c.Owner, c.Name, iso, g, act.Name, cpIP)
+			release() // #1588: release once the attempt concludes, success or failure
+			if err != nil {
 				return fmt.Errorf("provision worker %s: %w", act.Name, err)
 			}
 			_ = r.store.UpsertNode(ctx, &clusterstore.Node{
@@ -284,18 +294,28 @@ func (r *ClusterReconciler) reconcileCluster(ctx context.Context, c *clusterstor
 
 // admitSize runs the CPU-admission gate for one VM-sized request; a
 // refusal is recorded as a REFUSED scale event (loud, never clamped).
-func (r *ClusterReconciler) admitSize(c *clusterstore.Cluster, g clustercore.DesiredGroup, what string) error {
+//
+// #1588: the returned release must be called by admitSize's own caller once
+// its ProvisionCP/ProvisionWorker attempt concludes, success or failure —
+// same admit-then-release contract every other admission call site follows.
+// The nil-admit and refused paths hand back a no-op so callers can defer it
+// unconditionally without a nil check.
+func (r *ClusterReconciler) admitSize(c *clusterstore.Cluster, g clustercore.DesiredGroup, what string) (release func(), err error) {
 	if r.admit == nil {
-		return nil
+		return func() {}, nil
 	}
-	if err := r.admit(c.Owner, g.CPU); err != nil {
+	release, err = r.admit(c.Owner, g.CPU)
+	if err != nil {
 		_ = r.store.AppendEvent(context.Background(), c.Owner, c.Name, clusterstore.Event{
 			At: time.Now().UTC(), Kind: clusterstore.EventRefused,
 			Group: what, Reason: fmt.Sprintf("admission refused %s cpu=%s: %v", what, g.CPU, err),
 		})
-		return err
+		return func() {}, err
 	}
-	return nil
+	if release == nil {
+		release = func() {}
+	}
+	return release, nil
 }
 
 // settleState publishes the endpoint once the CP is up and flips the

--- a/internal/server/cluster_reconciler_test.go
+++ b/internal/server/cluster_reconciler_test.go
@@ -378,7 +378,7 @@ func TestReconciler_AsyncDeleteDrainsEverything(t *testing.T) {
 func TestReconciler_AdmissionRefusalIsLoud(t *testing.T) {
 	srv, rec, host := testReconcilerRig(t)
 	ctx := context.Background()
-	rec.SetAdmission(func(owner, cpu string) error { return errors.New("host at capacity") })
+	rec.SetAdmission(func(owner, cpu string) (func(), error) { return nil, errors.New("host at capacity") })
 	mustCreate(t, srv, tenantCtx("alice"), "demo")
 
 	rec.ReconcileOnce(ctx)

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -161,6 +161,26 @@ type ContainerServer struct {
 	cpuOvercommitFactor  float64
 	cpuOvercommitEnforce bool
 	hostCoresFn          func() (float64, error)
+	// cpuReservations closes the #1588 check-then-act race: admitCPUCapacity
+	// reads a snapshot of committed cores with no lock held across the
+	// caller's subsequent mutation, so two concurrent admits against the
+	// same host can each pass against a stale snapshot and jointly exceed
+	// the ceiling. Every admitted (or advisory-logged) request reserves its
+	// cores here for the duration of the caller's mutation; a later admit
+	// checks committed cores plus every other tenant's live reservation, not
+	// just the real (possibly stale) committed total. The caller releases
+	// its reservation once the mutation concludes, success or failure — see
+	// admitCPUCapacity's returned release func. cpuReservationTTL is a
+	// safety net, not the primary mechanism: a caller whose completion this
+	// package can't observe (the k8s Box-CR reconciliation path) never
+	// calls release, and would otherwise hold a reservation forever.
+	cpuReservationsMu sync.Mutex
+	cpuReservations   map[string]cpuReservation
+	// nowFn overrides cpuNow's real time.Now() (mirrors hostCoresFn /
+	// localHealthCheckFn above) so a test can exercise reservation TTL
+	// expiry without an actual 10-minute wait. nil in production.
+	nowFn             func() time.Time
+	cpuReservationSeq uint64
 	// capacityStore holds this backend's spare-capacity advertise/withdraw
 	// state + local policy (#680). Lazily initialized so an unwired server
 	// (tests) still answers GetCapacityHeadroom with "not advertised".
@@ -575,8 +595,16 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 	// all three paths are gated uniformly. No-op unless an operator enabled the
 	// gate; peer-routed creates already returned above and are gated by the
 	// target peer's own daemon. See cpu_admission.go.
-	if err := s.admitCPUCapacity(req.Username, spec.Resources.CPU); err != nil {
-		return nil, err
+	//
+	// #1588: an admitted request reserves its cores until cpuRelease runs, so
+	// a concurrent admit against this host sees them as committed even
+	// before this container actually exists. Released below — inline for
+	// the Box-CR/sync paths (the top-level defer), inside the goroutine for
+	// async, matching exactly how asyncHandledInline already splits
+	// platformStats reporting between those two completion shapes.
+	cpuRelease, admitErr := s.admitCPUCapacity(req.Username, spec.Resources.CPU)
+	if admitErr != nil {
+		return nil, admitErr
 	}
 
 	// #1083: everything past this point is a genuine attempt to provision
@@ -600,6 +628,7 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 		if asyncHandledInline {
 			return
 		}
+		cpuRelease()
 		s.platformStats.RecordProvisionAttempt(platformstats.OperationCreate, err == nil, time.Since(provisionStart))
 	}()
 
@@ -670,6 +699,12 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 		// double-counted.
 		asyncHandledInline = true
 		go func() {
+			// #1588: the top-level defer stood down for async (above), so
+			// this goroutine owns releasing the CPU reservation too — on
+			// every exit path, including the early "cancelled by delete"
+			// return below, which is exactly why this is its own defer
+			// rather than a call at the bottom of the function.
+			defer cpuRelease()
 			info, err := s.boxes().Create(context.Background(), spec)
 			// Same contract as the sync path: an encrypted box whose
 			// placement cannot be recorded is removed rather than left
@@ -1769,11 +1804,22 @@ func (s *ContainerServer) ResizeContainer(ctx context.Context, req *pb.ResizeCon
 	// against the wrong host's capacity. The peer's own ResizeContainer
 	// handler runs this same check against its own host once the request is
 	// forwarded, so no forwarding-side admission logic is needed here.
+	//
+	// #1588: an admitted resize reserves its cores until cpuRelease runs.
+	// ResizeContainer is fully synchronous with several return points below
+	// (local success, peer-forwarded success, various errors) — deferring a
+	// closure over cpuRelease, rather than calling it inline, releases the
+	// reservation on every one of them uniformly instead of needing a call
+	// at each site.
+	cpuRelease := noopRelease
+	defer func() { cpuRelease() }()
 	if s.cpuOvercommitFactor > 0 && req.Cpu != "" {
 		if current, gerr := s.manager.GetInfo(containerName); gerr == nil && current != nil {
-			if aerr := s.admitCPUResize(req.Username, current.CPU, req.Cpu); aerr != nil {
+			rel, aerr := s.admitCPUResize(req.Username, current.CPU, req.Cpu)
+			if aerr != nil {
 				return nil, aerr
 			}
+			cpuRelease = rel
 		}
 	}
 

--- a/internal/server/cpu_admission.go
+++ b/internal/server/cpu_admission.go
@@ -3,12 +3,33 @@ package server
 import (
 	"fmt"
 	"log"
+	"time"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"github.com/footprintai/containarium/pkg/core/incus"
 )
+
+// cpuReservationTTL bounds how long an admitted request's reservation
+// (#1588) can outlive its caller before expiring on its own. Generous
+// enough to cover a slow create (image pull, disk allocation) well past
+// what's actually observed in practice, but bounded so a caller whose
+// completion this package can't observe — the k8s Box-CR path, which
+// hands off to the operator's own reconciliation — can't wedge a host's
+// admission gate forever.
+const cpuReservationTTL = 10 * time.Minute
+
+// cpuReservation is one tenant's outstanding admitted-but-not-yet-committed
+// CPU request. token disambiguates a release call from a stale/superseded
+// reservation for the same username (e.g. two overlapping admission checks
+// for one tenant) — release only clears the entry if it still holds the
+// token the release closure was handed.
+type cpuReservation struct {
+	cores     float64
+	expiresAt time.Time
+	token     uint64
+}
 
 // CPU capacity admission (#1029 direction 2).
 //
@@ -54,54 +75,135 @@ func admitCPURequest(physicalCores, committedCores, requestCores, factor float64
 	return ratio, projected <= physicalCores*factor
 }
 
+// noopRelease is returned from every admitCPUCapacity path that never
+// reserved anything (gate disabled, fail-open, or a rejected request) — safe
+// for every caller to defer unconditionally regardless of which path ran.
+func noopRelease() {}
+
+// cpuNow is time.Now unless a test overrides it via nowFn (seam for
+// exercising cpuReservationTTL expiry without an actual 10-minute wait).
+func (s *ContainerServer) cpuNow() time.Time {
+	if s.nowFn != nil {
+		return s.nowFn()
+	}
+	return time.Now()
+}
+
 // admitCPUCapacity applies the overcommit policy to one incoming create. It
 // returns a ResourceExhausted error only when the gate is enabled, enforcing,
 // and the request would exceed the ceiling; otherwise nil (including every
 // fail-open path). username is the tenant being (re)created — its own existing
 // container, if any, is excluded so a resize-by-recreate doesn't double-count.
 //
-// Known gap (#1588): this is a check-then-act read with no lock or
-// reservation held across the caller's subsequent mutation. Two concurrent
-// callers (create, resize, or the cluster reconciler — every caller of this
-// function) can each admit against a stale snapshot and jointly exceed the
-// ceiling. Pre-existing since #1029 for create; #1579 extends the same
-// window to resize without introducing a new kind of gap. Not fixed here —
-// closing it needs serialization (or a reservation step) shared across
-// every local operation that commits CPU, which is bigger than any one
-// caller's scope.
-func (s *ContainerServer) admitCPUCapacity(username, cpuRequest string) error {
+// #1588: admitting a request (fits, or advisory-mode logged-but-allowed)
+// reserves its cores against future admission checks for cpuReservationTTL
+// or until the returned release func runs, whichever is first. Every caller
+// MUST call (or defer) release once its subsequent mutation concludes,
+// success or failure — otherwise the reservation lingers until it expires,
+// and a concurrent admit in that window sees phantom committed capacity.
+// This is what turns admitCPURequest's committed-cores READ from a stale
+// snapshot into something safe under concurrent callers: two admits against
+// the same host now see each other's outstanding reservation, not just
+// whatever the last completed mutation already wrote back to Incus.
+//
+// The returned release is never nil — every return path hands back either a
+// real release or noopRelease, so `defer release()` is always safe.
+func (s *ContainerServer) admitCPUCapacity(username, cpuRequest string) (release func(), err error) {
 	if s.cpuOvercommitFactor <= 0 {
-		return nil // gate disabled (the default)
+		return noopRelease, nil // gate disabled (the default)
 	}
 
 	physical, err := s.hostPhysicalCores()
 	if err != nil || physical <= 0 {
 		log.Printf("[cpu-admission] capacity check skipped (host cores unavailable: %v) — allowing create for %s", err, username)
-		return nil
+		return noopRelease, nil
 	}
 	committed, err := s.committedCoresExcluding(username)
 	if err != nil {
 		log.Printf("[cpu-admission] capacity check skipped (container list failed: %v) — allowing create for %s", err, username)
-		return nil
+		return noopRelease, nil
 	}
 	request := incus.CommittedCores(cpuRequest)
 
+	// Everything from here — reading outstanding reservations, deciding
+	// fit against them, and recording this request's own reservation — has
+	// to happen under one lock. Deciding fit and THEN recording the
+	// reservation as two separate critical sections would just move the
+	// #1588 race into the reservation bookkeeping itself: two concurrent
+	// admits could each see the fit check pass before either recorded
+	// anything.
+	s.cpuReservationsMu.Lock()
+	if s.cpuReservations == nil {
+		// Lazily initialized rather than in a constructor: ContainerServer
+		// is built as a bare struct literal in several places (tests, and
+		// some production wiring), so a constructor-only init would leave
+		// this nil and panic on first write.
+		s.cpuReservations = make(map[string]cpuReservation)
+	}
+	committed += s.reservedCoresExcludingLocked(username)
 	ratio, fits := admitCPURequest(physical, committed, request, s.cpuOvercommitFactor)
-	if fits {
-		return nil
+
+	if !fits && s.cpuOvercommitEnforce {
+		s.cpuReservationsMu.Unlock()
+		detail := fmt.Sprintf(
+			"host has %.0f logical CPUs; %.2f already committed + %.2f requested = %.2f would exceed the %.2f× overcommit ceiling (%.2f cores) — projected %.2f×",
+			physical, committed, request, committed+request, s.cpuOvercommitFactor, physical*s.cpuOvercommitFactor, ratio)
+		log.Printf("[cpu-admission] REJECT %s — %s", username, detail)
+		return noopRelease, status.Errorf(codes.ResourceExhausted,
+			"CPU capacity exceeded on this backend: %s. Retry on a less-loaded backend/pool or a larger host, or ask an operator to raise the overcommit factor.", detail)
 	}
 
-	detail := fmt.Sprintf(
-		"host has %.0f logical CPUs; %.2f already committed + %.2f requested = %.2f would exceed the %.2f× overcommit ceiling (%.2f cores) — projected %.2f×",
-		physical, committed, request, committed+request, s.cpuOvercommitFactor, physical*s.cpuOvercommitFactor, ratio)
+	// Admitted — either it genuinely fits, or the gate is advisory-only and
+	// would have rejected this. Either way the caller's mutation proceeds,
+	// so its cores are reserved the same way: an advisory-mode host that
+	// keeps admitting over its ceiling needs its own log noise to reflect
+	// what's actually about to be committed, and flipping enforce=true
+	// later must not suddenly see a phantom-empty reservation table.
+	s.cpuReservationSeq++
+	token := s.cpuReservationSeq
+	s.cpuReservations[username] = cpuReservation{cores: request, expiresAt: s.cpuNow().Add(cpuReservationTTL), token: token}
+	s.cpuReservationsMu.Unlock()
 
-	if !s.cpuOvercommitEnforce {
+	release = func() {
+		s.cpuReservationsMu.Lock()
+		if r, ok := s.cpuReservations[username]; ok && r.token == token {
+			delete(s.cpuReservations, username)
+		}
+		s.cpuReservationsMu.Unlock()
+	}
+
+	if !fits {
+		detail := fmt.Sprintf(
+			"host has %.0f logical CPUs; %.2f already committed + %.2f requested = %.2f would exceed the %.2f× overcommit ceiling (%.2f cores) — projected %.2f×",
+			physical, committed, request, committed+request, s.cpuOvercommitFactor, physical*s.cpuOvercommitFactor, ratio)
 		log.Printf("[cpu-admission] ADVISORY (not enforced): would reject %s — %s", username, detail)
-		return nil
 	}
-	log.Printf("[cpu-admission] REJECT %s — %s", username, detail)
-	return status.Errorf(codes.ResourceExhausted,
-		"CPU capacity exceeded on this backend: %s. Retry on a less-loaded backend/pool or a larger host, or ask an operator to raise the overcommit factor.", detail)
+	return release, nil
+}
+
+// reservedCoresExcludingLocked sums every OTHER tenant's live (non-expired)
+// reservation. Must be called with cpuReservationsMu held. Excludes
+// `username` itself — this request's own prior reservation, if any, is
+// about to be superseded by whatever admitCPUCapacity decides here, the
+// same "don't double-count the tenant being (re)sized" rule
+// committedCoresExcluding already applies to the real committed total.
+//
+// Lazily drops expired entries it encounters — no separate GC goroutine is
+// needed for a map that's read on every admission call anyway.
+func (s *ContainerServer) reservedCoresExcludingLocked(username string) float64 {
+	now := s.cpuNow()
+	var sum float64
+	for user, r := range s.cpuReservations {
+		if now.After(r.expiresAt) {
+			delete(s.cpuReservations, user)
+			continue
+		}
+		if user == username {
+			continue
+		}
+		sum += r.cores
+	}
+	return sum
 }
 
 // admitCPUResize applies the capacity gate to a CPU-increasing resize
@@ -109,11 +211,12 @@ func (s *ContainerServer) admitCPUCapacity(username, cpuRequest string) error {
 // capacity with no check at all, even though create already goes through
 // admitCPUCapacity).
 //
-// It reuses admitCPUCapacity UNCHANGED rather than adding a delta-aware
-// variant of it — do not change admitCPUCapacity's own signature, since
-// dual_server.go wires that exact function into the cluster reconciler's
-// SetAdmission for VM creation, and a signature change breaks that call site
-// silently.
+// It reuses admitCPUCapacity's decision logic UNCHANGED rather than adding a
+// delta-aware variant of it — dual_server.go wires admitCPUCapacity itself
+// (not this function) into the cluster reconciler's SetAdmission for VM
+// creation, so admitCPUCapacity's signature has to keep matching that seam,
+// but admitCPUResize is free to mirror it (#1588 needs the same
+// admit-then-release shape here as every other caller).
 //
 // committedCoresExcluding already excludes the tenant's own current
 // container from the committed sum, so passing the resize's full new CPU
@@ -133,9 +236,9 @@ func (s *ContainerServer) admitCPUCapacity(username, cpuRequest string) error {
 // is skipped outright rather than relying on the arithmetic to always admit
 // a decrease — a host that is already over its ceiling (a legacy, pre-gate
 // fleet) would otherwise have a decrease wrongly rejected too.
-func (s *ContainerServer) admitCPUResize(username, currentCPU, newCPU string) error {
+func (s *ContainerServer) admitCPUResize(username, currentCPU, newCPU string) (release func(), err error) {
 	if incus.CommittedCores(newCPU) <= incus.CommittedCores(currentCPU) {
-		return nil
+		return noopRelease, nil
 	}
 	return s.admitCPUCapacity(username, newCPU)
 }

--- a/internal/server/cpu_admission_test.go
+++ b/internal/server/cpu_admission_test.go
@@ -3,7 +3,11 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -80,7 +84,7 @@ func TestAdmitCPUCapacity_Disabled(t *testing.T) {
 		tenant("a", "8"), tenant("b", "8"), tenant("c", "8"),
 	})
 	// factor stays 0
-	if err := s.admitCPUCapacity("newbie", "8"); err != nil {
+	if _, err := s.admitCPUCapacity("newbie", "8"); err != nil {
 		t.Fatalf("disabled gate must never reject, got %v", err)
 	}
 }
@@ -95,11 +99,11 @@ func TestAdmitCPUCapacity_Enforce(t *testing.T) {
 	s.SetCPUOvercommitPolicy(2, true)
 
 	// 12 + 4 = 16 == ceiling → fits.
-	if err := s.admitCPUCapacity("fits", "4"); err != nil {
+	if _, err := s.admitCPUCapacity("fits", "4"); err != nil {
 		t.Fatalf("at-ceiling create should fit, got %v", err)
 	}
 	// 12 + 8 = 20 > 16 → reject.
-	err := s.admitCPUCapacity("toobig", "8")
+	_, err := s.admitCPUCapacity("toobig", "8")
 	if err == nil {
 		t.Fatal("over-ceiling create should be rejected")
 	}
@@ -113,7 +117,7 @@ func TestAdmitCPUCapacity_Enforce(t *testing.T) {
 func TestAdmitCPUCapacity_Advisory(t *testing.T) {
 	s := seedServer(t, 8, []incus.ContainerInfo{tenant("a", "8"), tenant("b", "8")})
 	s.SetCPUOvercommitPolicy(2, false) // enabled, advisory
-	if err := s.admitCPUCapacity("toobig", "8"); err != nil {
+	if _, err := s.admitCPUCapacity("toobig", "8"); err != nil {
 		t.Fatalf("advisory gate must not reject, got %v", err)
 	}
 }
@@ -130,7 +134,7 @@ func TestAdmitCPUCapacity_ExcludesCoreAndSelf(t *testing.T) {
 	// Committed should count ONLY `other` (4), excluding the 8-core core box
 	// and my own existing 8-core box. So recreating "me" at 4 cores → 4+4=8 == ceiling → fits.
 	// If core/self weren't excluded, committed would be 8+4(+8 self) and this would reject.
-	if err := s.admitCPUCapacity("me", "4"); err != nil {
+	if _, err := s.admitCPUCapacity("me", "4"); err != nil {
 		t.Fatalf("core+self exclusion should let this fit, got %v", err)
 	}
 }
@@ -141,7 +145,7 @@ func TestAdmitCPUCapacity_FailOpenOnUnknownCores(t *testing.T) {
 	s := seedServer(t, 0, []incus.ContainerInfo{tenant("a", "8"), tenant("b", "8")})
 	s.hostCoresFn = func() (float64, error) { return 0, errors.New("incus unreachable") }
 	s.SetCPUOvercommitPolicy(1, true)
-	if err := s.admitCPUCapacity("newbie", "8"); err != nil {
+	if _, err := s.admitCPUCapacity("newbie", "8"); err != nil {
 		t.Fatalf("must fail open when host cores unknown, got %v", err)
 	}
 }
@@ -234,10 +238,10 @@ func TestAdmitCPUResize_DecreaseNeverBlocked(t *testing.T) {
 	s := seedServer(t, 8, []incus.ContainerInfo{tenant("other", "10")})
 	s.SetCPUOvercommitPolicy(1, true)
 
-	if err := s.admitCPUResize("me", "4", "2"); err != nil {
+	if _, err := s.admitCPUResize("me", "4", "2"); err != nil {
 		t.Fatalf("a decrease must never be blocked, got %v", err)
 	}
-	if err := s.admitCPUResize("me", "4", "4"); err != nil {
+	if _, err := s.admitCPUResize("me", "4", "4"); err != nil {
 		t.Fatalf("an unchanged value must never be blocked, got %v", err)
 	}
 }
@@ -255,7 +259,7 @@ func TestAdmitCPUResize_IncreaseUsesFullNewValueNotDelta(t *testing.T) {
 	s := seedServer(t, 8, []incus.ContainerInfo{tenant("other", "4"), tenant("me", "4")})
 	s.SetCPUOvercommitPolicy(1, true)
 
-	err := s.admitCPUResize("me", "4", "8")
+	_, err := s.admitCPUResize("me", "4", "8")
 	if err == nil {
 		t.Fatal("resize to 8 must be rejected (4 other + 8 new = 12 > 8-core ceiling); the delta formula would wrongly admit this")
 	}
@@ -272,7 +276,7 @@ func TestAdmitCPUResize_IncreaseWithinCeilingAdmitted(t *testing.T) {
 	s.SetCPUOvercommitPolicy(1, true)
 
 	// committed_excl("me") = 4 (other only, "me" itself is excluded); 4 + 4 == 8-core ceiling.
-	if err := s.admitCPUResize("me", "2", "4"); err != nil {
+	if _, err := s.admitCPUResize("me", "2", "4"); err != nil {
 		t.Fatalf("resize to 4 should fit (4 other + 4 new = 8 == ceiling), got %v", err)
 	}
 }
@@ -282,7 +286,7 @@ func TestAdmitCPUResize_IncreaseWithinCeilingAdmitted(t *testing.T) {
 func TestAdmitCPUResize_DisabledGateNeverBlocks(t *testing.T) {
 	s := seedServer(t, 8, []incus.ContainerInfo{tenant("other", "8")})
 	// factor stays 0 (disabled)
-	if err := s.admitCPUResize("me", "2", "16"); err != nil {
+	if _, err := s.admitCPUResize("me", "2", "16"); err != nil {
 		t.Fatalf("disabled gate must never reject a resize, got %v", err)
 	}
 }
@@ -325,5 +329,141 @@ func TestResizeContainer_AdmissionSkippedForDecrease(t *testing.T) {
 
 	if _, err := s.ResizeContainer(resizeCtx("me"), &pb.ResizeContainerRequest{Username: "me", Cpu: "2"}); err != nil {
 		t.Fatalf("a decrease must never be blocked, got %v", err)
+	}
+}
+
+// #1588 — the check-then-act race. These exercise admitCPUCapacity's
+// reservation mechanism directly, reproducing the issue's own worked
+// example: an 8-core host at factor 1 (ceiling 8), two tenants each already
+// committed at 2 cores, both concurrently resizing to 6. Each admission
+// check alone sees 2+6=8<=8 and would admit — the true post-resize total,
+// 6+6=12, exceeds the ceiling. Before this fix, both calls would return nil
+// because neither held anything across the other's (unmodeled, in this
+// direct-call test) mutation; the fix's reservation makes the SECOND call
+// see the FIRST one's outstanding cores even though nothing was actually
+// mutated yet.
+func TestAdmitCPUCapacity_ConcurrentAdmitsRaceIsClosed(t *testing.T) {
+	s := seedServer(t, 8, []incus.ContainerInfo{tenant("a", "2"), tenant("b", "2")})
+	s.SetCPUOvercommitPolicy(1, true) // 8-core ceiling, strict
+
+	releaseA, err := s.admitCPUCapacity("a", "6")
+	if err != nil {
+		t.Fatalf("first admit (a: 2->6) should fit alone (2 other + 6 = 8 == ceiling), got %v", err)
+	}
+	defer releaseA()
+
+	// Without the fix, this would also admit: committedCoresExcluding("b")
+	// still reads the REAL (unchanged) container list, seeing "a" at its
+	// OLD 2 cores, not the 6 it was just admitted for — 2(b's real
+	// other-tenant total, "a" unchanged)+6(requested)=8<=8 would wrongly
+	// fit. With the fix, b's check adds a's outstanding 6-core reservation
+	// on top: 2(real)+6(a's reservation)+6(requested)=14>8 — rejected.
+	_, err = s.admitCPUCapacity("b", "6")
+	if err == nil {
+		t.Fatal("second concurrent admit (b: 2->6) should be REJECTED once a's reservation is counted — this is the #1588 race")
+	}
+	if status.Code(err) != codes.ResourceExhausted {
+		t.Fatalf("want ResourceExhausted, got %v (%v)", status.Code(err), err)
+	}
+}
+
+// Releasing a reservation makes room for a subsequent admit that would
+// otherwise be rejected — proving release() actually does something, not
+// just that the reservation exists.
+func TestAdmitCPUCapacity_ReleaseFreesTheReservation(t *testing.T) {
+	s := seedServer(t, 8, []incus.ContainerInfo{tenant("a", "2"), tenant("b", "2")})
+	s.SetCPUOvercommitPolicy(1, true)
+
+	releaseA, err := s.admitCPUCapacity("a", "6")
+	if err != nil {
+		t.Fatalf("first admit should fit, got %v", err)
+	}
+	if _, err := s.admitCPUCapacity("b", "6"); err == nil {
+		t.Fatal("second admit should be rejected while a's reservation is outstanding")
+	}
+
+	releaseA()
+
+	if _, err := s.admitCPUCapacity("b", "6"); err != nil {
+		t.Fatalf("after releasing a's reservation, b's admit should fit (2 other + 6 = 8 == ceiling), got %v", err)
+	}
+}
+
+// A reservation nobody ever releases still stops counting once it expires —
+// the safety net for a caller whose completion this package can't observe
+// (the k8s Box-CR reconciliation path). Uses nowFn rather than a real
+// 10-minute wait.
+func TestAdmitCPUCapacity_ReservationExpiresAfterTTL(t *testing.T) {
+	s := seedServer(t, 8, []incus.ContainerInfo{tenant("a", "2"), tenant("b", "2")})
+	s.SetCPUOvercommitPolicy(1, true)
+
+	current := time.Now()
+	s.nowFn = func() time.Time { return current }
+
+	if _, err := s.admitCPUCapacity("a", "6"); err != nil {
+		t.Fatalf("first admit should fit, got %v", err)
+	}
+	if _, err := s.admitCPUCapacity("b", "6"); err == nil {
+		t.Fatal("second admit should be rejected while a's reservation is live")
+	}
+
+	// Never released — advance the clock past the TTL instead.
+	current = current.Add(cpuReservationTTL + time.Second)
+
+	if _, err := s.admitCPUCapacity("b", "6"); err != nil {
+		t.Fatalf("after a's reservation expires, b's admit should fit, got %v", err)
+	}
+}
+
+// A tenant's own outstanding reservation must not count against its own
+// next admit — the same "don't double-count the tenant being (re)sized"
+// rule committedCoresExcluding already applies to the real committed total,
+// extended to the reservation table.
+func TestAdmitCPUCapacity_OwnReservationExcludedFromOwnNextAdmit(t *testing.T) {
+	s := seedServer(t, 8, []incus.ContainerInfo{tenant("other", "2")})
+	s.SetCPUOvercommitPolicy(1, true)
+
+	if _, err := s.admitCPUCapacity("me", "6"); err != nil {
+		t.Fatalf("first admit for me should fit (2 other + 6 = 8 == ceiling), got %v", err)
+	}
+	// A second admit for the SAME tenant (e.g. a retried request) must be
+	// judged against the real committed total plus OTHER tenants'
+	// reservations, not doubled up with its own prior reservation.
+	if _, err := s.admitCPUCapacity("me", "6"); err != nil {
+		t.Fatalf("second admit for the same tenant should still fit (its own prior reservation must not stack against itself), got %v", err)
+	}
+}
+
+// TestAdmitCPUCapacity_ConcurrentGoroutinesNeverExceedCeiling drives the fix
+// with real concurrent goroutines (run with -race) rather than sequential
+// calls simulating concurrency — the shape of bug the issue actually
+// describes. 8-core host, 1x ceiling: ten different tenants each request 2
+// cores at once. 8 cores / 2 per admit divides evenly, so regardless of
+// goroutine scheduling order exactly 4 must be admitted and 6 rejected —
+// any other count means the ceiling was violated or admission was
+// needlessly conservative.
+func TestAdmitCPUCapacity_ConcurrentGoroutinesNeverExceedCeiling(t *testing.T) {
+	s := seedServer(t, 8, nil)
+	s.SetCPUOvercommitPolicy(1, true)
+
+	const tenants = 10
+	var wg sync.WaitGroup
+	var admitted int64
+	for i := 0; i < tenants; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, err := s.admitCPUCapacity(fmt.Sprintf("tenant-%d", i), "2")
+			if err == nil {
+				atomic.AddInt64(&admitted, 1)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if admitted != 4 {
+		t.Fatalf("admitted %d of %d concurrent 2-core requests on an 8-core/1x host, want exactly 4 (8/2) — "+
+			"a higher count means the ceiling was violated (the #1588 race), a lower count means admission "+
+			"was wrongly conservative", admitted, tenants)
 	}
 }


### PR DESCRIPTION
## What

Closes #1588. `admitCPUCapacity` read a snapshot of committed cores, decided fit/reject, and returned — with no lock or reservation held across the caller's subsequent mutation (`manager.Resize` for a resize, the create sink for `CreateContainer`, `ProvisionCP`/`ProvisionWorker` for the cluster reconciler). Two concurrent operations against the same host could each pass admission against a stale snapshot and jointly exceed the ceiling — the issue's own worked example: two boxes at 2 cores each, both concurrently resizing to 6 on an 8-core/1x host, each independently compute `2+6=8<=8` and admit; the true post-resize total is `6+6=12>8`.

## Fix (shape 2 from the issue: a reservation step)

An admitted (or advisory-mode logged) request now reserves its cores in an in-memory table (`ContainerServer.cpuReservations`) for the duration of the caller's mutation. Every subsequent admission check on that host adds *other* tenants' live reservations on top of the real committed total — not just the real, possibly-stale total alone. The caller releases its reservation once the mutation concludes, success or failure:

- **`CreateContainer`**: released inline for the Box-CR/sync paths via the existing top-level `defer` (which `asyncHandledInline` already distinguishes from async completion for `platformStats` reporting — I reused the exact same mechanism), and inside the async goroutine's own `defer` for the async path.
- **`ResizeContainer`**: released via a deferred closure covering all of its several return points (local success, peer-forwarded success, various errors).
- **`ClusterReconciler.admitSize`**: released by its two callers (`ActionCreateCP` / `ActionCreateWorker`) right after `ProvisionCP`/`ProvisionWorker` concludes — the issue explicitly asked for this call site to be covered too, not just the two `ContainerServer` handlers.

A reservation also expires after `cpuReservationTTL` (10 minutes) as a safety net for a caller whose completion this package genuinely can't observe — the k8s Box-CR path hands off to the operator's own reconciliation and never calls release explicitly. This isn't the primary correctness mechanism (that's the explicit release calls above); it just bounds how long a leaked reservation can wedge a host's admission gate.

`admitCPUCapacity` and `admitCPUResize` now return `(release func(), error)` instead of `error` alone. Every return path hands back either a real release or a safe no-op — `defer release()` is always valid, no nil check needed anywhere.

## Verifying this actually closes the race (not just compiles)

Added `TestAdmitCPUCapacity_ConcurrentGoroutinesNeverExceedCeiling`: 10 real goroutines (run under `-race`, not sequential calls simulating concurrency) each requesting 2 cores on an 8-core/1× host. 8/2 divides evenly, so regardless of scheduling order exactly 4 must be admitted.

- **With the fix**: exactly 4/10 admitted, every one of 5 repeated `-race` runs, zero data races.
- **Without the fix** (reverted just the one line that adds reservations into the fit check, keeping everything else): **all 10/10 admitted** — 20 committed cores jointly landed on an 8-core ceiling — on every one of 10 repeated runs. This is the exact violation the issue describes, reproduced and then closed.

Plus the sequential-call tests: concurrent-admit-rejects (issue's own worked example), release-frees-the-reservation, TTL-expiry-without-release (using a `nowFn` test seam mirroring the existing `hostCoresFn`/`localHealthCheckFn` pattern), and a same-tenant-doesn't-double-count-its-own-reservation case.

## Test plan

- [x] All existing `cpu_admission_test.go` / `cluster_reconciler_test.go` tests pass unchanged in outcome (signature updated mechanically via `sed`, verified with a diff review)
- [x] 5 new tests covering the reservation mechanism directly, plus the concurrent-goroutine `-race` test above
- [x] `go build ./...`, `go test ./internal/server/... -race`, `go vet`, `gofmt -l`, `golangci-lint run` — all clean
- [x] `docs/CPU-CAPACITY-ADMISSION.md`'s "Not covered here" section (which named #1588 as an open gap) updated with a "Concurrent admission" section describing the fix

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FHECHYsrFnSfXrqv94BZRc

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CPU capacity admission now reserves capacity during create and resize operations, preventing concurrent requests from exceeding configured limits.
  * Reservations are released after successful or failed operations, including cancellations, and automatically expire after 10 minutes.
  * Resize requests account for existing capacity reservations to avoid unnecessary refusals.

* **Documentation**
  * Updated CPU capacity documentation to describe reservation behavior and the resolved concurrency race.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->