### PR TITLE
feat(cli-split): collaborator add/remove/list get the --server remote path

### DIFF
--- a/internal/client/collaborator_test.go
+++ b/internal/client/collaborator_test.go
@@ -1,0 +1,152 @@
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestHTTPClient_AddCollaborator_Success pins #1785: the client sends the
+// owner/collaborator usernames, keys, and grant flags to the REST endpoint
+// the daemon's ContainerServer.AddCollaborator exposes, and parses the
+// collaborator + ssh_command back out of a grpc-gateway-shaped response.
+func TestHTTPClient_AddCollaborator_Success(t *testing.T) {
+	var gotPath, gotMethod string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"message": "Collaborator bob added to alice-container",
+			"collaborator": {
+				"ownerUsername": "alice",
+				"collaboratorUsername": "bob",
+				"containerName": "alice-container",
+				"accountName": "alice-container-bob",
+				"hasSudo": true
+			},
+			"sshCommand": "ssh -J jump alice-container-bob@jump"
+		}`))
+	}))
+	defer srv.Close()
+
+	c, err := NewHTTPClient(srv.URL, "tok")
+	if err != nil {
+		t.Fatalf("NewHTTPClient: %v", err)
+	}
+	resp, err := c.AddCollaborator("alice", "bob", []string{"ssh-ed25519 AAAA"}, true, false)
+	if err != nil {
+		t.Fatalf("AddCollaborator: %v", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q; want POST", gotMethod)
+	}
+	if gotPath != "/v1/containers/alice/collaborators" {
+		t.Errorf("path = %q; want /v1/containers/alice/collaborators", gotPath)
+	}
+	if gotBody["collaboratorUsername"] != "bob" {
+		t.Errorf("collaboratorUsername = %v; want bob", gotBody["collaboratorUsername"])
+	}
+	if gotBody["grantSudo"] != true {
+		t.Errorf("grantSudo = %v; want true", gotBody["grantSudo"])
+	}
+	if resp.GetCollaborator().GetAccountName() != "alice-container-bob" {
+		t.Errorf("account name = %q; want alice-container-bob", resp.GetCollaborator().GetAccountName())
+	}
+	if resp.GetSshCommand() == "" {
+		t.Errorf("ssh_command not parsed")
+	}
+}
+
+// TestHTTPClient_RemoveCollaborator_Success pins the DELETE half of #1785.
+func TestHTTPClient_RemoveCollaborator_Success(t *testing.T) {
+	var gotPath, gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"message": "Collaborator bob removed from alice-container"}`))
+	}))
+	defer srv.Close()
+
+	c, err := NewHTTPClient(srv.URL, "tok")
+	if err != nil {
+		t.Fatalf("NewHTTPClient: %v", err)
+	}
+	resp, err := c.RemoveCollaborator("alice", "bob")
+	if err != nil {
+		t.Fatalf("RemoveCollaborator: %v", err)
+	}
+
+	if gotMethod != http.MethodDelete {
+		t.Errorf("method = %q; want DELETE", gotMethod)
+	}
+	if gotPath != "/v1/containers/alice/collaborators/bob" {
+		t.Errorf("path = %q; want /v1/containers/alice/collaborators/bob", gotPath)
+	}
+	if resp.GetMessage() == "" {
+		t.Errorf("message not parsed")
+	}
+}
+
+// TestHTTPClient_ListCollaborators_Success pins the GET half of #1785.
+func TestHTTPClient_ListCollaborators_Success(t *testing.T) {
+	var gotPath, gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"collaborators": [
+				{"collaboratorUsername": "bob", "accountName": "alice-container-bob", "createdBy": "alice"},
+				{"collaboratorUsername": "carol", "accountName": "alice-container-carol"}
+			]
+		}`))
+	}))
+	defer srv.Close()
+
+	c, err := NewHTTPClient(srv.URL, "tok")
+	if err != nil {
+		t.Fatalf("NewHTTPClient: %v", err)
+	}
+	resp, err := c.ListCollaborators("alice")
+	if err != nil {
+		t.Fatalf("ListCollaborators: %v", err)
+	}
+
+	if gotMethod != http.MethodGet {
+		t.Errorf("method = %q; want GET", gotMethod)
+	}
+	if gotPath != "/v1/containers/alice/collaborators" {
+		t.Errorf("path = %q; want /v1/containers/alice/collaborators", gotPath)
+	}
+	if len(resp.GetCollaborators()) != 2 {
+		t.Fatalf("got %d collaborators; want 2", len(resp.GetCollaborators()))
+	}
+	if resp.GetCollaborators()[0].GetCollaboratorUsername() != "bob" {
+		t.Errorf("collaborators[0] username = %q; want bob", resp.GetCollaborators()[0].GetCollaboratorUsername())
+	}
+}
+
+// TestHTTPClient_AddCollaborator_ErrorPropagated pins that a 4xx daemon
+// error surfaces to the caller instead of being swallowed.
+func TestHTTPClient_AddCollaborator_ErrorPropagated(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error": "container alice-container does not exist"}`))
+	}))
+	defer srv.Close()
+
+	c, err := NewHTTPClient(srv.URL, "tok")
+	if err != nil {
+		t.Fatalf("NewHTTPClient: %v", err)
+	}
+	_, err = c.AddCollaborator("alice", "bob", []string{"ssh-ed25519 AAAA"}, false, false)
+	if err == nil {
+		t.Fatalf("expected an error for a 400 response, got nil")
+	}
+}

