### PR TITLE
feat(cli-split): tag-split resolveServerAddr + no-server-configured error

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,6 +12,17 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
+
+// ErrNoServerConfigured is what NewGRPCClient/NewHTTPClient return when
+// handed an empty server address, instead of attempting to dial it. This is
+// the single seam a remote or hybrid command in the containarium client
+// passes through when --server, CONTAINARIUM_SERVER, and credentials.json's
+// default_server all resolved to nothing — see
+// docs/architecture/cli-client-server-split.md ("Server resolution in the
+// client"). Offline commands (cert generate, token inspect, version, …)
+// never construct a client, so they never hit this — no pre-run failure or
+// exemption list needed.
+var ErrNoServerConfigured = errors.New("no server configured — run `containarium login` or pass --server")
 
 const (
 	// DefaultUserCertsDir is the default directory for user certificates

--- a/internal/client/grpc.go
+++ b/internal/client/grpc.go
@@ -32,6 +32,10 @@ type GRPCClient struct {
 
 // NewGRPCClient creates a new gRPC client
 func NewGRPCClient(serverAddr string, certsDir string, insecureConn bool) (*GRPCClient, error) {
+	if serverAddr == "" {
+		return nil, ErrNoServerConfigured
+	}
+
 	var opts []grpc.DialOption
 
 	if insecureConn {

--- a/internal/client/grpc_test.go
+++ b/internal/client/grpc_test.go
@@ -1,0 +1,16 @@
+package client
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestNewGRPCClient_EmptyServerRejected pins #1776: an empty server address
+// must fail fast with ErrNoServerConfigured, before ever touching cert
+// paths or attempting to dial.
+func TestNewGRPCClient_EmptyServerRejected(t *testing.T) {
+	_, err := NewGRPCClient("", "", false)
+	if !errors.Is(err, ErrNoServerConfigured) {
+		t.Errorf("NewGRPCClient(\"\", ...) error = %v, want ErrNoServerConfigured", err)
+	}
+}

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -30,6 +30,10 @@ type HTTPClient struct {
 
 // NewHTTPClient creates a new HTTP client
 func NewHTTPClient(baseURL string, token string) (*HTTPClient, error) {
+	if baseURL == "" {
+		return nil, ErrNoServerConfigured
+	}
+
 	// Ensure baseURL has proper format
 	if !strings.HasPrefix(baseURL, "http://") && !strings.HasPrefix(baseURL, "https://") {
 		baseURL = "http://" + baseURL

--- a/internal/client/http_test.go
+++ b/internal/client/http_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -90,6 +91,17 @@ func TestNewHTTPClient_PinsHTTP1(t *testing.T) {
 	// (not a zero-value transport with no timeouts).
 	if tr.DialContext == nil {
 		t.Error("expected DialContext preserved from http.DefaultTransport clone")
+	}
+}
+
+// TestNewHTTPClient_EmptyServerRejected pins #1776: an empty server address
+// must fail fast with ErrNoServerConfigured, not silently become
+// "http://" (baseURL's own prefix-normalization would otherwise turn ""
+// into a dialable-looking URL) and attempt to dial it.
+func TestNewHTTPClient_EmptyServerRejected(t *testing.T) {
+	_, err := NewHTTPClient("", "tok")
+	if !errors.Is(err, ErrNoServerConfigured) {
+		t.Errorf("NewHTTPClient(\"\", ...) error = %v, want ErrNoServerConfigured", err)
 	}
 }
 

--- a/internal/cmd/offline_commands_client_test.go
+++ b/internal/cmd/offline_commands_client_test.go
@@ -1,0 +1,56 @@
+//go:build containarium_client
+
+package cmd
+
+import "testing"
+
+// TestOfflineCommands_SucceedWithNoServerConfigured is #1776's Done-when:
+// cert generate, token inspect, token generate, and version must all
+// succeed under containarium_client with no --server, no
+// CONTAINARIUM_SERVER, and no credentials.json anywhere — because none of
+// them ever constructs a client. This is what "the server requirement
+// lives at the dial seam, not in pre-run" means in practice: adding
+// resolveServerAddr to PersistentPreRunE (server_resolve_client.go) must
+// not turn into an accidental pre-run gate on these.
+func TestOfflineCommands_SucceedWithNoServerConfigured(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // no credentials.json anywhere
+	serverAddr, httpMode, authToken = "", false, ""
+
+	t.Run("cert generate", func(t *testing.T) {
+		certOutputDir = t.TempDir()
+		certOrganization = "test-org"
+		certDNSNames = nil
+		certIPAddresses = nil
+		if err := runCertGenerate(testCmd(), nil); err != nil {
+			t.Errorf("runCertGenerate: %v", err)
+		}
+	})
+
+	t.Run("token generate", func(t *testing.T) {
+		tokenSecretFlag = "test-secret-at-least-32-bytes-long-for-hmac"
+		tokenSecretFile = ""
+		tokenUsername = "test-user"
+		tokenRoles = nil
+		tokenScopes = nil
+		tokenType = ""
+		tokenExpiry = "1h"
+		if err := runTokenGenerate(testCmd(), nil); err != nil {
+			t.Errorf("runTokenGenerate: %v", err)
+		}
+	})
+
+	t.Run("token inspect", func(t *testing.T) {
+		tok := makeJWT(t, map[string]any{"username": "test-user"})
+		inspectTokenSecretFlag = ""
+		inspectTokenSecretFile = ""
+		if err := runTokenInspect(testCmd(), []string{tok}); err != nil {
+			t.Errorf("runTokenInspect: %v", err)
+		}
+	})
+
+	t.Run("version", func(t *testing.T) {
+		versionCheck = false
+		// version's Run doesn't return an error; success is "doesn't panic".
+		versionCmd.Run(testCmd(), nil)
+	})
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -49,9 +49,20 @@ Examples:
 
   # Show system information
   containarium info`,
-	// PersistentPreRunE fills in the auth token from the
-	// credentials file when neither --token nor
-	// CONTAINARIUM_TOKEN are set. Precedence:
+	// PersistentPreRunE resolves the effective server address and fills in
+	// the auth token from the credentials file when neither --token nor
+	// CONTAINARIUM_TOKEN are set.
+	//
+	// Server precedence (see resolveServerAddr):
+	//   1. --server flag (explicit)
+	//   2. CONTAINARIUM_SERVER env var (becomes the flag default in init()
+	//      below — so by the time this runs, both collapse into serverAddr)
+	//   3. ~/.containarium/credentials.json default_server — client build
+	//      only (#1776); containariumd never picks this up, so an
+	//      operator's host can't be silently repointed from local Incus to
+	//      a stale remote fleet.
+	//
+	// Token precedence:
 	//   1. --token flag (explicit)
 	//   2. CONTAINARIUM_TOKEN env var (becomes the flag default
 	//      in init() below — so by the time this runs, both
@@ -64,11 +75,12 @@ Examples:
 		// commands that produce/consume the credentials file
 		// directly. Skip the auto-fill for them — login is
 		// unauthenticated by definition, and we don't want a
-		// stale token to leak into a logout call.
+		// stale token (or server) to leak into a logout call.
 		switch cmd {
 		case loginCmd, logoutCmd, whoamiCmd, configGetTokenCmd:
 			return nil
 		}
+		serverAddr = resolveServerAddr(serverAddr)
 		if authToken == "" {
 			authToken = resolveAuthToken(serverAddr)
 		}

--- a/internal/cmd/server_resolve_client.go
+++ b/internal/cmd/server_resolve_client.go
@@ -1,0 +1,30 @@
+//go:build containarium_client
+
+package cmd
+
+import "github.com/footprintai/containarium/internal/credentials"
+
+// resolveServerAddr adds the client-only third link in the server
+// resolution chain: --server flag > CONTAINARIUM_SERVER env (both already
+// collapsed into flagOrEnv by the time this runs, since the flag's default
+// is the env var) > credentials.json's default_server.
+//
+// Client-only: containariumd must NOT pick up a stale default_server on an
+// operator's host and silently repoint local-mode commands at a remote
+// fleet — see server_resolve_default.go and
+// docs/architecture/cli-client-server-split.md ("Server resolution in the
+// client").
+func resolveServerAddr(flagOrEnv string) string {
+	if flagOrEnv != "" {
+		return flagOrEnv
+	}
+	path, err := credentials.DefaultPath()
+	if err != nil {
+		return flagOrEnv
+	}
+	cf, err := credentials.Load(path)
+	if err != nil {
+		return flagOrEnv
+	}
+	return cf.DefaultServer
+}

--- a/internal/cmd/server_resolve_client_test.go
+++ b/internal/cmd/server_resolve_client_test.go
@@ -1,0 +1,52 @@
+//go:build containarium_client
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/footprintai/containarium/internal/credentials"
+)
+
+// writeDefaultServer writes a minimal credentials.json under a temp HOME
+// (set via t.Setenv, so it's undone automatically) with the given
+// default_server, so resolveServerAddr's fallback has something to read.
+func writeDefaultServer(t *testing.T, defaultServer string) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	path, err := credentials.DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath: %v", err)
+	}
+	cf := credentials.NewCredentialsFile()
+	// Set (not a bare DefaultServer assignment) is required: Save
+	// auto-repairs an unset-in-Servers DefaultServer back to empty, so the
+	// server needs a real (if minimal) entry to survive the write.
+	cf.Set(defaultServer, credentials.ServerCreds{Token: "test-token"})
+	if err := credentials.Save(path, cf); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+}
+
+func TestResolveServerAddr_Client(t *testing.T) {
+	t.Run("non-empty flag/env wins over credentials file", func(t *testing.T) {
+		writeDefaultServer(t, "https://from-file.example.com")
+		if got := resolveServerAddr("https://from-flag.example.com"); got != "https://from-flag.example.com" {
+			t.Errorf("resolveServerAddr = %q, want the flag/env value unchanged", got)
+		}
+	})
+
+	t.Run("empty falls back to credentials file default_server", func(t *testing.T) {
+		writeDefaultServer(t, "https://from-file.example.com")
+		if got := resolveServerAddr(""); got != "https://from-file.example.com" {
+			t.Errorf("resolveServerAddr = %q, want default_server from the credentials file", got)
+		}
+	})
+
+	t.Run("empty stays empty with no credentials file", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir()) // no credentials.json written here
+		if got := resolveServerAddr(""); got != "" {
+			t.Errorf("resolveServerAddr = %q, want empty (no file, no fallback)", got)
+		}
+	})
+}

--- a/internal/cmd/server_resolve_default.go
+++ b/internal/cmd/server_resolve_default.go
@@ -1,0 +1,12 @@
+//go:build !containarium_client
+
+package cmd
+
+// resolveServerAddr is the identity function under containariumd: the
+// credentials-file default_server fallback is client-only (see
+// server_resolve_client.go) so an operator's host never gets silently
+// repointed from local Incus to a stale remote fleet by a leftover
+// credentials file.
+func resolveServerAddr(flagOrEnv string) string {
+	return flagOrEnv
+}

--- a/internal/cmd/server_resolve_default_test.go
+++ b/internal/cmd/server_resolve_default_test.go
@@ -1,0 +1,17 @@
+//go:build !containarium_client
+
+package cmd
+
+import "testing"
+
+// TestResolveServerAddr_Default pins that containariumd's resolveServerAddr
+// is the identity function: no credentials-file fallback, even with an
+// empty input. An operator's host must never get silently repointed from
+// local Incus to a stale remote fleet by a leftover default_server (#1776).
+func TestResolveServerAddr_Default(t *testing.T) {
+	for _, in := range []string{"", "35.229.246.67:50051", "https://cloud.example.com"} {
+		if got := resolveServerAddr(in); got != in {
+			t.Errorf("resolveServerAddr(%q) = %q, want unchanged under containariumd", in, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- `server_resolve_client.go` (`containarium_client`): `resolveServerAddr` falls back to `credentials.json`'s `default_server` when the flag/env value is empty. `server_resolve_default.go` (`!containarium_client`): the identity function, so `containariumd` is never silently repointed from local Incus to a stale remote fleet by a leftover credentials file. `rootCmd.PersistentPreRunE` now calls `resolveServerAddr` unconditionally, honouring the existing `login`/`logout`/`whoami`/`config get-token` exemption (same `switch` the token auto-fill already sits in).
- `client.NewGRPCClient("", ...)` and `client.NewHTTPClient("", ...)` now return `client.ErrNoServerConfigured` (`"no server configured — run `containarium login` or pass --server"`) instead of dialing. Single seam, no pre-run failure, no exemption list. `NewHTTPClient` in particular used to silently turn `""` into `"http://"` via its own prefix-normalization and attempt to dial that — the new check runs before it.

Design: `docs/architecture/cli-client-server-split.md` (#1769). Builds on #1773, #1774, #1775 (targets `feat/1775-split-hybrid-commands`, none of the three is merged yet — retarget to `main` once they land). With this PR, the design's core "structurally cannot fall into local mode" guarantee for the client build is fully in place: every one of the twelve hybrids now fails at either this dial seam or its own `*Local` stub (#1775) before it can touch Incus.

## Test evidence
- Under `containarium_client`: `resolveServerAddr("x") == "x"` regardless of the credentials file; `resolveServerAddr("")` falls back to `default_server`, or stays `""` with no credentials file (`server_resolve_client_test.go`)
- Under the default build: `resolveServerAddr` is the identity function for every input including `""` (`server_resolve_default_test.go`)
- `cert generate --output <tmp>`, `token inspect <jwt>`, `token generate --secret <32+ bytes>`, and `version` all succeed under `containarium_client` with `$HOME` pointed at an empty temp dir (no server, no credentials.json anywhere) — proves the new `PersistentPreRunE` call isn't an accidental pre-run gate on offline commands (`offline_commands_client_test.go`)
- `NewGRPCClient("", ...)` and `NewHTTPClient("", ...)` both return `ErrNoServerConfigured` in **both** builds (`internal/client` isn't tag-gated) — new `grpc_test.go` / `http_test.go` cases
- Full repo `go build ./...` and `go test -race -timeout 8m $(go list ./... | grep -v /test/integration)` (CI's exact command) green under the default tag set
- `golangci-lint run` → `0 issues`; `gofmt -l` → clean
- `go build -tags containarium_client ./cmd/containarium` compiles

## Notes for reviewers
- No behavior change under the default (daemon) tag set — `resolveServerAddr` is a pure identity function there, and the two constructors' new empty-check only rejects an address that would otherwise fail moments later anyway (a dial to `""`/`"http://"`), just with a clearer message and before any cert-path work.

Closes #1776

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling when no server is configured, providing a clear error instead of attempting an invalid connection.
  - Server settings now follow the expected precedence: explicit configuration, environment settings, then saved client defaults.
  - Authentication-related commands no longer use stale server settings when they should operate independently.

- **New Features**
  - Certificate, token, and version commands can now run offline without server configuration or credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->