### PR TITLE
feat(cli-split): split the 12 hybrid commands into *_local.go + local_stubs_client.go

### DIFF
--- a/internal/cmd/create.go
+++ b/internal/cmd/create.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/footprintai/containarium/internal/client"
-	"github.com/footprintai/containarium/pkg/core/container"
 	"github.com/footprintai/containarium/pkg/core/incus"
 	"github.com/footprintai/containarium/pkg/core/ostype"
 	"github.com/footprintai/containarium/pkg/core/stacks"
@@ -362,12 +361,11 @@ func runCreate(cmd *cobra.Command, args []string) error {
 			containerExists = (err == nil)
 		} else {
 			// Local mode via Incus
-			mgr, err := container.New()
-			if err != nil {
-				return fmt.Errorf("failed to connect to Incus: %w", err)
+			var existsErr error
+			containerExists, existsErr = containerExistsLocal(username)
+			if existsErr != nil {
+				return existsErr
 			}
-			containerName := username + "-container"
-			containerExists = mgr.ContainerExists(containerName)
 		}
 
 		if containerExists {
@@ -422,8 +420,8 @@ func runCreate(cmd *cobra.Command, args []string) error {
 			fmt.Println("Setting up jump server access...")
 		}
 
-		if err := container.CreateJumpServerAccount(username, sshKey, verbose); err != nil {
-			return fmt.Errorf("failed to create jump server account: %w\nNote: This command must be run with sudo/root privileges", err)
+		if err := createJumpServerAccountLocal(username, sshKey, verbose); err != nil {
+			return err
 		}
 
 		if verbose {
@@ -478,7 +476,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		info, err = createLocal(username, containerImage, cpuLimit, memoryLimit, diskLimit, staticIP, sshKeys, parsedLabels, enablePodman, stackID, gpuDevices, osType, monitoring, gitOpts, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds, createStorageClass)
 		if err != nil {
 			// Cleanup jump server account on failure
-			_ = container.DeleteJumpServerAccount(username, false)
+			cleanupJumpServerAccountLocal(username)
 			return fmt.Errorf("failed to create container: %w", err)
 		}
 	}
@@ -637,79 +635,6 @@ func resolveGitSourceOpts() (client.GitSourceOpts, error) {
 		opts.Credential = strings.TrimSpace(string(data))
 	}
 	return opts, nil
-}
-
-// createLocal creates a container using local Incus daemon
-func createLocal(username, image, cpu, memory, disk, staticIP string, sshKeys []string, labelMap map[string]string, enablePodman bool, stack string, gpus []string, osType pb.OSType, monitoring bool, git client.GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64, _ string) (*incus.ContainerInfo, error) {
-	mgr, err := container.New()
-	if err != nil {
-		return nil, fmt.Errorf("failed to connect to Incus: %w (is Incus running?)", err)
-	}
-
-	opts := container.CreateOptions{
-		Username:               username,
-		Image:                  image,
-		CPU:                    cpu,
-		Memory:                 memory,
-		Disk:                   disk,
-		GPUs:                   gpus,
-		StaticIP:               staticIP,
-		SSHKeys:                sshKeys,
-		Labels:                 labelMap,
-		EnablePodman:           enablePodman,
-		EnablePodmanPrivileged: enablePodman, // Enable privileged mode for proper Podman-in-LXC
-		AutoStart:              true,
-		Verbose:                verbose,
-		Stack:                  stack,
-		OSType:                 osType,
-		Monitoring:             monitoring,
-		GitSource:              git.Source,
-		GitRef:                 git.Ref,
-		GitCredential:          git.Credential,
-		WorkspacePath:          git.WorkspacePath,
-	}
-
-	info, err := mgr.Create(opts)
-	if err != nil {
-		return nil, err
-	}
-
-	// Birth TTL (#523), local path. The daemon's CreateContainer stamps this
-	// server-side; in local Incus mode we stamp the same key+format directly
-	// so the box is born with its death date (reaped by whichever daemon
-	// manages this host's ttlsweeper). On failure delete the box rather than
-	// leave an ephemeral box that would leak — default-dead (#522), matching
-	// the server path.
-	if ttlSeconds > 0 {
-		expiresAt := time.Now().Add(time.Duration(ttlSeconds) * time.Second).UTC()
-		if serr := mgr.SetConfig(info.Name, incus.TTLExpiresAtKey, expiresAt.Format(time.RFC3339)); serr != nil {
-			_ = deleteLocal(username, true)
-			return nil, fmt.Errorf("failed to set birth TTL on %s (box deleted to avoid a leak): %w", info.Name, serr)
-		}
-	}
-
-	// Birth idle-stop (#524), local path. Mirror the daemon's best-effort
-	// stamp: enable auto-sleep with the requested threshold so the box is
-	// born with its idle→stop timer. Best-effort — auto-sleep is an
-	// optimization, not a leak contract, so a failed stamp warns and the box
-	// keeps running (unlike the TTL path, we do NOT delete the box).
-	if idleStopMinutes > 0 {
-		if serr := mgr.SetConfig(info.Name, incus.AutoSleepEnabledKey, "true"); serr != nil {
-			fmt.Printf("warning: failed to enable birth auto-sleep on %s: %v (continuing; box has no idle-stop)\n", info.Name, serr)
-		} else if serr := mgr.SetConfig(info.Name, incus.IdleThresholdMinutesKey, fmt.Sprintf("%d", idleStopMinutes)); serr != nil {
-			fmt.Printf("warning: enabled auto-sleep on %s but failed to set idle threshold: %v\n", info.Name, serr)
-		}
-	}
-
-	// Birth stopped→delete (#525), local path. Best-effort, same as the
-	// server path — persist the window; the clock starts when the box stops.
-	if deleteAfterStoppedSeconds > 0 {
-		if serr := mgr.SetConfig(info.Name, incus.DeleteAfterStoppedSecondsKey, fmt.Sprintf("%d", deleteAfterStoppedSeconds)); serr != nil {
-			fmt.Printf("warning: failed to set birth stopped→delete on %s: %v (continuing; box has no stopped→delete)\n", info.Name, serr)
-		}
-	}
-
-	return info, nil
 }
 
 // parseLabels parses labels from key=value format

--- a/internal/cmd/create_local.go
+++ b/internal/cmd/create_local.go
@@ -1,0 +1,115 @@
+//go:build !containarium_client
+
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/footprintai/containarium/internal/client"
+	"github.com/footprintai/containarium/pkg/core/container"
+	"github.com/footprintai/containarium/pkg/core/incus"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// containerExistsLocal is runCreate's --force existence check in local mode
+// (Incus ContainerExists on the container's fully-qualified name).
+func containerExistsLocal(username string) (bool, error) {
+	mgr, err := container.New()
+	if err != nil {
+		return false, fmt.Errorf("failed to connect to Incus: %w", err)
+	}
+	containerName := username + "-container"
+	return mgr.ContainerExists(containerName), nil
+}
+
+// createJumpServerAccountLocal creates the proxy-only SSH jump-server
+// account for a new local-mode container. Only called when a key was
+// provided (a keyless service tenant has no SSH path, so there's no jump
+// account to seed).
+func createJumpServerAccountLocal(username, sshKey string, verbose bool) error {
+	if err := container.CreateJumpServerAccount(username, sshKey, verbose); err != nil {
+		return fmt.Errorf("failed to create jump server account: %w\nNote: This command must be run with sudo/root privileges", err)
+	}
+	return nil
+}
+
+// cleanupJumpServerAccountLocal best-effort removes the jump-server account
+// created by createJumpServerAccountLocal when the subsequent createLocal
+// call fails. Mirrors the original inline `_ = container.DeleteJumpServerAccount(username, false)`.
+func cleanupJumpServerAccountLocal(username string) {
+	_ = container.DeleteJumpServerAccount(username, false)
+}
+
+// createLocal creates a container using local Incus daemon
+func createLocal(username, image, cpu, memory, disk, staticIP string, sshKeys []string, labelMap map[string]string, enablePodman bool, stack string, gpus []string, osType pb.OSType, monitoring bool, git client.GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64, _ string) (*incus.ContainerInfo, error) {
+	mgr, err := container.New()
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to Incus: %w (is Incus running?)", err)
+	}
+
+	opts := container.CreateOptions{
+		Username:               username,
+		Image:                  image,
+		CPU:                    cpu,
+		Memory:                 memory,
+		Disk:                   disk,
+		GPUs:                   gpus,
+		StaticIP:               staticIP,
+		SSHKeys:                sshKeys,
+		Labels:                 labelMap,
+		EnablePodman:           enablePodman,
+		EnablePodmanPrivileged: enablePodman, // Enable privileged mode for proper Podman-in-LXC
+		AutoStart:              true,
+		Verbose:                verbose,
+		Stack:                  stack,
+		OSType:                 osType,
+		Monitoring:             monitoring,
+		GitSource:              git.Source,
+		GitRef:                 git.Ref,
+		GitCredential:          git.Credential,
+		WorkspacePath:          git.WorkspacePath,
+	}
+
+	info, err := mgr.Create(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	// Birth TTL (#523), local path. The daemon's CreateContainer stamps this
+	// server-side; in local Incus mode we stamp the same key+format directly
+	// so the box is born with its death date (reaped by whichever daemon
+	// manages this host's ttlsweeper). On failure delete the box rather than
+	// leave an ephemeral box that would leak — default-dead (#522), matching
+	// the server path.
+	if ttlSeconds > 0 {
+		expiresAt := time.Now().Add(time.Duration(ttlSeconds) * time.Second).UTC()
+		if serr := mgr.SetConfig(info.Name, incus.TTLExpiresAtKey, expiresAt.Format(time.RFC3339)); serr != nil {
+			_ = deleteLocal(username, true)
+			return nil, fmt.Errorf("failed to set birth TTL on %s (box deleted to avoid a leak): %w", info.Name, serr)
+		}
+	}
+
+	// Birth idle-stop (#524), local path. Mirror the daemon's best-effort
+	// stamp: enable auto-sleep with the requested threshold so the box is
+	// born with its idle→stop timer. Best-effort — auto-sleep is an
+	// optimization, not a leak contract, so a failed stamp warns and the box
+	// keeps running (unlike the TTL path, we do NOT delete the box).
+	if idleStopMinutes > 0 {
+		if serr := mgr.SetConfig(info.Name, incus.AutoSleepEnabledKey, "true"); serr != nil {
+			fmt.Printf("warning: failed to enable birth auto-sleep on %s: %v (continuing; box has no idle-stop)\n", info.Name, serr)
+		} else if serr := mgr.SetConfig(info.Name, incus.IdleThresholdMinutesKey, fmt.Sprintf("%d", idleStopMinutes)); serr != nil {
+			fmt.Printf("warning: enabled auto-sleep on %s but failed to set idle threshold: %v\n", info.Name, serr)
+		}
+	}
+
+	// Birth stopped→delete (#525), local path. Best-effort, same as the
+	// server path — persist the window; the clock starts when the box stops.
+	if deleteAfterStoppedSeconds > 0 {
+		if serr := mgr.SetConfig(info.Name, incus.DeleteAfterStoppedSecondsKey, fmt.Sprintf("%d", deleteAfterStoppedSeconds)); serr != nil {
+			fmt.Printf("warning: failed to set birth stopped→delete on %s: %v (continuing; box has no stopped→delete)\n", info.Name, serr)
+		}
+	}
+
+	return info, nil
+}

--- a/internal/cmd/delete.go
+++ b/internal/cmd/delete.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/footprintai/containarium/internal/client"
-	"github.com/footprintai/containarium/pkg/core/container"
 	"github.com/spf13/cobra"
 )
 
@@ -70,31 +69,10 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	// Delete jump server account (only in local mode)
 	// This removes the proxy-only user account from the jump server
 	if serverAddr == "" {
-		if verbose {
-			fmt.Println("Removing jump server account...")
-		}
-
-		if err := container.DeleteJumpServerAccount(username, verbose); err != nil {
-			// Don't fail the entire operation if jump server account deletion fails
-			// Container is already deleted at this point
-			fmt.Printf("Warning: Failed to delete jump server account for %s: %v\n", username, err)
-			fmt.Println("You may need to manually remove the account with: sudo userdel -r " + username)
-		} else {
-			fmt.Printf("✓ Jump server account %s deleted\n", username)
-		}
+		deleteJumpServerAccountLocal(username, verbose)
 	}
 
 	return nil
-}
-
-// deleteLocal deletes a container using local Incus daemon
-func deleteLocal(username string, force bool) error {
-	mgr, err := container.New()
-	if err != nil {
-		return fmt.Errorf("failed to connect to Incus: %w (is Incus running?)", err)
-	}
-
-	return mgr.Delete(username, force)
 }
 
 // deleteRemote deletes a container using remote gRPC server

