### PR TITLE
fix(gateway): add the tenant check the /terminal WebSocket route was missing

### DIFF
--- a/internal/gateway/console.go
+++ b/internal/gateway/console.go
@@ -71,29 +71,12 @@ func parseConsoleUsername(path string) string {
 	return parts[2]
 }
 
-// authorizeConsoleAccess reports whether claims may attach to
-// requestedUsername's console: the subject must own the tenant or hold the
-// admin role. Mirrors auth.AuthorizeTenant's decision exactly, adapted for
-// an already-validated *auth.Claims (the gRPC-context form AuthorizeTenant
-// reads doesn't exist on this HTTP/WebSocket upgrade path).
-func authorizeConsoleAccess(claims *auth.Claims, requestedUsername string) error {
-	if claims == nil {
-		return fmt.Errorf("no authenticated subject")
-	}
-	if auth.HasRole(claims.Roles, auth.RoleAdmin) {
-		return nil
-	}
-	if claims.Username != requestedUsername {
-		return fmt.Errorf("not authorized for this tenant")
-	}
-	return nil
-}
-
 // HandleConsole upgrades the request to a WebSocket and relays raw bytes
 // between the caller and the instance's serial console. Callers must
 // already be authenticated and tenant-authorized (see
-// authorizeConsoleAccess) — matching TerminalHandler's contract, that
-// check happens in the route registration closure, not here.
+// authorizeTenantWSAccess in gateway.go) — matching TerminalHandler's
+// contract, that check happens in the route registration closure, not
+// here.
 func (ch *ConsoleHandler) HandleConsole(w http.ResponseWriter, r *http.Request) {
 	username := parseConsoleUsername(r.URL.Path)
 	if username == "" {

--- a/internal/gateway/console_test.go
+++ b/internal/gateway/console_test.go
@@ -2,8 +2,6 @@ package gateway
 
 import (
 	"testing"
-
-	"github.com/footprintai/containarium/internal/auth"
 )
 
 func TestParseConsoleUsername(t *testing.T) {
@@ -24,30 +22,5 @@ func TestParseConsoleUsername(t *testing.T) {
 		if got := parseConsoleUsername(c.path); got != c.want {
 			t.Errorf("parseConsoleUsername(%q) = %q, want %q", c.path, got, c.want)
 		}
-	}
-}
-
-func TestAuthorizeConsoleAccess(t *testing.T) {
-	cases := []struct {
-		name      string
-		claims    *auth.Claims
-		requested string
-		wantErr   bool
-	}{
-		{"nil claims", nil, "alice", true},
-		{"own tenant", &auth.Claims{Username: "alice"}, "alice", false},
-		{"wrong tenant", &auth.Claims{Username: "mallory"}, "alice", true},
-		{"admin, different username", &auth.Claims{Username: "root-op", Roles: []string{auth.RoleAdmin}}, "alice", false},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			err := authorizeConsoleAccess(c.claims, c.requested)
-			if c.wantErr && err == nil {
-				t.Fatal("expected an error, got nil")
-			}
-			if !c.wantErr && err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-		})
 	}
 }

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -112,6 +112,26 @@ type GatewayServer struct {
 	recordDeliveryFn func(ctx context.Context, alertName, source, webhookURL string, success bool, httpStatus int, errMsg string, payloadSize, durationMs int)
 }
 
