### PR TITLE
feat(console): live interactive attach to a VM instance's serial console

### DIFF
--- a/internal/cmd/console.go
+++ b/internal/cmd/console.go
@@ -22,11 +22,14 @@ or has panicked before bringing up networking.
 Empty output means either the instance is an LXC container (no serial
 console device) or a VM that hasn't produced any console output yet.
 
-Currently supports --log (a static read). Live interactive attach is not
-yet implemented (see FootprintAI/Containarium#1751).
+Live interactive attach (no --log) requires --http with an http(s)://
+--server address — it dials a WebSocket, which a plain gRPC endpoint has
+no upgrade path for. To detach without killing the instance, press
+<ctrl>+a then q (matching Incus's own console command's convention).
 
 Examples:
-  containarium console alice --log`,
+  containarium console alice --log
+  containarium console alice --http --server https://daemon.example.com`,
 	Args: cobra.ExactArgs(1),
 	RunE: runConsole,
 }
@@ -42,7 +45,7 @@ func runConsole(cmd *cobra.Command, args []string) error {
 		return errUnsupportedOnCloud("console", "use `containarium connect "+username+"` to inspect the box")
 	}
 	if !consoleLog {
-		return fmt.Errorf("live interactive console attach is not yet implemented — pass --log to read the console ring-buffer log")
+		return attachConsole(username)
 	}
 
 	resp, err := fetchConsoleLog(username)