--- a/internal/cmd/delete_local.go
+++ b/internal/cmd/delete_local.go
@@ -1,0 +1,37 @@
+//go:build !containarium_client
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/footprintai/containarium/pkg/core/container"
+)
+
+// deleteLocal deletes a container using local Incus daemon
+func deleteLocal(username string, force bool) error {
+	mgr, err := container.New()
+	if err != nil {
+		return fmt.Errorf("failed to connect to Incus: %w (is Incus running?)", err)
+	}
+
+	return mgr.Delete(username, force)
+}
+
+// deleteJumpServerAccountLocal removes the local jump-server account after a
+// local delete. Best-effort: prints a warning rather than failing the
+// command — the container is already gone by the time this runs.
+func deleteJumpServerAccountLocal(username string, verbose bool) {
+	if verbose {
+		fmt.Println("Removing jump server account...")
+	}
+
+	if err := container.DeleteJumpServerAccount(username, verbose); err != nil {
+		// Don't fail the entire operation if jump server account deletion fails
+		// Container is already deleted at this point
+		fmt.Printf("Warning: Failed to delete jump server account for %s: %v\n", username, err)
+		fmt.Println("You may need to manually remove the account with: sudo userdel -r " + username)
+	} else {
+		fmt.Printf("✓ Jump server account %s deleted\n", username)
+	}
+}