--- a/internal/client/grpc.go
+++ b/internal/client/grpc.go
@@ -557,6 +557,53 @@ func (c *GRPCClient) GetContainer(username string) (*incus.ContainerInfo, error)
 	return info, nil
 }
 
+// AddCollaborator adds a collaborator to a container via gRPC.
+func (c *GRPCClient) AddCollaborator(ownerUsername, collaboratorUsername string, sshPublicKeys []string, grantSudo, grantContainerRuntime bool) (*pb.AddCollaboratorResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resp, err := c.client.AddCollaborator(ctx, &pb.AddCollaboratorRequest{
+		OwnerUsername:         ownerUsername,
+		CollaboratorUsername:  collaboratorUsername,
+		SshPublicKeys:         sshPublicKeys,
+		GrantSudo:             grantSudo,
+		GrantContainerRuntime: grantContainerRuntime,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to add collaborator: %w", err)
+	}
+	return resp, nil
+}
+
+// RemoveCollaborator removes a collaborator from a container via gRPC.
+func (c *GRPCClient) RemoveCollaborator(ownerUsername, collaboratorUsername string) (*pb.RemoveCollaboratorResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resp, err := c.client.RemoveCollaborator(ctx, &pb.RemoveCollaboratorRequest{
+		OwnerUsername:        ownerUsername,
+		CollaboratorUsername: collaboratorUsername,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to remove collaborator: %w", err)
+	}
+	return resp, nil
+}
+
+// ListCollaborators lists collaborators for a container via gRPC.
+func (c *GRPCClient) ListCollaborators(ownerUsername string) (*pb.ListCollaboratorsResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resp, err := c.client.ListCollaborators(ctx, &pb.ListCollaboratorsRequest{
+		OwnerUsername: ownerUsername,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list collaborators: %w", err)
+	}
+	return resp, nil
+}
+
 // DebugContainer returns a diagnostic report for a container's SSH path.
 func (c *GRPCClient) DebugContainer(username string) (*pb.DebugContainerResponse, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -1274,6 +1274,87 @@ func (c *HTTPClient) GetContainer(username string) (*incus.ContainerInfo, error)
 	return &info, nil
 }
 
+// AddCollaborator adds a collaborator to a container via HTTP.
+func (c *HTTPClient) AddCollaborator(ownerUsername, collaboratorUsername string, sshPublicKeys []string, grantSudo, grantContainerRuntime bool) (*pb.AddCollaboratorResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	req := &pb.AddCollaboratorRequest{
+		OwnerUsername:         ownerUsername,
+		CollaboratorUsername:  collaboratorUsername,
+		SshPublicKeys:         sshPublicKeys,
+		GrantSudo:             grantSudo,
+		GrantContainerRuntime: grantContainerRuntime,
+	}
+	body, err := protojson.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("encode request: %w", err)
+	}
+
+	path := fmt.Sprintf("/v1/containers/%s/collaborators", url.PathEscape(ownerUsername))
+	resp, err := c.doRequest(ctx, http.MethodPost, path, json.RawMessage(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to add collaborator: %w", err)
+	}
+	defer drainClose(resp)
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return nil, httpError(bodyBytes, resp.StatusCode, "add collaborator")
+	}
+	out := &pb.AddCollaboratorResponse{}
+	if err := protojson.Unmarshal(bodyBytes, out); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return out, nil
+}
+
+// RemoveCollaborator removes a collaborator from a container via HTTP.
+func (c *HTTPClient) RemoveCollaborator(ownerUsername, collaboratorUsername string) (*pb.RemoveCollaboratorResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	path := fmt.Sprintf("/v1/containers/%s/collaborators/%s", url.PathEscape(ownerUsername), url.PathEscape(collaboratorUsername))
+	resp, err := c.doRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to remove collaborator: %w", err)
+	}
+	defer drainClose(resp)
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return nil, httpError(bodyBytes, resp.StatusCode, "remove collaborator")
+	}
+	out := &pb.RemoveCollaboratorResponse{}
+	if err := protojson.Unmarshal(bodyBytes, out); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return out, nil
+}
+
+// ListCollaborators lists collaborators for a container via HTTP.
+func (c *HTTPClient) ListCollaborators(ownerUsername string) (*pb.ListCollaboratorsResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	path := fmt.Sprintf("/v1/containers/%s/collaborators", url.PathEscape(ownerUsername))
+	resp, err := c.doRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list collaborators: %w", err)
+	}
+	defer drainClose(resp)
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return nil, httpError(bodyBytes, resp.StatusCode, "list collaborators")
+	}
+	out := &pb.ListCollaboratorsResponse{}
+	if err := protojson.Unmarshal(bodyBytes, out); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return out, nil
+}
+
 // DebugContainer returns a diagnostic report for a container's SSH path.
 func (c *HTTPClient) DebugContainer(username string) (*pb.DebugContainerResponse, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/internal/cmd/collaborator.go
+++ b/internal/cmd/collaborator.go
@@ -1,5 +1,3 @@
-//go:build !containarium_client
-
 package cmd
 
 import (

--- a/internal/cmd/collaborator_add.go
+++ b/internal/cmd/collaborator_add.go
@@ -1,15 +1,12 @@
-//go:build !windows && !containarium_client
-
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"strings"
 
-	"github.com/footprintai/containarium/internal/collaborator"
-	"github.com/footprintai/containarium/pkg/core/container"
+	"github.com/footprintai/containarium/internal/client"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 	"github.com/spf13/cobra"
 )
 
@@ -50,7 +47,10 @@ Examples:
   containarium collaborator add alice carol --ssh-key /path/to/carol.pub
 
   # Authorize several of bob's keys (one per machine)
-  containarium collaborator add alice bob --ssh-key ~/.ssh/bob-laptop.pub --ssh-key ~/.ssh/bob-desktop.pub`,
+  containarium collaborator add alice bob --ssh-key ~/.ssh/bob-laptop.pub --ssh-key ~/.ssh/bob-desktop.pub
+
+  # Against a remote daemon
+  containarium collaborator add alice bob --ssh-key ~/.ssh/bob.pub --server daemon.example.com:50051`,
 	Args: cobra.ExactArgs(2),
 	RunE: runCollaboratorAdd,
 }
