### PR TITLE
fix(debug): detect a missing in-container user, not just a missing host user

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -9268,6 +9268,10 @@
         "sshIngressHost": {
           "type": "string",
           "description": "Public SSH entrypoint (the sentinel host) clients dial to reach\ncontainers on this backend — the daemon's advertised --ssh-host.\n**Empty means this backend advertises NO external SSH entrypoint**\n(direct / in-network mode: reach the container by IP, or deploy through\nan in-network pipeline). When empty, the sentinel-side remediation hints\ndon't apply — there is no sentinel to check. Lets an agent stop hunting\nfor a jump host that doesn't exist. See #1011."
+        },
+        "inContainerUserMissing": {
+          "type": "boolean",
+          "description": "True when the host-level Linux user exists but the SAME username does\nNOT exist inside the running container (#1487). containarium-shell's\nlogin path `su`s into this username INSIDE the container, so this\ncombination — host account provisioned, in-container account never\ncreated — makes the box permanently unreachable over SSH even though\nevery other signal (Incus RUNNING, host user present, sshd healthy)\nlooks fine. Only meaningful (and only checked) when host_user_exists\nis true and container_state is \"running\"; false otherwise, including\n\"not checked\" — callers must read it alongside those two fields, the\nsame convention host_user_shell_exists already follows."
         }
       },
       "title": "DebugContainerResponse is the structured diagnostic report"

--- a/internal/server/debug_container.go
+++ b/internal/server/debug_container.go
@@ -67,6 +67,17 @@ func (s *ContainerServer) DebugContainer(ctx context.Context, req *pb.DebugConta
 		resp.HostUserShellExists = isExecutableFile(shell)
 	}
 
+	// #1487: the host account can exist, look healthy, and still be
+	// unreachable because containarium-shell `su`s into the SAME username
+	// INSIDE the container — and in-container user creation is a separate
+	// provisioning step that can silently fail to run. Only worth checking
+	// once the box is actually running and the host half is confirmed
+	// present; a stopped/missing container or missing host user is already
+	// diagnosed by the checks above.
+	if exists && resp.ContainerState == "running" {
+		resp.InContainerUserMissing = s.inContainerUserMissing(req.Username)
+	}
+
 	resp.RecentSshdRejections = recentSshdLines(req.Username, 8)
 
 	// Advertised SSH entrypoint (sentinel host), or empty for direct/in-network
@@ -97,6 +108,23 @@ func (s *ContainerServer) debugContainerState(username string) string {
 		return "unknown"
 	}
 	return state
+}
+
+// inContainerUserMissing reports whether the in-container Linux user does
+// NOT exist inside username's container (#1487). It runs `id <username>`
+// via incus exec and reads the exit code, not err: err means the exec
+// itself couldn't run (transport/backend problem, or a mock backend in
+// tests) — that's "we don't know", not "missing", so it deliberately
+// returns false rather than risk a false positive that sends an operator
+// down the wrong remediation path. A non-zero exit with no error means the
+// command ran and `id` genuinely found no such user.
+func (s *ContainerServer) inContainerUserMissing(username string) bool {
+	containerName := username + "-container"
+	_, _, exitCode, err := s.manager.ExecWithExitCode(containerName, []string{"id", username})
+	if err != nil {
+		return false
+	}
+	return exitCode != 0
 }
 
 // lookupHostUserShell returns (exists, shell, homedir) for the host user with
@@ -252,6 +280,22 @@ func Diagnose(username string, r *pb.DebugContainerResponse) (string, []string) 
 			[]string{
 				"install the containarium-shell wrapper on the backend (see scripts/setup-ssh-container-proxy.sh)",
 				"this is a deploy-time gap, not a per-container issue — fix the backend image/startup",
+			}
+	}
+
+	if r.InContainerUserMissing {
+		// #1487: every host-side signal is healthy — user, shell, sshd — but
+		// containarium-shell's `su - username` dies INSIDE the container
+		// because create never ran (or failed) its in-container user step.
+		// `containarium connect`/SSH cannot repair this themselves: both
+		// route through the same broken containarium-shell su. The fix has
+		// to run on the BACKEND HOST as an operator (or via a future daemon
+		// RPC — no such repair endpoint exists yet), directly against Incus.
+		return fmt.Sprintf("host user exists, but %q was never created INSIDE the container — containarium-shell's su fails there, not at the host; SSH cannot repair this, only an operator on the backend host can", username),
+			[]string{
+				fmt.Sprintf("on the backend host: sudo incus exec %s-container -- useradd -m -s /bin/bash -G sudo,users %s", username, username),
+				fmt.Sprintf("then: sudo incus exec %s-container -- sh -c 'printf \"%%s ALL=(ALL) NOPASSWD:ALL\\n\" %s > /etc/sudoers.d/%s && chmod 440 /etc/sudoers.d/%s'", username, username, username, username),
+				"this is a create-time provisioning gap (OSS #1487) — if it recurs across boxes, the create path itself needs fixing, not each box repaired one at a time",
 			}
 	}
 

