### PR TITLE
feat(hypervisor): console-multiplex agent for VirtualBox-hosted BYOC hosts

### DIFF
--- a/internal/cmd/hypervisor_agent.go
+++ b/internal/cmd/hypervisor_agent.go
@@ -1,0 +1,138 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/footprintai/containarium/internal/hypervisor"
+	"github.com/footprintai/containarium/internal/sentinel"
+	"github.com/spf13/cobra"
+)
+
+var (
+	hvSentinelAddr string
+	hvTunnelToken  string
+	hvSpotID       string
+	hvConsolePort  int
+	hvConsoleToken string
+	hvVBoxDir      string
+)
+
+var hypervisorAgentCmd = &cobra.Command{
+	Use:   "hypervisor-agent",
+	Short: "Serve console access to VirtualBox-hosted BYOC guests from their physical host",
+	Long: `Run on the PHYSICAL machine hosting VirtualBox VMs — not inside any guest.
+
+A guest hung at BIOS POST, in its bootloader, or panicked before its own
+network stack comes up has nothing running that could serve SSH or the
+tunnel client's own port-forwards (both live inside the guest). This agent
+runs on the hypervisor host instead, dialing outbound to the sentinel with
+its own identity via the existing tunnel client (unmodified — this is one
+more advertised port, not a protocol change), and serves a small
+console-multiplex protocol on that port: present a token and a guest name,
+get back a raw byte relay to that guest's serial console.
+
+Reaching this agent from outside the sentinel's own host requires the
+sentinel-side console router (see FootprintAI/Containarium#1756) — not yet
+built. This command is independently useful without it for anyone with
+direct network access to the sentinel.
+
+The guest's serial port must already be redirected to a UNIX socket at
+--vbox-console-dir/<guest-name>.sock — VirtualBox only accepts UART
+changes while the VM is powered off:
+
+  VBoxManage modifyvm <vm> --uart1 0x3F8 4 --uartmode1 server /path/to.sock
+
+Examples:
+  containarium hypervisor-agent --sentinel-addr sentinel.example.com:9443 \
+                                --token SECRET \
+                                --spot-id lab-vbox-host-1 \
+                                --console-token CONSOLE_SECRET \
+                                --vbox-console-dir /var/lib/containarium/consoles`,
+	RunE: runHypervisorAgent,
+}
+
+func init() {
+	rootCmd.AddCommand(hypervisorAgentCmd)
+
+	hypervisorAgentCmd.Flags().StringVar(&hvSentinelAddr, "sentinel-addr", "", "Sentinel address (host:port) to connect to (required)")
+	hypervisorAgentCmd.Flags().StringVar(&hvTunnelToken, "token", "", "Pre-shared tunnel registration token (or CONTAINARIUM_TUNNEL_TOKEN env) — authorizes joining the tunnel, distinct from --console-token")
+	hypervisorAgentCmd.Flags().StringVar(&hvSpotID, "spot-id", "", "Unique identifier for this hypervisor host (required) — its own identity, not any guest's")
+	hypervisorAgentCmd.Flags().IntVar(&hvConsolePort, "console-port", 8082, "Local port to advertise through the tunnel and listen on for console requests")
+	hypervisorAgentCmd.Flags().StringVar(&hvConsoleToken, "console-token", "", "Pre-shared token a caller must present to open a console (or CONTAINARIUM_CONSOLE_TOKEN env) — a separate, narrower credential from --token")
+	hypervisorAgentCmd.Flags().StringVar(&hvVBoxDir, "vbox-console-dir", "", "Base directory containing one <guest-name>.sock UNIX socket per VirtualBox guest, set up via VBoxManage --uartmode1 server (required)")
+}
+
+func runHypervisorAgent(cmd *cobra.Command, args []string) error {
+	if hvSentinelAddr == "" {
+		return fmt.Errorf("--sentinel-addr is required")
+	}
+	if hvSpotID == "" {
+		return fmt.Errorf("--spot-id is required")
+	}
+	if hvVBoxDir == "" {
+		return fmt.Errorf("--vbox-console-dir is required")
+	}
+
+	tunnelToken := hvTunnelToken
+	if tunnelToken == "" {
+		tunnelToken = os.Getenv("CONTAINARIUM_TUNNEL_TOKEN")
+	}
+	if tunnelToken == "" {
+		return fmt.Errorf("--token or CONTAINARIUM_TUNNEL_TOKEN is required")
+	}
+
+	consoleToken := hvConsoleToken
+	if consoleToken == "" {
+		consoleToken = os.Getenv("CONTAINARIUM_CONSOLE_TOKEN")
+	}
+	if consoleToken == "" {
+		return fmt.Errorf("--console-token or CONTAINARIUM_CONSOLE_TOKEN is required")
+	}
+
+	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", hvConsolePort))
+	if err != nil {
+		return fmt.Errorf("failed to listen on 127.0.0.1:%d: %w", hvConsolePort, err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	agent := &hypervisor.Agent{
+		Token:    consoleToken,
+		Provider: hypervisor.NewVirtualBoxProvider(hvVBoxDir),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		sig := <-sigChan
+		log.Printf("[hypervisor-agent] received signal: %v", sig)
+		cancel()
+		_ = ln.Close()
+	}()
+
+	go func() {
+		if err := agent.Serve(ctx, ln); err != nil {
+			log.Printf("[hypervisor-agent] serve error: %v", err)
+		}
+	}()
+
+	tunnel := &sentinel.TunnelClient{
+		SentinelAddr: hvSentinelAddr,
+		Token:        tunnelToken,
+		SpotID:       hvSpotID,
+		Ports:        []int{hvConsolePort},
+	}
+
+	log.Printf("[hypervisor-agent] connecting to sentinel at %s as %q, serving consoles from %s on port %d", hvSentinelAddr, hvSpotID, hvVBoxDir, hvConsolePort)
+	return tunnel.Run(ctx)
+}

--- a/internal/hypervisor/agent.go
+++ b/internal/hypervisor/agent.go
@@ -1,0 +1,166 @@
+package hypervisor
+
+import (
+	"bufio"
+	"context"
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+)
+
+// defaultMaxHandshakeLine bounds how many bytes are read looking for the
+// handshake's trailing newline, so a caller that never sends one can't hold
+// a connection open reading unboundedly.
+const defaultMaxHandshakeLine = 4096
+
+// handshakeRequest is the single JSON line a caller sends before the
+// connection turns into a raw byte relay to the target's console. Not
+// exported: this is an internal wire detail of the hypervisor-agent
+// listener, not a public API — the sentinel-side console router (#1756)
+// that will actually originate these requests is a separate, not-yet-built
+// component, and its exact shape may still change this framing.
+type handshakeRequest struct {
+	Token  string `json:"token"`
+	Target string `json:"target"`
+}
+
+// Agent serves the hypervisor-agent's console-multiplex protocol: a caller
+// connects, sends one JSON handshake line ({"token":"...","target":"..."}),
+// and — once authorized — the connection becomes a raw, bidirectional relay
+// to that target's console via Provider.
+type Agent struct {
+	// Token is the shared secret a caller must present in the handshake.
+	// Matches the tunnel client's own pre-shared-token convention
+	// (--token/CONTAINARIUM_TUNNEL_TOKEN) rather than introducing a new
+	// credential system. Required — HandleConn refuses every request if
+	// this is empty, since an empty Token would otherwise make an empty
+	// presented token "valid".
+	Token string
+
+	// Provider opens the actual console stream once a request is
+	// authorized.
+	Provider ConsoleProvider
+
+	// MaxHandshakeLine overrides defaultMaxHandshakeLine. Zero uses the
+	// default; only tests need to set this.
+	MaxHandshakeLine int
+}
+
+// Serve accepts connections on ln until ctx is cancelled or Accept fails,
+// handling each one in its own goroutine.
+func (a *Agent) Serve(ctx context.Context, ln net.Listener) error {
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			select {
+			case <-ctx.Done():
+				return nil
+			default:
+				return fmt.Errorf("hypervisor-agent: accept: %w", err)
+			}
+		}
+		go a.HandleConn(ctx, conn)
+	}
+}
+
+// HandleConn reads one handshake off conn, authorizes it, opens the
+// requested console, and relays bytes until either side closes. It always
+// closes conn before returning.
+func (a *Agent) HandleConn(ctx context.Context, conn net.Conn) {
+	defer func() { _ = conn.Close() }()
+
+	req, err := readHandshake(conn, a.maxHandshakeLine())
+	if err != nil {
+		writeAgentError(conn, err)
+		return
+	}
+	if !tokenAuthorized(a.Token, req.Token) {
+		writeAgentError(conn, errors.New("unauthorized"))
+		return
+	}
+	if req.Target == "" {
+		writeAgentError(conn, errors.New("target is required"))
+		return
+	}
+	if a.Provider == nil {
+		writeAgentError(conn, errors.New("no console provider configured"))
+		return
+	}
+
+	console, err := a.Provider.OpenConsole(ctx, req.Target)
+	if err != nil {
+		writeAgentError(conn, err)
+		return
+	}
+	defer func() { _ = console.Close() }()
+
+	if _, err := conn.Write([]byte("ok\n")); err != nil {
+		return
+	}
+
+	relay(conn, console)
+}
+
+func (a *Agent) maxHandshakeLine() int {
+	if a.MaxHandshakeLine > 0 {
+		return a.MaxHandshakeLine
+	}
+	return defaultMaxHandshakeLine
+}
+
+// readHandshake reads one newline-terminated JSON line from r and decodes
+// it as a handshakeRequest. maxLine is a hard cap: bufio.Reader.ReadString
+// alone does NOT enforce its buffer size as a line-length limit — it just
+// refills as many times as needed to find the delimiter — so this wraps r
+// in an io.LimitReader first to actually bound how much a caller that never
+// sends '\n' can make this read.
+func readHandshake(r io.Reader, maxLine int) (handshakeRequest, error) {
+	reader := bufio.NewReader(io.LimitReader(r, int64(maxLine)))
+	line, err := reader.ReadString('\n')
+	if err != nil && line == "" {
+		return handshakeRequest{}, fmt.Errorf("hypervisor-agent: read handshake: %w", err)
+	}
+
+	var req handshakeRequest
+	if err := json.Unmarshal([]byte(line), &req); err != nil {
+		return handshakeRequest{}, fmt.Errorf("hypervisor-agent: invalid handshake: %w", err)
+	}
+	return req, nil
+}
+
+// tokenAuthorized reports whether presented matches expected. Both must be
+// non-empty — an unconfigured Agent.Token never authorizes anything, rather
+// than an empty presented token matching an equally-empty expectation.
+func tokenAuthorized(expected, presented string) bool {
+	if expected == "" || presented == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(expected), []byte(presented)) == 1
+}
+
+// writeAgentError sends a single-line, best-effort error to conn. Errors
+// writing it are swallowed — the connection is being torn down either way.
+func writeAgentError(conn net.Conn, err error) {
+	log.Printf("[hypervisor-agent] rejecting connection from %s: %v", conn.RemoteAddr(), err)
+	_, _ = conn.Write([]byte("error: " + err.Error() + "\n"))
+}
+
+// relay bidirectionally copies bytes between a and b until either side's
+// copy finishes (EOF or error), then returns. Matches the tunnel client's
+// own bidirectional-copy shape (internal/sentinel/tunnel_client.go).
+func relay(a, b io.ReadWriteCloser) {
+	done := make(chan struct{}, 2)
+	go func() {
+		_, _ = io.Copy(a, b)
+		done <- struct{}{}
+	}()
+	go func() {
+		_, _ = io.Copy(b, a)
+		done <- struct{}{}
+	}()
+	<-done
+}

