### PR TITLE
fix(hypervisor): agent's handshake reader can silently swallow console input

### DIFF
--- a/internal/hypervisor/agent.go
+++ b/internal/hypervisor/agent.go
@@ -1,7 +1,6 @@
 package hypervisor
 
 import (
-	"bufio"
 	"context"
 	"crypto/subtle"
 	"encoding/json"
@@ -113,20 +112,42 @@ func (a *Agent) maxHandshakeLine() int {
 }
 
 // readHandshake reads one newline-terminated JSON line from r and decodes
-// it as a handshakeRequest. maxLine is a hard cap: bufio.Reader.ReadString
-// alone does NOT enforce its buffer size as a line-length limit — it just
-// refills as many times as needed to find the delimiter — so this wraps r
-// in an io.LimitReader first to actually bound how much a caller that never
-// sends '\n' can make this read.
+// it as a handshakeRequest.
+//
+// Deliberately reads one byte at a time rather than through a bufio.Reader:
+// a buffered reader's first Read pulls a full internal buffer's worth from
+// the underlying connection, and on a real socket that read can coalesce
+// the handshake line together with whatever the caller sends immediately
+// after it (the first chunk of console input, sent without waiting for the
+// "ok" response). Those extra bytes would be captured in the bufio.Reader's
+// internal buffer — which is discarded once the handshake is parsed — and
+// never reach relay(), which reads directly off conn. A byte-at-a-time read
+// never consumes past the delimiter, so nothing is lost. This mirrors
+// internal/sentinel/tunnel_auth.go's readHandshakeLine, which hit the same
+// class of bug for the same reason (its own comment calls out the identical
+// "SYN frame" scenario for the tunnel handshake).
 func readHandshake(r io.Reader, maxLine int) (handshakeRequest, error) {
-	reader := bufio.NewReader(io.LimitReader(r, int64(maxLine)))
-	line, err := reader.ReadString('\n')
-	if err != nil && line == "" {
-		return handshakeRequest{}, fmt.Errorf("hypervisor-agent: read handshake: %w", err)
+	buf := make([]byte, 0, 256)
+	one := make([]byte, 1)
+	for {
+		n, err := r.Read(one)
+		if err != nil {
+			return handshakeRequest{}, fmt.Errorf("hypervisor-agent: read handshake: %w", err)
+		}
+		if n == 0 {
+			continue
+		}
+		if one[0] == '\n' {
+			break
+		}
+		buf = append(buf, one[0])
+		if len(buf) > maxLine {
+			return handshakeRequest{}, fmt.Errorf("hypervisor-agent: handshake exceeded %d bytes", maxLine)
+		}
 	}
 
 	var req handshakeRequest
-	if err := json.Unmarshal([]byte(line), &req); err != nil {
+	if err := json.Unmarshal(buf, &req); err != nil {
 		return handshakeRequest{}, fmt.Errorf("hypervisor-agent: invalid handshake: %w", err)
 	}
 	return req, nil

--- a/internal/hypervisor/agent_test.go
+++ b/internal/hypervisor/agent_test.go
@@ -258,6 +258,66 @@ func TestAgent_HandleConn_NoProviderConfigured(t *testing.T) {
 	<-done
 }
 
+// TestAgent_HandleConn_NoOverreadPastHandshake is a regression test: a
+// bufio.Reader-based implementation of readHandshake would silently
+// swallow bytes the caller sends immediately after the handshake line
+// (without waiting for the "ok" response) into its own internal buffer,
+// which relay() never sees since it reads directly off the raw conn. This
+// sends the handshake and a follow-up console-input chunk in a SINGLE
+// Write call — reproducing them arriving in one underlying read — and
+// asserts the follow-up bytes still reach the console.
+func TestAgent_HandleConn_NoOverreadPastHandshake(t *testing.T) {
+	server, client := net.Pipe()
+	defer func() { _ = client.Close() }()
+
+	consoleInputR, consoleInputW := io.Pipe()
+	console := &fakeConsole{Reader: strings.NewReader(""), Writer: consoleInputW}
+	provider := &fakeProvider{console: console}
+
+	agent := &Agent{Token: "secret", Provider: provider}
+	done := make(chan struct{})
+	go func() {
+		agent.HandleConn(context.Background(), server)
+		close(done)
+	}()
+
+	hs, err := json.Marshal(handshakeRequest{Token: "secret", Target: "containarium-byoc-1"})
+	if err != nil {
+		t.Fatalf("failed to marshal handshake: %v", err)
+	}
+	// One Write, handshake + follow-up console input together — the
+	// scenario a real socket read can coalesce.
+	payload := append(append(hs, '\n'), []byte("boot-time keypress")...)
+	writeDone := make(chan struct{})
+	go func() {
+		if _, err := client.Write(payload); err != nil {
+			t.Errorf("write failed: %v", err)
+		}
+		close(writeDone)
+	}()
+
+	reader := bufio.NewReader(client)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		t.Fatalf("failed to read response: %v", err)
+	}
+	if strings.TrimSpace(line) != "ok" {
+		t.Fatalf("got %q, want \"ok\"", line)
+	}
+
+	got := make([]byte, len("boot-time keypress"))
+	if _, err := io.ReadFull(consoleInputR, got); err != nil {
+		t.Fatalf("follow-up bytes never reached the console (over-read bug): %v", err)
+	}
+	if string(got) != "boot-time keypress" {
+		t.Fatalf("got %q, want %q", got, "boot-time keypress")
+	}
+
+	<-writeDone
+	_ = client.Close()
+	<-done
+}
+
 func TestTokenAuthorized(t *testing.T) {
 	cases := []struct {
 		name      string


### PR DESCRIPTION
## Summary
- `internal/hypervisor/agent.go`'s `readHandshake` used `bufio.Reader.ReadString('\n')`. Over a real connection, a caller that sends its handshake JSON line and immediately follows with console input (without waiting for the `"ok\n"` response) can have both coalesce into one underlying `Read`. `bufio` buffers the whole thing, `ReadString` returns just the handshake line, and the trailing bytes are stranded inside the now-discarded `bufio.Reader` — `relay()` reads directly off the raw `net.Conn` and never sees them. Silent data loss, not a crash.
- `internal/sentinel/tunnel_auth.go`'s `readHandshakeLine` already hit this exact bug class for the tunnel's own handshake (see its own "SYN frame" comment) and fixed it with a byte-at-a-time reader. This applies the identical fix here.

## Why this wasn't caught in #1757
Every existing test used `net.Pipe()` with the handshake and any follow-up bytes written in **separate** `Write` calls, which `net.Pipe()` never coalesces — masking exactly the scenario a real socket can produce.

## Test plan
- [x] New regression test `TestAgent_HandleConn_NoOverreadPastHandshake`: sends the handshake and a follow-up console-input chunk in a **single** `Write` call (reproducing a coalesced real-socket read), asserts the follow-up bytes reach the console
- [x] Verified the test actually catches the bug: temporarily restored the old `bufio` implementation and the test hung forever (`io.ReadFull` blocking on bytes that never arrive) — the exact failure signature this fix prevents
- [x] All 17 tests in `internal/hypervisor` pass with the fix
- [x] `go build ./...`, `golangci-lint run` — clean
- [ ] CI (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where console input sent immediately after connection setup could be lost.
  * Improved handshake processing to preserve subsequent console data and enforce line-length limits.
* **Tests**
  * Added regression coverage for console input received alongside the handshake.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->