### PR TITLE
feat(cli-split): release workflow publishes containariumd-* and mirrors under containarium-*

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -327,6 +327,9 @@ jobs:
             bin/containarium-darwin-amd64
             bin/containarium-darwin-arm64
             bin/containarium-windows-amd64.exe
+            bin/containariumd-linux-amd64
+            bin/containariumd-darwin-amd64
+            bin/containariumd-darwin-arm64
             bin/mcp-server-linux-amd64
             bin/mcp-server-darwin-amd64
             bin/mcp-server-darwin-arm64

--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,15 @@ build-all: proto web-ui swagger-ui ## Build for all platforms (includes Swagger 
 	# subcommands are //go:build !windows, so this binary exposes only the
 	# remote-client commands (create/list/ssh/…). The daemon stays linux/mac.
 	@GOOS=windows GOARCH=amd64 go build $(GO_TAGS) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-windows-amd64.exe cmd/containariumd/main.go
+	# #1782 (design doc, Rollout Phase 1): mirror the server build under
+	# containariumd-* too. The fleet's self-update chain now fetches
+	# containariumd-* by name (#1779's releaseBinaryName); containarium-*
+	# stays published alongside it so a host still fetching the old name
+	# keeps working. Byte-identical copies, not a second compile — no
+	# windows mirror, the daemon never ships there.
+	@cp $(BUILD_DIR)/$(BINARY_NAME)-linux-amd64  $(BUILD_DIR)/$(DAEMON_BINARY_NAME)-linux-amd64
+	@cp $(BUILD_DIR)/$(BINARY_NAME)-darwin-amd64 $(BUILD_DIR)/$(DAEMON_BINARY_NAME)-darwin-amd64
+	@cp $(BUILD_DIR)/$(BINARY_NAME)-darwin-arm64 $(BUILD_DIR)/$(DAEMON_BINARY_NAME)-darwin-arm64
 	@echo "==> Binaries built in $(BUILD_DIR)/"
 
 # NOTE: mcp-server is a pure-Go REST/gRPC client and is dropped into arbitrary
@@ -238,10 +247,11 @@ sidecar-build-otel: ## Build the otel-sidecar Docker image locally (tag = pkg/ve
 	@echo "==> Built. The compose snippet from \`containarium sidecar otel compose <user>\` references this tag."
 
 # build-release produces every release artifact for every supported
-# platform: containarium + mcp-server + agent-box, each for
-# linux/amd64, darwin/amd64, darwin/arm64. Used by the release.yml
-# workflow on v* tag pushes; safe to run locally to dry-run a release.
-build-release: build-all build-mcp-all build-agent-box-all ## Build all 10 release artifacts (CLI ×4 platforms incl. windows; mcp/agent-box ×3) + checksums
+# platform: containarium + containariumd (#1782 mirror) + mcp-server +
+# agent-box, each for linux/amd64, darwin/amd64, darwin/arm64. Used by
+# the release.yml workflow on v* tag pushes; safe to run locally to
+# dry-run a release.
+build-release: build-all build-mcp-all build-agent-box-all ## Build all 13 release artifacts (CLI ×4 platforms incl. windows, +3 containariumd mirrors; mcp/agent-box ×3) + checksums
 	@echo "==> Generating SHA256SUMS..."
 	@cd $(BUILD_DIR) && \
 	  shasum -a 256 \
@@ -249,6 +259,9 @@ build-release: build-all build-mcp-all build-agent-box-all ## Build all 10 relea
 	    $(BINARY_NAME)-darwin-amd64 \
 	    $(BINARY_NAME)-darwin-arm64 \
 	    $(BINARY_NAME)-windows-amd64.exe \
+	    $(DAEMON_BINARY_NAME)-linux-amd64 \
+	    $(DAEMON_BINARY_NAME)-darwin-amd64 \
+	    $(DAEMON_BINARY_NAME)-darwin-arm64 \
 	    $(MCP_BINARY_NAME)-linux-amd64 \
 	    $(MCP_BINARY_NAME)-darwin-amd64 \
 	    $(MCP_BINARY_NAME)-darwin-arm64 \
