### PR TITLE
docs(cli-split): operator docs and runbooks say containariumd for on-host commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,12 +460,12 @@ credentials.
 
 ```bash
 # LXC/Incus (default)
-containarium daemon
+containariumd daemon
 
 # Kubernetes — uses in-cluster config or KUBECONFIG
-CONTAINARIUM_RUNTIME=k8s containarium daemon
+CONTAINARIUM_RUNTIME=k8s containariumd daemon
 # or
-containarium daemon --runtime=k8s
+containariumd daemon --runtime=k8s
 ```
 
 Both backends share the same CLI, MCP tools, JWT auth, and REST/gRPC API.
@@ -640,6 +640,20 @@ least-privilege scope catalog.
 
 ## Deployment
 
+### Two binaries: `containarium` vs `containariumd`
+
+Same convention as `docker`/`dockerd` or `incus`/`incusd`: `containarium`
+is the CLI you run from your laptop (`create`, `list`, `ssh-config`,
+`expose-port`, …); `containariumd` is what runs *on the host* — the
+daemon, the sentinel, and every on-host admin verb (`daemon`,
+`sentinel`, `service install`, `sync-accounts`, `pool join`, `node`,
+`hosting`, `recover`, `doctor`). Install `containarium` wherever you
+want to drive the platform from (your laptop, a jump box); install
+`containariumd` on every host that runs the daemon or sentinel itself.
+A compat symlink (`/usr/local/bin/containarium -> containariumd`) keeps
+existing hosts and scripts that still invoke `containarium <daemon verb>`
+working during the rollout.
+
 ### Manual install (recommended for getting started)
 
 ```bash
@@ -757,7 +771,7 @@ K8s orchestrates application containers across nodes — that's the
 infrastructure layer. Containarium is the agent runtime that runs *on
 top of* Kubernetes (or LXC), giving each agent a persistent, SSH-native
 box without handing it cluster credentials. If you're already on K8s,
-run `containarium daemon --runtime=k8s` and use your existing cluster as
+run `containariumd daemon --runtime=k8s` and use your existing cluster as
 the backend. See the [Kubernetes backend](#kubernetes-backend-experimental)
 section and [docs/KIND-QUICKSTART.md](docs/KIND-QUICKSTART.md).
 

--- a/docs/API-SERVICE-DESIGN.md
+++ b/docs/API-SERVICE-DESIGN.md
@@ -45,7 +45,7 @@ You → SSH to jump server → Run: sudo containarium create alice
 
 ```
 GCE VM (Host OS - Ubuntu 24.04)
-├─ systemd service: containarium daemon (port 50051)  ← Runs HERE
+├─ systemd service: containariumd daemon (port 50051)  ← Runs HERE
 │  └─ Connects to: /var/lib/incus/unix.socket
 │
 └─ LXC Containers (managed by daemon):
@@ -292,7 +292,7 @@ Wants=incus.service
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/containarium daemon --config /etc/containarium/config.yaml
+ExecStart=/usr/local/bin/containariumd daemon --config /etc/containarium/config.yaml
 Restart=on-failure
 RestartSec=5s
 User=root
@@ -467,8 +467,9 @@ scp bin/containarium-linux-amd64 admin@jump-1:/tmp/
 ssh admin@jump-1
 
 # 3. Install binary
-sudo mv /tmp/containarium-linux-amd64 /usr/local/bin/containarium
-sudo chmod +x /usr/local/bin/containarium
+sudo mv /tmp/containarium-linux-amd64 /usr/local/bin/containariumd
+sudo chmod +x /usr/local/bin/containariumd
+sudo ln -sf /usr/local/bin/containariumd /usr/local/bin/containarium
 
 # 4. Install systemd service (if not exists)
 sudo cp scripts/containarium.service /etc/systemd/system/

--- a/docs/APP-HOSTING-SUMMARY.md
+++ b/docs/APP-HOSTING-SUMMARY.md
@@ -423,7 +423,7 @@ sudo systemctl enable caddy
 sudo systemctl start caddy
 
 # Start Containarium daemon
-containarium daemon \
+containariumd daemon \
   --app-hosting \
   --postgres "postgres://user:pass@localhost:5432/containarium" \
   --base-domain "containarium.dev" \

--- a/docs/BACKEND-STORAGE-DRIVER.md
+++ b/docs/BACKEND-STORAGE-DRIVER.md
@@ -68,7 +68,7 @@ it has not established for it.
 For a backend that runs mutually untrusting tenants:
 
 ```bash
-containarium daemon --require-isolated-storage ...
+containariumd daemon --require-isolated-storage ...
 ```
 
 The daemon then refuses to initialize infrastructure on a pool whose driver
@@ -126,7 +126,7 @@ incus storage create isolated zfs source=<dataset>
 #    during the migration land on the new pool rather than the old one.
 #    (--storage-pool is the incus STORAGE pool; --pool is a
 #    sentinel-fronted cluster and is unrelated. See MULTI-POOL.md.)
-containarium daemon --storage-pool isolated ...     # then restart the daemon
+containariumd daemon --storage-pool isolated ...     # then restart the daemon
 
 # 3. Move tenants across one at a time. Rollback is per tenant:
 #    `incus move <container> --storage default`.

--- a/docs/CADDY-SETUP.md
+++ b/docs/CADDY-SETUP.md
@@ -290,7 +290,7 @@ When Caddy runs inside a container (e.g., Incus/LXD), you need to forward ports 
 When running the Containarium daemon with `--app-hosting`, port forwarding is **automatically configured** on startup:
 
 ```bash
-containarium daemon --app-hosting --base-domain example.com
+containariumd daemon --app-hosting --base-domain example.com
 ```
 
 The daemon will:
@@ -447,7 +447,7 @@ sudo tcpdump -i any port 80 -n
 When starting the Containarium daemon with app hosting:
 
 ```bash
-containarium daemon \
+containariumd daemon \
   --app-hosting \
   --postgres "postgres://user:pass@localhost:5432/containarium" \
   --base-domain "example.com" \

--- a/docs/CLOUD-ACTUATION-SMOKE.md
+++ b/docs/CLOUD-ACTUATION-SMOKE.md
@@ -20,7 +20,7 @@ exercised together against a live control plane + a real backend.
 
 - A running **cloud control plane** (the `cloud-daemon`) reachable over gRPC, and
   cloud **sysadmin** access to it (to mint a host token).
-- A **backend host** running the OSS `containarium daemon` (the actuation client
+- A **backend host** running the OSS `containariumd daemon` (the actuation client
   ships in the default build — no special build flag). Incus present.
 - For the *enforcement* half: the eBPF object built on the backend and the daemon
   armed, per [`security/OPERATOR-SECURITY-RUNBOOK.md` → Pinning per-tenant network

--- a/docs/CLOUD-NATIVE-METRICS-EXPORT-DESIGN.md
+++ b/docs/CLOUD-NATIVE-METRICS-EXPORT-DESIGN.md
@@ -34,7 +34,7 @@ in-process in the daemon**, not in the core-otelcollector LXC. Reasons:
 
 ```mermaid
 flowchart LR
