### PR TITLE
feat(sentinel): console router for public reachability of a hypervisor-agent

### DIFF
--- a/internal/cmd/sentinel.go
+++ b/internal/cmd/sentinel.go
@@ -48,6 +48,8 @@ var (
 	sentinelMetricsExport          bool
 	sentinelMetricsExportProject   string
 	sentinelMetricsExportInterval  int32
+	sentinelConsoleRouterAddr      string
+	sentinelConsoleRouterToken     string
 )
 
 var sentinelCmd = &cobra.Command{
@@ -78,6 +80,8 @@ func init() {
 	sentinelCmd.Flags().StringVar(&sentinelProvider, "provider", "gcp", "Cloud provider: \"gcp\", \"none\" (local testing), or \"tunnel\" (reverse tunnel)")
 	sentinelCmd.Flags().StringVar(&sentinelTunnelToken, "tunnel-token", "", "Pre-shared token for tunnel authentication, allowed for any pool (legacy; use --tunnel-token-policy for pool-restricted tokens, or CONTAINARIUM_TUNNEL_TOKEN env)")
 	sentinelCmd.Flags().StringSliceVar(&sentinelTunnelTokenPolicies, "tunnel-token-policy", nil, "Pool-restricted token in the form 'token=pool1,pool2'. Repeatable. Use '*' to mean any pool. Combined with --tunnel-token if both are provided.")
+	sentinelCmd.Flags().StringVar(&sentinelConsoleRouterAddr, "console-router-addr", "", "If set (host:port), run the console router — makes any connected tunnel spot's advertised port publicly reachable, gated by --console-router-token. Opt-in: unset means no console router runs. See FootprintAI/Containarium#1756.")
+	sentinelCmd.Flags().StringVar(&sentinelConsoleRouterToken, "console-router-token", "", "Pre-shared token authorizing console-router requests (or CONTAINARIUM_CONSOLE_ROUTER_TOKEN env). A separate, coarser credential from --tunnel-token — the real per-guest check happens downstream at the hypervisor-agent.")
 	sentinelCmd.Flags().StringVar(&sentinelSpotVM, "spot-vm", "", "Name of the backend VM instance (required for gcp provider)")
 	sentinelCmd.Flags().StringVar(&sentinelZone, "zone", "", "Cloud zone (required for gcp provider)")
 	sentinelCmd.Flags().StringVar(&sentinelProject, "project", "", "Cloud project ID (required for gcp provider)")
@@ -283,6 +287,9 @@ func runSentinel(cmd *cobra.Command, args []string) error {
 			manager.InitBYOCRoutes(sentinel.DefaultBYOCRouteStorePath)
 			manager.SetTunnelPolicy(tunnelPolicy)
 			manager.SetHTTPSListener(connMux.HTTPSChanListener())
+			if err := maybeStartConsoleRouter(ctx, registry); err != nil {
+				return err
+			}
 
 			sigChan := make(chan os.Signal, 1)
 			signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
@@ -372,6 +379,9 @@ func runSentinel(cmd *cobra.Command, args []string) error {
 		manager.InitBYOCRoutes(sentinel.DefaultBYOCRouteStorePath)
 		manager.SetTunnelPolicy(tunnelPolicy)
 		manager.SetHTTPSListener(connMux.HTTPSChanListener())
+		if err := maybeStartConsoleRouter(ctx, registry); err != nil {
+			return err
+		}
 
 		// Graceful shutdown on signals
 		sigChan := make(chan os.Signal, 1)
@@ -431,6 +441,33 @@ func runSentinel(cmd *cobra.Command, args []string) error {
 
 	defer startSentinelMetricsExport(ctx, manager)()
 	return manager.Run(ctx)
+}
+
+// maybeStartConsoleRouter starts the console router (#1756) in the
+// background if --console-router-addr is set, using registry — the same
+// TunnelRegistry the tunnel server just populated. Opt-in: with no
+// --console-router-addr this is a silent no-op, so an existing sentinel
+// deployment doesn't need to configure anything new to keep working.
+func maybeStartConsoleRouter(ctx context.Context, registry *sentinel.TunnelRegistry) error {
+	if sentinelConsoleRouterAddr == "" {
+		return nil
+	}
+
+	token := sentinelConsoleRouterToken
+	if token == "" {
+		token = os.Getenv("CONTAINARIUM_CONSOLE_ROUTER_TOKEN")
+	}
+	if token == "" {
+		return fmt.Errorf("--console-router-token or CONTAINARIUM_CONSOLE_ROUTER_TOKEN is required when --console-router-addr is set")
+	}
+
+	router := sentinel.NewConsoleRouter(sentinelConsoleRouterAddr, sentinel.NewConsoleRouterPolicy(token), registry)
+	go func() {
+		if err := router.Run(ctx); err != nil {
+			log.Printf("[sentinel] console router error: %v", err)
+		}
+	}()
+	return nil
 }
 
 func parseForwardedPorts(s string) ([]int, error) {

--- a/internal/sentinel/console_router.go
+++ b/internal/sentinel/console_router.go
@@ -1,0 +1,188 @@
+package sentinel
+
+import (
+	"context"
+	"crypto/subtle"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"time"
+)
+
+// ConsoleRouterPolicy authorizes a caller to route through the console
+// router to any registered spot's advertised port. Deliberately
+// coarse-grained — one shared secret, not a per-spot ACL — because the
+// real per-guest authorization happens one hop downstream, at the
+// hypervisor-agent's own token + target check
+// (internal/hypervisor.Agent.HandleConn). This layer only gates "can this
+// caller reach the tunnel infrastructure for console routing at all",
+// matching the tunnel's own legacy single-token shape (see PolicyFromCLI)
+// rather than inventing a second fine-grained credential system.
+type ConsoleRouterPolicy struct {
+	token string
+}
+
+// NewConsoleRouterPolicy returns a policy that authorizes exactly one
+// shared token. An empty token authorizes nothing — Validate always fails
+// on an unconfigured policy rather than treating "no token configured" as
+// "any token is fine".
+func NewConsoleRouterPolicy(token string) *ConsoleRouterPolicy {
+	return &ConsoleRouterPolicy{token: token}
+}
+
+// Validate reports whether presented matches the configured token.
+func (p *ConsoleRouterPolicy) Validate(presented string) error {
+	if p.token == "" || presented == "" {
+		return fmt.Errorf("invalid token")
+	}
+	if subtle.ConstantTimeCompare([]byte(p.token), []byte(presented)) != 1 {
+		return fmt.Errorf("invalid token")
+	}
+	return nil
+}
+
+// ConsoleRouterHandshake is the single JSON line a caller sends immediately
+// after connecting, before the connection becomes a raw relay. SpotID and
+// Port identify which hypervisor-agent (or, in principle, any tunnel
+// backend) to reach — the router itself is agnostic to what is actually
+// listening on that port, exactly like the existing tunnel port-forward
+// path.
+type ConsoleRouterHandshake struct {
+	Token  string `json:"token"`
+	SpotID string `json:"spot_id"`
+	Port   int    `json:"port"`
+}
+
+// ConsoleRouterResponse is the single JSON line the router sends back
+// before either closing (on failure) or turning into a raw relay (on
+// success).
+type ConsoleRouterResponse struct {
+	OK    bool   `json:"ok"`
+	Error string `json:"error,omitempty"`
+}
+
+// ConsoleRouter makes any port a connected tunnel spot advertises publicly
+// reachable through the sentinel, gated by ConsoleRouterPolicy. It is a
+// sibling to sshpiper (:22, routed by username) and the SNI router (:443,
+// routed by hostname) — those are this codebase's only two existing public
+// routes into the tunnel; nothing previously exposed an arbitrary
+// advertised port. See docs/architecture/byoc-vm-console-access.md.
+type ConsoleRouter struct {
+	listenAddr string
+	policy     *ConsoleRouterPolicy
+	registry   *TunnelRegistry
+}
+
+// NewConsoleRouter returns a ConsoleRouter. registry is the same
+// TunnelRegistry the TunnelServer populates — DialTunnel is the only
+// registry method this needs.
+func NewConsoleRouter(listenAddr string, policy *ConsoleRouterPolicy, registry *TunnelRegistry) *ConsoleRouter {
+	return &ConsoleRouter{listenAddr: listenAddr, policy: policy, registry: registry}
+}
+
+// Run starts the console router on its own port. Blocks until ctx is
+// cancelled.
+func (cr *ConsoleRouter) Run(ctx context.Context) error {
+	ln, err := net.Listen("tcp", cr.listenAddr)
+	if err != nil {
+		return fmt.Errorf("console router listen on %s: %w", cr.listenAddr, err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	log.Printf("[console-router] listening on %s", cr.listenAddr)
+	return cr.Serve(ctx, ln)
+}
+
+// Serve accepts connections from the given listener. Use this when the
+// listener is provided externally (e.g., from a ConnMux), mirroring
+// TunnelServer.Serve. Blocks until ctx is cancelled or the listener closes.
+func (cr *ConsoleRouter) Serve(ctx context.Context, ln net.Listener) error {
+	go func() {
+		<-ctx.Done()
+		_ = ln.Close()
+	}()
+
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			select {
+			case <-ctx.Done():
+				return nil
+			default:
+				if isClosedErr(err) {
+					return nil
+				}
+				log.Printf("[console-router] accept error: %v", err)
+				continue
+			}
+		}
+		go cr.handleConnection(conn)
+	}
+}
+
+func (cr *ConsoleRouter) handleConnection(conn net.Conn) {
+	defer func() { _ = conn.Close() }()
+	remoteAddr := conn.RemoteAddr().String()
+
+	_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
+
+	var hs ConsoleRouterHandshake
+	if err := readHandshakeLine(conn, &hs); err != nil {
+		log.Printf("[console-router] handshake read error from %s: %v", remoteAddr, err)
+		return
+	}
+
+	if err := cr.policy.Validate(hs.Token); err != nil {
+		log.Printf("[console-router] rejecting %s: %v", remoteAddr, err)
+		cr.reject(conn, "unauthorized")
+		return
+	}
+	if hs.SpotID == "" {
+		cr.reject(conn, "spot_id is required")
+		return
+	}
+	if hs.Port <= 0 || hs.Port > 65535 {
+		cr.reject(conn, "a valid port is required")
+		return
+	}
+
+	stream, err := cr.registry.DialTunnel(hs.SpotID, hs.Port)
+	if err != nil {
+		log.Printf("[console-router] dial failed for %s (spot=%q port=%d): %v", remoteAddr, hs.SpotID, hs.Port, err)
+		cr.reject(conn, err.Error())
+		return
+	}
+	defer func() { _ = stream.Close() }()
+
+	_ = conn.SetDeadline(time.Time{})
+	if err := json.NewEncoder(conn).Encode(ConsoleRouterResponse{OK: true}); err != nil {
+		return
+	}
+
+	log.Printf("[console-router] routing %s to spot=%q port=%d", remoteAddr, hs.SpotID, hs.Port)
+	relayConsole(conn, stream)
+}
+
+func (cr *ConsoleRouter) reject(conn net.Conn, reason string) {
+	_ = json.NewEncoder(conn).Encode(ConsoleRouterResponse{OK: false, Error: reason})
+}
+
+// relayConsole bidirectionally copies bytes between a and b until either
+// side's copy finishes, then returns. Matches the tunnel client's own
+// bidirectional-copy shape (internal/sentinel/tunnel_client.go); named
+// distinctly from any helper in this file's neighbors since it is a
+// package-level function other sentinel code may already shadow.
+func relayConsole(a, b io.ReadWriteCloser) {
+	done := make(chan struct{}, 2)
+	go func() {
+		_, _ = io.Copy(a, b)
+		done <- struct{}{}
+	}()
+	go func() {
+		_, _ = io.Copy(b, a)
+		done <- struct{}{}
+	}()
+	<-done
+}

--- a/internal/sentinel/console_router_test.go
+++ b/internal/sentinel/console_router_test.go
@@ -1,0 +1,212 @@
+package sentinel
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConsoleRouterPolicy_Validate(t *testing.T) {
+	cases := []struct {
+		name      string
+		configure string
+		presented string
+		wantErr   bool
+	}{
+		{"matching", "secret", "secret", false},
+		{"mismatched", "secret", "wrong", true},
+		{"unconfigured policy", "", "secret", true},
+		{"empty presented", "secret", "", true},
+		{"both empty", "", "", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			p := NewConsoleRouterPolicy(c.configure)
+			err := p.Validate(c.presented)
+			if c.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestConsoleRouterIntegration exercises the full path a real console
+// request takes: a caller dials the router, presents the router's own
+// coarse-grained token plus a spot/port, the router calls
+// TunnelRegistry.DialTunnel exactly like the SNI router and sshpiper
+// already do for :443/:22, and the connection becomes a raw relay to
+// whatever is listening on that advertised port — standing in here for
+// the hypervisor-agent's own Agent.Serve (internal/hypervisor), which has
+// its own handshake and auth one hop further in.
+func TestConsoleRouterIntegration(t *testing.T) {
+	withRecordedAliases(t)
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	tunnelToken := "tunnel-integration-token"
+	routerToken := "console-router-token"
+
+	// Stand in for the hypervisor-agent's console listener: an echo server
+	// on the "spot" side, reached by the same port-forward mechanism any
+	// other tunnel-advertised service already uses.
+	hvConsolePort := freePort(t)
+	hvLn, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", hvConsolePort))
+	require.NoError(t, err)
+	defer func() { _ = hvLn.Close() }()
+	go func() {
+		for {
+			conn, err := hvLn.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer func() { _ = c.Close() }()
+				buf := make([]byte, 4096)
+				for {
+					n, err := c.Read(buf)
+					if n > 0 {
+						if _, werr := c.Write(buf[:n]); werr != nil {
+							return
+						}
+					}
+					if err != nil {
+						return
+					}
+				}
+			}(conn)
+		}
+	}()
+
+	// Sentinel side: ConnMux for the tunnel + TunnelServer + registry.
+	muxPort := freePort(t)
+	muxLn, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", muxPort))
+	require.NoError(t, err)
+
+	connMux := NewConnMuxFromListener(muxLn)
+	go connMux.Run()
+	defer func() { _ = connMux.Close() }()
+
+	registry := NewTunnelRegistry()
+	tunnelServer := NewTunnelServer("", policyAny(tunnelToken), registry, 0)
+
+	connectCh := make(chan *TunnelSpot, 1)
+	tunnelServer.OnConnect = func(spot *TunnelSpot) {
+		select {
+		case connectCh <- spot:
+		default:
+		}
+	}
+
+	go func() { _ = tunnelServer.Serve(ctx, connMux.TunnelListener()) }()
+	time.Sleep(100 * time.Millisecond)
+
+	// The hypervisor host's tunnel client — reused completely unmodified,
+	// exactly as internal/cmd/hypervisor_agent.go does in production.
+	client := &TunnelClient{
+		SentinelAddr: fmt.Sprintf("127.0.0.1:%d", muxPort),
+		Token:        tunnelToken,
+		SpotID:       "lab-vbox-host-1",
+		Ports:        []int{hvConsolePort},
+	}
+	go func() { _ = client.Run(ctx) }()
+
+	select {
+	case <-connectCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for tunnel connection")
+	}
+	time.Sleep(200 * time.Millisecond)
+
+	// The console router itself, under test.
+	routerPort := freePort(t)
+	router := NewConsoleRouter(fmt.Sprintf("127.0.0.1:%d", routerPort), NewConsoleRouterPolicy(routerToken), registry)
+	go func() { _ = router.Run(ctx) }()
+	time.Sleep(100 * time.Millisecond)
+
+	dial := func(t *testing.T) net.Conn {
+		t.Helper()
+		conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", routerPort), 3*time.Second)
+		require.NoError(t, err)
+		return conn
+	}
+
+	t.Run("wrong router token is rejected", func(t *testing.T) {
+		conn := dial(t)
+		defer func() { _ = conn.Close() }()
+
+		require.NoError(t, json.NewEncoder(conn).Encode(ConsoleRouterHandshake{
+			Token: "wrong", SpotID: "lab-vbox-host-1", Port: hvConsolePort,
+		}))
+		var resp ConsoleRouterResponse
+		_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+		require.NoError(t, json.NewDecoder(conn).Decode(&resp))
+		assert.False(t, resp.OK)
+	})
+
+	t.Run("unknown spot is rejected", func(t *testing.T) {
+		conn := dial(t)
+		defer func() { _ = conn.Close() }()
+
+		require.NoError(t, json.NewEncoder(conn).Encode(ConsoleRouterHandshake{
+			Token: routerToken, SpotID: "no-such-hypervisor", Port: hvConsolePort,
+		}))
+		var resp ConsoleRouterResponse
+		_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+		require.NoError(t, json.NewDecoder(conn).Decode(&resp))
+		assert.False(t, resp.OK)
+	})
+
+	t.Run("valid request relays end to end", func(t *testing.T) {
+		conn := dial(t)
+		defer func() { _ = conn.Close() }()
+
+		require.NoError(t, json.NewEncoder(conn).Encode(ConsoleRouterHandshake{
+			Token: routerToken, SpotID: "lab-vbox-host-1", Port: hvConsolePort,
+		}))
+
+		reader := bufio.NewReader(conn)
+		respLine, err := reader.ReadString('\n')
+		require.NoError(t, err)
+		var resp ConsoleRouterResponse
+		require.NoError(t, json.Unmarshal([]byte(respLine), &resp))
+		require.True(t, resp.OK, "response: %+v", resp)
+
+		// From here the connection is a raw relay to the echo listener
+		// standing in for the hypervisor-agent.
+		_ = conn.SetDeadline(time.Now().Add(3 * time.Second))
+		_, err = conn.Write([]byte("hello from operator"))
+		require.NoError(t, err)
+
+		buf := make([]byte, len("hello from operator"))
+		_, err = fullRead(reader, buf)
+		require.NoError(t, err)
+		assert.Equal(t, "hello from operator", string(buf))
+	})
+}
+
+// fullRead reads exactly len(buf) bytes from r, since bufio.Reader may
+// already hold some of them buffered from the handshake response line.
+func fullRead(r *bufio.Reader, buf []byte) (int, error) {
+	total := 0
+	for total < len(buf) {
+		n, err := r.Read(buf[total:])
+		total += n
+		if err != nil {
+			return total, err
+		}
+	}
+	return total, nil
+}


### PR DESCRIPTION
## Summary
- New `ConsoleRouterPolicy` + `ConsoleRouter` in `internal/sentinel`: accepts a connection, reads one JSON handshake (`token`, `spot_id`, `port`), authorizes the token (one shared secret — coarse-grained by design, see below), calls the already-existing `TunnelRegistry.DialTunnel(spotID, port)` (the same call the SNI router already uses for `:443`), then relays raw bytes.
- Wired into `containarium sentinel` as **opt-in**: `--console-router-addr` / `--console-router-token` (or `CONTAINARIUM_CONSOLE_ROUTER_TOKEN`). Unset, it's a no-op — no existing sentinel deployment needs to change anything.
- Auth is deliberately coarse: one shared secret gates "can this caller reach the router at all," not per-guest access. The actual per-guest authorization already happens one hop downstream, at the hypervisor-agent's own `Agent.Token` + target check (#1752, `internal/hypervisor`). Two-layer model: sentinel gates network reachability, hypervisor-agent gates which guest.

## Motivation
Last piece of #1749's design doc (`docs/architecture/byoc-vm-console-access.md`). #1752 built the hypervisor-agent, which advertises a port through the tunnel and is therefore reachable *from the sentinel*, but the sentinel only publicly routes two specific ports today (`:22` via sshpiper, `:443` via SNI) — nothing generically exposed an arbitrary advertised port to an operator on the public internet. This closes that gap.

Together with #1752, this is the piece that actually reaches `containarium-byoc-2`'s real failure mode: a hung *host*, not a hung workload VM on an otherwise-healthy one (which is what #1750/#1751 solve).

## Test plan
- [x] `TestConsoleRouterPolicy_Validate`: matching/mismatched/unconfigured/empty-token cases
- [x] `TestConsoleRouterIntegration`: a real `TunnelRegistry` + `TunnelServer` + a real `TunnelClient` advertising a port, with an echo listener standing in for the hypervisor-agent, and the router under test dialing through it — covers wrong router token rejected, unknown spot rejected, and a real end-to-end byte relay
- [x] Reused `readHandshakeLine` (already in `tunnel_auth.go`) rather than re-implementing handshake parsing a third time, for the same over-read-safety reason #1758 just fixed in the hypervisor-agent's own reader
- [x] Full `internal/sentinel` and `internal/cmd` suites pass, no regressions
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run` — clean
- [x] CLI smoke test: `containarium sentinel --help` shows the new flags
- [ ] CI (this PR)
- **Not done, deferred**: real end-to-end verification against the actual `containarium-byoc-1`/`-2` lab hardware (needs the hypervisor-agent actually deployed and a guest's UART provisioned — separate, deliberate follow-up per #1752's own PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional console router for Sentinel mode, configurable with a router address and authorization token via command-line options or environment settings.
  - Authenticated clients can request access to configured tunnels and relay traffic through them.
  - The router operates across supported hybrid and tunnel-provider modes and remains disabled when no address is configured.
  - Requests with missing or invalid credentials, unknown tunnels, or invalid connection details are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->