@@ -256,6 +269,16 @@ build-release: build-all build-mcp-all build-agent-box-all ## Build all 10 relea
 	    $(AGENTBOX_BINARY_NAME)-darwin-amd64 \
 	    $(AGENTBOX_BINARY_NAME)-darwin-arm64 \
 	    > SHA256SUMS.txt
+	@echo "==> Verifying containariumd-* mirrors containarium-* byte-for-byte (#1782)..."
+	@cd $(BUILD_DIR) && for plat in linux-amd64 darwin-amd64 darwin-arm64; do \
+	  a=$$(shasum -a 256 $(BINARY_NAME)-$$plat | awk '{print $$1}'); \
+	  b=$$(shasum -a 256 $(DAEMON_BINARY_NAME)-$$plat | awk '{print $$1}'); \
+	  if [ "$$a" != "$$b" ]; then \
+	    echo "FAIL  $(BINARY_NAME)-$$plat ($$a) != $(DAEMON_BINARY_NAME)-$$plat ($$b)"; \
+	    exit 1; \
+	  fi; \
+	  echo "PASS  $(BINARY_NAME)-$$plat == $(DAEMON_BINARY_NAME)-$$plat ($$a)"; \
+	done
 	@echo "==> Release artifacts ready in $(BUILD_DIR)/:"
 	@ls -1 $(BUILD_DIR)/
 


### PR DESCRIPTION
Closes #1782

Stacked on #1797 (feat/1781-flip-scripts-containariumd — merge that first).

## Summary

`make build-all` now produces byte-identical `containariumd-{linux-amd64,darwin-amd64,darwin-arm64}`
copies alongside the existing `containarium-*` server build (no windows mirror — the daemon never
ships there, and the windows build is already client-only via `//go:build !windows` file-level tags).

`build-release`'s `SHA256SUMS.txt` lists both sets, and a new verification step in `build-release`
asserts `sha256(containarium-<plat>) == sha256(containariumd-<plat>)` for all three platforms,
failing the build if they ever diverge.

`release.yml`'s GitHub Release upload now includes the three `containariumd-*` artifacts alongside
the existing `containarium-*` ones.

`containarium-*` **stays the server build** in Phase 1 (renaming it to the client build is a later
phase, not in scope here) — this only *adds* `containariumd-*` as an available name so the fleet's
self-update chain (sentinel `selfupdate.go`'s `releaseBinaryName`, #1779) can fetch it by that name.
Any host still fetching the old name keeps working unchanged.

`scripts/bundle/build-bundle.sh` needs no change — it already stages the binary as `containariumd`
inside the bundle (#1781), sourced from `bin/containarium-${OS}-${ARCH}`, which is unaffected by
this mirror (the two are now guaranteed byte-identical anyway).

## Test evidence

- `make build-release VERSION=v0.0.0-test` run locally end-to-end: all 13 artifacts produced, the
  new sha256-equality check passes for all three mirrored platforms:
  ```
  PASS  containarium-linux-amd64 == containariumd-linux-amd64 (436a2a01...)
  PASS  containarium-darwin-amd64 == containariumd-darwin-amd64 (4d9a7bc0...)
  PASS  containarium-darwin-arm64 == containariumd-darwin-arm64 (4a539113...)
  ```
  `SHA256SUMS.txt` lists both `containarium-*` and `containariumd-*` entries with matching digests.
- `scripts/bundle/build-bundle.sh` run locally against that build: bundle still assembles with
  `bin/containariumd` staged correctly.
- `go build ./...`, `go vet ./...` clean (no Go source touched).
- `./scripts/test-old-binary-path-gate.sh`, `./scripts/test-cli-split-deps.sh` — PASS.
- YAML-parsed the touched workflow file.

## Needs verification (real infra — this sandbox can't cut a release)

- [ ] A release-candidate run (`workflow_dispatch` rehearsal or a real tag) uploads both artifact
      sets with checksums, confirmed on the actual GitHub Release page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)