--- a/internal/cmd/get.go
+++ b/internal/cmd/get.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/footprintai/containarium/internal/client"
-	"github.com/footprintai/containarium/pkg/core/container"
 	"github.com/footprintai/containarium/pkg/core/incus"
 	"github.com/spf13/cobra"
 )
@@ -82,14 +81,6 @@ func boolToCount(b bool) int {
 		return 1
 	}
 	return 0
-}
-
-func getLocal(username string) (*incus.ContainerInfo, error) {
-	mgr, err := container.New()
-	if err != nil {
-		return nil, fmt.Errorf("failed to connect to Incus: %w (is Incus running?)", err)
-	}
-	return mgr.Get(username)
 }
 
 func getRemote(username string) (*incus.ContainerInfo, error) {

--- a/internal/cmd/get_local.go
+++ b/internal/cmd/get_local.go
@@ -1,0 +1,18 @@
+//go:build !containarium_client
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/footprintai/containarium/pkg/core/container"
+	"github.com/footprintai/containarium/pkg/core/incus"
+)
+
+func getLocal(username string) (*incus.ContainerInfo, error) {
+	mgr, err := container.New()
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to Incus: %w (is Incus running?)", err)
+	}
+	return mgr.Get(username)
+}

--- a/internal/cmd/info.go
+++ b/internal/cmd/info.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/footprintai/containarium/internal/client"
-	"github.com/footprintai/containarium/pkg/core/container"
 	"github.com/footprintai/containarium/pkg/core/incus"
 	"github.com/spf13/cobra"
 )
@@ -104,20 +103,9 @@ func showSystemInfo() error {
 		}
 	} else {
 		// Local mode via Incus
-		var mgr *container.Manager
-		mgr, err = container.New()
+		serverInfo, containers, err = getSystemInfoLocal()
 		if err != nil {
-			return fmt.Errorf("failed to connect to Incus: %w (is Incus running?)", err)
-		}
-
-		serverInfo, err = mgr.GetServerInfo()
-		if err != nil {
-			return fmt.Errorf("failed to get server info: %w", err)
-		}
-
-		containers, err = mgr.List()
-		if err != nil {
-			return fmt.Errorf("failed to list containers: %w", err)
+			return err
 		}
 	}
 
