### PR TITLE
feat(cli-split): tag ~45 server-only files !containarium_client

### DIFF
--- a/internal/cmd/audit.go
+++ b/internal/cmd/audit.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !containarium_client
 
 package cmd
 

--- a/internal/cmd/audit_test.go
+++ b/internal/cmd/audit_test.go
@@ -1,3 +1,5 @@
+//go:build !containarium_client
+
 package cmd
 
 import (

--- a/internal/cmd/cloud.go
+++ b/internal/cmd/cloud.go
@@ -1,3 +1,5 @@
+//go:build !containarium_client
+
 package cmd
 
 import (

--- a/internal/cmd/cloud_test.go
+++ b/internal/cmd/cloud_test.go
@@ -1,3 +1,5 @@
+//go:build !containarium_client
+
 package cmd
 
 import (

--- a/internal/cmd/collaborator.go
+++ b/internal/cmd/collaborator.go
@@ -1,3 +1,5 @@
+//go:build !containarium_client
+
 package cmd
 
 import (

--- a/internal/cmd/collaborator_add.go
+++ b/internal/cmd/collaborator_add.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !containarium_client
 
 package cmd
 

--- a/internal/cmd/collaborator_list.go
+++ b/internal/cmd/collaborator_list.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !containarium_client
 
 package cmd
 

--- a/internal/cmd/collaborator_remove.go
+++ b/internal/cmd/collaborator_remove.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !containarium_client
 
 package cmd
 

--- a/internal/cmd/daemon.go
+++ b/internal/cmd/daemon.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !containarium_client
 
 package cmd
 

--- a/internal/cmd/daemon_base_domains_test.go
+++ b/internal/cmd/daemon_base_domains_test.go
@@ -1,3 +1,5 @@
+//go:build !containarium_client
+
 package cmd
 
 import (

--- a/internal/cmd/debug_actions_parse_test.go
+++ b/internal/cmd/debug_actions_parse_test.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !containarium_client
 
 package cmd
 

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !containarium_client
 
 package cmd
 

--- a/internal/cmd/doctor_test.go
+++ b/internal/cmd/doctor_test.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !containarium_client
 
 package cmd
 

--- a/internal/cmd/egress_relay.go
+++ b/internal/cmd/egress_relay.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !containarium_client
 
 package cmd
 

--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -1,3 +1,5 @@
+//go:build !containarium_client
+
 package cmd
 
 import (

--- a/internal/cmd/hosting.go
+++ b/internal/cmd/hosting.go
@@ -1,3 +1,5 @@
+//go:build !containarium_client
+
 package cmd
 
 import (

--- a/internal/cmd/hosting_config.go
+++ b/internal/cmd/hosting_config.go
@@ -1,3 +1,5 @@
+//go:build !containarium_client
+
 package cmd
 
 import (

--- a/internal/cmd/hosting_providers.go
+++ b/internal/cmd/hosting_providers.go
@@ -1,3 +1,5 @@
+//go:build !containarium_client
+
 package cmd
 
 import (

--- a/internal/cmd/hosting_setup.go
+++ b/internal/cmd/hosting_setup.go
@@ -1,3 +1,5 @@
+//go:build !containarium_client
+
 package cmd
 
 import (

--- a/internal/cmd/hosting_status.go
+++ b/internal/cmd/hosting_status.go
@@ -1,3 +1,5 @@
+//go:build !containarium_client
+
 package cmd
 
 import (

--- a/internal/cmd/hypervisor_agent.go
+++ b/internal/cmd/hypervisor_agent.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !containarium_client
 
 package cmd
 

--- a/internal/cmd/imagebake.go
+++ b/internal/cmd/imagebake.go
@@ -1,3 +1,5 @@
+//go:build !containarium_client
+
 package cmd
 
 import (

--- a/internal/cmd/node.go
+++ b/internal/cmd/node.go
@@ -1,3 +1,5 @@
+//go:build !containarium_client
+
 package cmd
 
 import (

--- a/internal/cmd/passthrough.go
+++ b/internal/cmd/passthrough.go
@@ -1,3 +1,5 @@
+//go:build !containarium_client
+
 package cmd
 
 import (

--- a/internal/cmd/passthrough_add.go
+++ b/internal/cmd/passthrough_add.go
@@ -1,3 +1,5 @@
+//go:build !containarium_client
+
 package cmd
 
 import (

--- a/internal/cmd/passthrough_list.go
+++ b/internal/cmd/passthrough_list.go
@@ -1,3 +1,5 @@
+//go:build !containarium_client
+
 package cmd
 
 import (

--- a/internal/cmd/passthrough_remove.go
+++ b/internal/cmd/passthrough_remove.go
@@ -1,3 +1,5 @@
+//go:build !containarium_client
+
 package cmd
 
 import (

--- a/internal/cmd/pool_join.go
+++ b/internal/cmd/pool_join.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !containarium_client
 
 package cmd
 

--- a/internal/cmd/pool_join_handshake.go
+++ b/internal/cmd/pool_join_handshake.go
@@ -1,3 +1,5 @@
+//go:build !containarium_client
+
 package cmd
 
 import (

--- a/internal/cmd/pool_join_handshake_test.go
+++ b/internal/cmd/pool_join_handshake_test.go
@@ -1,3 +1,5 @@
+//go:build !containarium_client
+
 package cmd
 
 import (

--- a/internal/cmd/pool_join_test.go
+++ b/internal/cmd/pool_join_test.go
@@ -1,29 +1,18 @@
-//go:build !windows
+//go:build !windows && !containarium_client
 
 package cmd
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
-	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/encoding/protojson"
 
 	cloudv1 "github.com/footprintai/containarium/pkg/pb/containarium/cloud/v1"
 )
-
-// testCmd returns a *cobra.Command with a real context — a bare
-// &cobra.Command{} has a nil Context() (unlike OutOrStdout/ErrOrStderr,
-// which do fall back), which panics deep inside net/context on first use.
-func testCmd() *cobra.Command {
-	c := &cobra.Command{}
-	c.SetContext(context.Background())
-	return c
-}
 
 func TestRenderTunnelUnit_RequiredFlags(t *testing.T) {
 	u := renderTunnelUnit(tunnelUnitParams{

--- a/internal/cmd/pool_leave.go
+++ b/internal/cmd/pool_leave.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !containarium_client
 
 package cmd
 

--- a/internal/cmd/pool_regions.go
+++ b/internal/cmd/pool_regions.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !containarium_client
 
 package cmd
 

--- a/internal/cmd/pool_sentinel.go
+++ b/internal/cmd/pool_sentinel.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !containarium_client
 
 package cmd
 

--- a/internal/cmd/pool_sentinel_test.go
+++ b/internal/cmd/pool_sentinel_test.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !containarium_client
 
 package cmd
 

--- a/internal/cmd/portforward.go
+++ b/internal/cmd/portforward.go
@@ -1,3 +1,5 @@
+//go:build !containarium_client
+
 package cmd
 
 import (

--- a/internal/cmd/portforward_remove.go
+++ b/internal/cmd/portforward_remove.go
@@ -1,3 +1,5 @@
+//go:build !containarium_client
+
 package cmd
 
 import (

--- a/internal/cmd/portforward_setup.go
+++ b/internal/cmd/portforward_setup.go
@@ -1,3 +1,5 @@
+//go:build !containarium_client
+
 package cmd
 
 import (

--- a/internal/cmd/portforward_show.go
+++ b/internal/cmd/portforward_show.go
@@ -1,3 +1,5 @@
+//go:build !containarium_client
+
 package cmd
 
 import (

--- a/internal/cmd/postgres.go
+++ b/internal/cmd/postgres.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !containarium_client
 
 package cmd
 

--- a/internal/cmd/recover.go
+++ b/internal/cmd/recover.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !containarium_client
 
 package cmd
 

--- a/internal/cmd/secrets_migrate.go
+++ b/internal/cmd/secrets_migrate.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !containarium_client
 
 package cmd
 

--- a/internal/cmd/sentinel.go
+++ b/internal/cmd/sentinel.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !containarium_client
 
 package cmd
 

--- a/internal/cmd/sentinel_fetch_release.go
+++ b/internal/cmd/sentinel_fetch_release.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !containarium_client
 
 package cmd
 

--- a/internal/cmd/sentinel_keygen.go
+++ b/internal/cmd/sentinel_keygen.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !containarium_client
 
 // The sentinel command tree (sentinelCmd, defined in sentinel.go) is
 // !windows-only — the Windows build ships only the remote-client commands. This

--- a/internal/cmd/sentinel_pprof.go
+++ b/internal/cmd/sentinel_pprof.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !containarium_client
 
 package cmd
 

--- a/internal/cmd/sentinel_pprof_test.go
+++ b/internal/cmd/sentinel_pprof_test.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !containarium_client
 
 package cmd
 

--- a/internal/cmd/sentinel_register_token.go
+++ b/internal/cmd/sentinel_register_token.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !containarium_client
 
 package cmd
 

--- a/internal/cmd/sentinel_service.go
+++ b/internal/cmd/sentinel_service.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !containarium_client
 
 package cmd
 

--- a/internal/cmd/sentinel_unit.go
+++ b/internal/cmd/sentinel_unit.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !containarium_client
 
 package cmd
 

--- a/internal/cmd/service.go
+++ b/internal/cmd/service.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !containarium_client
 
 package cmd
 

--- a/internal/cmd/service_backoff_test.go
+++ b/internal/cmd/service_backoff_test.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !containarium_client
 
 package cmd
 

--- a/internal/cmd/service_memory_test.go
+++ b/internal/cmd/service_memory_test.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !containarium_client
 
 package cmd
 

--- a/internal/cmd/service_test.go
+++ b/internal/cmd/service_test.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !containarium_client
 
 package cmd
 

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -1,3 +1,5 @@
+//go:build !containarium_client
+
 package cmd
 
 import (

--- a/internal/cmd/sidecar_test.go
+++ b/internal/cmd/sidecar_test.go
@@ -1,3 +1,5 @@
+//go:build !containarium_client
+
 package cmd
 
 import (

--- a/internal/cmd/storage_probe.go
+++ b/internal/cmd/storage_probe.go
@@ -1,3 +1,5 @@
+//go:build !containarium_client
+
 package cmd
 
 import (

--- a/internal/cmd/sync_accounts.go
+++ b/internal/cmd/sync_accounts.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !containarium_client
 
 package cmd
 

--- a/internal/cmd/testutil_test.go
+++ b/internal/cmd/testutil_test.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+)
+
+// testCmd returns a *cobra.Command with a real context — a bare
+// &cobra.Command{} has a nil Context() (unlike OutOrStdout/ErrOrStderr,
+// which do fall back), which panics deep inside net/context on first use.
+//
+// Deliberately untagged (both build sets): originally lived in
+// pool_join_test.go, but security_sentry_test.go/security_findings_test.go/
+// security_bad_destinations_test.go — tests for commands that stay in both
+// binaries — depend on it too, so it can't move behind
+// !containarium_client with the rest of pool_join_test.go (#1774).
+func testCmd() *cobra.Command {
+	c := &cobra.Command{}
+	c.SetContext(context.Background())
+	return c
+}

--- a/internal/cmd/tunnel.go
+++ b/internal/cmd/tunnel.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !containarium_client
 
 package cmd
 

--- a/internal/cmd/tunnel_forward_test.go
+++ b/internal/cmd/tunnel_forward_test.go
@@ -1,3 +1,5 @@
+//go:build !containarium_client
+
 package cmd
 
 import "testing"

--- a/internal/cmd/upgrade_watchdog.go
+++ b/internal/cmd/upgrade_watchdog.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !containarium_client
 
 // The upgrade watchdog drives the daemon's post-upgrade auto-rollback, so it
 // imports internal/server (which pulls in the Linux-only eBPF loader). The


### PR DESCRIPTION
## Summary
- Add `//go:build !containarium_client` to every server-only file named in `docs/architecture/cli-client-server-split.md`'s *Full binary layout* / *Local-only commands* / *Classification method* sections (47 non-test files: `daemon`, `sentinel*` (7), `hypervisor-agent`, `egress-relay`, `node`, the 5 `pool_*` join/leave/regions/sentinel/join-handshake files, `postgres`, `upgrade-watchdog`, `sync-accounts`, `imagebake`, `recover`, `storage-probe`, `doctor`, `hosting*` (5), `sidecar`, `portforward*` (4), `passthrough*` (4), `collaborator*` (4), `export`, `audit`, `cloud.go`, `secrets_migrate`, `service`, `tunnel`). Group parents whose children split (`pool`, `secrets`, `token`, `runner`, `label`) stay untagged, per the design's group-parent rule.
- Same tag on the doc's 10 named test files, **plus 4 more the compiler named** (the issue explicitly anticipated this): `pool_join_handshake_test.go`, `pool_sentinel_test.go`, `service_memory_test.go`, `sidecar_test.go` — each references a symbol defined only in a file this issue tags out.
- **One real coupling bug the compiler caught**: `testCmd()`, a shared cobra-command test helper, lived in `pool_join_test.go` — but `security_sentry_test.go`/`security_findings_test.go`/`security_bad_destinations_test.go` (tests for `security*`, which stays in *both* binaries) depend on it too. Tagging `pool_join_test.go` alone would have broken those three unrelated files under `containarium_client`. Extracted `testCmd()` into a new, deliberately untagged `internal/cmd/testutil_test.go`.

Design: `docs/architecture/cli-client-server-split.md` (#1769). Builds on #1773 (base branch here, since #1773 isn't merged yet — retarget to `main` once it lands).

## Test evidence
- `go build -tags containarium_client ./cmd/containarium` → compiles ✅ (issue flagged this as needing #1775/#1776 to *fully* land, but it already compiles today since no untagged file references a symbol from a tagged-out group)
- `go test ./internal/cmd/...` → `ok` under **both** tag sets (default and `-tags containarium_client`) ✅
- `go vet ./internal/cmd/...` → clean under both tag sets ✅ (iterating this is how the 4 extra test files and the `testCmd` coupling were found)
- `grep -l '^//go:build.*!containarium_client' internal/cmd/*.go` → matches the doc's server-only file set exactly, plus the 4 compiler-found test files (61 files total) ✅
- `gofmt -l internal/cmd/*.go` → clean
- `golangci-lint run ./internal/cmd/...` → `0 issues`
- Repo-wide regression check: `go build ./...` and `go test -race -timeout 8m $(go list ./... | grep -v /test/integration)` (CI's exact command from `proxyproto-e2e.yml`) → all green under the default tag set — confirms nothing outside `internal/cmd` references a newly-excluded symbol
- Sanity-checked that `cloud_target.go`, `sync.go`, `pool.go`, `secrets.go`, `token.go`, `runner.go`, `label.go`, `debug.go` are **not** tagged (must stay in both binaries per the design)

CI run on this PR: see checks below.

## Notes for reviewers
- This PR targets `feat/1773-scaffold-cli-split`, not `main`, since #1774 is blocked by #1773 and the diff would otherwise include #1773's changes too.
- No behavior change under the default (daemon) tag set — every touched file only gained a build tag.

Closes #1774

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Compatibility**
  * Updated platform-specific command availability so unsupported commands are excluded from `containarium_client` builds.
  * Preserved existing command behavior on supported platforms.

* **Bug Fixes**
  * Improved test compatibility across build variants by sharing a reliable command context and excluding incompatible tests where necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->