+// authorizeTenantWSAccess reports whether claims may access requestedUsername's
+// resource over a WebSocket upgrade: the subject must own the tenant or hold
+// the admin role. Mirrors auth.AuthorizeTenant's decision exactly, adapted
+// for an already-validated *auth.Claims (the gRPC-context form
+// AuthorizeTenant reads doesn't exist on this HTTP/WebSocket upgrade path).
+// Shared by both the /terminal and /console-attach WebSocket routes below —
+// the two per-tenant WebSocket surfaces this gateway serves.
+func authorizeTenantWSAccess(claims *auth.Claims, requestedUsername string) error {
+	if claims == nil {
+		return fmt.Errorf("no authenticated subject")
+	}
+	if auth.HasRole(claims.Roles, auth.RoleAdmin) {
+		return nil
+	}
+	if claims.Username != requestedUsername {
+		return fmt.Errorf("not authorized for this tenant")
+	}
+	return nil
+}
+
 // NewGatewayServer creates a new gateway server
 func NewGatewayServer(grpcAddress string, httpPort int, authMiddleware *auth.AuthMiddleware, swaggerDir string, certsDir string, caddyCertDir string) *GatewayServer {
 	// Try to create terminal handler (may fail if Incus not available)
@@ -566,17 +586,27 @@ func (gs *GatewayServer) Start(ctx context.Context) error {
 				return
 			}
 
+			// Extract container name from URL path (e.g. /v1/containers/{name}/terminal)
+			parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+			containerName := ""
+			for i, p := range parts {
+				if p == "containers" && i+1 < len(parts) {
+					containerName = parts[i+1]
+					break
+				}
+			}
+
+			// #1754: a validly-authenticated caller was previously routed
+			// straight through regardless of whose container it named — any
+			// tenant could open a shell into any other tenant's box. Same
+			// tenant check the /console-attach route below already has.
+			if authErr := authorizeTenantWSAccess(claims, containerName); authErr != nil {
+				http.Error(w, fmt.Sprintf(`{"error": "forbidden: %s", "code": 403}`, authErr.Error()), http.StatusForbidden)
+				return
+			}
+
 			// Log terminal access to audit store
 			if gs.auditStore != nil {
-				// Extract container name from URL path (e.g. /v1/containers/{name}/terminal)
-				parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
-				containerName := ""
-				for i, p := range parts {
-					if p == "containers" && i+1 < len(parts) {
-						containerName = parts[i+1]
-						break
-					}
-				}
 				auditUsername := ""
 				if claims != nil {
 					auditUsername = claims.Username
@@ -629,7 +659,7 @@ func (gs *GatewayServer) Start(ctx context.Context) error {
 				}
 
 				username := parseConsoleUsername(r.URL.Path)
-				if authErr := authorizeConsoleAccess(claims, username); authErr != nil {
+				if authErr := authorizeTenantWSAccess(claims, username); authErr != nil {
 					http.Error(w, fmt.Sprintf(`{"error": "forbidden: %s", "code": 403}`, authErr.Error()), http.StatusForbidden)
 					return
 				}

--- a/internal/gateway/gateway_test.go
+++ b/internal/gateway/gateway_test.go
@@ -1,0 +1,39 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/footprintai/containarium/internal/auth"
+)
+
+// TestAuthorizeTenantWSAccess covers the tenant check shared by both
+// WebSocket routes this gateway serves (/terminal and /console-attach).
+// Replaces the old TestAuthRequiredForTerminal placeholder
+// (security_test.go), which only logged what the code was supposed to do
+// rather than asserting it — the gap that let #1754 (any authenticated
+// tenant could open a shell into any other tenant's container via
+// /terminal) go unnoticed.
+func TestAuthorizeTenantWSAccess(t *testing.T) {
+	cases := []struct {
+		name      string
+		claims    *auth.Claims
+		requested string
+		wantErr   bool
+	}{
+		{"nil claims", nil, "alice", true},
+		{"own tenant", &auth.Claims{Username: "alice"}, "alice", false},
+		{"wrong tenant", &auth.Claims{Username: "mallory"}, "alice", true},
+		{"admin, different username", &auth.Claims{Username: "root-op", Roles: []string{auth.RoleAdmin}}, "alice", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := authorizeTenantWSAccess(c.claims, c.requested)
+			if c.wantErr && err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+			if !c.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/internal/gateway/security_test.go
+++ b/internal/gateway/security_test.go
@@ -158,19 +158,7 @@ func TestCORSOriginNotWildcard(t *testing.T) {
 	}
 }
 
-// TestAuthRequiredForTerminal verifies that the terminal endpoint requires authentication
-func TestAuthRequiredForTerminal(t *testing.T) {
-	// This test verifies the authentication requirement by checking the code path
-	// In the gateway.go, the terminal handler now requires a token:
-	//
-	// if token == "" {
-	//     http.Error(w, `{"error": "unauthorized: token required for terminal access", "code": 401}`, http.StatusUnauthorized)
-	//     return
-	// }
-	//
-	// This is a documentation test - the actual integration test would require
-	// setting up the full gateway server.
-
-	t.Log("Terminal authentication is enforced in gateway.go lines 152-156")
-	t.Log("Code path: token == \"\" -> returns 401 Unauthorized")
-}
+// Terminal WebSocket auth (token required, tenant-scoped) is exercised by
+// TestAuthorizeTenantWSAccess in gateway_test.go — a real assertion on the
+// decision logic the /terminal and /console-attach route closures both
+// call, not a documentation placeholder. See #1754.


### PR DESCRIPTION
## Summary
- **Security fix**: the `/terminal` WebSocket route (`internal/gateway/gateway.go`) validated that a caller presented a *valid* JWT, but never checked the token's subject against the `{username}` in the path, and never checked for the admin role either. Any authenticated tenant could open an interactive shell into any other tenant's container.
- Renamed `authorizeConsoleAccess` → `authorizeTenantWSAccess` and moved it to `gateway.go` — it's no longer console-specific; both WebSocket routes this gateway serves (`/terminal`, `/console-attach`) now call the same tenant check.
- Replaced `TestAuthRequiredForTerminal`, a documentation-only placeholder (`t.Log`, no assertion — it never exercised the code path, which is exactly why this gap had no tripwire), with `TestAuthorizeTenantWSAccess`, a real assertion over nil-claims/own-tenant/wrong-tenant/admin.

## How this was found
While building #1751's `/console-attach` route, I gave it a proper tenant check and noticed the existing, older `/terminal` route sitting right next to it had none. Filed as #1754, fixed here as its own scoped PR.

## Test plan
- [x] `TestAuthorizeTenantWSAccess` (`gateway_test.go`): nil claims / own tenant / wrong tenant / admin-different-username
- [x] Full `internal/gateway`, `internal/auth`, `internal/server` suites pass, no regressions
- [x] `go build ./...`, `golangci-lint run` — clean
- [x] Confirmed `TestAuthRequiredForTerminal` is gone, not just skipped — it asserted nothing, so removing it loses no coverage
- [ ] CI (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Standardized authorization for terminal and console connections.
  - Access is limited to the authenticated tenant owner or an authorized administrator.
  - Requests with missing credentials or mismatched tenant ownership are denied consistently.

- **Bug Fixes**
  - Improved protection for tenant-scoped WebSocket connections by applying the same authorization checks across supported connection types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->