@@ -199,15 +187,9 @@ func showContainerInfo(username string) error {
 		}
 	} else {
 		// Local mode via Incus
-		var mgr *container.Manager
-		mgr, err = container.New()
+		info, err = getContainerInfoLocal(username)
 		if err != nil {
-			return fmt.Errorf("failed to connect to Incus: %w (is Incus running?)", err)
-		}
-
-		info, err = mgr.Get(username)
-		if err != nil {
-			return fmt.Errorf("container not found: %w", err)
+			return err
 		}
 	}
 

--- a/internal/cmd/info_local.go
+++ b/internal/cmd/info_local.go
@@ -1,0 +1,45 @@
+//go:build !containarium_client
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/footprintai/containarium/pkg/core/container"
+	"github.com/footprintai/containarium/pkg/core/incus"
+)
+
+// getSystemInfoLocal is showSystemInfo's local-mode branch: server info plus
+// the full container list, both read directly from Incus.
+func getSystemInfoLocal() (*incus.ServerInfo, []incus.ContainerInfo, error) {
+	mgr, err := container.New()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to connect to Incus: %w (is Incus running?)", err)
+	}
+
+	serverInfo, err := mgr.GetServerInfo()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get server info: %w", err)
+	}
+
+	containers, err := mgr.List()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to list containers: %w", err)
+	}
+
+	return serverInfo, containers, nil
+}
+
+// getContainerInfoLocal is showContainerInfo's local-mode branch.
+func getContainerInfoLocal(username string) (*incus.ContainerInfo, error) {
+	mgr, err := container.New()
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to Incus: %w (is Incus running?)", err)
+	}
+
+	info, err := mgr.Get(username)
+	if err != nil {
+		return nil, fmt.Errorf("container not found: %w", err)
+	}
+	return info, nil
+}

--- a/internal/cmd/install_stack.go
+++ b/internal/cmd/install_stack.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/footprintai/containarium/internal/client"
-	"github.com/footprintai/containarium/pkg/core/container"
 	"github.com/spf13/cobra"
 )
 
@@ -49,20 +48,6 @@ func runInstallStack(cmd *cobra.Command, args []string) error {
 		return installStackRemoteGRPC(username, stackID)
 	}
 	return installStackLocal(username, stackID)
-}
-
-func installStackLocal(username, stackID string) error {
-	mgr, err := container.New()
-	if err != nil {
-		return fmt.Errorf("failed to connect to Incus: %w", err)
-	}
-
-	if err := mgr.InstallStack(username, stackID); err != nil {
-		return fmt.Errorf("failed to install stack: %w", err)
-	}
-
-	fmt.Printf("\n✓ Stack %q installed successfully on %s-container\n", stackID, username)
-	return nil
 }
 
 func installStackRemoteGRPC(username, stackID string) error {

--- a/internal/cmd/install_stack_local.go
+++ b/internal/cmd/install_stack_local.go
@@ -1,0 +1,23 @@
+//go:build !containarium_client
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/footprintai/containarium/pkg/core/container"
+)
+
+func installStackLocal(username, stackID string) error {
+	mgr, err := container.New()
+	if err != nil {
+		return fmt.Errorf("failed to connect to Incus: %w", err)
+	}
+
+	if err := mgr.InstallStack(username, stackID); err != nil {
+		return fmt.Errorf("failed to install stack: %w", err)
+	}
+
+	fmt.Printf("\n✓ Stack %q installed successfully on %s-container\n", stackID, username)
+	return nil
+}

--- a/internal/cmd/label_list.go
+++ b/internal/cmd/label_list.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/footprintai/containarium/internal/client"
-	"github.com/footprintai/containarium/pkg/core/container"
 	"github.com/spf13/cobra"
 )
 