--- a/internal/cmd/console_attach.go
+++ b/internal/cmd/console_attach.go
@@ -1,0 +1,158 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/footprintai/containarium/internal/auth"
+	"github.com/gorilla/websocket"
+	"golang.org/x/term"
+)
+
+// detachEscape is a byte-scanning io.Reader that watches for Incus's own
+// detach sequence — <ctrl>+a then 'q' — so `containarium console` behaves
+// the same way `incus console` does for anyone already used to it. Closing
+// detach signals a clean detach without killing the target instance.
+type detachEscape struct {
+	r          io.Reader
+	detach     chan struct{}
+	once       sync.Once
+	foundCtrlA bool
+}
+
+func newDetachEscape(r io.Reader) (*detachEscape, <-chan struct{}) {
+	ch := make(chan struct{})
+	return &detachEscape{r: r, detach: ch}, ch
+}
+
+func (d *detachEscape) Read(p []byte) (int, error) {
+	n, err := d.r.Read(p)
+	for _, b := range p[:n] {
+		switch {
+		case b == '\x01': // <ctrl>+a
+			d.foundCtrlA = true
+		case b == 'q' && d.foundCtrlA:
+			d.once.Do(func() { close(d.detach) })
+			d.foundCtrlA = false
+		default:
+			d.foundCtrlA = false
+		}
+	}
+	return n, err
+}
+
+// attachConsole opens a live, bidirectional connection to a VM instance's
+// serial console. Unlike --log, this requires --http with an http(s)://
+// --server: it needs a WebSocket upgrade, which a plain gRPC endpoint has
+// no path for.
+func attachConsole(username string) error {
+	if !httpMode || serverAddr == "" {
+		return fmt.Errorf("live console attach requires --http with an http(s):// --server address (the ring-buffer log via --log works over gRPC too)")
+	}
+
+	wsURL, err := consoleWebSocketURL(serverAddr, username)
+	if err != nil {
+		return err
+	}
+
+	headers := http.Header{}
+	headers.Set("Sec-WebSocket-Protocol", auth.WSSubprotocolBearer+", "+authToken)
+
+	conn, resp, err := websocket.DefaultDialer.Dial(wsURL, headers)
+	if err != nil {
+		if resp != nil {
+			body, _ := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			return fmt.Errorf("failed to attach console (%d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		}
+		return fmt.Errorf("failed to attach console: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	stdinFd := int(os.Stdin.Fd())
+	oldState, err := term.MakeRaw(stdinFd)
+	if err != nil {
+		return fmt.Errorf("failed to set raw terminal mode: %w", err)
+	}
+	defer func() { _ = term.Restore(stdinFd, oldState) }()
+
+	fmt.Print("To detach from the console, press: <ctrl>+a q\r\n")
+
+	stdin, detach := newDetachEscape(os.Stdin)
+	done := make(chan struct{})
+
+	// stdin -> console
+	go func() {
+		buf := make([]byte, 1)
+		for {
+			n, err := stdin.Read(buf)
+			if n > 0 {
+				if writeErr := conn.WriteMessage(websocket.BinaryMessage, buf[:n]); writeErr != nil {
+					close(done)
+					return
+				}
+			}
+			if err != nil {
+				close(done)
+				return
+			}
+		}
+	}()
+
+	// console -> stdout
+	go func() {
+		for {
+			msgType, data, err := conn.ReadMessage()
+			if err != nil {
+				close(done)
+				return
+			}
+			if msgType == websocket.BinaryMessage {
+				_, _ = os.Stdout.Write(data)
+			}
+		}
+	}()
+
+	select {
+	case <-detach:
+		closeMsg := websocket.FormatCloseMessage(websocket.CloseNormalClosure, "detaching")
+		_ = conn.WriteMessage(websocket.CloseMessage, closeMsg)
+	case <-done:
+	}
+
+	fmt.Print("\r\n")
+	return nil
+}
+
+// consoleWebSocketURL builds the console-attach WebSocket URL from an
+// http(s):// --server address.
+func consoleWebSocketURL(serverAddr, username string) (string, error) {
+	base := serverAddr
+	if !strings.Contains(base, "://") {
+		base = "http://" + base
+	}
+	u, err := url.Parse(strings.TrimSuffix(base, "/"))
+	if err != nil {
+		return "", fmt.Errorf("invalid --server address: %w", err)
+	}
+	switch u.Scheme {
+	case "http":
+		u.Scheme = "ws"
+	case "https":
+		u.Scheme = "wss"
+	default:
+		return "", fmt.Errorf("unsupported --server scheme %q for console attach", u.Scheme)
+	}
+	// Path takes the decoded form (a literal "/" in username is just
+	// another path separator there); RawPath carries the pre-escaped form
+	// url.URL.String() actually serializes, matching how the HTTP client
+	// escapes a username in its own container paths.
+	u.Path = fmt.Sprintf("/v1/containers/%s/console-attach", username)
+	u.RawPath = fmt.Sprintf("/v1/containers/%s/console-attach", url.PathEscape(username))
+	return u.String(), nil
+}

--- a/internal/cmd/console_attach_test.go
+++ b/internal/cmd/console_attach_test.go
@@ -1,0 +1,113 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestDetachEscape_FiresOnCtrlAThenQ(t *testing.T) {
+	src := bytes.NewReader([]byte("hello\x01qworld"))
+	d, detach := newDetachEscape(src)
+
+	buf := make([]byte, 64)
+	n, err := d.Read(buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != len("hello\x01qworld") {
+		t.Fatalf("expected to read all bytes in one call, got %d", n)
+	}
+
+	select {
+	case <-detach:
+	default:
+		t.Fatal("expected detach channel to be closed after <ctrl>+a q")
+	}
+}
+
+func TestDetachEscape_DoesNotFireOnQAlone(t *testing.T) {
+	src := bytes.NewReader([]byte("just q with no ctrl-a"))
+	d, detach := newDetachEscape(src)
+
+	buf := make([]byte, 64)
+	if _, err := d.Read(buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	select {
+	case <-detach:
+		t.Fatal("detach fired without the <ctrl>+a prefix")
+	default:
+	}
+}
+
+func TestDetachEscape_CtrlAThenOtherKeyDoesNotArmAcrossReads(t *testing.T) {
+	// <ctrl>+a followed by something other than 'q' should not leave the
+	// escape armed for a later, unrelated 'q'.
+	src := bytes.NewReader([]byte("\x01xq"))
+	d, detach := newDetachEscape(src)
+
+	buf := make([]byte, 64)
+	if _, err := d.Read(buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	select {
+	case <-detach:
+		t.Fatal("detach fired even though <ctrl>+a was followed by a non-'q' byte")
+	default:
+	}
+}
+
+func TestDetachEscape_OnlyFiresOnce(t *testing.T) {
+	src := bytes.NewReader([]byte("\x01q\x01q"))
+	d, detach := newDetachEscape(src)
+
+	buf := make([]byte, 64)
+	if _, err := d.Read(buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Closing an already-closed channel would panic; reading it twice here
+	// (once via select, once via receive) proves it was only closed once.
+	<-detach
+	select {
+	case <-detach:
+	default:
+		t.Fatal("channel should read as already-closed")
+	}
+}
+
+func TestConsoleWebSocketURL(t *testing.T) {
+	cases := []struct {
+		name       string
+		serverAddr string
+		username   string
+		want       string
+		wantErr    bool
+	}{
+		{"http scheme becomes ws", "http://daemon.example.com:8080", "alice", "ws://daemon.example.com:8080/v1/containers/alice/console-attach", false},
+		{"https scheme becomes wss", "https://daemon.example.com", "alice", "wss://daemon.example.com/v1/containers/alice/console-attach", false},
+		{"bare host defaults to http/ws", "daemon.example.com:8080", "alice", "ws://daemon.example.com:8080/v1/containers/alice/console-attach", false},
+		{"trailing slash stripped", "http://daemon.example.com/", "alice", "ws://daemon.example.com/v1/containers/alice/console-attach", false},
+		{"username is path-escaped", "http://daemon.example.com", "a/b", "ws://daemon.example.com/v1/containers/a%2Fb/console-attach", false},
+		{"unsupported scheme rejected", "ws://daemon.example.com", "alice", "", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := consoleWebSocketURL(c.serverAddr, c.username)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got url %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != c.want {
+				t.Fatalf("got %q, want %q", got, c.want)
+			}
+		})
+	}
+}

--- a/internal/gateway/console.go
+++ b/internal/gateway/console.go
@@ -1,0 +1,158 @@
+package gateway
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/footprintai/containarium/internal/auth"
+	"github.com/gorilla/websocket"
+	incus "github.com/lxc/incus/v6/client"
+	"github.com/lxc/incus/v6/shared/api"
+	"github.com/lxc/incus/v6/shared/ws"
+)
+
+// ConsoleHandler handles WebSocket live-attach connections to a VM
+// instance's serial console via Incus's ConsoleInstance. Unlike
+// TerminalHandler (an exec'd shell, JSON-framed for browser xterm.js
+// resize support), a serial console is a dumb byte pipe — no PTY
+// negotiation, no resize after attach — so this relays raw binary
+// WebSocket frames directly.
+type ConsoleHandler struct {
+	upgrader    websocket.Upgrader
+	incusClient incus.InstanceServer
+}
+
+// NewConsoleHandler creates a new console handler backed by the local
+// Incus unix socket.
+func NewConsoleHandler() (*ConsoleHandler, error) {
+	client, err := incus.ConnectIncusUnix("", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to Incus: %w", err)
+	}
+
+	return &ConsoleHandler{
+		upgrader: websocket.Upgrader{
+			CheckOrigin: func(r *http.Request) bool {
+				origin := r.Header.Get("Origin")
+				if origin == "" {
+					// No Origin header at all — this is the expected shape
+					// for a non-browser client (the containarium CLI), which
+					// is the only client this endpoint is built for today.
+					return true
+				}
+				for _, allowed := range getTerminalAllowedOrigins() {
+					if origin == allowed {
+						return true
+					}
+				}
+				log.Printf("console WebSocket connection rejected: origin %s not in allowed list", origin)
+				return false
+			},
+			Subprotocols:    []string{auth.WSSubprotocolBearer},
+			ReadBufferSize:  1024,
+			WriteBufferSize: 1024,
+		},
+		incusClient: client,
+	}, nil
+}
+
+// parseConsoleUsername extracts the username from a
+// /v1/containers/{username}/console-attach path. Returns "" if the path
+// doesn't match that shape.
+func parseConsoleUsername(path string) string {
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	// ["v1", "containers", "{username}", "console-attach"]
+	if len(parts) != 4 || parts[0] != "v1" || parts[1] != "containers" || parts[3] != "console-attach" {
+		return ""
+	}
+	return parts[2]
+}
+
+// authorizeConsoleAccess reports whether claims may attach to
+// requestedUsername's console: the subject must own the tenant or hold the
+// admin role. Mirrors auth.AuthorizeTenant's decision exactly, adapted for
+// an already-validated *auth.Claims (the gRPC-context form AuthorizeTenant
+// reads doesn't exist on this HTTP/WebSocket upgrade path).
+func authorizeConsoleAccess(claims *auth.Claims, requestedUsername string) error {
+	if claims == nil {
+		return fmt.Errorf("no authenticated subject")
+	}
+	if auth.HasRole(claims.Roles, auth.RoleAdmin) {
+		return nil
+	}
+	if claims.Username != requestedUsername {
+		return fmt.Errorf("not authorized for this tenant")
+	}
+	return nil
+}
+
+// HandleConsole upgrades the request to a WebSocket and relays raw bytes
+// between the caller and the instance's serial console. Callers must
+// already be authenticated and tenant-authorized (see
+// authorizeConsoleAccess) — matching TerminalHandler's contract, that
+// check happens in the route registration closure, not here.
+func (ch *ConsoleHandler) HandleConsole(w http.ResponseWriter, r *http.Request) {
+	username := parseConsoleUsername(r.URL.Path)
+	if username == "" {
+		http.Error(w, "invalid path", http.StatusBadRequest)
+		return
+	}
+	containerName := username + "-container"
+
+	state, _, err := ch.incusClient.GetInstanceState(containerName)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("container not found: %v", err), http.StatusNotFound)
+		return
+	}
+	if state.Status != "Running" {
+		http.Error(w, fmt.Sprintf("container is not running (status: %s)", state.Status), http.StatusBadRequest)
+		return
+	}
+
+	conn, err := ch.upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Printf("console WebSocket upgrade failed: %v", err)
+		return
+	}
+	defer func() { _ = conn.Close() }()
+
+	log.Printf("console attached for container %s", containerName)
+	ch.attachConsole(conn, containerName)
+	log.Printf("console detached for container %s", containerName)
+}
+
+// attachConsole bridges conn (the caller's WebSocket) to the instance's
+// serial console and blocks until the session ends. It does not depend on
+// op.Wait()'s exact completion semantics for a clean detach: closing conn
+// (a client-initiated close frame, or the connection simply dying) is
+// observed via SetCloseHandler, which is what actually drives the
+// ConsoleDisconnect signal telling Incus to detach without killing the
+// instance — the same signal upstream's own `incus console` CLI relies on.
+func (ch *ConsoleHandler) attachConsole(conn *websocket.Conn, containerName string) {
+	disconnect := make(chan bool)
+	var closeOnce sync.Once
+	closeDisconnect := func() { closeOnce.Do(func() { close(disconnect) }) }
+
+	conn.SetCloseHandler(func(code int, text string) error {
+		closeDisconnect()
+		return nil
+	})
+
+	op, err := ch.incusClient.ConsoleInstance(containerName, api.InstanceConsolePost{Type: "console"}, &incus.InstanceConsoleArgs{
+		Terminal:          ws.NewWrapper(conn),
+		Control:           func(*websocket.Conn) {}, // resize not meaningful for a serial console
+		ConsoleDisconnect: disconnect,
+	})
+	if err != nil {
+		_ = conn.WriteMessage(websocket.TextMessage, []byte("error: "+err.Error()))
+		return
+	}
+
+	if err := op.Wait(); err != nil {
+		log.Printf("console session for %s ended with error: %v", containerName, err)
+	}
+	closeDisconnect()
+}

--- a/internal/gateway/console_test.go
+++ b/internal/gateway/console_test.go
@@ -1,0 +1,53 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/footprintai/containarium/internal/auth"
+)
+
+func TestParseConsoleUsername(t *testing.T) {
+	cases := []struct {
+		path string
+		want string
+	}{
+		{"/v1/containers/alice/console-attach", "alice"},
+		{"v1/containers/alice/console-attach", "alice"},
+		{"/v1/containers/alice/console-attach/", "alice"},
+		{"/v1/containers/alice/terminal", ""},
+		{"/v1/containers/alice/console-attach/extra", ""},
+		{"/v1/containers//console-attach", ""},
+		{"/v1/containers", ""},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := parseConsoleUsername(c.path); got != c.want {
+			t.Errorf("parseConsoleUsername(%q) = %q, want %q", c.path, got, c.want)
+		}
+	}
+}
+
+func TestAuthorizeConsoleAccess(t *testing.T) {
+	cases := []struct {
+		name      string
+		claims    *auth.Claims
+		requested string
+		wantErr   bool
+	}{
+		{"nil claims", nil, "alice", true},
+		{"own tenant", &auth.Claims{Username: "alice"}, "alice", false},
+		{"wrong tenant", &auth.Claims{Username: "mallory"}, "alice", true},
+		{"admin, different username", &auth.Claims{Username: "root-op", Roles: []string{auth.RoleAdmin}}, "alice", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := authorizeConsoleAccess(c.claims, c.requested)
+			if c.wantErr && err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+			if !c.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -47,6 +47,7 @@ type GatewayServer struct {
 	securityStore          *security.Store // Optional: for CSV export endpoint
 	auditStore             *audit.Store    // Optional: for HTTP audit middleware
 	terminalHandler        *TerminalHandler
+	consoleHandler         *ConsoleHandler
 	labelHandler           *LabelHandler
 	eventHandler           *EventHandler
 	coreServicesHandler    *CoreServicesHandler
@@ -119,6 +120,12 @@ func NewGatewayServer(grpcAddress string, httpPort int, authMiddleware *auth.Aut
 		log.Printf("Warning: Terminal handler not available: %v", err)
 	}
 
+	// Try to create console handler (may fail if Incus not available)
+	consoleHandler, err := NewConsoleHandler()
+	if err != nil {
+		log.Printf("Warning: Console handler not available: %v", err)
+	}
+
 	// Try to create label handler (may fail if Incus not available)
 	labelHandler, err := NewLabelHandler()
 	if err != nil {
@@ -142,6 +149,7 @@ func NewGatewayServer(grpcAddress string, httpPort int, authMiddleware *auth.Aut
 		certsDir:            certsDir,
 		caddyCertDir:        caddyCertDir,
 		terminalHandler:     terminalHandler,
+		consoleHandler:      consoleHandler,
 		labelHandler:        labelHandler,
 		eventHandler:        eventHandler,
 		coreServicesHandler: coreServicesHandler,
@@ -591,11 +599,71 @@ func (gs *GatewayServer) Start(ctx context.Context) error {
 			gs.terminalHandler.HandleTerminal(w, r)
 		}))
 
+		// Console-attach WebSocket route (live VM serial console, #1751).
+		// Same auth shape as terminal above, plus a tenant check terminal
+		// itself does not have: the caller must own the requested username
+		// or hold the admin role (auth.RoleAdmin), matching
+		// auth.AuthorizeTenant's decision used by every other per-tenant
+		// RPC in this codebase (DebugContainer, GetConsoleLog, ...).
+		var consoleWithCORS http.Handler
+		if gs.consoleHandler != nil {
+			consoleWithCORS = cors.New(cors.Options{
+				AllowedOrigins:   getAllowedOrigins(),
+				AllowedMethods:   []string{"GET", "POST", "OPTIONS"},
+				AllowedHeaders:   []string{"Authorization", "Content-Type", "Upgrade", "Connection", "Sec-WebSocket-Protocol"},
+				AllowCredentials: true,
+			}).Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				token, src := auth.ExtractBearerForUpgrade(r)
+				if src == auth.TokenSourceQueryParam {
+					log.Printf("WARNING: console client used deprecated ?token= (remote=%s, host=%q) — switch to Sec-WebSocket-Protocol", r.RemoteAddr, r.Host)
+				}
+				if token == "" {
+					http.Error(w, `{"error": "unauthorized: token required for console access", "code": 401}`, http.StatusUnauthorized)
+					return
+				}
+
+				claims, err := gs.authMiddleware.ValidateToken(token)
+				if err != nil {
+					http.Error(w, `{"error": "unauthorized: invalid token", "code": 401}`, http.StatusUnauthorized)
+					return
+				}
+
+				username := parseConsoleUsername(r.URL.Path)
+				if authErr := authorizeConsoleAccess(claims, username); authErr != nil {
+					http.Error(w, fmt.Sprintf(`{"error": "forbidden: %s", "code": 403}`, authErr.Error()), http.StatusForbidden)
+					return
+				}
+
+				if gs.auditStore != nil {
+					sourceIP := r.Header.Get("X-Forwarded-For")
+					if sourceIP == "" {
+						sourceIP = r.RemoteAddr
+					}
+					if err := gs.auditStore.Log(r.Context(), &audit.AuditEntry{
+						Username:     claims.Username,
+						Action:       "console_access",
+						ResourceType: "container",
+						ResourceID:   username,
+						SourceIP:     sourceIP,
+					}); err != nil {
+						log.Printf("Failed to write audit log for console_access: %v", err)
+					}
+				}
+
+				gs.consoleHandler.HandleConsole(w, r)
+			}))
+		}
+
 		// Handler for container routes
 		containerHandler := func(w http.ResponseWriter, r *http.Request) {
 			// Check if this is a terminal request
 			if strings.HasSuffix(r.URL.Path, "/terminal") {
 				terminalWithCORS.ServeHTTP(w, r)
+				return
+			}
+			// Check if this is a console-attach request
+			if strings.HasSuffix(r.URL.Path, "/console-attach") && consoleWithCORS != nil {
+				consoleWithCORS.ServeHTTP(w, r)
 				return
 			}
 			// Check if this is a labels request


### PR DESCRIPTION
## Summary
- New WebSocket route `GET /v1/containers/{username}/console-attach`, relaying raw binary frames between the caller and Incus's `ConsoleInstance` (a serial console is a dumb byte pipe — no PTY negotiation, no resize-after-attach, unlike the existing `/terminal` route's JSON-framed exec session).
- Detach-without-kill is driven by the client's WebSocket close frame (via `SetCloseHandler`) closing Incus's `ConsoleDisconnect` channel — the same signal upstream's own `incus console` CLI relies on for a clean detach.
- CLI: `containarium console <username>` (no `--log`) puts the local terminal in raw mode and attaches live. Detach with `<ctrl>+a q`, matching Incus's own convention so nothing new to learn for anyone who already knows `incus console`.
- Live attach requires `--http` with an `http(s)://` `--server` — a plain gRPC endpoint has no WebSocket upgrade path; `--log` continues to work over either transport (unchanged from #1750).
- Added a tenant check (`authorizeConsoleAccess`, own username or admin role) that the existing `/terminal` WebSocket route does **not** have — filed as a followup, #1754, rather than fixed here (out of scope for this PR, but real and worth flagging: any authenticated tenant can currently open a shell into any other tenant's container via `/terminal`).

## Motivation
Phase 2 of #1749 (design doc: `docs/architecture/byoc-vm-console-access.md`, PR #1748). #1750 covered the static ring-buffer read; this covers live attach for the cases where the console log alone isn't enough — e.g. an interactive bootloader prompt, or watching a boot proceed in real time.

Closes #1751.

## Test plan
- [x] `console_test.go`: `TestParseConsoleUsername`, `TestAuthorizeConsoleAccess` (nil claims / own tenant / wrong tenant / admin) — the actual new security-relevant logic
- [x] `console_attach_test.go`: `TestDetachEscape_*` (fires on `<ctrl>+a q`, doesn't fire on `q` alone, doesn't stay armed across an unrelated key, only fires once), `TestConsoleWebSocketURL` (scheme translation, bare-host default, trailing slash, username path-escaping, rejected non-http(s) scheme) — this test caught two real bugs (a `ws://` scheme being mangled instead of rejected, and username double-escaping) before merge
- [x] `go build ./...`, `golangci-lint run` — clean
- **Known gap, by design, matching this repo's existing precedent**: the WebSocket relay wiring itself (`ConsoleHandler.HandleConsole`/`attachConsole`, the CLI's actual dial+raw-mode+pump loop) has no automated test — it needs a real Incus daemon with a running VM instance, which CI doesn't have. This is the same posture `TerminalHandler` (the pre-existing `/terminal` route) already has zero coverage for; I did not attempt to close that gap for either route in this PR, only to make sure the new *decision logic* (auth, path parsing, URL building, escape detection) is real, verified, and better-covered than the precedent it's built next to.
- [ ] CI (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added live interactive console attachment for running virtual machines through authenticated WebSocket connections.
  - Console sessions now support bidirectional terminal input and output, graceful disconnects, and terminal restoration.
  - Added secure access controls, tenant ownership checks, administrator access, and origin validation for console connections.

- **Documentation**
  - Updated console command documentation with HTTP server requirements and the detach shortcut: `Ctrl+A`, then `Q`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->