### PR TITLE
fix(cli-split): make test-old-binary-path-gate.sh portable to BSD grep

### DIFF
--- a/scripts/test-old-binary-path-gate.sh
+++ b/scripts/test-old-binary-path-gate.sh
@@ -11,14 +11,21 @@
 # script still downloads or installs the OLD path as if it were the real
 # binary — exactly the class of bug #1781 exists to catch.
 #
-# Pattern uses a negative lookahead (grep -P) so it does NOT false-positive
-# on unrelated binaries that happen to share the "containarium" prefix
-# (containarium-shell, containarium-info, containarium-runtime,
-# containarium-runner-loop, containarium-zfs-backup, containariumd itself).
+# Portability note: this deliberately avoids grep -P (a negative-lookahead
+# version of this gate silently misbehaved on stock macOS, whose BSD grep
+# has no -P at all — flagged on #1797). Instead of "containarium not
+# followed by a word/hyphen char", we capture the FULL identifier run
+# after the path (grep -oE '...containarium[a-zA-Z0-9_-]*') and check in
+# the shell whether that run is exactly "containarium" — everything else
+# (containariumd, containarium-shell, containarium-info,
+# containarium-runner-loop, containarium-zfs-backup, ...) is a different,
+# unrelated binary and never matches. -n/-o/-E are POSIX and behave
+# identically under GNU and BSD grep.
 set -uo pipefail
 cd "$(dirname "$0")/.."
 
-PATTERN='/usr/local/bin/containarium(?![a-zA-Z0-9_-])'
+PATTERN='/usr/local/bin/containarium[a-zA-Z0-9_-]*'
+OLD_PATH='/usr/local/bin/containarium'
 
 # Client-side / compat-shim files where the OLD path is the correct,
 # intentional value — not a stale reference.
@@ -52,15 +59,25 @@ is_allowlisted() {
   return 1
 }
 
+# stale_hits_in_file prints "LINENO: MATCH" for every occurrence in $1
+# whose full identifier run is exactly the bare old path — i.e. filters
+# out containariumd and every unrelated containarium-* binary.
+stale_hits_in_file() {
+  local file="$1"
+  grep -noE "$PATTERN" "$file" 2>/dev/null | while IFS=: read -r lineno match; do
+    [ "$match" = "$OLD_PATH" ] && printf '%s: %s\n' "$lineno" "$match"
+  done
+}
+
 SELF="scripts/$(basename "$0")"
 
 fail=0
 while IFS= read -r -d '' file; do
-  # Skip this gate script itself — its own comments and PATTERN literal
-  # necessarily contain the string being searched for.
+  # Skip this gate script itself — its own comments and PATTERN/OLD_PATH
+  # literals necessarily contain the string being searched for.
   [ "$file" = "$SELF" ] && continue
 
-  hits="$(grep -nP "$PATTERN" "$file" 2>/dev/null || true)"
+  hits="$(stale_hits_in_file "$file")"
   [ -z "$hits" ] && continue
 
   if is_allowlisted "$file"; then
@@ -82,7 +99,7 @@ for a in "${ALLOWLIST[@]}"; do
     fail=1
     continue
   fi
-  if ! grep -qP "$PATTERN" "$a"; then
+  if [ -z "$(stale_hits_in_file "$a")" ]; then
     echo "FAIL  allow-list entry '$a' no longer references the old path — remove it from scripts/test-old-binary-path-gate.sh"
     fail=1
   fi


### PR DESCRIPTION
Fixes a nit filed against #1797 during its independent review (see the
2026-09-10 update on #1787): `scripts/test-old-binary-path-gate.sh`'s
negative-lookahead pattern (`grep -P '...containarium(?!...)'`) silently
misbehaves on stock macOS — BSD grep has no `-P` at all, so the main
check false-negatives (never flags anything) and the allow-list
dead-entry check false-fails on every entry. CI runs `ubuntu-latest` so
this was never visible there; anyone running the gate locally on a Mac
got wrong results either way.

## Fix

Replaced the lookahead with `grep -noE '...containarium[a-zA-Z0-9_-]*'`
(POSIX ERE, no GNU/PCRE extension) that captures the full identifier run
after the path, then compares it in the shell against the bare old path.
Same filtering behavior as before — `containariumd`,
`containarium-shell`, `containarium-info`, etc. are still correctly
excluded — just without depending on `-P`.

## Test evidence

- `./scripts/test-old-binary-path-gate.sh` — PASS (unchanged behavior on
  the current tree).
- Sabotage-tested both directions:
  - Appended a real stale reference (`/usr/local/bin/containarium`) to a
    non-allow-listed script — correctly caught, reverted.
  - Appended `containarium-shell` and `containariumd` mentions to the
    same script — correctly NOT flagged, reverted.
- Verified the allow-list dead-entry check still fires: built a scratch
  repo with a fake allow-list entry pointing at a file with no old-path
  mention, confirmed it's flagged as dead.
- `./scripts/test-cli-split-deps.sh`, `go build ./...` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated validation to detect only exact matches for the legacy executable path.
  - Prevented similarly named executables from being incorrectly flagged.
  - Applied consistent matching when checking files and allow-list entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->