### PR TITLE
fix(charts): guard namespace.yaml on gateway.enabled

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -45,3 +45,25 @@ jobs:
           helm template containarium charts/containarium-k8s \
             --set gateway.upstreamKeySecret=smoke-test-placeholder \
             > /dev/null
+
+      - name: Template render — gateway disabled (#1526)
+        # values.yaml documents clearing gateway.namespace as how to disable
+        # gateway routing entirely, but namespace.yaml had no
+        # gateway.enabled guard (unlike every other gateway-only resource in
+        # this chart), so it rendered a Namespace with an empty name —
+        # `resource name may not be empty` on install, only failing at
+        # install/dry-run time since `helm template` alone doesn't validate
+        # object names. --show-only asserts the template renders nothing at
+        # all for this file (matching every sibling gateway resource) rather
+        # than just checking the overall command doesn't error, which
+        # wouldn't have caught the empty-name manifest.
+        run: |
+          if helm template containarium charts/containarium-k8s \
+            --set gateway.enabled=false --set gateway.namespace="" \
+            --show-only templates/namespace.yaml > /dev/null 2>&1; then
+            echo "::error::namespace.yaml still rendered something with gateway.enabled=false — expected it to render nothing, the same as every other gateway-only resource"
+            exit 1
+          fi
+          helm template containarium charts/containarium-k8s \
+            --set gateway.enabled=false --set gateway.namespace="" \
+            > /dev/null

--- a/charts/containarium-k8s/templates/namespace.yaml
+++ b/charts/containarium-k8s/templates/namespace.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.gateway.enabled }}
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -8,3 +9,4 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
     {{- end }}
+{{- end }}


### PR DESCRIPTION
## What

Closes #1526. `values.yaml`'s own comment documents clearing `gateway.namespace` as how to disable gateway routing entirely, but `templates/namespace.yaml` had no `{{- if }}` guard at all — unlike `clusterrole.yaml`, `clusterrolebinding.yaml`, `serviceaccount.yaml`, `sshpiper-deployment.yaml`, and `sshpiper-service.yaml`, which all correctly guard on `.Values.gateway.enabled`. With `gateway.namespace=""` it rendered a `Namespace` object with an empty name, which Kubernetes rejects outright — `resource name may not be empty` on `helm install`. The documented disable path didn't actually install.

## Confirming the bug (and the fix) without a live cluster

`helm template` alone doesn't catch this — it only renders text, it doesn't validate Kubernetes object names the way `helm install` does. Confirmed the actual defect by inspecting the rendered manifest directly:

```
$ helm template test charts/containarium-k8s --set gateway.enabled=false --set gateway.namespace="" --show-only templates/namespace.yaml
---
# Source: containarium-k8s/templates/namespace.yaml
apiVersion: v1
kind: Namespace
metadata:
  name:           # <- empty. This is what "resource name may not be empty" comes from.
  ...
```

After the fix, the same command errors with "could not find template templates/namespace.yaml in chart" — i.e. it renders nothing at all, exactly matching every sibling gateway-only resource's behavior when disabled.

## Fix

Same `{{- if .Values.gateway.enabled }}` guard every sibling gateway-only resource already uses — this is also literally the workaround the issue reporter already used elsewhere ("worked around there by keeping `gateway.namespace` at its default and only disabling `gateway.enabled`"), so it's the established, working disable mechanism this template was simply missing.

## Test plan

- [x] `helm template ... --show-only templates/namespace.yaml` with `gateway.enabled=false` — renders nothing (post-fix), rendered an empty-named `Namespace` (pre-fix, confirmed by temporarily reverting)
- [x] `helm template` with the gateway properly enabled (upstream key set) still renders the `Namespace` resource correctly — the guard doesn't break the normal path
- [x] `helm lint charts/containarium-k8s` — clean (unrelated #1496 info-level message, pre-existing)
- [x] Added a new `helm-lint.yml` CI step rendering with the gateway disabled and asserting `namespace.yaml` produces no output — confirmed it fails against the pre-fix template and passes after, so this specific regression can't silently reappear

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FHECHYsrFnSfXrqv94BZRc

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Kubernetes Namespace resources are no longer created when the gateway is disabled, preventing unnecessary resources in disabled-gateway configurations.
  - Charts continue to render successfully when the gateway is disabled and no gateway namespace is specified.

- **Tests**
  - Added Helm validation covering disabled-gateway configurations and confirming that no Namespace resource is rendered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->