--- a/internal/server/debug_container_test.go
+++ b/internal/server/debug_container_test.go
@@ -1,8 +1,11 @@
 package server
 
 import (
+	"errors"
 	"testing"
 
+	"github.com/footprintai/containarium/pkg/core/container"
+	"github.com/footprintai/containarium/pkg/core/incus/incustest"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 	"github.com/stretchr/testify/assert"
 )
@@ -105,6 +108,26 @@ func TestDiagnose(t *testing.T) {
 			wantCause:    "daemon failed",
 			wantActionCt: 1,
 		},
+		{
+			// #1487: host user + shell both healthy, but the SAME username
+			// was never created inside the container — containarium-shell's
+			// `su` dies there, several layers past every check above this
+			// one. Must fire BEFORE the sshd-journal/sentinel fallback
+			// branches, not after — those would misdiagnose this as "no
+			// obvious host-side problem".
+			name: "running, host user healthy, in-container user missing",
+			report: &pb.DebugContainerResponse{
+				ContainerState:         "running",
+				HostUserExists:         true,
+				HostUserShell:          "/usr/local/bin/containarium-shell",
+				HostUserShellExists:    true,
+				InContainerUserMissing: true,
+				SshIngressHost:         "asia-east1.containarium.dev",
+			},
+			wantCause:    "never created INSIDE the container",
+			wantActionCt: 3,
+			wantFirstHas: "incus exec",
+		},
 	}
 
 	for _, c := range cases {
@@ -115,6 +138,46 @@ func TestDiagnose(t *testing.T) {
 			assert.Len(t, actions, c.wantActionCt)
 			if c.wantFirstHas != "" && len(actions) > 0 {
 				assert.Contains(t, actions[0], c.wantFirstHas)
+			}
+		})
+	}
+}
+
+// TestInContainerUserMissing exercises the exec-based check in isolation
+// from the sshd/passwd inspection above — it should distinguish a genuine
+// "id ran and found no such user" (exitCode != 0, err == nil) from "the
+// exec itself couldn't run" (err != nil: transport/backend problem), the
+// latter deliberately reported as false rather than a false-positive
+// "missing".
+func TestInContainerUserMissing(t *testing.T) {
+	cases := []struct {
+		name     string
+		exitCode int
+		execErr  error
+		want     bool
+	}{
+		{name: "user exists — id exits 0", exitCode: 0, want: false},
+		{name: "user missing — id exits non-zero, no error", exitCode: 1, want: true},
+		{name: "exec transport error — unknown, not missing", execErr: errors.New("incus: connection refused"), want: false},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			mock := incustest.NewMockBackend()
+			mock.ExecWithExitCodeFunc = func(name string, cmd []string) (string, string, int, error) {
+				if name != "alice-container" {
+					t.Fatalf("unexpected container name: %s", name)
+				}
+				if len(cmd) != 2 || cmd[0] != "id" || cmd[1] != "alice" {
+					t.Fatalf("unexpected command: %v", cmd)
+				}
+				return "", "", c.exitCode, c.execErr
+			}
+			cs := &ContainerServer{manager: container.NewWithBackend(mock)}
+
+			got := cs.inContainerUserMissing("alice")
+			if got != c.want {
+				t.Fatalf("inContainerUserMissing() = %v, want %v", got, c.want)
 			}
 		})
 	}

--- a/pkg/core/container/manager.go
+++ b/pkg/core/container/manager.go
@@ -1039,6 +1039,17 @@ func (m *Manager) ExecWithOutput(containerName string, command []string) (string
 	return "", "", fmt.Errorf("ExecWithOutput not supported on this incus backend (mock?)")
 }
 