-    subgraph daemon["containarium daemon (existing binary)"]
+    subgraph daemon["containariumd daemon (existing binary)"]
         SRC["metrics sources (existing)\nGetSystemResources / GetAllMetrics"]
         COL["internal/metrics Collector (existing)\nOTLP push"]
         CE["internal/metrics/cloudexport (NEW)\nCloudExportCollector + Sink"]

--- a/docs/CPU-CAPACITY-ADMISSION.md
+++ b/docs/CPU-CAPACITY-ADMISSION.md
@@ -83,7 +83,7 @@ Two daemon flags (each with an environment-variable fallback):
 Example — allow up to 4× overcommit, enforced:
 
 ```
-containarium daemon --cpu-overcommit-factor 4 --cpu-overcommit-enforce
+containariumd daemon --cpu-overcommit-factor 4 --cpu-overcommit-enforce
 ```
 
 ## Recommended rollout (advisory → enforce)
@@ -135,7 +135,7 @@ routed to the **least CPU-committed** healthy peer — lowest committed-cores /
 logical-CPU ratio — instead of the arbitrary first-healthy peer picked today.
 
 ```
-containarium daemon --placement-cpu-aware
+containariumd daemon --placement-cpu-aware
 ```
 
 - **No per-create cost.** Each peer's committed and logical-CPU counts are cached on

