### PR TITLE
feat(cli-split): moved-command stubs in the client

### DIFF
--- a/internal/cmd/moved_stubs_client.go
+++ b/internal/cmd/moved_stubs_client.go
@@ -1,0 +1,63 @@
+//go:build containarium_client
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// osExit is os.Exit, indirected so tests can observe the exit code instead
+// of killing the test binary.
+var osExit = os.Exit
+
+// movedServerCommands are every top-level server/operator command name that
+// exists in containariumd but is tagged !containarium_client (#1774) out of
+// the client build. Registering a stub for each — rather than leaving
+// cobra's default "unknown command" — exists for exactly one failure mode
+// (design doc, Rollout Phase 2): a host whose systemd unit or startup
+// script still runs e.g. `containarium daemon` after the client build has
+// taken over the `containarium` name. The stub's message names the fix.
+var movedServerCommands = []string{
+	"daemon",
+	"sentinel",
+	"service",
+	"tunnel",
+	"node",
+	"hypervisor-agent",
+	"egress-relay",
+	"upgrade-watchdog",
+	"sync-accounts",
+	"recover",
+	"image-bake",
+	"doctor",
+	"hosting",
+	"portforward",
+	"passthrough",
+	"collaborator",
+	"audit",
+	"export",
+	"cloud",
+}
+
+// movedCommandMessage is the stub's stderr line — factored out so the exact
+// wording is covered by a plain unit test without going through cobra/exit.
+func movedCommandMessage(name string) string {
+	return fmt.Sprintf("%s lives in containariumd on the host; this is the client binary", name)
+}
+
+func init() {
+	for _, name := range movedServerCommands {
+		rootCmd.AddCommand(&cobra.Command{
+			Use:                name,
+			Short:              name + " (moved to containariumd)",
+			DisableFlagParsing: true, // accept any flags/subcommand args without cobra erroring first
+			Run: func(cmd *cobra.Command, args []string) {
+				fmt.Fprintln(os.Stderr, movedCommandMessage(name))
+				osExit(2)
+			},
+		})
+	}
+}

--- a/internal/cmd/moved_stubs_client_test.go
+++ b/internal/cmd/moved_stubs_client_test.go
@@ -1,0 +1,56 @@
+//go:build containarium_client
+
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestMovedServerCommands_ExitTwoNamingContainariumd is #1777's Done-when:
+// each moved-command name is registered in the client build as a leaf stub
+// (not the real command — those are tagged !containarium_client and don't
+// exist in this build at all) that exits 2.
+func TestMovedServerCommands_ExitTwoNamingContainariumd(t *testing.T) {
+	for _, name := range movedServerCommands {
+		t.Run(name, func(t *testing.T) {
+			cmd, _, err := rootCmd.Find([]string{name})
+			if err != nil {
+				t.Fatalf("command %q not registered: %v", name, err)
+			}
+			if cmd.Name() != name || cmd.Run == nil {
+				t.Fatalf("Find(%q) resolved to %q, not the registered stub", name, cmd.Name())
+			}
+
+			orig := osExit
+			var gotCode int
+			exited := false
+			osExit = func(code int) { gotCode = code; exited = true }
+			t.Cleanup(func() { osExit = orig })
+
+			cmd.Run(cmd, nil)
+
+			if !exited {
+				t.Fatal("expected the stub to call osExit")
+			}
+			if gotCode != 2 {
+				t.Errorf("exit code = %d, want 2", gotCode)
+			}
+		})
+	}
+}
+
+// TestMovedCommandMessage_NamesContainariumd pins the exact stub message
+// shape: it must name the moved command and containariumd, so an
+// operator's journal shows the fix instead of a bare "unknown command".
+func TestMovedCommandMessage_NamesContainariumd(t *testing.T) {
+	for _, name := range movedServerCommands {
+		msg := movedCommandMessage(name)
+		if !strings.Contains(msg, name) {
+			t.Errorf("message for %q = %q, want it to name the moved command", name, msg)
+		}
+		if !strings.Contains(msg, "containariumd") {
+			t.Errorf("message for %q = %q, want it to name containariumd", name, msg)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- `moved_stubs_client.go` (`containarium_client`) registers the 19 top-level server/operator command names #1774 tagged out of the client build — `daemon`, `sentinel`, `service`, `tunnel`, `node`, `hypervisor-agent`, `egress-relay`, `upgrade-watchdog`, `sync-accounts`, `recover`, `image-bake`, `doctor`, `hosting`, `portforward`, `passthrough`, `collaborator`, `audit`, `export`, `cloud` — as leaf stubs that print `"<name> lives in containariumd on the host; this is the client binary"` to stderr and exit 2.
- Exists for exactly one failure mode (design doc, Rollout Phase 2): a host whose systemd unit or startup script still runs e.g. `containarium daemon` after the client build takes over the `containarium` name — the stub names the fix instead of cobra's bare "unknown command". `DisableFlagParsing` on each stub means a subcommand invocation (`sentinel install --foo`) hits the same stub rather than erroring on an unrecognized flag first.
- `osExit` (`os.Exit` indirected through a package var) lets the exit-2 path be asserted directly in a unit test without killing the test binary — same shape as the already-untested `os.Exit` calls in `connect.go`/`sandbox.go`, just made observable here since the design explicitly requires testing it.

Design: `docs/architecture/cli-client-server-split.md` (#1769). Builds on #1773-#1776 (targets `feat/1776-server-resolve-and-dial-error`, none merged yet — retarget to `main` once they land). Last piece before #1778's CI gates.

## Test evidence
- All 19 names resolve via `rootCmd.Find` to the registered stub under `containarium_client` (not cobra's "unknown command") — `moved_stubs_client_test.go`
- Table-driven test: every stub calls `osExit(2)`; message contains both the command name and `containariumd`
- **Real end-to-end check** (built both binaries): `containarium daemon` → prints the message, exit 2; `containarium sentinel install --foo` → same, proving the subcommand case works too; `containariumd daemon --help` → shows the real command, unaffected
- Stubs are structurally absent from `containariumd`: the whole file is tagged `containarium_client`, so none of it compiles into the default build — the real, untouched commands from #1774 are what's registered there (no runtime check needed; the tag makes the two sets mutually exclusive at compile time, same reasoning as #1774's disjoint-symbol-set proof)
- `go build`/`go vet`/`go test -race` clean under both tag sets
- Full repo `go build ./...` and `go test -race -timeout 8m $(go list ./... | grep -v /test/integration)` green under the default tag set
- `golangci-lint run` → `0 issues`; `gofmt -l` → clean

## Notes for reviewers
- No behavior change under the default (daemon) tag set.

Closes #1777

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Server and operator commands that have moved to `containariumd` now clearly direct users to the new command location.
  - Running these commands from the client exits with status 2 after displaying a relocation message.
  - The commands continue to accept provided flags and arguments while reporting that they are no longer handled locally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->