@@ -92,51 +92,60 @@ func runCollaboratorAdd(cmd *cobra.Command, args []string) error {
 		sshPublicKeys = append(sshPublicKeys, sshPublicKey)
 	}
 
-	// Local mode only for now (requires PostgreSQL)
-	return addCollaboratorLocal(ownerUsername, collaboratorUsername, sshPublicKeys)
+	switch {
+	case httpMode && serverAddr != "":
+		return addCollaboratorRemoteHTTP(ownerUsername, collaboratorUsername, sshPublicKeys)
+	case serverAddr != "":
+		return addCollaboratorRemote(ownerUsername, collaboratorUsername, sshPublicKeys)
+	default:
+		return addCollaboratorLocal(ownerUsername, collaboratorUsername, sshPublicKeys)
+	}
 }
 
-func addCollaboratorLocal(ownerUsername, collaboratorUsername string, sshPublicKeys []string) error {
-	// Create container manager
-	containerMgr, err := container.New()
+func addCollaboratorRemote(ownerUsername, collaboratorUsername string, sshPublicKeys []string) error {
+	grpcClient, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
 	if err != nil {
-		return fmt.Errorf("failed to connect to Incus: %w (is Incus running?)", err)
+		return fmt.Errorf("failed to connect to remote server: %w", err)
 	}
+	defer func() { _ = grpcClient.Close() }()
 
-	// Check if container exists
-	containerName := ownerUsername + "-container"
-	if !containerMgr.ContainerExists(containerName) {
-		return fmt.Errorf("container %q does not exist", containerName)
-	}
-
-	// Create collaborator store
-	collaboratorStore, err := collaborator.NewStore(context.Background(), getPostgresConnString())
-	if err != nil {
-		return fmt.Errorf("failed to connect to collaborator database: %w\n(Is PostgreSQL running? Set CONTAINARIUM_POSTGRES_URL if using non-default location)", err)
-	}
-	defer collaboratorStore.Close()
-
-	// Create collaborator manager
-	collaboratorMgr := container.NewCollaboratorManager(containerMgr, collaboratorStore)
-
-	// Add collaborator
-	collab, err := collaboratorMgr.AddCollaborator(ownerUsername, collaboratorUsername, sshPublicKeys, collaboratorGrantSudo, collaboratorGrantRuntime)
+	resp, err := grpcClient.AddCollaborator(ownerUsername, collaboratorUsername, sshPublicKeys, collaboratorGrantSudo, collaboratorGrantRuntime)
 	if err != nil {
 		return fmt.Errorf("failed to add collaborator: %w", err)
 	}
+	printAddCollaboratorResponse(resp)
+	return nil
+}
 
-	fmt.Printf("Collaborator %s added to %s-container\n\n", collaboratorUsername, ownerUsername)
-	fmt.Printf("Account name: %s\n", collab.AccountName)
-	fmt.Printf("SSH command:  %s\n\n", collaboratorMgr.GenerateSSHCommand(ownerUsername, collaboratorUsername, "<jump-server-ip>"))
-	if collab.HasSudo {
+func addCollaboratorRemoteHTTP(ownerUsername, collaboratorUsername string, sshPublicKeys []string) error {
+	httpClient, err := client.NewHTTPClient(serverAddr, authToken)
+	if err != nil {
+		return fmt.Errorf("failed to create HTTP client: %w", err)
+	}
+	defer func() { _ = httpClient.Close() }()
+
+	resp, err := httpClient.AddCollaborator(ownerUsername, collaboratorUsername, sshPublicKeys, collaboratorGrantSudo, collaboratorGrantRuntime)
+	if err != nil {
+		return fmt.Errorf("failed to add collaborator: %w", err)
+	}
+	printAddCollaboratorResponse(resp)
+	return nil
+}
+
+func printAddCollaboratorResponse(resp *pb.AddCollaboratorResponse) {
+	collab := resp.GetCollaborator()
+	fmt.Printf("Collaborator %s added to %s\n\n", collab.GetCollaboratorUsername(), collab.GetContainerName())
+	fmt.Printf("Account name: %s\n", collab.GetAccountName())
+	if resp.GetSshCommand() != "" {
+		fmt.Printf("SSH command:  %s\n\n", resp.GetSshCommand())
+	}
+	if collab.GetHasSudo() {
 		fmt.Printf("Sudo access:  full (ALL commands)\n")
 	} else {
-		fmt.Printf("After connecting, use: sudo su - %s\n", ownerUsername)
+		fmt.Printf("After connecting, use: sudo su - %s\n", collab.GetOwnerUsername())
 	}
-	if collab.HasContainerRuntime {
+	if collab.GetHasContainerRuntime() {
 		fmt.Printf("Container runtime: docker/podman group membership granted\n")
 	}
-	fmt.Printf("Sessions are logged to: /var/log/sudo-io/%s/\n", collab.AccountName)
-
-	return nil
+	fmt.Printf("Sessions are logged to: /var/log/sudo-io/%s/\n", collab.GetAccountName())
 }

--- a/internal/cmd/collaborator_list.go
+++ b/internal/cmd/collaborator_list.go
@@ -1,15 +1,13 @@
-//go:build !windows && !containarium_client
-
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"text/tabwriter"
 	"time"
 
-	"github.com/footprintai/containarium/internal/collaborator"
+	"github.com/footprintai/containarium/internal/client"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 	"github.com/spf13/cobra"
 )
 
@@ -20,7 +18,10 @@ var collaboratorListCmd = &cobra.Command{
 
 Examples:
   # List collaborators for alice's container
-  containarium collaborator list alice`,
+  containarium collaborator list alice
+
+  # Against a remote daemon
+  containarium collaborator list alice --server daemon.example.com:50051`,
 	Args: cobra.ExactArgs(1),
 	RunE: runCollaboratorList,
 }
@@ -29,51 +30,105 @@ func init() {
 	collaboratorCmd.AddCommand(collaboratorListCmd)
 }
 
-func runCollaboratorList(cmd *cobra.Command, args []string) error {
-	ownerUsername := args[0]
-
-	// Local mode only for now (requires PostgreSQL)
-	return listCollaboratorsLocal(ownerUsername)
+// collaboratorRow is the local/remote-agnostic shape printCollaboratorTable
+// needs — local mode reads internal/collaborator.Collaborator straight from
+// Postgres, remote mode gets pb.Collaborator off the wire; both normalize
+// into this before printing so the table code is written once. Defined
+// here (not in collaborator_local.go) so it's visible under both build
+// tags: the containarium_client stub for listCollaboratorsLocal returns
+// this same type.
+type collaboratorRow struct {
+	CollaboratorUsername string
+	AccountName          string
+	CreatedAt            time.Time
+	CreatedBy            string
 }
 
-func listCollaboratorsLocal(ownerUsername string) error {
+func runCollaboratorList(cmd *cobra.Command, args []string) error {
+	ownerUsername := args[0]
 	containerName := ownerUsername + "-container"
 
-	// Create collaborator store
-	collaboratorStore, err := collaborator.NewStore(context.Background(), getPostgresConnString())
-	if err != nil {
-		return fmt.Errorf("failed to connect to collaborator database: %w\n(Is PostgreSQL running? Set CONTAINARIUM_POSTGRES_URL if using non-default location)", err)
+	var (
+		rows []collaboratorRow
+		err  error
+	)
+	switch {
+	case httpMode && serverAddr != "":
+		rows, err = listCollaboratorsRemoteHTTP(ownerUsername)
+	case serverAddr != "":
+		rows, err = listCollaboratorsRemote(ownerUsername)
+	default:
+		rows, err = listCollaboratorsLocal(ownerUsername)
 	}
-	defer collaboratorStore.Close()
-
-	// List collaborators
-	collaborators, err := collaboratorStore.List(context.Background(), containerName)
 	if err != nil {
-		return fmt.Errorf("failed to list collaborators: %w", err)
+		return err
 	}
 
-	if len(collaborators) == 0 {
+	printCollaboratorTable(containerName, rows)
+	return nil
+}
+
+func listCollaboratorsRemote(ownerUsername string) ([]collaboratorRow, error) {
+	grpcClient, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to remote server: %w", err)
+	}
+	defer func() { _ = grpcClient.Close() }()
+
+	resp, err := grpcClient.ListCollaborators(ownerUsername)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list collaborators: %w", err)
+	}
+	return pbCollaboratorsToRows(resp.GetCollaborators()), nil
+}
+
+func listCollaboratorsRemoteHTTP(ownerUsername string) ([]collaboratorRow, error) {
+	httpClient, err := client.NewHTTPClient(serverAddr, authToken)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP client: %w", err)
+	}
+	defer func() { _ = httpClient.Close() }()
+
+	resp, err := httpClient.ListCollaborators(ownerUsername)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list collaborators: %w", err)
+	}
+	return pbCollaboratorsToRows(resp.GetCollaborators()), nil
+}
+
+func pbCollaboratorsToRows(collaborators []*pb.Collaborator) []collaboratorRow {
+	rows := make([]collaboratorRow, 0, len(collaborators))
+	for _, c := range collaborators {
+		rows = append(rows, collaboratorRow{
+			CollaboratorUsername: c.GetCollaboratorUsername(),
+			AccountName:          c.GetAccountName(),
+			CreatedAt:            time.Unix(c.GetAddedAt(), 0),
+			CreatedBy:            c.GetCreatedBy(),
+		})
+	}
+	return rows
+}
+
+func printCollaboratorTable(containerName string, rows []collaboratorRow) {
+	if len(rows) == 0 {
 		fmt.Printf("No collaborators found for %s\n", containerName)
-		return nil
+		return
 	}
 
 	fmt.Printf("Collaborators for %s:\n\n", containerName)
 
-	// Print as table
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(w, "USERNAME\tACCOUNT NAME\tADDED AT\tADDED BY")
 	fmt.Fprintln(w, "--------\t------------\t--------\t--------")
 
-	for _, c := range collaborators {
-		addedAt := c.CreatedAt.Format(time.RFC3339)
-		addedBy := c.CreatedBy
+	for _, row := range rows {
+		addedBy := row.CreatedBy
 		if addedBy == "" {
 			addedBy = "-"
 		}
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", c.CollaboratorUsername, c.AccountName, addedAt, addedBy)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", row.CollaboratorUsername, row.AccountName, row.CreatedAt.Format(time.RFC3339), addedBy)
 	}
 	_ = w.Flush()
 
-	fmt.Printf("\nTotal: %d collaborator(s)\n", len(collaborators))
-	return nil
+	fmt.Printf("\nTotal: %d collaborator(s)\n", len(rows))
 }

--- a/internal/cmd/collaborator_local.go
+++ b/internal/cmd/collaborator_local.go
@@ -1,0 +1,116 @@
+//go:build !windows && !containarium_client
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/footprintai/containarium/internal/collaborator"
+	"github.com/footprintai/containarium/pkg/core/container"
+)
+
+func addCollaboratorLocal(ownerUsername, collaboratorUsername string, sshPublicKeys []string) error {
+	// Create container manager
+	containerMgr, err := container.New()
+	if err != nil {
+		return fmt.Errorf("failed to connect to Incus: %w (is Incus running?)", err)
+	}
+
+	// Check if container exists
+	containerName := ownerUsername + "-container"
+	if !containerMgr.ContainerExists(containerName) {
+		return fmt.Errorf("container %q does not exist", containerName)
+	}
+
+	// Create collaborator store
+	collaboratorStore, err := collaborator.NewStore(context.Background(), getPostgresConnString())
+	if err != nil {
+		return fmt.Errorf("failed to connect to collaborator database: %w\n(Is PostgreSQL running? Set CONTAINARIUM_POSTGRES_URL if using non-default location)", err)
+	}
+	defer collaboratorStore.Close()
+
+	// Create collaborator manager
+	collaboratorMgr := container.NewCollaboratorManager(containerMgr, collaboratorStore)
+
+	// Add collaborator
+	collab, err := collaboratorMgr.AddCollaborator(ownerUsername, collaboratorUsername, sshPublicKeys, collaboratorGrantSudo, collaboratorGrantRuntime)
+	if err != nil {
+		return fmt.Errorf("failed to add collaborator: %w", err)
+	}
+
+	fmt.Printf("Collaborator %s added to %s-container\n\n", collaboratorUsername, ownerUsername)
+	fmt.Printf("Account name: %s\n", collab.AccountName)
+	fmt.Printf("SSH command:  %s\n\n", collaboratorMgr.GenerateSSHCommand(ownerUsername, collaboratorUsername, "<jump-server-ip>"))
+	if collab.HasSudo {
+		fmt.Printf("Sudo access:  full (ALL commands)\n")
+	} else {
+		fmt.Printf("After connecting, use: sudo su - %s\n", ownerUsername)
+	}
+	if collab.HasContainerRuntime {
+		fmt.Printf("Container runtime: docker/podman group membership granted\n")
+	}
+	fmt.Printf("Sessions are logged to: /var/log/sudo-io/%s/\n", collab.AccountName)
+
+	return nil
+}
+
+func removeCollaboratorLocal(ownerUsername, collaboratorUsername string) error {
+	// Create container manager
+	containerMgr, err := container.New()
+	if err != nil {
+		return fmt.Errorf("failed to connect to Incus: %w (is Incus running?)", err)
+	}
+
+	// Create collaborator store
+	collaboratorStore, err := collaborator.NewStore(context.Background(), getPostgresConnString())
+	if err != nil {
+		return fmt.Errorf("failed to connect to collaborator database: %w\n(Is PostgreSQL running? Set CONTAINARIUM_POSTGRES_URL if using non-default location)", err)
+	}
+	defer collaboratorStore.Close()
+
+	// Create collaborator manager
+	collaboratorMgr := container.NewCollaboratorManager(containerMgr, collaboratorStore)
+
+	// Remove collaborator
+	if err := collaboratorMgr.RemoveCollaborator(ownerUsername, collaboratorUsername); err != nil {
+		return fmt.Errorf("failed to remove collaborator: %w", err)
+	}
+
+	fmt.Printf("Collaborator %s removed from %s-container\n", collaboratorUsername, ownerUsername)
+	return nil
+}
+
+// listCollaboratorsLocal returns []collaboratorRow, not []collaborator.Collaborator
+// — the dispatcher (collaborator_list.go, no build tag) needs a signature
+// that also exists under containarium_client (local_stubs_client.go's
+// stub), and internal/collaborator imports pgx, which the client build
+// must never link in. collaboratorRow is a plain cmd-package type with no
+// such dependency.
+func listCollaboratorsLocal(ownerUsername string) ([]collaboratorRow, error) {
+	containerName := ownerUsername + "-container"
+
+	// Create collaborator store
+	collaboratorStore, err := collaborator.NewStore(context.Background(), getPostgresConnString())
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to collaborator database: %w\n(Is PostgreSQL running? Set CONTAINARIUM_POSTGRES_URL if using non-default location)", err)
+	}
+	defer collaboratorStore.Close()
+
+	// List collaborators
+	collaborators, err := collaboratorStore.List(context.Background(), containerName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list collaborators: %w", err)
+	}
+
+	rows := make([]collaboratorRow, 0, len(collaborators))
+	for _, c := range collaborators {
+		rows = append(rows, collaboratorRow{
+			CollaboratorUsername: c.CollaboratorUsername,
+			AccountName:          c.AccountName,
+			CreatedAt:            c.CreatedAt,
+			CreatedBy:            c.CreatedBy,
+		})
+	}
+	return rows, nil
+}

