### PR TITLE
feat(cli-split): flip binary-name constants to containariumd

### DIFF
--- a/internal/cmd/upgrade_watchdog.go
+++ b/internal/cmd/upgrade_watchdog.go
@@ -37,8 +37,10 @@ Not meant to be called directly by operators.`,
 
 func init() {
 	rootCmd.AddCommand(upgradeWatchdogCmd)
+	// #1779: matches autoupdate.go's caller in dual_server.go — the watchdog
+	// restores .old at the same path the daemon just swapped.
 	upgradeWatchdogCmd.Flags().StringVar(&watchdogBinaryPath, "binary-path",
-		"/usr/local/bin/containarium", "Path to the binary being watched")
+		"/usr/local/bin/containariumd", "Path to the binary being watched")
 	upgradeWatchdogCmd.Flags().StringVar(&watchdogHealthURL, "health-url",
 		"http://localhost:8080/health", "URL to poll for daemon health")
 }

--- a/internal/cmd/upgrade_watchdog_test.go
+++ b/internal/cmd/upgrade_watchdog_test.go
@@ -1,0 +1,19 @@
+//go:build !windows && !containarium_client
+
+package cmd
+
+import "testing"
+
+// TestUpgradeWatchdogDefaultBinaryPath is part of #1779's artifact-name
+// gate: the watchdog restores .old at the same path the daemon just
+// swapped (dual_server.go's NewAutoUpdater call, sentinel/binaryserver.go's
+// defaultBinaryPath) — all three must agree on containariumd.
+func TestUpgradeWatchdogDefaultBinaryPath(t *testing.T) {
+	f := upgradeWatchdogCmd.Flags().Lookup("binary-path")
+	if f == nil {
+		t.Fatal("--binary-path flag not registered")
+	}
+	if f.DefValue != "/usr/local/bin/containariumd" {
+		t.Errorf("--binary-path default = %q, want %q", f.DefValue, "/usr/local/bin/containariumd")
+	}
+}

--- a/internal/sentinel/artifact_name_test.go
+++ b/internal/sentinel/artifact_name_test.go
@@ -1,0 +1,19 @@
+package sentinel
+
+import "testing"
+
+// TestArtifactNameGate pins #1779 / the design doc's "Artifact-name gate
+// (Phase 1)": the fleet's self-update chain must ask for and serve the
+// containariumd artifact from release N on. A regression here silently
+// re-widens the client/server split hole the whole design exists to close
+// (the sentinel would serve, and backends would install, a binary that no
+// longer has the daemon in it once containarium-* switches to the client
+// build in Phase 2).
+func TestArtifactNameGate(t *testing.T) {
+	if releaseBinaryName != "containariumd-linux-amd64" {
+		t.Errorf("releaseBinaryName = %q, want %q", releaseBinaryName, "containariumd-linux-amd64")
+	}
+	if defaultBinaryPath != "/usr/local/bin/containariumd" {
+		t.Errorf("defaultBinaryPath = %q, want %q", defaultBinaryPath, "/usr/local/bin/containariumd")
+	}
+}

--- a/internal/sentinel/binaryserver.go
+++ b/internal/sentinel/binaryserver.go
@@ -18,7 +18,10 @@ import (
 	"github.com/footprintai/containarium/pkg/version"
 )
 
-const defaultBinaryPath = "/usr/local/bin/containarium"
+// defaultBinaryPath is what this sentinel serves to backends over
+// /sentinel/fetch-release. #1779: flipped to containariumd for release N —
+// see selfupdate.go's releaseBinaryName for the matching fetch-side rename.
+const defaultBinaryPath = "/usr/local/bin/containariumd"
 
 // StatusJSON is the JSON response for the /status endpoint.
 type StatusJSON struct {

--- a/internal/sentinel/selfupdate.go
+++ b/internal/sentinel/selfupdate.go
@@ -18,7 +18,14 @@ import (
 
 const (
 	githubReleaseBaseURL = "https://github.com/FootprintAI/Containarium/releases/download"
-	releaseBinaryName    = "containarium-linux-amd64"
+	// releaseBinaryName names the daemon artifact fetched from a GitHub
+	// release. #1779 (design doc, Rollout Phase 1): containarium-* becomes
+	// the client build in Phase 2, so from release N on, the self-update
+	// chain must ask for containariumd-* instead. containarium-* keeps
+	// shipping the same server build in parallel (#1782) so a host still
+	// asking for the old name during the rollout window gets a working
+	// daemon too — but the sentinel's own fetch always asks for the new one.
+	releaseBinaryName = "containariumd-linux-amd64"
 )
 
 type fetchReleaseRequest struct {

--- a/internal/server/autoupdate.go
+++ b/internal/server/autoupdate.go
@@ -19,7 +19,7 @@ import (
 // self-updates if a new version is available.
 type AutoUpdater struct {
 	sentinelURL       string // e.g. "http://10.130.0.13:8888"
-	binaryPath        string // e.g. "/usr/local/bin/containarium"
+	binaryPath        string // e.g. "/usr/local/bin/containariumd" (#1779)
 	interval          time.Duration
 	watchdogHealthURL string // polled by upgrade-watchdog to confirm liveness (#507); defaults to http://localhost:8080/health
 }

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -2958,7 +2958,9 @@ func (ds *DualServer) Start(ctx context.Context) error {
 
 	// Start auto-updater if sentinel URL is configured
 	if ds.config.SentinelURL != "" {
-		updater := NewAutoUpdater(ds.config.SentinelURL, "/usr/local/bin/containarium", 5*time.Minute)
+		// #1779: matches sentinel/binaryserver.go's defaultBinaryPath — the
+		// backend swaps its own binary at the same path the sentinel serves.
+		updater := NewAutoUpdater(ds.config.SentinelURL, "/usr/local/bin/containariumd", 5*time.Minute)
 		if ds.containerServer != nil {
 			ds.containerServer.SetAutoUpdater(updater) // enables on-demand TriggerUpgrade (#354)
 		}


### PR DESCRIPTION
## Summary
Flip the four spots the design doc names in the fleet's self-update chain, so a host on release N is self-consistent:

- `internal/sentinel/selfupdate.go`: `releaseBinaryName` → `"containariumd-linux-amd64"` (what the sentinel fetches from a GitHub release)
- `internal/sentinel/binaryserver.go`: `defaultBinaryPath` → `"/usr/local/bin/containariumd"` (what the sentinel serves to backends over `/sentinel/fetch-release`)
- `internal/server/dual_server.go`: the `NewAutoUpdater` call site's literal binary path → `"/usr/local/bin/containariumd"` (what a backend swaps its own binary at)
- `internal/cmd/upgrade_watchdog.go`: `--binary-path` default → `"/usr/local/bin/containariumd"` (what the watchdog restores `.old` at on a failed upgrade)

All four now agree with each other and with `sentinel_unit.go`/`service.go`/`pool_join.go`'s *future* `ExecStart` path (#1780, ships in the same release).

Design: `docs/architecture/cli-client-server-split.md` (#1769), Rollout Phase 1. Part of #1787 Phase 2. Builds on the merged Phase 1 stack (#1773–#1778).

## Test evidence
- New `artifact_name_test.go` asserts `releaseBinaryName == "containariumd-linux-amd64"` and `defaultBinaryPath == "/usr/local/bin/containariumd"` — the design's own "Artifact-name gate"
- New `upgrade_watchdog_test.go` asserts the `--binary-path` flag's default matches
- `grep -rn '/usr/local/bin/containarium\b' internal/ pkg/ --include=*.go`, minus this PR's four spots, only hits #1780's unit-writer files (`sentinel_unit.go`, `service.go`, `pool_join.go`) and #1781's deploy-script scope (`pkg/core/nodevm`) — both explicitly out of scope here
- `go build`/`go vet`/`go test -race` clean under both tag sets
- Full repo `go build ./...` and `go test -race -timeout 8m $(go list ./... | grep -v /test/integration)` green
- `golangci-lint run` → `0 issues`; `gofmt -l` → clean

## Needs verification (flagged on the issue)
> Sentinel self-update on a lab host fetches `containariumd-linux-amd64` and serves `/usr/local/bin/containariumd` to a backend.

Can't do this from a sandbox with no deployed lab host. The code path itself is unchanged except for the two renamed constants it already reads — low risk, but real; needs a batched verification pass once this deploys alongside #1780/#1781/#1782 in release N.

Closes #1779

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved daemon self-updates by consistently using the `containariumd` binary name and installation path.
  - Ensured the watchdog, update service, and binary delivery process target the same daemon artifact, reducing the risk of failed or incomplete upgrades.

- **Tests**
  - Added coverage to verify the daemon artifact name and default installation path remain consistent across update components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->