--- a/internal/hypervisor/agent_test.go
+++ b/internal/hypervisor/agent_test.go
@@ -1,0 +1,314 @@
+package hypervisor
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeConsole is an in-memory io.ReadWriteCloser standing in for a real
+// console socket, so agent tests never touch VirtualBox or the filesystem.
+type fakeConsole struct {
+	io.Reader
+	io.Writer
+	closed bool
+}
+
+func (f *fakeConsole) Close() error {
+	f.closed = true
+	return nil
+}
+
+// fakeProvider hands out a fixed console (or error) regardless of target,
+// recording what target it was asked to open.
+type fakeProvider struct {
+	console      *fakeConsole
+	err          error
+	lastTarget   string
+	openCalled   bool
+	openCanceled bool
+}
+
+func (p *fakeProvider) OpenConsole(ctx context.Context, target string) (io.ReadWriteCloser, error) {
+	p.openCalled = true
+	p.lastTarget = target
+	if ctx.Err() != nil {
+		p.openCanceled = true
+	}
+	if p.err != nil {
+		return nil, p.err
+	}
+	return p.console, nil
+}
+
+func writeHandshakeLine(t *testing.T, conn net.Conn, req handshakeRequest) {
+	t.Helper()
+	b, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("failed to marshal handshake: %v", err)
+	}
+	if _, err := conn.Write(append(b, '\n')); err != nil {
+		t.Fatalf("failed to write handshake: %v", err)
+	}
+}
+
+func TestAgent_HandleConn_Success(t *testing.T) {
+	server, client := net.Pipe()
+	defer func() { _ = client.Close() }()
+
+	consoleReader, testWriter := io.Pipe()
+	console := &fakeConsole{Reader: consoleReader, Writer: io.Discard}
+	provider := &fakeProvider{console: console}
+
+	agent := &Agent{Token: "secret", Provider: provider}
+	done := make(chan struct{})
+	go func() {
+		agent.HandleConn(context.Background(), server)
+		close(done)
+	}()
+
+	writeHandshakeLine(t, client, handshakeRequest{Token: "secret", Target: "containarium-byoc-1"})
+
+	reader := bufio.NewReader(client)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		t.Fatalf("failed to read response: %v", err)
+	}
+	if strings.TrimSpace(line) != "ok" {
+		t.Fatalf("got %q, want \"ok\"", line)
+	}
+
+	// Prove the connection is now a raw relay to the console: bytes written
+	// into the console's read side arrive at the client.
+	go func() { _, _ = testWriter.Write([]byte("boot log line\n")); _ = testWriter.Close() }()
+	relayed, err := reader.ReadString('\n')
+	if err != nil {
+		t.Fatalf("failed to read relayed console output: %v", err)
+	}
+	if relayed != "boot log line\n" {
+		t.Fatalf("got %q, want %q", relayed, "boot log line\n")
+	}
+
+	if provider.lastTarget != "containarium-byoc-1" {
+		t.Fatalf("provider opened target %q, want %q", provider.lastTarget, "containarium-byoc-1")
+	}
+
+	_ = client.Close()
+	<-done
+
+	if !console.closed {
+		t.Fatal("expected the console to be closed once the session ended")
+	}
+}
+
+func TestAgent_HandleConn_WrongToken(t *testing.T) {
+	server, client := net.Pipe()
+	defer func() { _ = client.Close() }()
+
+	provider := &fakeProvider{console: &fakeConsole{Reader: strings.NewReader(""), Writer: io.Discard}}
+	agent := &Agent{Token: "secret", Provider: provider}
+	done := make(chan struct{})
+	go func() {
+		agent.HandleConn(context.Background(), server)
+		close(done)
+	}()
+
+	writeHandshakeLine(t, client, handshakeRequest{Token: "wrong", Target: "containarium-byoc-1"})
+
+	reader := bufio.NewReader(client)
+	line, _ := reader.ReadString('\n')
+	if !strings.HasPrefix(line, "error:") {
+		t.Fatalf("got %q, want an error response", line)
+	}
+	<-done
+
+	if provider.openCalled {
+		t.Fatal("provider should never be consulted for an unauthorized request")
+	}
+}
+
+func TestAgent_HandleConn_EmptyAgentTokenAuthorizesNothing(t *testing.T) {
+	server, client := net.Pipe()
+	defer func() { _ = client.Close() }()
+
+	provider := &fakeProvider{console: &fakeConsole{Reader: strings.NewReader(""), Writer: io.Discard}}
+	agent := &Agent{Token: "", Provider: provider} // misconfigured: no token set
+	done := make(chan struct{})
+	go func() {
+		agent.HandleConn(context.Background(), server)
+		close(done)
+	}()
+
+	// Even an empty presented token must not match an empty Agent.Token.
+	writeHandshakeLine(t, client, handshakeRequest{Token: "", Target: "containarium-byoc-1"})
+
+	reader := bufio.NewReader(client)
+	line, _ := reader.ReadString('\n')
+	if !strings.HasPrefix(line, "error:") {
+		t.Fatalf("got %q, want an error response", line)
+	}
+	<-done
+
+	if provider.openCalled {
+		t.Fatal("an unconfigured Agent.Token must never authorize a request")
+	}
+}
+
+func TestAgent_HandleConn_MissingTarget(t *testing.T) {
+	server, client := net.Pipe()
+	defer func() { _ = client.Close() }()
+
+	provider := &fakeProvider{}
+	agent := &Agent{Token: "secret", Provider: provider}
+	done := make(chan struct{})
+	go func() {
+		agent.HandleConn(context.Background(), server)
+		close(done)
+	}()
+
+	writeHandshakeLine(t, client, handshakeRequest{Token: "secret", Target: ""})
+
+	reader := bufio.NewReader(client)
+	line, _ := reader.ReadString('\n')
+	if !strings.HasPrefix(line, "error:") {
+		t.Fatalf("got %q, want an error response", line)
+	}
+	<-done
+
+	if provider.openCalled {
+		t.Fatal("provider should never be consulted for a request with no target")
+	}
+}
+
+func TestAgent_HandleConn_ProviderError(t *testing.T) {
+	server, client := net.Pipe()
+	defer func() { _ = client.Close() }()
+
+	provider := &fakeProvider{err: errors.New("no such guest")}
+	agent := &Agent{Token: "secret", Provider: provider}
+	done := make(chan struct{})
+	go func() {
+		agent.HandleConn(context.Background(), server)
+		close(done)
+	}()
+
+	writeHandshakeLine(t, client, handshakeRequest{Token: "secret", Target: "ghost"})
+
+	reader := bufio.NewReader(client)
+	line, _ := reader.ReadString('\n')
+	if !strings.Contains(line, "no such guest") {
+		t.Fatalf("got %q, want it to surface the provider's error", line)
+	}
+	<-done
+}
+
+func TestAgent_HandleConn_MalformedHandshake(t *testing.T) {
+	server, client := net.Pipe()
+	defer func() { _ = client.Close() }()
+
+	provider := &fakeProvider{}
+	agent := &Agent{Token: "secret", Provider: provider}
+	done := make(chan struct{})
+	go func() {
+		agent.HandleConn(context.Background(), server)
+		close(done)
+	}()
+
+	if _, err := client.Write([]byte("not json\n")); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	reader := bufio.NewReader(client)
+	line, _ := reader.ReadString('\n')
+	if !strings.HasPrefix(line, "error:") {
+		t.Fatalf("got %q, want an error response", line)
+	}
+	<-done
+
+	if provider.openCalled {
+		t.Fatal("provider should never be consulted for a malformed handshake")
+	}
+}
+
+func TestAgent_HandleConn_NoProviderConfigured(t *testing.T) {
+	server, client := net.Pipe()
+	defer func() { _ = client.Close() }()
+
+	agent := &Agent{Token: "secret"} // Provider left nil
+	done := make(chan struct{})
+	go func() {
+		agent.HandleConn(context.Background(), server)
+		close(done)
+	}()
+
+	writeHandshakeLine(t, client, handshakeRequest{Token: "secret", Target: "containarium-byoc-1"})
+
+	reader := bufio.NewReader(client)
+	line, _ := reader.ReadString('\n')
+	if !strings.HasPrefix(line, "error:") {
+		t.Fatalf("got %q, want an error response", line)
+	}
+	<-done
+}
+
+func TestTokenAuthorized(t *testing.T) {
+	cases := []struct {
+		name      string
+		expected  string
+		presented string
+		want      bool
+	}{
+		{"matching", "secret", "secret", true},
+		{"mismatched", "secret", "wrong", false},
+		{"both empty", "", "", false},
+		{"expected empty, presented set", "", "secret", false},
+		{"expected set, presented empty", "secret", "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := tokenAuthorized(c.expected, c.presented); got != c.want {
+				t.Errorf("tokenAuthorized(%q, %q) = %v, want %v", c.expected, c.presented, got, c.want)
+			}
+		})
+	}
+}
+
+func TestReadHandshake_RejectsOversizeLine(t *testing.T) {
+	huge := strings.NewReader(fmt.Sprintf(`{"token":"%s","target":"x"}`+"\n", strings.Repeat("a", 100)))
+	if _, err := readHandshake(huge, 16); err == nil {
+		t.Fatal("expected an error for a handshake line exceeding maxLine")
+	}
+}
+
+func TestAgent_Serve_StopsOnContextCancel(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	agent := &Agent{Token: "secret", Provider: &fakeProvider{}}
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- agent.Serve(ctx, ln) }()
+
+	cancel()
+	_ = ln.Close() // unblock Accept
+
+	select {
+	case err := <-serveErr:
+		if err != nil {
+			t.Fatalf("expected a nil error on clean shutdown, got: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Serve did not return after context cancellation")
+	}
+}