@@ -66,23 +65,6 @@ func runLabelList(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
-}
-
-func getLabelsLocal(username string) (map[string]string, error) {
-	mgr, err := container.New()
-	if err != nil {
-		return nil, fmt.Errorf("failed to connect to Incus: %w (is Incus running?)", err)
-	}
-
-	containerName := username + "-container"
-
-	// Check if container exists
-	if !mgr.ContainerExists(containerName) {
-		return nil, fmt.Errorf("container %q does not exist", containerName)
-	}
-
-	// Note: Manager methods expect username (without -container suffix)
-	return mgr.GetLabels(username)
 }
 
 func getLabelsRemoteHTTP(username string) (map[string]string, error) {

--- a/internal/cmd/label_local.go
+++ b/internal/cmd/label_local.go
@@ -1,0 +1,115 @@
+//go:build !containarium_client
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/footprintai/containarium/pkg/core/container"
+)
+
+func getLabelsLocal(username string) (map[string]string, error) {
+	mgr, err := container.New()
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to Incus: %w (is Incus running?)", err)
+	}
+
+	containerName := username + "-container"
+
+	// Check if container exists
+	if !mgr.ContainerExists(containerName) {
+		return nil, fmt.Errorf("container %q does not exist", containerName)
+	}
+
+	// Note: Manager methods expect username (without -container suffix)
+	return mgr.GetLabels(username)
+}
+
+func setLabelsLocal(username string, labels map[string]string) error {
+	mgr, err := container.New()
+	if err != nil {
+		return fmt.Errorf("failed to connect to Incus: %w (is Incus running?)", err)
+	}
+
+	containerName := username + "-container"
+
+	// Check if container exists
+	if !mgr.ContainerExists(containerName) {
+		return fmt.Errorf("container %q does not exist", containerName)
+	}
+
+	// Get current labels if not overwriting
+	// Note: Manager methods expect username (without -container suffix)
+	if !labelOverwrite {
+		currentLabels, err := mgr.GetLabels(username)
+		if err != nil {
+			return fmt.Errorf("failed to get current labels: %w", err)
+		}
+		// Only set labels that don't already exist
+		for key, value := range labels {
+			if _, exists := currentLabels[key]; !exists {
+				if err := mgr.AddLabel(username, key, value); err != nil {
+					return fmt.Errorf("failed to add label %s=%s: %w", key, value, err)
+				}
+				fmt.Printf("Added label: %s=%s\n", key, value)
+			} else {
+				fmt.Printf("Skipped existing label: %s (use --overwrite to update)\n", key)
+			}
+		}
+		return nil
+	}
+
+	// Set all labels (overwriting existing ones)
+	for key, value := range labels {
+		if err := mgr.AddLabel(username, key, value); err != nil {
+			return fmt.Errorf("failed to set label %s=%s: %w", key, value, err)
+		}
+		fmt.Printf("Set label: %s=%s\n", key, value)
+	}
+
+	fmt.Printf("\nLabels set on container %s\n", containerName)
+	return nil
+}
+
+func removeLabelsLocal(username string, keys []string) error {
+	mgr, err := container.New()
+	if err != nil {
+		return fmt.Errorf("failed to connect to Incus: %w (is Incus running?)", err)
+	}
+
+	containerName := username + "-container"
+
+	// Check if container exists
+	if !mgr.ContainerExists(containerName) {
+		return fmt.Errorf("container %q does not exist", containerName)
+	}
+
+	// Get current labels to show which were actually removed
+	// Note: Manager methods expect username (without -container suffix)
+	currentLabels, err := mgr.GetLabels(username)
+	if err != nil {
+		return fmt.Errorf("failed to get current labels: %w", err)
+	}
+
+	removedCount := 0
+	for _, key := range keys {
+		if _, exists := currentLabels[key]; exists {
+			if err := mgr.RemoveLabel(username, key); err != nil {
+				return fmt.Errorf("failed to remove label %q: %w", key, err)
+			}
+			fmt.Printf("Removed label: %s\n", key)
+			removedCount++
+		} else {
+			if verbose {
+				fmt.Printf("Label not found: %s (skipped)\n", key)
+			}
+		}
+	}
+
+	if removedCount > 0 {
+		fmt.Printf("\nRemoved %d label(s) from container %s\n", removedCount, containerName)
+	} else {
+		fmt.Println("No labels were removed (none matched)")
+	}
+	return nil
+}

--- a/internal/cmd/label_remove.go
+++ b/internal/cmd/label_remove.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/footprintai/containarium/internal/client"
-	"github.com/footprintai/containarium/pkg/core/container"
 	"github.com/spf13/cobra"
 )
 
@@ -42,49 +41,6 @@ func runLabelRemove(cmd *cobra.Command, args []string) error {
 	}
 
 	return removeLabelsLocal(username, keys)
-}
-
-func removeLabelsLocal(username string, keys []string) error {
-	mgr, err := container.New()
-	if err != nil {
-		return fmt.Errorf("failed to connect to Incus: %w (is Incus running?)", err)
-	}
-
-	containerName := username + "-container"
-
-	// Check if container exists
-	if !mgr.ContainerExists(containerName) {
-		return fmt.Errorf("container %q does not exist", containerName)
-	}
-
-	// Get current labels to show which were actually removed
-	// Note: Manager methods expect username (without -container suffix)
-	currentLabels, err := mgr.GetLabels(username)
-	if err != nil {
-		return fmt.Errorf("failed to get current labels: %w", err)
-	}
-
-	removedCount := 0
-	for _, key := range keys {
-		if _, exists := currentLabels[key]; exists {
-			if err := mgr.RemoveLabel(username, key); err != nil {
-				return fmt.Errorf("failed to remove label %q: %w", key, err)
-			}
-			fmt.Printf("Removed label: %s\n", key)
-			removedCount++
-		} else {
-			if verbose {
-				fmt.Printf("Label not found: %s (skipped)\n", key)
-			}
-		}
-	}
-
-	if removedCount > 0 {
-		fmt.Printf("\nRemoved %d label(s) from container %s\n", removedCount, containerName)
-	} else {
-		fmt.Println("No labels were removed (none matched)")
-	}
-	return nil
 }
 
 func removeLabelsRemoteHTTP(username string, keys []string) error {

--- a/internal/cmd/label_set.go
+++ b/internal/cmd/label_set.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/footprintai/containarium/internal/client"
-	"github.com/footprintai/containarium/pkg/core/container"
 	"github.com/spf13/cobra"
 )
 
@@ -68,52 +67,6 @@ func runLabelSet(cmd *cobra.Command, args []string) error {
 	}
 
 	return setLabelsLocal(username, labels)
-}
-
-func setLabelsLocal(username string, labels map[string]string) error {
-	mgr, err := container.New()
-	if err != nil {
-		return fmt.Errorf("failed to connect to Incus: %w (is Incus running?)", err)
-	}
-
-	containerName := username + "-container"
-
-	// Check if container exists
-	if !mgr.ContainerExists(containerName) {
-		return fmt.Errorf("container %q does not exist", containerName)
-	}
-
-	// Get current labels if not overwriting
-	// Note: Manager methods expect username (without -container suffix)
-	if !labelOverwrite {
-		currentLabels, err := mgr.GetLabels(username)
-		if err != nil {
-			return fmt.Errorf("failed to get current labels: %w", err)
-		}
-		// Only set labels that don't already exist
-		for key, value := range labels {
-			if _, exists := currentLabels[key]; !exists {
-				if err := mgr.AddLabel(username, key, value); err != nil {
-					return fmt.Errorf("failed to add label %s=%s: %w", key, value, err)
-				}
-				fmt.Printf("Added label: %s=%s\n", key, value)
-			} else {
-				fmt.Printf("Skipped existing label: %s (use --overwrite to update)\n", key)
-			}
-		}
-		return nil
-	}
-
-	// Set all labels (overwriting existing ones)
-	for key, value := range labels {
-		if err := mgr.AddLabel(username, key, value); err != nil {
-			return fmt.Errorf("failed to set label %s=%s: %w", key, value, err)
-		}
-		fmt.Printf("Set label: %s=%s\n", key, value)
-	}
-
-	fmt.Printf("\nLabels set on container %s\n", containerName)
-	return nil
 }
 
 func setLabelsRemoteHTTP(username string, labels map[string]string) error {

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/footprintai/containarium/internal/client"
-	"github.com/footprintai/containarium/pkg/core/container"
 	"github.com/footprintai/containarium/pkg/core/incus"
 	"github.com/spf13/cobra"
 )
