### PR TITLE
feat(cli-split): unit writers install containariumd + compat symlink

### DIFF
--- a/internal/cmd/compat_symlink_test.go
+++ b/internal/cmd/compat_symlink_test.go
@@ -1,0 +1,131 @@
+//go:build !windows && !containarium_client
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestEnsureCompatSymlink_NoOpWhenNewBinaryAbsent pins the safety property:
+// service install / pool join must not touch /usr/local/bin/containarium at
+// all until containariumd actually exists — replacing a still-in-use binary
+// with a symlink to nothing would brick the host instead of converging it.
+func TestEnsureCompatSymlink_NoOpWhenNewBinaryAbsent(t *testing.T) {
+	root := t.TempDir()
+	if err := ensureCompatSymlink(root); err != nil {
+		t.Fatalf("ensureCompatSymlink: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(root, compatSymlinkOldPath)); !os.IsNotExist(err) {
+		t.Errorf("expected no file at the old path, got err=%v", err)
+	}
+}
+
+// TestEnsureCompatSymlink_ReplacesOldRealBinary is the Phase 1 rollout case:
+// a host still has the real (pre-#1780) binary at the old path; once
+// containariumd is deployed there, the old path must become a symlink to it.
+func TestEnsureCompatSymlink_ReplacesOldRealBinary(t *testing.T) {
+	root := t.TempDir()
+	newPath := filepath.Join(root, compatSymlinkNewPath)
+	oldPath := filepath.Join(root, compatSymlinkOldPath)
+	if err := os.MkdirAll(filepath.Dir(newPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(newPath, []byte("fake binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(oldPath, []byte("old real binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ensureCompatSymlink(root); err != nil {
+		t.Fatalf("ensureCompatSymlink: %v", err)
+	}
+
+	fi, err := os.Lstat(oldPath)
+	if err != nil {
+		t.Fatalf("Lstat old path: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("old path is not a symlink: mode=%v", fi.Mode())
+	}
+	target, err := os.Readlink(oldPath)
+	if err != nil || target != newPath {
+		t.Errorf("symlink target = %q, err=%v, want %q", target, err, newPath)
+	}
+}
+
+// TestEnsureCompatSymlink_Idempotent mirrors pool join's documented
+// idempotency: re-running must not error, and must leave the symlink intact.
+func TestEnsureCompatSymlink_Idempotent(t *testing.T) {
+	root := t.TempDir()
+	newPath := filepath.Join(root, compatSymlinkNewPath)
+	if err := os.MkdirAll(filepath.Dir(newPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(newPath, []byte("fake binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ensureCompatSymlink(root); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if err := ensureCompatSymlink(root); err != nil {
+		t.Fatalf("second call should be idempotent, got: %v", err)
+	}
+
+	target, err := os.Readlink(filepath.Join(root, compatSymlinkOldPath))
+	if err != nil || target != newPath {
+		t.Errorf("symlink target = %q, err=%v, want %q", target, err, newPath)
+	}
+}
+
+// TestRemoveCompatSymlink_OnlyRemovesOurSymlink pins the uninstall-safety
+// property: a real file at the old path (some other mechanism's binary, or a
+// host that never converged) must never be deleted by uninstall — only a
+// symlink this package itself created is fair game.
+func TestRemoveCompatSymlink_OnlyRemovesOurSymlink(t *testing.T) {
+	t.Run("real file is left alone", func(t *testing.T) {
+		root := t.TempDir()
+		oldPath := filepath.Join(root, compatSymlinkOldPath)
+		if err := os.MkdirAll(filepath.Dir(oldPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(oldPath, []byte("a real binary"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		removeCompatSymlink(root)
+
+		if _, err := os.Stat(oldPath); err != nil {
+			t.Errorf("real file was removed: %v", err)
+		}
+	})
+
+	t.Run("our symlink is removed", func(t *testing.T) {
+		root := t.TempDir()
+		newPath := filepath.Join(root, compatSymlinkNewPath)
+		oldPath := filepath.Join(root, compatSymlinkOldPath)
+		if err := os.MkdirAll(filepath.Dir(newPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(newPath, []byte("fake binary"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(newPath, oldPath); err != nil {
+			t.Fatal(err)
+		}
+
+		removeCompatSymlink(root)
+
+		if _, err := os.Lstat(oldPath); !os.IsNotExist(err) {
+			t.Errorf("expected the symlink to be removed, got err=%v", err)
+		}
+	})
+
+	t.Run("absent old path is a no-op", func(t *testing.T) {
+		root := t.TempDir()
+		removeCompatSymlink(root) // must not panic or error
+	})
+}

--- a/internal/cmd/pool_join.go
+++ b/internal/cmd/pool_join.go
@@ -21,8 +21,9 @@ import (
 // no hand-authored, capability-trap-prone unit), drops in the --pool config,
 // and writes + starts the tunnel unit that dials the sentinel.
 //
-// MVP scope: it assumes the binary is already at /usr/local/bin/containarium
-// and that the operator passes a join token. Deferred to follow-ups (per the
+// MVP scope: it assumes the binary is already at /usr/local/bin/containariumd
+// (#1780; ensureDaemonUnitAndSecret's compat symlink covers the old name) and
+// that the operator passes a join token. Deferred to follow-ups (per the
 // PRD): the `doctor` capability self-check, scoped short-lived token minting,
 // binary fetch/--binary-src, and a --role=tunnel-only variant.
 
@@ -30,7 +31,7 @@ const (
 	tunnelUnitPath  = "/etc/systemd/system/containarium-tunnel.service"
 	daemonDropInDir = "/etc/systemd/system/containarium.service.d"
 	daemonDropIn    = daemonDropInDir + "/pool.conf"
-	daemonBinPath   = "/usr/local/bin/containarium"
+	daemonBinPath   = "/usr/local/bin/containariumd"
 
 	// sentinelAuthSecretFile holds CONTAINARIUM_SENTINEL_AUTH_SECRET for the
 	// EnvironmentFile= directive in the pool drop-in (see renderPoolDropIn).
@@ -153,7 +154,7 @@ func renderTunnelUnit(p tunnelUnitParams) string {
 	b.WriteString("After=network-online.target\nWants=network-online.target\n\n")
 	b.WriteString("[Service]\nType=simple\n")
 	fmt.Fprintf(&b, "EnvironmentFile=%s\n", tunnelTokenSecretFile)
-	b.WriteString("ExecStart=/usr/local/bin/containarium tunnel \\\n")
+	b.WriteString("ExecStart=/usr/local/bin/containariumd tunnel \\\n")
 	fmt.Fprintf(&b, "  --sentinel-addr %s \\\n", p.SentinelAddr)
 	fmt.Fprintf(&b, "  --spot-id %s \\\n", p.SpotID)
 	fmt.Fprintf(&b, "  --ports %s", p.Ports)
@@ -197,12 +198,17 @@ func renderPoolDropIn(argv []string, authSecretFile string) string {
 // parseExecStartArgv extracts the daemon argv from `systemctl show -p ExecStart
 // --value containarium` output, whose value looks like:
 //
-//	{ path=/usr/local/bin/containarium ; argv[]=/usr/local/bin/containarium daemon --rest … ; ignore_errors=no ; … }
+//	{ path=/usr/local/bin/containariumd ; argv[]=/usr/local/bin/containariumd daemon --rest … ; ignore_errors=no ; … }
 //
 // Returns (argv, true) only when the value clearly is the containarium daemon
 // command; (nil, false) otherwise (no unit, empty, or unrecognized). Pure.
 // Note: values containing spaces aren't recovered (systemd doesn't re-quote
 // them here) — daemon flag values (CIDRs, file paths, domains) don't have spaces.
+//
+// Accepts either the pre-#1780 "containarium" path or the post-#1780
+// "containariumd" one: a host mid-rollout may still be running the unit
+// this replaced when pool join re-runs, and #702's flag-preservation must
+// keep working across that transition, not just after it.
 func parseExecStartArgv(showOutput string) ([]string, bool) {
 	i := strings.Index(showOutput, "argv[]=")
 	if i < 0 {
@@ -213,7 +219,11 @@ func parseExecStartArgv(showOutput string) ([]string, bool) {
 		rest = rest[:j]
 	}
 	fields := strings.Fields(rest)
-	if len(fields) < 2 || !strings.HasSuffix(fields[0], "containarium") || fields[1] != "daemon" {
+	if len(fields) < 2 || fields[1] != "daemon" {
+		return nil, false
+	}
+	isDaemonBinary := strings.HasSuffix(fields[0], "containarium") || strings.HasSuffix(fields[0], "containariumd")
+	if !isDaemonBinary {
 		return nil, false
 	}
 	return fields, true

--- a/internal/cmd/pool_join_test.go
+++ b/internal/cmd/pool_join_test.go
@@ -82,7 +82,7 @@ func TestRenderPoolDropIn(t *testing.T) {
 	// ExecStart must be cleared then re-set (systemd override semantics).
 	argv := resolvePoolDaemonArgv(nil, false, "prod", "", nil)
 	d := renderPoolDropIn(argv, "")
-	if !strings.Contains(d, "ExecStart=\nExecStart=/usr/local/bin/containarium daemon") {
+	if !strings.Contains(d, "ExecStart=\nExecStart=/usr/local/bin/containariumd daemon") {
 		t.Errorf("drop-in must clear+reset ExecStart:\n%s", d)
 	}
 	if !strings.Contains(d, "--pool prod") {
@@ -117,7 +117,7 @@ func TestRenderPoolDropIn_SentinelAuthSecret(t *testing.T) {
 func TestResolvePoolDaemonArgv_FreshHostUsesMinimal(t *testing.T) {
 	argv := resolvePoolDaemonArgv(nil, false, "prod", "", nil)
 	got := strings.Join(argv, " ")
-	want := "/usr/local/bin/containarium daemon --rest --jwt-secret-file /etc/containarium/jwt.secret --pool prod"
+	want := "/usr/local/bin/containariumd daemon --rest --jwt-secret-file /etc/containarium/jwt.secret --pool prod"
 	if got != want {
 		t.Errorf("fresh host argv = %q, want %q", got, want)
 	}
@@ -205,6 +205,24 @@ func TestParseExecStartArgv(t *testing.T) {
 		if _, ok := parseExecStartArgv(bad); ok {
 			t.Errorf("parseExecStartArgv(%q) should be false", bad)
 		}
+	}
+}
+
+// TestParseExecStartArgv_RecognizesContainariumd is #1780's fix: a host
+// mid-rollout may already be running the post-flip unit
+// (/usr/local/bin/containariumd) when `pool join` re-runs, and #702's
+// flag-preservation must still recognize it as the daemon command rather
+// than falling back to the minimal baseline and silently dropping flags.
+func TestParseExecStartArgv_RecognizesContainariumd(t *testing.T) {
+	out := "{ path=/usr/local/bin/containariumd ; argv[]=/usr/local/bin/containariumd daemon --rest --jwt-secret-file /etc/containarium/jwt.secret --app-hosting ; ignore_errors=no }"
+	argv, ok := parseExecStartArgv(out)
+	if !ok {
+		t.Fatalf("expected to parse argv from %q", out)
+	}
+	got := strings.Join(argv, " ")
+	want := "/usr/local/bin/containariumd daemon --rest --jwt-secret-file /etc/containarium/jwt.secret --app-hosting"
+	if got != want {
+		t.Errorf("parsed argv = %q, want %q", got, want)
 	}
 }
 

--- a/internal/cmd/sentinel_service.go
+++ b/internal/cmd/sentinel_service.go
@@ -129,6 +129,9 @@ func runSentinelServiceInstall(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to write service file: %w", err)
 	}
 	log.Printf("Service file written: %s", sentinelSystemdServicePath)
+	if err := ensureCompatSymlink("/"); err != nil {
+		return err
+	}
 
 	if err := exec.Command("systemctl", "daemon-reload").Run(); err != nil {
 		return fmt.Errorf("failed to reload systemd: %w", err)
@@ -166,6 +169,7 @@ func runSentinelServiceUninstall(cmd *cobra.Command, args []string) error {
 	if err := os.Remove(sentinelSystemdServicePath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to remove service file: %w", err)
 	}
+	removeCompatSymlink("/")
 
 	_ = exec.Command("systemctl", "daemon-reload").Run()
 

--- a/internal/cmd/sentinel_unit.go
+++ b/internal/cmd/sentinel_unit.go
@@ -242,7 +242,7 @@ StartLimitIntervalSec=0
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/containarium sentinel \
+ExecStart=/usr/local/bin/containariumd sentinel \
   --spot-vm %s \
   --zone %s \
   --project %s

--- a/internal/cmd/service.go
+++ b/internal/cmd/service.go
@@ -14,6 +14,59 @@ import (
 
 const systemdServicePath = "/etc/systemd/system/containarium.service"
 
+// compatSymlinkOldPath / compatSymlinkNewPath name the Phase 1 rollout
+// compat symlink (design doc, Rollout Phase 1, #1780): for the duration of
+// the containariumd rollout, /usr/local/bin/containarium keeps working as a
+// symlink to /usr/local/bin/containariumd, so any runbook, cron, or script
+// this inventory missed still works — and shows up in the audit log as the
+// old name rather than failing outright.
+const (
+	compatSymlinkOldPath = "/usr/local/bin/containarium"
+	compatSymlinkNewPath = "/usr/local/bin/containariumd"
+)
+
+// ensureCompatSymlink makes compatSymlinkOldPath a symlink to
+// compatSymlinkNewPath, idempotently. root is prepended to both paths so
+// tests can exercise this without touching the real filesystem; callers
+// pass "/".
+//
+// Deliberately a no-op when compatSymlinkNewPath doesn't exist yet:
+// `service install` / `pool join` can run before this host's normal deploy
+// path (terraform startup script reconcile, self-update) has actually
+// placed containariumd, and replacing a still-in-use containarium binary
+// with a symlink to nothing would brick the host instead of converging it.
+// Both callers are documented idempotent, so the next re-run picks up the
+// symlink once the binary exists.
+func ensureCompatSymlink(root string) error {
+	newPath := filepath.Join(root, compatSymlinkNewPath)
+	if _, err := os.Stat(newPath); err != nil {
+		return nil
+	}
+	oldPath := filepath.Join(root, compatSymlinkOldPath)
+	if target, err := os.Readlink(oldPath); err == nil && target == newPath {
+		return nil // already correct
+	}
+	if err := os.Remove(oldPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove %s before symlinking to %s: %w", oldPath, newPath, err)
+	}
+	if err := os.Symlink(newPath, oldPath); err != nil {
+		return fmt.Errorf("failed to symlink %s -> %s: %w", oldPath, newPath, err)
+	}
+	log.Printf("Compat symlink: %s -> %s", oldPath, newPath)
+	return nil
+}
+
+// removeCompatSymlink removes compatSymlinkOldPath only if it is currently
+// our symlink to compatSymlinkNewPath — never a real file. Uninstall must
+// not delete a binary some other mechanism placed there.
+func removeCompatSymlink(root string) {
+	oldPath := filepath.Join(root, compatSymlinkOldPath)
+	newPath := filepath.Join(root, compatSymlinkNewPath)
+	if target, err := os.Readlink(oldPath); err == nil && target == newPath {
+		_ = os.Remove(oldPath)
+	}
+}
+
 // systemdServiceTemplate is the canonical systemd service file.
 // The daemon self-bootstraps from PostgreSQL so only --rest and --jwt-secret-file are needed.
 const systemdServiceTemplate = `[Unit]
@@ -31,7 +84,7 @@ StartLimitIntervalSec=0
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/containarium daemon \
+ExecStart=/usr/local/bin/containariumd daemon \
   --rest \
   --jwt-secret-file /etc/containarium/jwt.secret
 Restart=on-failure
@@ -236,6 +289,9 @@ func ensureDaemonUnitAndSecret() error {
 		return fmt.Errorf("failed to write service file: %w", err)
 	}
 	log.Printf("Service file written: %s", systemdServicePath)
+	if err := ensureCompatSymlink("/"); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -250,6 +306,7 @@ func runServiceUninstall(cmd *cobra.Command, args []string) error {
 	if err := os.Remove(systemdServicePath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to remove service file: %w", err)
 	}
+	removeCompatSymlink("/")
 
 	_ = exec.Command("systemctl", "daemon-reload").Run()
 


### PR DESCRIPTION
## Summary
Flip the ExecStart binary path in all three unit writers to `containariumd`, and make `service install` / `pool join` / `sentinel service install` converge `/usr/local/bin/containarium` to a symlink pointing at it, for the duration of the Phase 1 rollout:

- `service.go`: daemon unit's `ExecStart` → `containariumd`. New `ensureCompatSymlink(root)`/`removeCompatSymlink(root)`, called from `ensureDaemonUnitAndSecret` (shared by `service install` and `pool join`) and from `service uninstall`.
- `sentinel_unit.go`: `buildSentinelUnit`'s `ExecStart` → `containariumd`.
- `sentinel_service.go`: `sentinel service install` calls `ensureCompatSymlink` after writing its unit; `sentinel service uninstall` calls `removeCompatSymlink`.
- `pool_join.go`: `daemonBinPath` → `containariumd`; the tunnel unit's `ExecStart` → `containariumd`.

`ensureCompatSymlink` is a deliberate no-op until `containariumd` actually exists at the target path: `service install`/`pool join` can run before this host's normal deploy path (terraform startup reconcile, self-update — #1779/#1781/#1782) has placed the new binary, and replacing a still-in-use `containarium` binary with a symlink to nothing would brick the host instead of converging it. Both callers are already documented idempotent, so the next re-run picks up the symlink once the binary exists. `removeCompatSymlink` only ever removes a symlink this package itself created (verified via `os.Readlink`) — never a real file, so uninstall can't delete a binary some other mechanism placed there.

Design: `docs/architecture/cli-client-server-split.md` (#1769), Rollout Phase 1. Builds on #1779 (targets its branch; retarget once the stack merges).

## Real bug caught, flagged for review
`pool_join.go`'s `parseExecStartArgv` recognized an existing daemon ExecStart line by `strings.HasSuffix(fields[0], "containarium")` — which `"containariumd"` does **not** satisfy (it's a different suffix, not a superset — `"containariumd"` ends in `d`, not `m`). Left as-is, this would have silently broken #702's flag-preservation the first time `pool join` re-ran against a host already converged to `containariumd`: `current` would read `(nil, false)`, and the daemon's real flags (`--app-hosting`, `--network-subnet`, etc.) would silently reset to the minimal baseline instead of being preserved. Fixed to accept either suffix, with a regression test. Caught by reading the function against the rename, not by any test failing — worth a second pair of eyes given the consequence of missing it.

## Test evidence
- New `compat_symlink_test.go`: no-op when `containariumd` absent; replaces a real old binary once `containariumd` exists; idempotent re-run; uninstall never removes a real file (only our own symlink) — all via a root-parameterized helper so no test touches the real filesystem
- New `TestParseExecStartArgv_RecognizesContainariumd` pins the fix above; the existing test (old `containarium` path) is left unchanged, proving backward compatibility across the rollout window
- Existing tests whose fixtures hardcoded the old fresh-host baseline (`TestRenderPoolDropIn`, `TestResolvePoolDaemonArgv_FreshHostUsesMinimal`) updated to the new path; tests simulating an **existing** host's current ExecStart (`...PreservesExistingFlags`, `...ReRunDoesNotDuplicateManagedFlags`) deliberately left on the old path — they test flag-preservation generically, and a host mid-rollout is exactly the case being covered
- `go build`/`go vet`/`go test -race` clean under both tag sets
- Full repo `go build ./...` and `go test -race -timeout 8m $(go list ./... | grep -v /test/integration)` green
- `golangci-lint run` → `0 issues`; `gofmt -l` → clean

## Needs verification (flagged on the issue)
> Fresh `service install` on a lab host produces a unit running `containariumd daemon` and the symlink; upgrading an existing host rewrites the unit and restarts cleanly; `service uninstall` removes both.

Can't do this from a sandbox with no deployed lab host. The symlink helpers are unit-tested against a fake root; the actual `systemctl` reload/enable/start sequence is unchanged from before this PR.

Closes #1780

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - The daemon now runs as `containariumd`.
  - Existing service configurations continue to work during the transition, including preserved startup flags.
  - Service installation and generated systemd units now use the updated daemon name.
  - A compatibility link is created automatically when the updated binary is available and removed during uninstallation.
  - Compatibility handling is safe to repeat and preserves unrelated files at the previous executable path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->