--- a/internal/hypervisor/provider.go
+++ b/internal/hypervisor/provider.go
@@ -1,0 +1,68 @@
+// Package hypervisor implements the host-side half of console access to a
+// BYOC VM host that is itself unreachable — see
+// docs/architecture/byoc-vm-console-access.md. It runs on the physical
+// machine hosting the VM (VirtualBox, today), not inside any guest, since a
+// guest hung at BIOS POST has nothing running that could serve its own
+// console.
+package hypervisor
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"path/filepath"
+)
+
+// ConsoleProvider returns a raw byte stream to a target's serial console.
+// No PTY negotiation, no shell — a serial console is a dumb byte pipe.
+type ConsoleProvider interface {
+	OpenConsole(ctx context.Context, target string) (io.ReadWriteCloser, error)
+}
+
+// VirtualBoxProvider is a ConsoleProvider backed by VirtualBox's
+// serial-port-to-UNIX-socket redirect
+// (`VBoxManage modifyvm <vm> --uart1 0x3F8 4 --uartmode1 server <path>`),
+// configured once per guest while it is powered off — VirtualBox does not
+// accept UART changes on a running VM. OpenConsole itself is a plain
+// `net.Dial("unix", ...)`; no VBoxManage subprocess at attach time.
+type VirtualBoxProvider struct {
+	// SocketPath resolves a guest name to the UNIX socket path its serial
+	// port was configured to serve on. Required.
+	SocketPath func(target string) (string, error)
+}
+
+// NewVirtualBoxProvider returns a VirtualBoxProvider using the convention
+// "<baseDir>/<target>.sock" — the path this package's own provisioning
+// helper (see docs/architecture/byoc-vm-console-access.md) uses when it
+// sets up a guest's serial redirect. A deployment that names its sockets
+// differently can build a VirtualBoxProvider directly with a custom
+// SocketPath instead.
+func NewVirtualBoxProvider(baseDir string) *VirtualBoxProvider {
+	return &VirtualBoxProvider{
+		SocketPath: func(target string) (string, error) {
+			if target == "" {
+				return "", fmt.Errorf("hypervisor: target is required")
+			}
+			return filepath.Join(baseDir, target+".sock"), nil
+		},
+	}
+}
+
+// OpenConsole implements ConsoleProvider.
+func (p *VirtualBoxProvider) OpenConsole(ctx context.Context, target string) (io.ReadWriteCloser, error) {
+	if p.SocketPath == nil {
+		return nil, fmt.Errorf("hypervisor: VirtualBoxProvider has no SocketPath resolver configured")
+	}
+	path, err := p.SocketPath(target)
+	if err != nil {
+		return nil, fmt.Errorf("hypervisor: resolve console socket for %q: %w", target, err)
+	}
+
+	var d net.Dialer
+	conn, err := d.DialContext(ctx, "unix", path)
+	if err != nil {
+		return nil, fmt.Errorf("hypervisor: dial console socket %q for %q: %w", path, target, err)
+	}
+	return conn, nil
+}