--- a/docs/CUTOVER-DEMO-INTO-PROD-SENTINEL.md
+++ b/docs/CUTOVER-DEMO-INTO-PROD-SENTINEL.md
@@ -36,11 +36,11 @@ Run from your laptop. Each step is verifiable independently.
 1. **Confirm both binaries support the new flags.**
    ```sh
    # On the prod sentinel host
-   ssh <prod-gcp-project>-sentinel sudo /usr/local/bin/containarium version
+   ssh <prod-gcp-project>-sentinel sudo /usr/local/bin/containariumd version
    # On the prod daemon host
-   ssh -p 2222 <prod-gcp-project>-sentinel "ssh <prod-backend> sudo /usr/local/bin/containarium version"
+   ssh -p 2222 <prod-gcp-project>-sentinel "ssh <prod-backend> sudo /usr/local/bin/containariumd version"
    # On the demo daemon host
-   ssh <demo-base-domain> sudo /usr/local/bin/containarium version
+   ssh <demo-base-domain> sudo /usr/local/bin/containariumd version
    ```
    All three must print `vX.Y.Z` or later (a release that includes #204 + #205). If any is older, **upgrade it first** — the cutover assumes the prod sentinel knows about `base_domain` and the daemons know about `--public-base-domain`.
 
@@ -102,7 +102,7 @@ Wants=network-online.target
 
 [Service]
 Environment=CONTAINARIUM_TUNNEL_TOKEN=${TUNNEL_TOKEN}
-ExecStart=/usr/local/bin/containarium tunnel \\
+ExecStart=/usr/local/bin/containariumd tunnel \\
   --sentinel-addr ${PROD_SENTINEL} \\
   --spot-id <demo-backend>-spot \\
   --pool demo \\

--- a/docs/DEPLOYMENT-GUIDE.md
+++ b/docs/DEPLOYMENT-GUIDE.md
@@ -7,7 +7,7 @@ Complete step-by-step guide from zero to running containers.
 **What happens during deployment**:
 
 1. **Terraform** deploys GCE VM with Incus installed (automatic)
-2. **You** build and copy the `containarium` CLI to the VM (manual, one-time)
+2. **You** build and copy the `containariumd` daemon to the VM (manual, one-time)
 3. **You** create containers using `containarium create` (per user)
 4. **Users** SSH to their containers (ongoing use)
 
@@ -127,12 +127,14 @@ scp bin/containarium-linux-amd64 admin@35.203.123.45:/tmp/
 # SSH and install
 ssh admin@35.203.123.45
 
-# On the jump server:
-sudo mv /tmp/containarium-linux-amd64 /usr/local/bin/containarium
-sudo chmod +x /usr/local/bin/containarium
+# On the jump server (#1781: install as containariumd, symlink the old
+# name for compat with anything still invoking `containarium <verb>`):
+sudo mv /tmp/containarium-linux-amd64 /usr/local/bin/containariumd
+sudo chmod +x /usr/local/bin/containariumd
+sudo ln -sf /usr/local/bin/containariumd /usr/local/bin/containarium
 
 # Verify installation
-containarium version
+containariumd version
 # Output: Containarium dev
 
 # Exit back to your local machine
@@ -152,7 +154,7 @@ SERVERS=("35.203.123.45" "35.203.124.46" "35.203.125.47")
 for server in "${SERVERS[@]}"; do
   echo "Deploying to $server..."
   scp bin/containarium-linux-amd64 admin@$server:/tmp/
-  ssh admin@$server "sudo mv /tmp/containarium-linux-amd64 /usr/local/bin/containarium && sudo chmod +x /usr/local/bin/containarium"
+  ssh admin@$server "sudo mv /tmp/containarium-linux-amd64 /usr/local/bin/containariumd && sudo chmod +x /usr/local/bin/containariumd && sudo ln -sf /usr/local/bin/containariumd /usr/local/bin/containarium"
   echo "✓ Deployed to $server"
 done
 EOF
@@ -586,7 +588,7 @@ make build-linux
 
 # Copy to jump server
 scp bin/containarium-linux-amd64 admin@35.203.123.45:/tmp/
-ssh admin@35.203.123.45 "sudo mv /tmp/containarium-linux-amd64 /usr/local/bin/containarium && sudo chmod +x /usr/local/bin/containarium"
+ssh admin@35.203.123.45 "sudo mv /tmp/containarium-linux-amd64 /usr/local/bin/containariumd && sudo chmod +x /usr/local/bin/containariumd && sudo ln -sf /usr/local/bin/containariumd /usr/local/bin/containarium"
 ```
 
 Existing containers are NOT affected.
@@ -605,7 +607,7 @@ resource "null_resource" "deploy_containarium" {
     command = <<-EOT
       sleep 30  # Wait for instance to be ready
       scp -o StrictHostKeyChecking=no bin/containarium-linux-amd64 admin@${google_compute_address.jump_server_ip.address}:/tmp/
-      ssh -o StrictHostKeyChecking=no admin@${google_compute_address.jump_server_ip.address} "sudo mv /tmp/containarium-linux-amd64 /usr/local/bin/containarium && sudo chmod +x /usr/local/bin/containarium"
+      ssh -o StrictHostKeyChecking=no admin@${google_compute_address.jump_server_ip.address} "sudo mv /tmp/containarium-linux-amd64 /usr/local/bin/containariumd && sudo chmod +x /usr/local/bin/containariumd && sudo ln -sf /usr/local/bin/containariumd /usr/local/bin/containarium"
     EOT
   }
 }
@@ -629,8 +631,8 @@ Infrastructure:
 CLI Installation:
 □ Ran make build-linux on local machine
 □ Copied binary to jump server(s) with scp
-□ Moved to /usr/local/bin/containarium on jump server
-□ Verified: containarium version works
+□ Moved to /usr/local/bin/containariumd on jump server (symlinked as containarium for compat)
+□ Verified: containariumd version works
 □ Verified: sudo incus list shows no containers
 
 Container Creation:
@@ -671,8 +673,9 @@ scp bin/containarium-linux-amd64 admin@<ip>:/tmp/
 **On jump server:**
 ```bash
 # Install CLI (one-time)
-sudo mv /tmp/containarium-linux-amd64 /usr/local/bin/containarium
-sudo chmod +x /usr/local/bin/containarium
+sudo mv /tmp/containarium-linux-amd64 /usr/local/bin/containariumd
+sudo chmod +x /usr/local/bin/containariumd
+sudo ln -sf /usr/local/bin/containariumd /usr/local/bin/containarium
 
 # Create containers
 sudo containarium create alice --ssh-key ~/.ssh/alice.pub

--- a/docs/DISASTER-RECOVERY.md
+++ b/docs/DISASTER-RECOVERY.md
@@ -4,12 +4,12 @@ This guide covers how to recover Containarium and all containers after the jump 
 
 ## Overview
 
-When using persistent storage (ZFS on external disk), your containers survive instance recreation. The `containarium recover` command automates the full recovery process.
+When using persistent storage (ZFS on external disk), your containers survive instance recreation. The `containariumd recover` command automates the full recovery process.
 
 ## Prerequisites
 
 - External disk with ZFS storage pool attached and mounted
-- Containarium binary installed at `/usr/local/bin/containarium`
+- Containarium binary installed at `/usr/local/bin/containariumd`
 - Incus installed and running
 
 ## Recovery Process
@@ -20,10 +20,10 @@ If a recovery config exists on the persistent storage:
 
 ```bash
 # Auto-detect config from persistent storage
-sudo containarium recover
+sudo containariumd recover
 
 # Or explicitly specify config file
-sudo containarium recover --config /mnt/incus-data/containarium-recovery.yaml
+sudo containariumd recover --config /mnt/incus-data/containarium-recovery.yaml
 ```
 
 ### Manual Recovery
@@ -31,7 +31,7 @@ sudo containarium recover --config /mnt/incus-data/containarium-recovery.yaml
 If no config file exists, specify parameters explicitly:
 
 ```bash
-sudo containarium recover \
+sudo containariumd recover \
   --network-name incusbr0 \
   --network-cidr 10.0.3.1/24 \
   --storage-pool default \
@@ -44,12 +44,12 @@ sudo containarium recover \
 Preview what would be done without making changes:
 
 ```bash
-sudo containarium recover --config /mnt/incus-data/containarium-recovery.yaml --dry-run
+sudo containariumd recover --config /mnt/incus-data/containarium-recovery.yaml --dry-run
 ```
 
 ## What the Recovery Command Does
 
-The `containarium recover` command performs these steps automatically:
+The `containariumd recover` command performs these steps automatically:
 
 ### Step 1: Network Creation
 Creates the `incusbr0` network bridge with the configured CIDR:
@@ -79,7 +79,7 @@ incus start --all
 ### Step 5: Sync SSH Accounts
 Restores jump server SSH accounts from container public keys:
 ```bash
-containarium sync-accounts
+containariumd sync-accounts
 ```
 
 ## Recovery Config File
@@ -108,7 +108,7 @@ daemon:
 
 ## Post-Recovery Steps
 
-After running `containarium recover`, complete the setup:
+After running `containariumd recover`, complete the setup:
 
 ### 1. Regenerate JWT Secret (if needed)
 
@@ -129,7 +129,7 @@ After=network.target incus.service
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/containarium daemon --address 0.0.0.0 --rest --http-port 8080 --jwt-secret-file /etc/containarium/jwt.secret --app-hosting --base-domain <your-base-domain> --caddy-admin-url http://localhost:2019 --skip-infra-init
+ExecStart=/usr/local/bin/containariumd daemon --address 0.0.0.0 --rest --http-port 8080 --jwt-secret-file /etc/containarium/jwt.secret --app-hosting --base-domain <your-base-domain> --caddy-admin-url http://localhost:2019 --skip-infra-init
 Restart=on-failure
 RestartSec=5
 
@@ -192,7 +192,7 @@ incus restart --all
 
 Run the sync-accounts command:
 ```bash
-sudo containarium sync-accounts -v
+sudo containariumd sync-accounts -v
 ```
 
 ## Best Practices

--- a/docs/HORIZONTAL-SCALING-QUICKSTART.md
+++ b/docs/HORIZONTAL-SCALING-QUICKSTART.md
@@ -160,17 +160,18 @@ scp bin/containarium-linux-amd64 admin@35.x.x.x:/tmp/
 
 # SSH and install
 ssh admin@35.x.x.x
-sudo mv /tmp/containarium-linux-amd64 /usr/local/bin/containarium
-sudo chmod +x /usr/local/bin/containarium
+sudo mv /tmp/containarium-linux-amd64 /usr/local/bin/containariumd
+sudo chmod +x /usr/local/bin/containariumd
+sudo ln -sf /usr/local/bin/containariumd /usr/local/bin/containarium
 
 # Verify
-containarium version
+containariumd version
 ```
 
 **Repeat for each jump server** (if not using load balancer):
 ```bash
 scp bin/containarium-linux-amd64 admin@35.1.1.1:/tmp/
-ssh admin@35.1.1.1 "sudo mv /tmp/containarium-linux-amd64 /usr/local/bin/containarium && sudo chmod +x /usr/local/bin/containarium"
+ssh admin@35.1.1.1 "sudo mv /tmp/containarium-linux-amd64 /usr/local/bin/containariumd && sudo chmod +x /usr/local/bin/containariumd && sudo ln -sf /usr/local/bin/containariumd /usr/local/bin/containarium"
 
 # Repeat for jump-2, jump-3...
 ```

--- a/docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md
+++ b/docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md
@@ -445,11 +445,11 @@ The K8s backend is **always compiled into the daemon binary** (no build tag).
 for a simpler build surface. The active backend is selected at daemon start:
 
 ```sh
-CONTAINARIUM_RUNTIME=k8s containarium daemon start   # Kubernetes backend
-CONTAINARIUM_RUNTIME=lxc containarium daemon start   # LXC/incus backend (default)
+CONTAINARIUM_RUNTIME=k8s containariumd daemon start   # Kubernetes backend
+CONTAINARIUM_RUNTIME=lxc containariumd daemon start   # LXC/incus backend (default)
 ```
 
-or via the flag: `containarium daemon start --runtime=k8s`.
+or via the flag: `containariumd daemon start --runtime=k8s`.
 
 See [`internal/server/boxbackend_factory.go`](../internal/server/boxbackend_factory.go)
 for the factory. The interface lives in `pkg/core/box` (public, not `internal/`)
@@ -650,10 +650,10 @@ The daemon binary ships one factory that supports both backends:
 
 ```sh
 # Default: LXC/incus (unchanged behaviour)
-containarium daemon start
+containariumd daemon start
 
 # Kubernetes backend
-CONTAINARIUM_RUNTIME=k8s containarium daemon start --runtime=k8s \
+CONTAINARIUM_RUNTIME=k8s containariumd daemon start --runtime=k8s \
   --skip-infra-init \
   --standalone
 ```

--- a/docs/KIND-QUICKSTART.md
+++ b/docs/KIND-QUICKSTART.md
@@ -210,7 +210,7 @@ CONTAINARIUM_K8S_BOX_IMAGE="registry.k8s.io/pause:3.9" \
 CONTAINARIUM_K8S_GATEWAY_HOST="localhost" \
 CONTAINARIUM_K8S_GATEWAY_UPSTREAM_KEY_SECRET="sshpiper-upstream-key" \
 CONTAINARIUM_K8S_GATEWAY_UPSTREAM_PUBLIC_KEY="$(cat ./sshpiper_upstream.pub)" \
-./containarium daemon \
+./containariumd daemon \
   --skip-infra-init \
   --standalone \
   --jwt-secret "$JWT_SECRET" \
@@ -220,7 +220,7 @@ CONTAINARIUM_K8S_GATEWAY_UPSTREAM_PUBLIC_KEY="$(cat ./sshpiper_upstream.pub)" \
 ```
 
 > `daemon` has no `start` subcommand — the daemon runs directly under
-> `containarium daemon` (foreground; Ctrl+C to stop).
+> `containariumd daemon` (foreground; Ctrl+C to stop).
 >
 > The two `GATEWAY_UPSTREAM_*` vars are only required when gateway routing
 > is enabled (the default — step 4); using the "skip gateway routing"
@@ -282,7 +282,7 @@ CONTAINARIUM_K8S_GATEWAY_HOST="localhost" \
 CONTAINARIUM_K8S_GATEWAY_UPSTREAM_KEY_SECRET="sshpiper-upstream-key" \
 CONTAINARIUM_K8S_GATEWAY_UPSTREAM_PUBLIC_KEY="$(cat ./sshpiper_upstream.pub)" \
 CONTAINARIUM_K8S_STORAGE_CLASS="standard" \
-./containarium daemon \
+./containariumd daemon \
   --skip-infra-init --standalone \
   --jwt-secret "$JWT_SECRET" \
   --port 50051 --http-port 8080 --rest

--- a/docs/MCP-INTEGRATION.md
+++ b/docs/MCP-INTEGRATION.md
@@ -27,7 +27,7 @@ First, start the Containarium daemon with REST API:
 
 ```bash
 # On your Containarium server
-containarium daemon --rest --jwt-secret "your-secret-key"
+containariumd daemon --rest --jwt-secret "your-secret-key"
 
 # Generate a token for MCP
 containarium token generate \
@@ -445,7 +445,7 @@ date +%s
 **Solutions:**
 1. **Daemon not running**: Start the daemon
    ```bash
-   containarium daemon --rest --jwt-secret "your-secret"
+   containariumd daemon --rest --jwt-secret "your-secret"
    ```
 2. **Wrong port**: Check URL in MCP config matches daemon port
 3. **Firewall blocking**: Check firewall rules allow connections
@@ -575,7 +575,7 @@ func handleNewTool(client *Client, args map[string]interface{}) (string, error) 
 ```bash
 # Start daemon with persistent JWT secret
 export CONTAINARIUM_JWT_SECRET="$(openssl rand -base64 32)"
-containarium daemon --rest --address 0.0.0.0 --port 8080
+containariumd daemon --rest --address 0.0.0.0 --port 8080
 
 # Generate long-lived token
 containarium token generate \

--- a/docs/MCP-QUICKSTART.md
+++ b/docs/MCP-QUICKSTART.md
@@ -12,7 +12,7 @@ Get Claude Desktop controlling your Containarium containers in 5 minutes!
 
 ```bash
 # Start the daemon with REST API
-containarium daemon --rest --jwt-secret "my-test-secret"
+containariumd daemon --rest --jwt-secret "my-test-secret"
 
 # You should see:
 # ═══════════════════════════════════════════════════════════════

--- a/docs/METRICS-EXPORT-DEADMAN-ALERT-RUNBOOK.md
+++ b/docs/METRICS-EXPORT-DEADMAN-ALERT-RUNBOOK.md
@@ -79,7 +79,7 @@ channel id.
 {
   "displayName": "Containarium backend dead-man (heartbeat absent)",
   "documentation": {
-    "content": "The containarium.export.heartbeat series stopped arriving from a backend. The daemon or host is dead, wedged, or network-partitioned from Cloud Monitoring. Check the backend host and the containarium daemon; this alert fires precisely because the backend went silent, so host-local dashboards may be unreachable.",
+    "content": "The containarium.export.heartbeat series stopped arriving from a backend. The daemon or host is dead, wedged, or network-partitioned from Cloud Monitoring. Check the backend host and the containariumd daemon; this alert fires precisely because the backend went silent, so host-local dashboards may be unreachable.",
     "mimeType": "text/markdown"
   },
   "combiner": "OR",

--- a/docs/MULTI-BACKEND-PEERS.md
+++ b/docs/MULTI-BACKEND-PEERS.md
@@ -256,7 +256,7 @@ A toggle button group lets users switch between backends to view per-host CPU, m
 ## Adding a New Backend
 
 1. **Install Containarium** on the new host
-2. **Run in standalone mode**: `containarium daemon --standalone --rest --jwt-secret-file /etc/containarium/jwt.secret`
+2. **Run in standalone mode**: `containariumd daemon --standalone --rest --jwt-secret-file /etc/containarium/jwt.secret`
 3. **Run tunnel client**: `containarium tunnel --sentinel-addr sentinel:443 --token <token> --spot-id <id> --ports 22,8080`
 4. **Install containarium-shell**: `sudo bash scripts/setup-ssh-container-proxy.sh`
 5. The sentinel auto-discovers the new backend within 30 seconds

--- a/docs/MULTI-POOL.md
+++ b/docs/MULTI-POOL.md
@@ -221,7 +221,7 @@ On tunnel disconnect, the primary entry is removed automatically (`UnregisterByB
 2. **Provision a primary VM.** Same Terraform module as your existing primary (`terraform/modules/containarium/`). The new VM runs its own postgres/Grafana/Caddy core stack.
 3. **Configure the primary daemon** with the registration flags:
    ```
-   containarium daemon \
+   containariumd daemon \
      --sentinel-url http://<sentinel-internal-ip>:8888 \
      --pool lab \
      --public-hostname <lab-pool>.example.com \

--- a/docs/NODE-VM-PROVISIONING.md
+++ b/docs/NODE-VM-PROVISIONING.md
@@ -5,7 +5,7 @@ partial). Validated by hand on an RTX 3090 workstation (see "Validation").
 
 ## What this is
 
-A first-class `containarium node` command group that turns one physical
+A first-class `containariumd node` command group that turns one physical
 host into **several Containarium backends** by provisioning Incus VMs,
 each running its own daemon + tunnel and registering with the sentinel as
 a distinct pool-tagged node:
@@ -61,24 +61,24 @@ hardware.
 
 ```
 # One-time, reboot-class host prep for a GPU node (VFIO). Explicit + gated.
-containarium node prepare-gpu --gpu pci=0000:01:00.0
+containariumd node prepare-gpu --gpu pci=0000:01:00.0
     → adds intel_iommu=on iommu=pt to GRUB, binds the GPU's PCI IDs to
       vfio-pci, prints the reboot instruction. DOES NOT reboot for you.
       WARNS: the host (and its current GPU containers) lose the GPU.
 
 # Provision a node-VM (idempotent; re-run reconciles).
-containarium node provision \
+containariumd node provision \
     --name cpu-node --kind cpu --pool cpu \
     --cpu 16 --memory 64GiB --disk 200GiB \
     --sentinel <sentinel-host:port> --tunnel-token <token>
 
-containarium node provision \
+containariumd node provision \
     --name gpu-node --kind gpu --pool gpu \
     --cpu 8 --memory 32GiB --gpu pci=0000:01:00.0 \
     --sentinel <sentinel-host:port> --tunnel-token <token>
 
-containarium node list                    # node-VMs on this host + state
-containarium node destroy --name cpu-node # tear a node-VM down
+containariumd node list                    # node-VMs on this host + state
+containariumd node destroy --name cpu-node # tear a node-VM down
 ```
 
 `--tunnel-token` / `--sentinel` may also come from
@@ -97,12 +97,12 @@ history.
    the GPU on `vfio-pci`).
 3. **Bootstrap inside the VM via cloud-init** — the same sequence
    `scripts/setup-peer.sh` runs today, just executed in the guest:
-   - drop the `containarium` binary in (`/usr/local/bin/containarium`),
+   - drop the `containariumd` binary in (`/usr/local/bin/containariumd`),
    - install nested Incus + `incus admin init --auto` (+ the NVIDIA driver
      for a GPU node),
-   - `containarium service install` (daemon systemd unit + override),
+   - `containariumd service install` (daemon systemd unit + override),
    - a `containarium-tunnel.service` running
-     `containarium tunnel --sentinel-addr <addr> --pool <pool> --spot-id <name>-<pool>`,
+     `containariumd tunnel --sentinel-addr <addr> --pool <pool> --spot-id <name>-<pool>`,
    - the tunnel token delivered as a cloud-init secret, written
      `0600 root` (never on the kernel cmdline / process args).
 4. The node tunnels up and **registers as a backend**; verify with
@@ -154,7 +154,7 @@ alone in its IOMMU group), by hand:
 - Bare-metal → LXC GPU passthrough works (`nvidia.runtime` + GPU device →
   `nvidia-smi` sees the card), so the GPU-node nested path is sound.
 