@@ -424,16 +423,6 @@ func printGroupedYAMLFormat(containers []incus.ContainerInfo, labelKey string) {
 	}
 	fmt.Printf("group_count: %d\n", len(groups))
 	fmt.Printf("total_count: %d\n", len(containers))
-}
-
-// listLocal lists containers from local Incus daemon
-func listLocal() ([]incus.ContainerInfo, error) {
-	mgr, err := container.New()
-	if err != nil {
-		return nil, fmt.Errorf("failed to connect to Incus: %w (is Incus running?)", err)
-	}
-
-	return mgr.List()
 }
 
 // listRemote lists containers from remote gRPC server

--- a/internal/cmd/list_local.go
+++ b/internal/cmd/list_local.go
@@ -1,0 +1,20 @@
+//go:build !containarium_client
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/footprintai/containarium/pkg/core/container"
+	"github.com/footprintai/containarium/pkg/core/incus"
+)
+
+// listLocal lists containers from local Incus daemon
+func listLocal() ([]incus.ContainerInfo, error) {
+	mgr, err := container.New()
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to Incus: %w (is Incus running?)", err)
+	}
+
+	return mgr.List()
+}

--- a/internal/cmd/local_stubs_client.go
+++ b/internal/cmd/local_stubs_client.go
@@ -1,0 +1,59 @@
+//go:build containarium_client
+
+package cmd
+
+import (
+	"errors"
+
+	"github.com/footprintai/containarium/internal/client"
+	"github.com/footprintai/containarium/pkg/core/incus"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// errNoLocalMode is what every stub below returns. The containarium client
+// has no local-Incus code path at all (see
+// docs/architecture/cli-client-server-split.md) — this is the message a
+// user sees if they somehow reach one of these stubs (in practice,
+// resolveServerAddr's server-resolution chain and the "no server
+// configured" error at the client constructors already fail earlier for
+// every one of the twelve hybrid commands; these stubs are defence in
+// depth, turning a future forgotten check into a clear error instead of a
+// build break or a silent local Incus call).
+var errNoLocalMode = errors.New("this is the containarium client; it has no local mode — pass --server, run `containarium login`, or use containariumd on the host")
+
+// create.go
+func containerExistsLocal(_ string) (bool, error) { return false, errNoLocalMode }
+func createJumpServerAccountLocal(_, _ string, _ bool) error {
+	return errNoLocalMode
+}
+func cleanupJumpServerAccountLocal(_ string) {}
+func createLocal(_, _, _, _, _, _ string, _ []string, _ map[string]string, _ bool, _ string, _ []string, _ pb.OSType, _ bool, _ client.GitSourceOpts, _ int64, _ int32, _ int64, _ string) (*incus.ContainerInfo, error) {
+	return nil, errNoLocalMode
+}
+
+// delete.go
+func deleteLocal(_ string, _ bool) error            { return errNoLocalMode }
+func deleteJumpServerAccountLocal(_ string, _ bool) {}
+
+// get.go
+func getLocal(_ string) (*incus.ContainerInfo, error) { return nil, errNoLocalMode }
+
+// list.go
+func listLocal() ([]incus.ContainerInfo, error) { return nil, errNoLocalMode }
+
+// info.go — "the two info helpers"
+func getSystemInfoLocal() (*incus.ServerInfo, []incus.ContainerInfo, error) {
+	return nil, nil, errNoLocalMode
+}
+func getContainerInfoLocal(_ string) (*incus.ContainerInfo, error) { return nil, errNoLocalMode }
+
+// label_list.go / label_set.go / label_remove.go
+func getLabelsLocal(_ string) (map[string]string, error) { return nil, errNoLocalMode }
+func setLabelsLocal(_ string, _ map[string]string) error { return errNoLocalMode }
+func removeLabelsLocal(_ string, _ []string) error       { return errNoLocalMode }
+
+// install_stack.go
+func installStackLocal(_, _ string) error { return errNoLocalMode }
+
+// resize.go
+func runResizeLocal(_, _ string) error { return errNoLocalMode }

--- a/internal/cmd/local_stubs_client_test.go
+++ b/internal/cmd/local_stubs_client_test.go
@@ -1,0 +1,125 @@
+//go:build containarium_client
+
+package cmd
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestHybridCommands_NoServer_NeverReachRealLocalMode is #1775's Done-when
+// table-driven test: with no --server (and no CONTAINARIUM_SERVER/
+// credentials.json fallback in play), every one of the twelve hybrid
+// commands must error via a *Local stub — never via a working local-Incus
+// call, because under containarium_client every *Local symbol IS one of
+// those stubs (local_stubs_client.go). errors.Is against errNoLocalMode is
+// exactly the assertion that proves this: it can only be true if the
+// call reached a stub, since errNoLocalMode is not constructible any other
+// way in this build.
+func TestHybridCommands_NoServer_NeverReachRealLocalMode(t *testing.T) {
+	// isCloudTarget (used by `info`) reads $HOME/.containarium/credentials.json
+	// to resolve default_server's cached access model. Redirect HOME to an
+	// empty temp dir so this test is hermetic — it must not depend on (or be
+	// broken by) whoever is actually logged in on the machine running it.
+	t.Setenv("HOME", t.TempDir())
+
+	tests := []struct {
+		name  string
+		setup func()
+		run   func() error
+	}{
+		{
+			name: "create",
+			setup: func() {
+				noSSHKey = true // skip --ssh-key file I/O; the point here is reaching createLocal, not key handling
+				forceRecreate = false
+				createEncrypted = false
+				createTenantID = ""
+				createPool = ""
+				createBackendID = ""
+				createWait = false
+			},
+			run: func() error { return runCreate(testCmd(), []string{"testuser"}) },
+		},
+		{
+			name:  "delete",
+			setup: func() { forceDelete = false },
+			run:   func() error { return runDelete(testCmd(), []string{"testuser"}) },
+		},
+		{
+			name:  "get",
+			setup: func() { containerGetFormat = "table" },
+			run:   func() error { return runGet(testCmd(), []string{"testuser"}) },
+		},
+		{
+			name:  "list",
+			setup: func() { outputFormat = "table"; filterState = "all"; groupByLabel = "" },
+			run:   func() error { return runList(testCmd(), nil) },
+		},
+		{
+			name:  "info (system)",
+			setup: func() {},
+			run:   func() error { return runInfo(testCmd(), nil) },
+		},
+		{
+			name:  "info (container)",
+			setup: func() {},
+			run:   func() error { return runInfo(testCmd(), []string{"testuser"}) },
+		},
+		{
+			name:  "label list",
+			setup: func() { labelListFormat = "table" },
+			run:   func() error { return runLabelList(testCmd(), []string{"testuser"}) },
+		},
+		{
+			name:  "label set",
+			setup: func() { labelOverwrite = true },
+			run:   func() error { return runLabelSet(testCmd(), []string{"testuser", "k=v"}) },
+		},
+		{
+			name:  "label remove",
+			setup: func() {},
+			run:   func() error { return runLabelRemove(testCmd(), []string{"testuser", "k"}) },
+		},
+		{
+			name:  "install-stack",
+			setup: func() {},
+			run:   func() error { return runInstallStack(testCmd(), []string{"testuser", "nodejs"}) },
+		},
+		{
+			name: "resize",
+			setup: func() {
+				newCPU, newMemory, newDisk, newCPURequest, newMemoryRequest = "4", "", "", "", ""
+			},
+			run: func() error { return runResize(testCmd(), []string{"testuser"}) },
+		},
+		{
+			name:  "ssh-config sync",
+			setup: func() { sshConfigOutPath = t.TempDir() + "/ssh_config"; sshConfigForce = true },
+			run:   func() error { return runSSHConfigSync(testCmd(), nil) },
+		},
+		{
+			name:  "prune",
+			setup: func() { pruneState, pruneNameContains, pruneOlderThan, pruneLabels = "stopped", "", "", nil },
+			run:   func() error { return runPrune(testCmd(), nil) },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Every hybrid dispatches on serverAddr/httpMode; pin both to the
+			// "no server anywhere" case regardless of what an earlier subtest
+			// (or -run reordering) left them at.
+			serverAddr, httpMode, authToken = "", false, ""
+			tt.setup()
+
+			err := tt.run()
+			if err == nil {
+				t.Fatalf("expected an error with no server configured, got nil")
+			}
+			if !errors.Is(err, errNoLocalMode) {
+				t.Errorf("expected errNoLocalMode (i.e. the call resolved to a *Local stub, not real Incus code), got: %v", err)
+			}
+		})
+	}
+}