--- a/internal/cmd/collaborator_remove.go
+++ b/internal/cmd/collaborator_remove.go
@@ -1,13 +1,9 @@
-//go:build !windows && !containarium_client
-
 package cmd
 
 import (
-	"context"
 	"fmt"
 
-	"github.com/footprintai/containarium/internal/collaborator"
-	"github.com/footprintai/containarium/pkg/core/container"
+	"github.com/footprintai/containarium/internal/client"
 	"github.com/spf13/cobra"
 )
 
@@ -23,7 +19,10 @@ This will:
 
 Examples:
   # Remove bob as a collaborator from alice's container
-  containarium collaborator remove alice bob`,
+  containarium collaborator remove alice bob
+
+  # Against a remote daemon
+  containarium collaborator remove alice bob --server daemon.example.com:50051`,
 	Args: cobra.ExactArgs(2),
 	RunE: runCollaboratorRemove,
 }
@@ -36,32 +35,42 @@ func runCollaboratorRemove(cmd *cobra.Command, args []string) error {
 	ownerUsername := args[0]
 	collaboratorUsername := args[1]
 
-	// Local mode only for now (requires PostgreSQL)
-	return removeCollaboratorLocal(ownerUsername, collaboratorUsername)
+	switch {
+	case httpMode && serverAddr != "":
+		return removeCollaboratorRemoteHTTP(ownerUsername, collaboratorUsername)
+	case serverAddr != "":
+		return removeCollaboratorRemote(ownerUsername, collaboratorUsername)
+	default:
+		return removeCollaboratorLocal(ownerUsername, collaboratorUsername)
+	}
 }
 