-`containarium node provision --kind cpu` was then run **live** on that host
+`containariumd node provision --kind cpu` was then run **live** on that host
 (against a real sentinel, token delivered via a 0600 file): it created the
 VM, installed nested Incus, pushed the binary, and launched the tunnel —
 which dialed the sentinel under the right pool/spot-id, **with the token

--- a/docs/PER-POOL-BASE-DOMAIN.md
+++ b/docs/PER-POOL-BASE-DOMAIN.md
@@ -63,7 +63,7 @@ The fallback stays as a safety net for unpooled single-backend deployments (no `
 `TunnelHandshake` gains `PublicBaseDomains []string`. Repeatable flag on both daemon and tunnel commands:
 
 ```
-containarium daemon ... --public-base-domain lab.example.com --public-base-domain demo.example.org
+containariumd daemon ... --public-base-domain lab.example.com --public-base-domain demo.example.org
 containarium tunnel ... --public-base-domain lab.example.com --public-base-domain demo.example.org
 ```
 

--- a/docs/PROXY-PROTOCOL.md
+++ b/docs/PROXY-PROTOCOL.md
@@ -234,7 +234,7 @@ fall back to the raw TCP peer (loopback) for the XFF value.
 
 ### TLS handshake fails silently for a tunnel-promoted pool primary
 
-**Symptom.** A new pool primary (`containarium daemon --pool X --app-hosting --base-domain X.example.com` paired with a `containarium tunnel ... --pool X --public-hostname X.example.com --public-port 443` on the same box) registers cleanly — `/v1/backends` lists it healthy, `/sentinel/primaries` has the right hostname — but `curl https://X.example.com/` fails the TLS handshake:
+**Symptom.** A new pool primary (`containariumd daemon --pool X --app-hosting --base-domain X.example.com` paired with a `containarium tunnel ... --pool X --public-hostname X.example.com --public-port 443` on the same box) registers cleanly — `/v1/backends` lists it healthy, `/sentinel/primaries` has the right hostname — but `curl https://X.example.com/` fails the TLS handshake:
 
 ```
 curl: (35) LibreSSL SSL_connect: SSL_ERROR_SYSCALL in connection to X.example.com:443
@@ -260,7 +260,7 @@ So the cert and Caddy are fine — the failure is between sentinel and primary's
 # /etc/systemd/system/containarium.service.d/override.conf
 [Service]
 ExecStart=
-ExecStart=/usr/local/bin/containarium daemon --pool X --rest --jwt-secret-file /etc/containarium/jwt.secret \
+ExecStart=/usr/local/bin/containariumd daemon --pool X --rest --jwt-secret-file /etc/containarium/jwt.secret \
   --app-hosting --base-domain X.example.com \
   --proxy-protocol --proxy-protocol-trusted=127.0.0.0/8
 ```

--- a/docs/REST-API-QUICKSTART.md
+++ b/docs/REST-API-QUICKSTART.md
@@ -14,7 +14,7 @@ Containarium now supports both gRPC and REST APIs running simultaneously:
 
 #### Development (Auto-Generated Secret)
 ```bash
-containarium daemon --rest
+containariumd daemon --rest
 
 # Output will show:
 # ═══════════════════════════════════════════════════════════════
@@ -30,7 +30,7 @@ containarium daemon --rest
 export CONTAINARIUM_JWT_SECRET="your-secure-secret-key"
 
 # Start daemon
-containarium daemon --rest
+containariumd daemon --rest
 
 # Secret is used but not printed - production ready!
 ```
@@ -42,7 +42,7 @@ openssl rand -base64 32 > /etc/containarium/jwt.secret
 chmod 600 /etc/containarium/jwt.secret
 
 # Start daemon
-containarium daemon --rest --jwt-secret-file /etc/containarium/jwt.secret
+containariumd daemon --rest --jwt-secret-file /etc/containarium/jwt.secret
 ```
 
 ---

--- a/docs/SECURITY-REMEDIATION-PLAN.md
+++ b/docs/SECURITY-REMEDIATION-PLAN.md
@@ -381,19 +381,20 @@ BINARY_URL="https://github.com/footprintai/containarium/releases/latest/download
 CHECKSUM_URL="https://github.com/footprintai/containarium/releases/latest/download/containarium-linux-amd64.sha256"
 
 # Download binary and checksum
-curl -fsSL -o /tmp/containarium "$BINARY_URL"
-curl -fsSL -o /tmp/containarium.sha256 "$CHECKSUM_URL"
+curl -fsSL -o /tmp/containariumd "$BINARY_URL"
+curl -fsSL -o /tmp/containariumd.sha256 "$CHECKSUM_URL"
 
 # Verify checksum
 cd /tmp
-if ! sha256sum -c containarium.sha256; then
+if ! sha256sum -c containariumd.sha256; then
     echo "ERROR: Checksum verification failed!"
     exit 1
 fi
 
 # Install
-sudo mv /tmp/containarium /usr/local/bin/
-sudo chmod +x /usr/local/bin/containarium
+sudo mv /tmp/containariumd /usr/local/bin/
+sudo chmod +x /usr/local/bin/containariumd
+sudo ln -sf /usr/local/bin/containariumd /usr/local/bin/containarium
 ```
 
 **Files to modify:**

--- a/docs/SENTINEL-DESIGN.md
+++ b/docs/SENTINEL-DESIGN.md
@@ -97,7 +97,7 @@ The sentinel clears all iptables DNAT rules and starts its own HTTP/HTTPS server
 4. Sentinel switches to MAINTENANCE mode (serves 503 maintenance page)
 5. Sentinel calls `StartInstance()` on the stopped VM
 6. VM boots with existing boot disk — all software already in place
-7. systemd auto-starts Incus and containarium daemon
+7. systemd auto-starts Incus and containariumd daemon
 8. Sentinel TCP health check detects backend healthy (2 consecutive passes)
 9. Sentinel switches back to PROXY mode — traffic flows again
 
@@ -201,11 +201,13 @@ The startup script configures sshd to listen on both port 22 and port 2222. A de
 
 ## Binary Server (Port 8888)
 
-The sentinel serves the `containarium` binary on port 8888 so newly created spot VMs (without external IPs) can download it over the internal VPC network:
+The sentinel serves the `containariumd` binary on port 8888 so newly created spot VMs (without external IPs) can download it over the internal VPC network:
 
 ```bash
 # Spot VM startup script downloads binary from sentinel
-curl -fsSL http://<sentinel-internal-ip>:8888/binary -o /usr/local/bin/containarium
+curl -fsSL http://<sentinel-internal-ip>:8888/binary -o /usr/local/bin/containariumd
+chmod +x /usr/local/bin/containariumd
+ln -sf /usr/local/bin/containariumd /usr/local/bin/containarium
 ```
 
 This avoids requiring Cloud NAT or external IP on the spot VM just to download the binary.
@@ -213,7 +215,7 @@ This avoids requiring Cloud NAT or external IP on the spot VM just to download t
 ## CLI Reference
 
 ```bash
-containarium sentinel [flags]
+containariumd sentinel [flags]
 ```
 
 ### Flags
@@ -241,7 +243,7 @@ containarium sentinel [flags]
 
 ```bash
 # Install as systemd service
-sudo containarium sentinel service install \
+sudo containariumd sentinel service install \
   --spot-vm <vm-name> \
   --zone <zone> \
   --project <project-id>
@@ -257,7 +259,7 @@ sudo systemctl restart containarium-sentinel
 
 ```bash
 # Sentinel accepts reverse tunnel connections on port 443
-containarium sentinel --provider=tunnel --tunnel-token SECRET
+containariumd sentinel --provider=tunnel --tunnel-token SECRET
 
 # Firewalled spot connects outbound to sentinel
 containarium tunnel \
@@ -273,7 +275,7 @@ See [TUNNEL-REVERSE-PROXY.md](TUNNEL-REVERSE-PROXY.md) for full details.
 
 ```bash
 # No GCP, no iptables — just health check and maintenance page
-containarium sentinel \
+containariumd sentinel \
   --provider=none \
   --backend-addr=127.0.0.1 \
   --health-port 8080 \

--- a/docs/SENTINEL-ED25519-MIGRATION-RUNBOOK.md
+++ b/docs/SENTINEL-ED25519-MIGRATION-RUNBOOK.md
@@ -65,7 +65,7 @@ exactly why the signing key goes on the sentinel **last** (see ordering).
 On any host with the v0.45.0 binary:
 
 ```bash
-containarium sentinel keygen
+containariumd sentinel keygen
 ```
 
 Output (two env lines):

--- a/docs/SPOT-RECOVERY.md
+++ b/docs/SPOT-RECOVERY.md
@@ -57,7 +57,7 @@ The MIG's auto-healing **deletes** the stopped instance and creates a new one fr
 4. Sentinel immediately switches to maintenance mode (serves 503 page)
 5. Sentinel calls `StartInstance()` on the stopped VM
 6. VM boots with existing boot disk — all software already installed
-7. systemd auto-starts Incus and containarium daemon
+7. systemd auto-starts Incus and containariumd daemon
 8. Sentinel TCP health check detects backend healthy, switches to proxy mode
 9. Traffic flows again — users see the service resume
 
@@ -103,7 +103,7 @@ With `instance_termination_action: STOP`, GCE stops the VM but preserves it:
 - Persistent disk still attached
 - Network config preserved
 
-The sentinel calls `StartInstance()` which boots the existing VM. systemd starts Incus and the containarium daemon automatically. No startup script reinstallation needed.
+The sentinel calls `StartInstance()` which boots the existing VM. systemd starts Incus and the containariumd daemon automatically. No startup script reinstallation needed.
 
 Spot VMs (provisioning_model: SPOT) have **no 24-hour time limit** — unlike old preemptible VMs. They run indefinitely until GCE needs capacity. Restarting a stopped spot VM does not affect preemption scheduling.
 
@@ -231,10 +231,10 @@ The sentinel runs the same `containarium` binary:
 
 ```bash
 # Production (on sentinel VM, installed via systemd)
-containarium sentinel --spot-vm containarium-jump --zone us-west1-a --project my-project
+containariumd sentinel --spot-vm containarium-jump --zone us-west1-a --project my-project
 
 # Local testing (no GCP, no iptables)
-containarium sentinel --provider=none --backend-addr=127.0.0.1 --health-port 8080 --http-port 9090
+containariumd sentinel --provider=none --backend-addr=127.0.0.1 --health-port 8080 --http-port 9090
 ```
 
 Key flags:

--- a/docs/TESTING-DAEMON-ON-GCE.md
+++ b/docs/TESTING-DAEMON-ON-GCE.md
@@ -247,8 +247,8 @@ sudo journalctl -u containarium -n 50
 sudo systemctl restart containarium
 
 # Check if binary exists
-ls -lh /usr/local/bin/containarium
-/usr/local/bin/containarium version
+ls -lh /usr/local/bin/containariumd
+/usr/local/bin/containariumd version
 ```
 
 ### Connection refused
@@ -273,8 +273,9 @@ terraform state show 'null_resource.copy_containarium_binary[0]'
 # Manually copy if needed
 scp bin/containarium-linux-amd64 admin@<jump-server-ip>:/tmp/
 ssh admin@<jump-server-ip>
-sudo mv /tmp/containarium-linux-amd64 /usr/local/bin/containarium
-sudo chmod +x /usr/local/bin/containarium
+sudo mv /tmp/containarium-linux-amd64 /usr/local/bin/containariumd
+sudo chmod +x /usr/local/bin/containariumd
+sudo ln -sf /usr/local/bin/containariumd /usr/local/bin/containarium
 sudo systemctl restart containarium
 ```
 
@@ -329,7 +330,7 @@ After successful testing:
 If you encounter issues:
 1. Check logs: `sudo journalctl -u containarium -f`
 2. Verify Incus: `sudo incus list`
-3. Test manually: `sudo /usr/local/bin/containarium daemon`
+3. Test manually: `sudo /usr/local/bin/containariumd daemon`
 4. Review startup script execution: `sudo journalctl -t containarium-startup`
 
 ---

--- a/docs/TUNNEL-REVERSE-PROXY.md
+++ b/docs/TUNNEL-REVERSE-PROXY.md
@@ -151,7 +151,7 @@ Add `--tunnel-token` to your existing GCP sentinel command:
 TOKEN=$(openssl rand -hex 32)
 
 # Sentinel (add --tunnel-token to existing command)
-containarium sentinel \
+containariumd sentinel \
   --spot-vm my-spot-vm --zone us-west1-a --project my-project \
   --tunnel-token "$TOKEN" \
   --forwarded-ports 80,443
@@ -184,7 +184,7 @@ The tunnel client:
 ### Pure Tunnel Mode (no GCP)
 
 ```bash
-containarium sentinel \
+containariumd sentinel \
   --provider=tunnel \
   --tunnel-token SECRET \
   --forwarded-ports 80,443
@@ -274,7 +274,7 @@ Bare metal
 
 - **Outbound TCP to port 443** on the sentinel's public IP (most firewalls allow this)
 - No inbound ports needed
-- Running containarium daemon and services locally (sshd, Caddy, etc.)
+- Running containariumd daemon and services locally (sshd, Caddy, etc.)
 - The `containarium` binary installed
 - Go toolchain (to build from source) or pre-built binary
 

--- a/docs/ZFS-PER-CONTAINER-ENCRYPTION-DESIGN.md
+++ b/docs/ZFS-PER-CONTAINER-ENCRYPTION-DESIGN.md
@@ -49,7 +49,7 @@ This doc designs that path. It is OSS-scope only where the OSS daemon's hooks ne
 │                ▼   32-byte key + key_ref (e.g. "kms://…/cryptoKeys/org-alice")  │
 │                                                                                 │
 │   ┌─────────────────────────────────────────────────────────────────────────┐  │
-│   │ containarium daemon                                                     │  │
+│   │ containariumd daemon                                                    │  │
 │   │                                                                         │  │
 │   │   ┌──────────────────┐   ③ pre-create hook:                             │  │
 │   │   │ KeyProvider      │      zfs create -o encryption=on \               │  │

--- a/docs/architecture/byoc-vm-console-access.md
+++ b/docs/architecture/byoc-vm-console-access.md
@@ -246,7 +246,7 @@ path alongside the existing daemon-gateway one.
 
 ### Enrollment
 
-`containarium pool join` (`internal/cmd/pool_join.go`) remains the
+`containariumd pool join` (`internal/cmd/pool_join.go`) remains the
 enrollment path for a BYOC host's own daemon/tunnel identity. The
 hypervisor-agent is a *distinct* enrollment (a different spot, run once
 per physical hypervisor machine, not per guest) — it does not extend

--- a/docs/architecture/cloud-export-domain-metrics.md
+++ b/docs/architecture/cloud-export-domain-metrics.md
@@ -29,7 +29,7 @@ counters cost nothing when export is disabled.
 
 ```mermaid
 flowchart LR
-    subgraph daemon["containarium daemon (existing binary)"]
+    subgraph daemon["containariumd daemon (existing binary)"]
         INT["gRPC unary interceptor (NEW)\ncounts requests/errors"]
         RPC["CreateContainer/DeleteContainer\nhandlers (instrumented)"]
         PS["internal/metrics/platformstats (NEW)\natomic counters, zero deps"]

--- a/docs/architecture/managed-k8s-clusters.md
+++ b/docs/architecture/managed-k8s-clusters.md
@@ -26,7 +26,7 @@ flowchart LR
     cli["containarium cluster …"]
   end
   subgraph host["Backend host"]
-    daemon["containarium daemon\nClusterService + CA-provider gRPC"]
+    daemon["containariumd daemon\nClusterService + CA-provider gRPC"]
     pt["passthrough (iptables DNAT)\n:extPort → cp:6443"]
     subgraph cp["control-plane VM (platform territory)"]
       k3ss["k3s server\n(tainted, sqlite)"]
@@ -337,7 +337,7 @@ not per-PR).
   choreography (exactly the ops burden the product removes); k0s is
   viable but k3s has in-tree precedent (kubeflow recipe), the manifest
   auto-apply dir we use for VPA, and the smallest single-binary story.
-- **Reusing the `containarium node` scaffold for workers** — its
+- **Reusing the `containariumd node` scaffold for workers** — its
   documented rationale (day-0 host carve, pre-daemon, deliberately
   CLI-only/no-proto) does not fit daemon-served tenant resources, and
   it has a known bootstrap gap (nodes come up sentinel-unhealthy). We

--- a/docs/product/managed-k8s-clusters.md
+++ b/docs/product/managed-k8s-clusters.md
@@ -76,7 +76,7 @@ customer's cluster; this feature is the inverse — Containarium
 > never SSHes a node, and never files a resize request.
 
 Nodes are **Containarium VMs** (Incus `virtual-machine` instances, the
-substrate the `containarium node` scaffold already targets), not LXC
+substrate the `containariumd node` scaffold already targets), not LXC
 containers: a kubelet wants its own kernel, and the VM boundary keeps a
 tenant's cluster kernel-isolated from the host and from other tenants.
 The distribution is assumed to be **k3s** (single binary, conformant,
@@ -180,7 +180,7 @@ the automation is doing, and hard caps on what it may consume.
   auto-sleep machinery, waking on API/traffic. This is where the two
   "serverless" stories meet; needs the wake path to understand the K8s
   API port.
-- **P1 — GPU node pools:** the `containarium node` GPU/VFIO path is
+- **P1 — GPU node pools:** the `containariumd node` GPU/VFIO path is
   partial today; GPU nodes ride on finishing it, plus device-plugin
   install. High-value (it is the substrate's differentiator) but not
   needed to prove the managed-cluster loop.
@@ -228,7 +228,7 @@ the automation is doing, and hard caps on what it may consume.
   enough on the chosen K8s version for Story 4; if not, Story 4's
   fallback is VPA recreate-mode (pods restart on resize) — degraded but
   still "no hand-tuning".
-- **Open:** node VM provisioning path — extend the `containarium node`
+- **Open:** node VM provisioning path — extend the `containariumd node`
   scaffold (whose CPU path exists, deliberately CLI-only/no-proto) or a
   new internal provisioner behind `ClusterService`? The node scaffold's
   no-proto stance conflicts with cluster nodes being API-managed

--- a/docs/security/NETWORK-ISOLATION-DESIGN.md
+++ b/docs/security/NETWORK-ISOLATION-DESIGN.md
@@ -122,7 +122,7 @@ The Phase 0 / 0.5 harnesses (`experimental/ebpf-phase0/validate.sh`,
                             │
                             v
                   ┌──────────────────────────────┐
-                  │  containarium daemon         │
+                  │  containariumd daemon        │
                   │   policy compiler            │
                   │   (rules → BPF maps)         │
                   └──────────────────────────────┘

--- a/docs/security/PHASE-0-OPERATOR-RUNBOOK.md
+++ b/docs/security/PHASE-0-OPERATOR-RUNBOOK.md
@@ -185,7 +185,7 @@ gcloud compute ssh sentinel-vm
 # 2. Move the old key aside (don't delete — emergency rollback).
 sudo mv /etc/containarium/ca.key /etc/containarium/ca.key.prev
 # 3. Generate a fresh one.
-sudo /usr/local/bin/containarium pki generate-ca | sudo tee /etc/containarium/ca.key >/dev/null
+sudo /usr/local/bin/containariumd pki generate-ca | sudo tee /etc/containarium/ca.key >/dev/null
 sudo chmod 0400 /etc/containarium/ca.key
 sudo chown root:root /etc/containarium/ca.key
 


### PR DESCRIPTION
Closes #1783

Stacked on #1798 (feat/1782-release-publishes-containariumd — merge that first).

## Summary

Every doc/runbook example that runs an on-host verb (`daemon`, `sentinel`, `service install`,
`sync-accounts`, `pool join`, `node`, `hosting`, `recover`, `doctor`) now says `containariumd`.
Client-verb examples (`containarium create/list/connect/…`) are unchanged, as is every systemd
unit **name** (`containarium.service`, `containarium-sentinel`, etc.) — only the `ExecStart`
binary path inside a unit changes, per #1780's convention.

Also fixed the install-path half of the same problem: every doc showing a manual `scp`/`mv`/
`curl -o` install of the binary onto a host now installs it as `/usr/local/bin/containariumd`
and symlinks the old name for compat — matching what `scripts/deploy-binary.sh` and
`hacks/install.sh` actually do post-#1781. The release-artifact **source** name stays
`bin/containarium-linux-amd64` (that's #1782's mirror, still correct).

Two ASCII-art box diagrams (`ZFS-PER-CONTAINER-ENCRYPTION-DESIGN.md`,
`security/NETWORK-ISOLATION-DESIGN.md`) needed a trailing-space adjustment to stay aligned
after the rename added one character.

Added the two-binary explainer section to README.md's Deployment section
(`containarium`/`containariumd`, the docker/dockerd convention, which one to install where,
the compat symlink) and a matching line to DEPLOYMENT-GUIDE.md's Overview.

No concrete host/instance names introduced — every edit reused the doc's existing placeholder
IPs/hostnames.

## Test evidence

- `grep -rn 'containarium \(daemon\|sentinel\|service\|sync-accounts\|pool join\|node\|hosting\|recover\|doctor\)' docs README.md` — empty (Done-when criterion #1).
- README has the two-binary section (Done-when criterion #2).
- Manually reviewed every diff hunk (36 files) for false positives — confirmed untouched:
  systemd unit names, proto package names (`containarium.v1.*`), the unrelated
  `containarium-shell`/`containarium-runtime`/`containarium-info`/`containarium-zfs-backup`
  wrapper binaries, the `containarium-recovery.yaml` config filename, release artifact names.
- `go build ./...` clean (no Go source touched — sanity check only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)