### PR TITLE
docs(readme): show the --http --server form of ssh-config sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,14 @@ containarium ssh-config sync
 ssh alice  # connects through the sentinel
 ```
 
+Running this from your own laptop against a remote server, rather than on
+the box itself? The bare form above only reaches a local Incus socket —
+add `--http --server <host:port>`:
+
+```bash
+containarium ssh-config sync --http --server <host:port>
+```
+
 ### 4. Point your agent at the box
 
 In `~/.cursor/mcp.json` or `~/.claude.json`:
@@ -586,6 +594,10 @@ containarium ssh-config show
 containarium ssh-config sync
 containarium ssh-config sync --sentinel sentinel.example.com  # via sentinel
 containarium ssh-config sync --identity ~/.ssh/containarium_ed25519
+
+# From a client machine, against a remote server (the bare form above
+# only reaches a local Incus socket)
+containarium ssh-config sync --http --server <host:port>
 ```
 
 ### Authentication


### PR DESCRIPTION
## What

The README's `ssh-config sync` examples (quickstart step 3, and the
CLI reference block) only show the bare form:

```bash
containarium ssh-config sync
```

That reaches a local Incus socket by default, which is correct for
the quickstart's self-hosted-on-the-same-VM walkthrough. But it's the
*wrong* form for the other use case this README advertises up front
(line 13: `agent: "wire up SSH so I can reach it" → containarium ssh-config sync`) —
a laptop/client wiring up SSH against a remote server. Run bare there
and you get a confusing `dial unix /var/lib/incus/unix.socket: ... is
Incus running?` error instead of a hint to pass `--server`.

Verified interactively: `--http --server <host:port>` is required
together (passing only one or the other still falls through to the
local-Incus path).

## Change

Adds the `--http --server <host:port>` form alongside the existing
examples in both spots, matching the pattern already used by the
`passthrough-route` examples just above the SSH config reference
block.

No code changes — README only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for using `containarium ssh-config sync` with a remote server.
  - Documented the `--http --server <host:port>` options in the SSH setup walkthrough and CLI reference.
  - Clarified that the command without these options targets a local Incus socket.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->