-func removeCollaboratorLocal(ownerUsername, collaboratorUsername string) error {
-	// Create container manager
-	containerMgr, err := container.New()
+func removeCollaboratorRemote(ownerUsername, collaboratorUsername string) error {
+	grpcClient, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
 	if err != nil {
-		return fmt.Errorf("failed to connect to Incus: %w (is Incus running?)", err)
+		return fmt.Errorf("failed to connect to remote server: %w", err)
 	}
+	defer func() { _ = grpcClient.Close() }()
 
-	// Create collaborator store
-	collaboratorStore, err := collaborator.NewStore(context.Background(), getPostgresConnString())
+	resp, err := grpcClient.RemoveCollaborator(ownerUsername, collaboratorUsername)
 	if err != nil {
-		return fmt.Errorf("failed to connect to collaborator database: %w\n(Is PostgreSQL running? Set CONTAINARIUM_POSTGRES_URL if using non-default location)", err)
-	}
-	defer collaboratorStore.Close()
-
-	// Create collaborator manager
-	collaboratorMgr := container.NewCollaboratorManager(containerMgr, collaboratorStore)
-
-	// Remove collaborator
-	if err := collaboratorMgr.RemoveCollaborator(ownerUsername, collaboratorUsername); err != nil {
 		return fmt.Errorf("failed to remove collaborator: %w", err)
 	}
+	fmt.Println(resp.GetMessage())
+	return nil
+}
 
-	fmt.Printf("Collaborator %s removed from %s-container\n", collaboratorUsername, ownerUsername)
+func removeCollaboratorRemoteHTTP(ownerUsername, collaboratorUsername string) error {
+	httpClient, err := client.NewHTTPClient(serverAddr, authToken)
+	if err != nil {
+		return fmt.Errorf("failed to create HTTP client: %w", err)
+	}
+	defer func() { _ = httpClient.Close() }()
+
+	resp, err := httpClient.RemoveCollaborator(ownerUsername, collaboratorUsername)
+	if err != nil {
+		return fmt.Errorf("failed to remove collaborator: %w", err)
+	}
+	fmt.Println(resp.GetMessage())
 	return nil
 }

--- a/internal/cmd/collaborator_windows_stub.go
+++ b/internal/cmd/collaborator_windows_stub.go
@@ -1,0 +1,22 @@
+//go:build windows && !containarium_client
+
+package cmd
+
+import "fmt"
+
+// Collaborator management needs a local Postgres store
+// (getPostgresConnString, in turn internal/server) which does not compile
+// on Windows — internal/server pulls in Unix-only file-ownership and eBPF
+// code (see postgres.go's own !windows tag). This is the same "Windows is
+// CLIENT-ONLY" shape the rest of cmd/containariumd's windows build already
+// has via scattered !windows tags on individual files (see build-all's
+// comment in the Makefile): these stubs keep that windows target
+// compiling, and the collaborator commands behave there exactly like they
+// do on the containarium_client build — they need --server.
+var errCollaboratorNotOnWindows = fmt.Errorf("collaborator management requires a Linux/macOS host — pass --server to reach one")
+
+func addCollaboratorLocal(_, _ string, _ []string) error { return errCollaboratorNotOnWindows }
+func removeCollaboratorLocal(_, _ string) error          { return errCollaboratorNotOnWindows }
+func listCollaboratorsLocal(_ string) ([]collaboratorRow, error) {
+	return nil, errCollaboratorNotOnWindows
+}

--- a/internal/cmd/local_stubs_client.go
+++ b/internal/cmd/local_stubs_client.go
@@ -16,7 +16,8 @@ import (
 // user sees if they somehow reach one of these stubs (in practice,
 // resolveServerAddr's server-resolution chain and the "no server
 // configured" error at the client constructors already fail earlier for
-// every one of the twelve hybrid commands; these stubs are defence in
+// every one of the thirteen hybrid commands (#1785 added collaborator as
+// the thirteenth); these stubs are defence in
 // depth, turning a future forgotten check into a clear error instead of a
 // build break or a silent local Incus call).
 var errNoLocalMode = errors.New("this is the containarium client; it has no local mode — pass --server, run `containarium login`, or use containariumd on the host")
@@ -57,3 +58,10 @@ func installStackLocal(_, _ string) error { return errNoLocalMode }
 
 // resize.go
 func runResizeLocal(_, _ string) error { return errNoLocalMode }
+
+// collaborator_add.go / collaborator_remove.go / collaborator_list.go
+func addCollaboratorLocal(_, _ string, _ []string) error { return errNoLocalMode }
+func removeCollaboratorLocal(_, _ string) error          { return errNoLocalMode }
+func listCollaboratorsLocal(_ string) ([]collaboratorRow, error) {
+	return nil, errNoLocalMode
+}

--- a/internal/cmd/local_stubs_client_test.go
+++ b/internal/cmd/local_stubs_client_test.go
@@ -4,14 +4,16 @@ package cmd
 
 import (
 	"errors"
+	"os"
 	"testing"
 )
 
 // TestHybridCommands_NoServer_NeverReachRealLocalMode is #1775's Done-when
 // table-driven test: with no --server (and no CONTAINARIUM_SERVER/
-// credentials.json fallback in play), every one of the twelve hybrid
-// commands must error via a *Local stub — never via a working local-Incus
-// call, because under containarium_client every *Local symbol IS one of
+// credentials.json fallback in play), every one of the thirteen hybrid
+// commands (#1785 added collaborator) must error via a *Local stub — never
+// via a working local-Incus call, because under containarium_client every
+// *Local symbol IS one of
 // those stubs (local_stubs_client.go). errors.Is against errNoLocalMode is
 // exactly the assertion that proves this: it can only be true if the
 // call reached a stub, since errNoLocalMode is not constructible any other
@@ -97,6 +99,29 @@ func TestHybridCommands_NoServer_NeverReachRealLocalMode(t *testing.T) {
 			name:  "ssh-config sync",
 			setup: func() { sshConfigOutPath = t.TempDir() + "/ssh_config"; sshConfigForce = true },
 			run:   func() error { return runSSHConfigSync(testCmd(), nil) },
+		},
+		{
+			name: "collaborator add",
+			setup: func() {
+				keyFile := t.TempDir() + "/bob.pub"
+				if err := os.WriteFile(keyFile, []byte("ssh-ed25519 AAAAtest bob@example.com"), 0o600); err != nil {
+					t.Fatalf("write test ssh key: %v", err)
+				}
+				collaboratorSSHKeyFiles = []string{keyFile}
+				collaboratorGrantSudo = false
+				collaboratorGrantRuntime = false
+			},
+			run: func() error { return runCollaboratorAdd(testCmd(), []string{"owner", "bob"}) },
+		},
+		{
+			name:  "collaborator remove",
+			setup: func() {},
+			run:   func() error { return runCollaboratorRemove(testCmd(), []string{"owner", "bob"}) },
+		},
+		{
+			name:  "collaborator list",
+			setup: func() {},
+			run:   func() error { return runCollaboratorList(testCmd(), []string{"owner"}) },
 		},
 		{
 			name:  "prune",

--- a/internal/cmd/testdata/client_command_tree.golden
+++ b/internal/cmd/testdata/client_command_tree.golden
@@ -42,6 +42,9 @@ code install
 code run
 code status
 code stop
+collaborator add
+collaborator list
+collaborator remove
 compose disable
 compose discover
 compose enable


### PR DESCRIPTION
Closes #1785

## Summary

`internal/cmd/collaborator_{add,remove,list}.go` only ever called `container.New()` +
`NewCollaboratorManager` — no `--server` branch — so after the client/server split the
client binary had no `collaborator` verb at all, even though the proto
(`AddCollaborator`/`RemoveCollaborator`/`ListCollaborators`, already wired into
`container_server.go` and the REST gateway) and the cloud shim both already use these RPCs.

Added the remote branch with the same three-way dispatch shape as `get.go` (HTTP / gRPC /
local), making `collaborator` the thirteenth hybrid:

- `internal/client/grpc.go`, `http.go`: `AddCollaborator`/`RemoveCollaborator`/
  `ListCollaborators` on both `GRPCClient` and `HTTPClient`, following the
  `CreateBackup`/`DebugContainer` pattern — `protojson` marshal the pb request, unmarshal
  the pb response, no ad-hoc structs needed since the proto types already carry everything
  the CLI prints.
- `collaborator_local.go` (new, `!windows && !containarium_client`): the local half, moved
  verbatim from the three original files.
- `collaborator_windows_stub.go` (new, `windows && !containarium_client`): a real gap I
  found while cross-compiling — `getPostgresConnString` (and `internal/server` underneath
  it) doesn't compile on Windows, same reason `postgres.go` itself is `!windows`-tagged.
  The windows-target `containariumd` build (built from `cmd/containariumd/main.go` with no
  client tag, per the Makefile's "Windows is CLIENT-ONLY" convention) needs its own stub for
  the three Local functions or it fails to link.
- `local_stubs_client.go`: the `containarium_client`-build stubs, extending the existing
  `errNoLocalMode` pattern.
- `testdata/client_command_tree.golden`: added the three new client paths.

`collaborator.go` (the parent cobra command) lost its `!containarium_client` tag so it's
registered in both builds.

## Test evidence

- `TestHybridCommands_NoServer_NeverReachRealLocalMode` (#1775's Done-when table test)
  extended with collaborator add/remove/list — all reach the `errNoLocalMode` stub under
  `containarium_client`, not real Incus/Postgres code.
- `TestClientCommandTree_MatchesGoldenAllowList`,
  `TestContainariumdCommandTree_SupersetOfClientGolden` — both green with the three new
  paths.
- `scripts/test-cli-split-deps.sh` — green: `pkg/core/container`, `internal/server`, and
  `github.com/jackc/pgx` (pulled in transitively by `internal/collaborator`) all stay absent
  from the client's dependency graph.
- New `internal/client/collaborator_test.go`: HTTP-layer tests (request path/method/body,
  response parsing, error propagation) for all three RPCs — matches this package's existing
  test coverage level (none of `DebugContainer`/`GetConsoleLog`/`CreateBackup` have
  gRPC-layer unit tests either; that surface is covered by the e2e lanes).
- `go build`/`vet`/`test` clean across: default tags, `containarium_client` (native +
  windows cross-compile), and a plain `go build cmd/containariumd/main.go` cross-compiled
  for windows and darwin/arm64 (the three-way tag split above only shows up on that windows
  daemon target).
- `golangci-lint`: 0 issues.

## Deviation from the design doc worth flagging

The issue text says "same shape as `label` (gRPC + HTTP)" — `label`'s own gRPC branch is
actually a stub today (`"label operations not yet supported via gRPC - use --http mode"`).
I implemented collaborator's gRPC branch for real (matching `get.go`'s fully-working
three-way shape instead), since the issue explicitly asked for gRPC + HTTP and the proto/
server side were already there for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added collaborator management through local, gRPC, and HTTP modes.
  - Added commands to add, list, and remove collaborators on remote daemons.
  - Collaborator access can include SSH keys, sudo permissions, and container-runtime permissions.
  - Added Windows handling for unsupported local collaborator operations.

- **Tests**
  - Added coverage for collaborator API requests, responses, error handling, and command routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->