### PR TITLE
fix(hypervisor): fix a flaky race in the over-read regression test

### DIFF
--- a/internal/hypervisor/agent_test.go
+++ b/internal/hypervisor/agent_test.go
@@ -270,8 +270,19 @@ func TestAgent_HandleConn_NoOverreadPastHandshake(t *testing.T) {
 	server, client := net.Pipe()
 	defer func() { _ = client.Close() }()
 
+	// relay() returns as soon as EITHER direction finishes (by design —
+	// matches the tunnel client's own bidirectional-copy shape). A
+	// strings.NewReader("") for the console's output side hits instant EOF,
+	// racing that direction's shutdown against the operator-input direction
+	// this test actually cares about — on an unlucky scheduling the whole
+	// session tears down before "boot-time keypress" is transferred. Use a
+	// pipe that stays open (no synthetic EOF) until this test explicitly
+	// closes it, once the assertion below has already run.
+	consoleOutR, consoleOutW := io.Pipe()
+	defer func() { _ = consoleOutW.Close() }()
+
 	consoleInputR, consoleInputW := io.Pipe()
-	console := &fakeConsole{Reader: strings.NewReader(""), Writer: consoleInputW}
+	console := &fakeConsole{Reader: consoleOutR, Writer: consoleInputW}
 	provider := &fakeProvider{console: console}
 
 	agent := &Agent{Token: "secret", Provider: provider}
@@ -312,6 +323,11 @@ func TestAgent_HandleConn_NoOverreadPastHandshake(t *testing.T) {
 	if string(got) != "boot-time keypress" {
 		t.Fatalf("got %q, want %q", got, "boot-time keypress")
 	}
+
+	// Only now let the console's own output side end — before this
+	// assertion, closing it would race relay()'s "return on first
+	// direction to finish" shutdown against the transfer above.
+	_ = consoleOutW.Close()
 
 	<-writeDone
 	_ = client.Close()


### PR DESCRIPTION
## Summary
`TestAgent_HandleConn_NoOverreadPastHandshake` (added in #1758) used `strings.NewReader("")` for the fake console's output side. `relay()` intentionally returns as soon as **either** direction finishes (matching the tunnel client's own bidirectional-copy shape in `internal/sentinel/tunnel_client.go`) — an empty reader hits instant EOF, racing that direction's shutdown against the operator-input direction the test actually asserts on. On an unlucky scheduling, the whole session tears down before `"boot-time keypress"` transfers, and the test's `io.ReadFull` blocks forever on bytes that will never arrive.

## Impact
Surfaced in CI (Linux runner) as an 8-minute test timeout that failed **#1765** — an entirely unrelated PR — since the flaky test lives in already-merged code and runs as part of every PR's full suite: https://github.com/FootprintAI/Containarium/actions/runs/34090913135/job/101644024022. It passed locally on macOS across many manual runs before merging #1758, which is exactly what a scheduling-dependent race looks like — small sample size, got lucky.

## Fix
Replace the instant-EOF reader with an `io.Pipe()` that stays open (no synthetic EOF) until the test explicitly closes it, *after* the assertion it actually cares about has already run. This removes the race by construction, not by making it merely less likely.

## Test plan
- [x] `go test ./internal/hypervisor/... -race -count=200` — 200/200 pass
- [x] `go test ./internal/hypervisor/... -count=10` — 10/10 pass
- [x] `golangci-lint run` — clean
- [ ] CI (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved connection handling test reliability by preventing premature console relay shutdown during follow-up input verification.
  - Added validation that combined post-handshake data is delivered correctly to the console.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->