+// ExecWithExitCode runs a command inside the container and reports a
+// non-zero exit as data (exitCode) rather than folding it into err — the
+// caller needs to distinguish "ran and failed" (e.g. `id` reporting no
+// such user, #1487) from "couldn't run it at all" (transport/backend
+// error). Unlike ExecWithOutput, ExecWithExitCode is already part of the
+// incus.Backend interface, so this is a direct call, not a type-assertion
+// to the concrete client — it works against the mock backend in tests.
+func (m *Manager) ExecWithExitCode(containerName string, command []string) (stdout, stderr string, exitCode int, err error) {
+	return m.incus.ExecWithExitCode(containerName, command)
+}
+
 // ReadFile pulls a file from inside the container into host memory.
 // Used by the backup server to retrieve a pg_dump artifact written to
 // the container's /tmp before shipping it off-host. Suitable for

--- a/pkg/pb/containarium/v1/container.pb.go
+++ b/pkg/pb/containarium/v1/container.pb.go
@@ -1856,8 +1856,19 @@ type DebugContainerResponse struct {
 	// don't apply — there is no sentinel to check. Lets an agent stop hunting
 	// for a jump host that doesn't exist. See #1011.
 	SshIngressHost string `protobuf:"bytes,10,opt,name=ssh_ingress_host,json=sshIngressHost,proto3" json:"ssh_ingress_host,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// True when the host-level Linux user exists but the SAME username does
+	// NOT exist inside the running container (#1487). containarium-shell's
+	// login path `su`s into this username INSIDE the container, so this
+	// combination — host account provisioned, in-container account never
+	// created — makes the box permanently unreachable over SSH even though
+	// every other signal (Incus RUNNING, host user present, sshd healthy)
+	// looks fine. Only meaningful (and only checked) when host_user_exists
+	// is true and container_state is "running"; false otherwise, including
+	// "not checked" — callers must read it alongside those two fields, the
+	// same convention host_user_shell_exists already follows.
+	InContainerUserMissing bool `protobuf:"varint,11,opt,name=in_container_user_missing,json=inContainerUserMissing,proto3" json:"in_container_user_missing,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
 func (x *DebugContainerResponse) Reset() {
@@ -1958,6 +1969,13 @@ func (x *DebugContainerResponse) GetSshIngressHost() string {
 		return x.SshIngressHost
 	}
 	return ""
+}
+
+func (x *DebugContainerResponse) GetInContainerUserMissing() bool {
+	if x != nil {
+		return x.InContainerUserMissing
+	}
+	return false
 }
 
 // GetConsoleLogRequest is the request to fetch a VM instance's boot-time
@@ -6236,7 +6254,7 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\tcontainer\x18\x01 \x01(\v2\x1a.containarium.v1.ContainerR\tcontainer\x12;\n" +
 	"\ametrics\x18\x02 \x01(\v2!.containarium.v1.ContainerMetricsR\ametrics\"3\n" +
 	"\x15DebugContainerRequest\x12\x1a\n" +
-	"\busername\x18\x01 \x01(\tR\busername\"\xb6\x03\n" +
+	"\busername\x18\x01 \x01(\tR\busername\"\xf1\x03\n" +
 	"\x16DebugContainerResponse\x12'\n" +
 	"\x0fcontainer_state\x18\x01 \x01(\tR\x0econtainerState\x12(\n" +
 	"\x10host_user_exists\x18\x02 \x01(\bR\x0ehostUserExists\x12&\n" +
@@ -6249,7 +6267,8 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"sourceRepo\x12%\n" +
 	"\x0edaemon_version\x18\t \x01(\tR\rdaemonVersion\x12(\n" +
 	"\x10ssh_ingress_host\x18\n" +
-	" \x01(\tR\x0esshIngressHost\"2\n" +
+	" \x01(\tR\x0esshIngressHost\x129\n" +
+	"\x19in_container_user_missing\x18\v \x01(\bR\x16inContainerUserMissing\"2\n" +
 	"\x14GetConsoleLogRequest\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\")\n" +
 	"\x15GetConsoleLogResponse\x12\x10\n" +

--- a/proto/containarium/v1/container.proto
+++ b/proto/containarium/v1/container.proto
@@ -618,6 +618,18 @@ message DebugContainerResponse {
   // don't apply — there is no sentinel to check. Lets an agent stop hunting
   // for a jump host that doesn't exist. See #1011.
   string ssh_ingress_host = 10;
+
+  // True when the host-level Linux user exists but the SAME username does
+  // NOT exist inside the running container (#1487). containarium-shell's
+  // login path `su`s into this username INSIDE the container, so this
+  // combination — host account provisioned, in-container account never
+  // created — makes the box permanently unreachable over SSH even though
+  // every other signal (Incus RUNNING, host user present, sshd healthy)
+  // looks fine. Only meaningful (and only checked) when host_user_exists
+  // is true and container_state is "running"; false otherwise, including
+  // "not checked" — callers must read it alongside those two fields, the
+  // same convention host_user_shell_exists already follows.
+  bool in_container_user_missing = 11;
 }
 
 // GetConsoleLogRequest is the request to fetch a VM instance's boot-time


### PR DESCRIPTION
## Bug

#1487: `create_container` can succeed at the host-side half of user
provisioning (host account, sentinel key, sshd — all healthy) while the
in-container `useradd` never runs. `containarium-shell`'s login path
`su`s into the SAME username **inside** the container, so the box is
permanently unreachable over SSH even though every daemon-visible
signal looks fine.

The core "hang forever in CREATING" mechanism behind that report was
already fixed by #1612 (bounding `createUser`'s exec against a wedged
Incus operation) — but `containarium debug`, the tool that exists
specifically to diagnose SSH failures like this one, had no check for
the failure itself. It verifies `host_user_exists` and
`host_user_shell_exists`, then falls straight to sshd-journal/
sentinel-hop guesses — misdiagnosing "no obvious host-side problem"
for a box that's simply missing its in-container account, several
layers past every check it runs. This closes that specific gap from
#1487's suggested fix list (item 4: "a doctor/audit check for this
state").

## Change

- `proto/containarium/v1/container.proto`: adds
  `in_container_user_missing` to `DebugContainerResponse`. Only
  meaningful (and only checked) once `host_user_exists` is true and
  the container is running — false otherwise, matching the existing
  convention `host_user_shell_exists` already follows.
- `pkg/core/container/manager.go`: adds `Manager.ExecWithExitCode`,
  a thin passthrough to `incus.Backend.ExecWithExitCode` — already
  part of the interface, so (unlike the type-asserted `Exec`/
  `ExecWithOutput` wrappers) it's mockable in tests without touching
  the concrete `*incus.Client`.
- `internal/server/debug_container.go`: runs `id <username>` inside
  the container and reads the **exit code**, not `err`, to decide the
  verdict — `err` means the exec itself couldn't run (transport
  problem, or a mock backend in tests), which is "unknown", not
  "missing," so it deliberately returns `false` rather than risk a
  false positive. `Diagnose()` gets a new branch between the
  shell-exists check and the sshd-journal fallback, pointing at the
  actual repair: an operator running `incus exec ... useradd` **on
  the backend host** — SSH/`connect` can't fix this themselves, since
  both route through the same broken `su`.

## Test plan

- [x] `TestInContainerUserMissing`: exit 0 → false; non-zero exit with
      no error → true; exec transport error → false (not a false
      positive)
- [x] `TestDiagnose`: new case fires the new branch ahead of the
      sentinel/sshd-journal fallback; every pre-existing "healthy"
      case (which doesn't set the new field) is unaffected — confirms
      the zero-value default doesn't regress prior diagnoses
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean
- [x] `golangci-lint run ./internal/server/... ./pkg/core/container/...`: 0 issues
- [x] `gosec`: no new findings
- [x] `buf generate`: swagger + `.pb.go` regenerated from the proto
      change, zero unrelated diff

Related: #1487, #1612 (already fixes the CREATING-forever mechanism;
this fixes the diagnostic gap on top of it).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Container diagnostics now identify cases where a host user exists but the corresponding user is missing inside the running container.
  - Diagnostic responses include a clear indicator for this SSH inaccessibility condition.

- **Bug Fixes**
  - Troubleshooting guidance now provides repair commands to restore the missing container user and required sudo configuration.
  - Container command checks distinguish confirmed missing users from undetermined results caused by execution errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->