--- a/internal/cmd/resize.go
+++ b/internal/cmd/resize.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/footprintai/containarium/internal/client"
-	"github.com/footprintai/containarium/pkg/core/container"
 	"github.com/spf13/cobra"
 )
 
@@ -116,40 +115,6 @@ func runResize(cmd *cobra.Command, args []string) error {
 
 	// Local mode
 	return runResizeLocal(username, containerName)
-}
-
-func runResizeLocal(username, containerName string) error {
-	// Create container manager
-	mgr, err := container.New()
-	if err != nil {
-		return fmt.Errorf("failed to connect to Incus: %w", err)
-	}
-
-	// Resize resources
-	if err := mgr.Resize(containerName, newCPU, newMemory, newDisk, verbose); err != nil {
-		return fmt.Errorf("failed to resize container: %w", err)
-	}
-
-	fmt.Printf("\n✓ Container %s resized successfully!\n", containerName)
-
-	// Show updated configuration
-	if verbose {
-		fmt.Println("\nUpdated configuration:")
-		info, err := mgr.GetInfo(containerName)
-		if err == nil {
-			if newCPU != "" {
-				fmt.Printf("  CPU:    %s\n", info.CPU)
-			}
-			if newMemory != "" {
-				fmt.Printf("  Memory: %s\n", info.Memory)
-			}
-			if newDisk != "" {
-				fmt.Printf("  Disk:   %s\n", newDisk)
-			}
-		}
-	}
-
-	return nil
 }
 
 func runResizeRemote(username, containerName string) error {

--- a/internal/cmd/resize_local.go
+++ b/internal/cmd/resize_local.go
@@ -1,0 +1,43 @@
+//go:build !containarium_client
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/footprintai/containarium/pkg/core/container"
+)
+
+func runResizeLocal(username, containerName string) error {
+	// Create container manager
+	mgr, err := container.New()
+	if err != nil {
+		return fmt.Errorf("failed to connect to Incus: %w", err)
+	}
+
+	// Resize resources
+	if err := mgr.Resize(containerName, newCPU, newMemory, newDisk, verbose); err != nil {
+		return fmt.Errorf("failed to resize container: %w", err)
+	}
+
+	fmt.Printf("\n✓ Container %s resized successfully!\n", containerName)
+
+	// Show updated configuration
+	if verbose {
+		fmt.Println("\nUpdated configuration:")
+		info, err := mgr.GetInfo(containerName)
+		if err == nil {
+			if newCPU != "" {
+				fmt.Printf("  CPU:    %s\n", info.CPU)
+			}
+			if newMemory != "" {
+				fmt.Printf("  Memory: %s\n", info.Memory)
+			}
+			if newDisk != "" {
+				fmt.Printf("  Disk:   %s\n", newDisk)
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary
- For `create`, `delete`, `get`, `list`, `info`, `label list/set/remove`, `install-stack`, `resize`: move every local-mode-only function into a sibling `*_local.go` tagged `!containarium_client` — the 8 files the design names exactly (`create_local`, `delete_local`, `get_local`, `list_local`, `info_local`, `label_local`, `install_stack_local`, `resize_local`). `ssh-config sync` and `prune` need no file of their own — they already dispatch through `listLocal()`/`deleteLocal()`.
- Beyond the functions that already existed as standalone (`createLocal`, `deleteLocal`, `getLocal`, `listLocal`, `getLabelsLocal`/`setLabelsLocal`/`removeLabelsLocal`, `installStackLocal`, `runResizeLocal` — moved verbatim), **4 more things had to be extracted** from inline `serverAddr == ""` branches to satisfy "`create.go`/`delete.go` import neither `pkg/core/container` nor call `incus.New`" under the client build:
  - `containerExistsLocal` (create's `--force` existence check)
  - `createJumpServerAccountLocal` / `cleanupJumpServerAccountLocal` (create's host-account create + on-failure cleanup)
  - `deleteJumpServerAccountLocal` (delete's host-account cleanup)
  - `getSystemInfoLocal` / `getContainerInfoLocal` ("the two info helpers" the design's stub list names generically, without giving them names)
- **Design interpretation flagged for reviewers**: the design doc says to fold `container.CreateJumpServerAccount`/`DeleteJumpServerAccount` "into" `createLocal`/`deleteLocal`. I read that as "move into the local file", not "literally merge into the same function body" — merging would reorder stdout (the account create/cleanup prints happen at specific points relative to the container-create prints today), and this issue's own done-when requires local-mode behavior to stay **byte-for-byte** identical. Each became its own small function instead, called at the exact same point as before. Happy to restructure if the literal merge was intended.
- `local_stubs_client.go` (`containarium_client`) defines all 15 of the above as one-liners returning a shared `errNoLocalMode` — the 9 named in the design's stub list plus the 6 extras above.

Design: `docs/architecture/cli-client-server-split.md` (#1769). Builds on #1773 and #1774 (this PR targets `feat/1774-tag-server-only-files`, not `main`, since neither is merged yet — retarget once they land).

## Test evidence
- **containariumd byte-for-byte unchanged**: full repo `go test -race -timeout 8m $(go list ./... | grep -v /test/integration)` (CI's exact command) → all green under the default tag set
- **No pkg/core/container in the client build's create/delete**: `grep -n "pkg/core/container\|incus\.New(" internal/cmd/create.go internal/cmd/delete.go` → empty
- **Stub message**: names `--server`, `` `containarium login` ``, and `containariumd` (verbatim from the design)
- **New table-driven test** (`local_stubs_client_test.go`, tagged `containarium_client`): all twelve hybrid commands, invoked with no server anywhere, return an error satisfying `errors.Is(err, errNoLocalMode)` — proving every one resolves to a stub, never to working Incus code. Redirects `$HOME` to an empty temp dir so the assertion is hermetic — `info`'s `isCloudTarget` check reads `~/.containarium/credentials.json`, and the box this was developed on has a real one (caught this via a genuinely flaky first run, not by inspection).
- `go build -tags containarium_client ./cmd/containarium` compiles ✅; `GOOS=windows GOARCH=amd64 go build -tags containarium_client ./cmd/containarium/` compiles ✅ (CI's guard from #1773)
- `go build`/`go vet`/`go test -race` clean under **both** tag sets
- `golangci-lint run ./internal/cmd/...` → `0 issues`
- `gofmt -l` → clean

## Notes for reviewers
- **Diff size**: 918 lines (612+/306-) across 20 files, over the usual ~400-line soft ceiling. Almost all of it is verbatim code relocation (functions moved to a new file behind a tag) plus the stub file and its test, not new logic — I considered splitting this into smaller PRs but the design's own acceptance criteria are atomic (the table-driven test needs all twelve hybrids done together, and `local_stubs_client.go` needs every stub defined at once to compile under the client tag), so a partial split would leave an unprovable middle state.
- No behavior change under the default (daemon) tag set.

Closes #1775

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added direct local container management for creation, deletion, lookup, listing, resizing, system information, stack installation, and lifecycle settings.
  - Added local label management, including viewing, adding, updating, and removing labels.
  - Added safeguards so client mode reports that local operations are unavailable when no server is configured.

- **Bug Fixes**
  - Improved error messages and contextual feedback for local container and stack operations.
  - Local jump-server account cleanup now continues with warnings when cleanup cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->