### PR TITLE
chore(release): cut v0.76.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.76.2] - 2026-09-11
+
+### Fixed
+
+- **`POST /v1/backends/upgrade` (`TriggerUpgrade`) 404'd over HTTP/REST on
+  every version that has shipped it** (#1805) — `containarium backends
+  upgrade --http` and the MCP `upgrade_backend` tool were both broken, with
+  no working fallback (the CLI's upgrade subcommand hardcodes an HTTP URL
+  regardless of `--server` scheme, so there was no gRPC escape hatch
+  either). `http.ServeMux`'s longest-prefix-wins rule routed the request
+  into the legacy `/v1/backends/` subtree handler (kept around for the
+  per-backend `/system-info` forward), which 404s anything it doesn't
+  recognize, instead of the exact-path grpc-gateway route the RPC needed —
+  a gap left over from when `/v1/backends` was promoted to proto-first
+  (#354) without accounting for later sub-routes. Registered as its own
+  exact path now, same pattern as the existing `ListBackends` entry.
+
+**Full diff**: https://github.com/FootprintAI/Containarium/compare/v0.76.1...v0.76.2
+
 ## [0.76.1] - 2026-09-10
 
 ### Added

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,7 +11,7 @@ var (
 	// ldflags (`make build-release VERSION=<tag>` in .github/workflows/release.yml),
 	// so the tag is the source of truth; keep this constant in sync as the
 	// fallback for plain `make build` / `go build`.
-	Version = "0.76.1"
+	Version = "0.76.2"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
## Summary
- Bumps `pkg/version/version.go` and adds the `CHANGELOG.md` section for v0.76.2, per `docs/RELEASE-PROCESS.md`.
- Patch release carrying the #1805 fix (#1806): `TriggerUpgrade` was unreachable over HTTP/REST on every prior version.

## Test plan
- [x] `go build ./...` clean
- [ ] CI green on this PR
- [ ] Tag the merge commit `v0.76.2` and verify all four release workflows + the release-blocking `cluster-e2e.yml` KVM lane

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014SxL7T4nzMdwAKqPah2Gw1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where backend upgrades returned a 404 error when requested through the HTTP/REST API.
  - Backend upgrade requests are now routed correctly.

- **Chores**
  - Updated the application version to 0.76.2.
  - Added release documentation for version 0.76.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->