--- a/internal/hypervisor/provider_test.go
+++ b/internal/hypervisor/provider_test.go
@@ -1,0 +1,120 @@
+package hypervisor
+
+import (
+	"context"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// shortTempDir returns a short-path temp directory. Unlike t.TempDir()
+// (which embeds the full test name), this stays under the ~104-byte
+// sun_path limit UNIX domain sockets have on macOS/BSD.
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "hv")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+// listenFakeConsoleSocket starts a UNIX listener standing in for VirtualBox's
+// serial-port redirect and echoes back everything it reads, so a test can
+// verify OpenConsole actually reaches the right socket without VirtualBox.
+func listenFakeConsoleSocket(t *testing.T, path string) net.Listener {
+	t.Helper()
+	ln, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatalf("failed to listen on fake console socket: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		buf := make([]byte, 4096)
+		for {
+			n, err := conn.Read(buf)
+			if n > 0 {
+				_, _ = conn.Write(buf[:n])
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+	return ln
+}
+
+func TestVirtualBoxProvider_OpenConsole_RoundTrips(t *testing.T) {
+	dir := shortTempDir(t)
+	sockPath := filepath.Join(dir, "containarium-byoc-1.sock")
+	listenFakeConsoleSocket(t, sockPath)
+
+	p := NewVirtualBoxProvider(dir)
+	conn, err := p.OpenConsole(context.Background(), "containarium-byoc-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	if _, err := conn.Write([]byte("hello console")); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	buf := make([]byte, 32)
+	_ = conn.(interface{ SetReadDeadline(time.Time) error }).SetReadDeadline(time.Now().Add(2 * time.Second))
+	n, err := conn.Read(buf)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	if got := string(buf[:n]); got != "hello console" {
+		t.Fatalf("got %q, want echoed %q", got, "hello console")
+	}
+}
+
+func TestVirtualBoxProvider_OpenConsole_NoSocketForTarget(t *testing.T) {
+	dir := shortTempDir(t)
+	p := NewVirtualBoxProvider(dir)
+
+	if _, err := p.OpenConsole(context.Background(), "no-such-guest"); err == nil {
+		t.Fatal("expected an error dialing a socket that doesn't exist")
+	}
+}
+
+func TestVirtualBoxProvider_OpenConsole_EmptyTarget(t *testing.T) {
+	dir := shortTempDir(t)
+	p := NewVirtualBoxProvider(dir)
+
+	if _, err := p.OpenConsole(context.Background(), ""); err == nil {
+		t.Fatal("expected an error for an empty target")
+	}
+}
+
+func TestVirtualBoxProvider_OpenConsole_NoResolverConfigured(t *testing.T) {
+	p := &VirtualBoxProvider{}
+	if _, err := p.OpenConsole(context.Background(), "containarium-byoc-1"); err == nil {
+		t.Fatal("expected an error when SocketPath is unset")
+	}
+}
+
+func TestVirtualBoxProvider_SocketPathConvention(t *testing.T) {
+	p := NewVirtualBoxProvider("/var/lib/containarium/consoles")
+	got, err := p.SocketPath("containarium-byoc-2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "/var/lib/containarium/consoles/containarium-byoc-2.sock"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+var _ io.ReadWriteCloser = (*net.UnixConn)(nil) // sanity: net.Dial("unix", ...) satisfies our interface


### PR DESCRIPTION
## Summary
- New `internal/hypervisor` package: `ConsoleProvider` interface + `VirtualBoxProvider` (dials a guest's serial-port UNIX socket — VirtualBox's `--uartmode1 server` redirect, configured once per guest while it's powered off), and `Agent`, which serves a tiny framed protocol (one JSON handshake line — token + target guest name — then a raw bidirectional relay to that guest's console).
- New CLI mode: `containarium hypervisor-agent`, which runs on the **physical machine hosting VirtualBox** (not inside any guest) and reuses `sentinel.TunnelClient` completely unmodified — the agent's console listener is just one more advertised port through the existing tunnel client, zero tunnel-protocol changes.
- A separate `--console-token` from the tunnel's own `--token`: "may this host join the tunnel at all" and "may this caller open a console for a specific guest" are different privileges and shouldn't share a credential.

## Motivation
Phase 2 of #1749, host-side half of #1752 (design doc: `docs/architecture/byoc-vm-console-access.md`, PR #1748 — see its latest commit for why this needed rescoping: neither #1750 nor #1751 could ever reach a guest hung at BIOS POST, since both live inside the guest's own daemon/tunnel-agent, which never started). This is the piece that runs *outside* the hung guest — on the physical hypervisor host, which stays reachable independent of any one guest's boot state.

I verified against the real lab machine hosting `containarium-byoc-1`/`-2` (VirtualBox 7.2.14, both registered) that this architecture is sound, and confirmed `containarium-byoc-2`'s serial port isn't provisioned yet (`uart1="off"`) — VirtualBox only accepts UART changes powered off, so I deliberately did not touch either live VM as part of this PR. Real-VM verification (against `-1`, not the already-broken `-2`) is left as an explicit follow-up pending sign-off on a brief stop/reconfigure/restart cycle.

Public reachability from outside the sentinel's own host needs a sentinel-side console router — split out as #1756, since it touches a shared production process (the sentinel fronts real customer SSH/TLS traffic) rather than an opt-in agent binary nobody has to run.

Closes #1752.

## Test plan
- [x] `provider_test.go`: `VirtualBoxProvider.OpenConsole` round-trips against a fake UNIX socket, rejects a missing target/socket/resolver — no real VirtualBox needed
- [x] `agent_test.go`: full handshake→relay success path over `net.Pipe()` with a fake `ConsoleProvider`, wrong/empty token rejected, missing target rejected, provider error surfaced, malformed handshake rejected, oversize handshake line rejected, clean shutdown on context cancel — 17 tests total, all green
- [x] Caught two real bugs via these tests before merge: `bufio.Reader.ReadString` doesn't actually enforce its buffer size as a line-length cap (fixed with an explicit `io.LimitReader`), and an unconfigured `Agent.Token` must never authorize an equally-empty presented token
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run` — clean
- [x] CLI smoke test: `--help` and required-flag error paths
- [ ] CI (this PR)
- **Explicitly not done**: end-to-end verification against a real VirtualBox guest (deferred, see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a non-Windows `hypervisor-agent` command for serving guest serial consoles from VirtualBox hosts.
  * Supports authenticated console connections with target validation and bidirectional data transfer.
  * Accepts tunnel and console credentials through command-line flags or environment variables.
  * Automatically registers the console listener with the sentinel tunnel.
  * Supports VirtualBox UNIX-socket console connections and graceful shutdown on termination signals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->