### PR TITLE
feat(hostcheck): warn loudly on posture at enrollment, publish BYOC baseline (#1103)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -130,6 +130,14 @@ tenants, and what's it good for" — including how it compares to
 hypervisor-based platforms — see the
 [security FAQ](docs/security/SECURITY-FAQ.md).
 
+## BYOC host hardening baseline
+
+Bring-your-own-compute means the machine is yours, in your own account,
+running an image we didn't build. What to check on it — disk
+encryption, Secure Boot, sshd hardening, audit logging, and more —
+before treating it as a security boundary is in the
+[BYOC host hardening baseline](docs/security/BYOC-HOST-HARDENING-BASELINE.md).
+
 ## Thank you
 
 Security reports help keep Containarium operators safe. We're

--- a/docs/security/BYOC-HOST-HARDENING-BASELINE.md
+++ b/docs/security/BYOC-HOST-HARDENING-BASELINE.md
@@ -1,0 +1,90 @@
+# BYOC Host Hardening Baseline
+
+This document names what a bring-your-own-compute (BYOC) host should
+meet before you rely on it as a security boundary. It exists because of
+a specific gap (#1103): enrollment proves a host **can** run
+Containarium — root, `incus`, working `useradd`/`userdel` — but says
+nothing about whether it's **safe** to run tenant workloads on. For a
+platform-managed backend that's Containarium's own problem. For BYOC,
+the machine is yours, in your own account, running an image we did not
+build — so "dedicated to you" is a claim we can only make as strong as
+the evidence we actually collect.
+
+If a claim here turns out to be wrong or stale, please open an issue —
+this doc is meant to be checked against, not just read.
+
+## What this is not
+
+This is **not** an enforcement gate today. Every check below is
+advisory: `containarium doctor`, `cloud enroll`, and `pool join` will
+print unmet items loudly, but none of them refuse to enroll or join a
+host that fails. Whether a posture miss should eventually block
+enrollment is an open product decision (#1103) — this baseline defines
+*what* to measure, not *what happens* when a measurement comes back bad.
+
+## The baseline
+
+Each row is one check in `internal/hostcheck/posture.go`, run by
+`containarium doctor`, at `cloud enroll` / `pool join` time, and again
+every status-report cycle (so drift after enrollment is caught too, not
+just the moment you joined). The wire name matches the check name
+verbatim — grep for it if you want the exact logic.
+
+| Check | What a pass means | What a miss means |
+|---|---|---|
+| `data volume encrypted (dm-crypt)` | The volume backing `/var/lib/incus` (tenant container data) is a guest-visible dm-crypt device | Either genuinely unencrypted, or encrypted at a layer this guest can't see (e.g. cloud-provider CMEK) — the check says which, don't read a miss here as "definitely plaintext" |
+| `secure boot enabled` | UEFI Secure Boot is on | Off, or the machine boots legacy BIOS with no measured-boot capability at all |
+| `auditd running` | A host-level audit trail exists | No audit trail — a post-incident investigation has nothing to work from |
+| `sshd hardened (no root login, no password auth)` | `PermitRootLogin` is not `yes` AND `PasswordAuthentication` is `no` | The host is brute-forceable, or root is reachable without a key |
+| `unattended security upgrades enabled` | APT's periodic unattended-upgrade is on (Debian-family only; other distros report unknown, not fail) | Security patches require someone to remember to `apt upgrade` |
+| `cloud metadata endpoint blocked` | `169.254.169.254:80` is unreachable from the host | A workload that escapes its container can reach instance credentials — see the network-policy caveat below |
+| `tunnel unit does not carry its token on ExecStart` | The pool-join bearer token lives in a root-only `EnvironmentFile=`, not on the (world-readable) `ExecStart=` line | Any local user can read a live bearer-equivalent credential via `systemctl show`, `ps`, or journald |
+
+A check that cannot gather evidence reports **unmet**, never a silent
+pass — an ordinary, unhardened host is expected to light up several
+warnings on first enrollment. That's the finding, not a defect in the
+check.
+
+## The metadata-endpoint control, honestly
+
+`cloud metadata endpoint blocked` is the one item on this list with a
+real enforcement mechanism behind it — Containarium's network-policy
+engine defaults `allow_metadata` to `false`. But that engine is **not
+armed by default** on a freshly enrolled BYOC host; arming it means
+turning on the daemon's eBPF network-policy stack at the systemd level,
+which is a bigger, host-wide lever than a single-purpose IMDS block (and
+one with its own capacity considerations on a small box — see #1103's
+tracking notes before wiring this up unconditionally). Until that's
+resolved, treat a "blocked" result here as "blocked because someone
+configured it," not "blocked because it's default."
+
+## How to check a host
+
+```bash
+containarium doctor
+```
+
+prints the capability checks (blocking, exit-code-gated) followed by a
+"Host security posture" section (advisory, this baseline). `cloud
+enroll` and `pool join` print the same posture section at the moment a
+host joins, so you don't have to run `doctor` separately to see it —
+though re-running `doctor` later is how you catch drift after
+enrollment.
+
+## What we don't check yet
+
+CIS-benchmark-style coverage beyond the table above — kernel hardening
+sysctls, mandatory access control (AppArmor/SELinux) enforcement mode,
+disk-image provenance/measured boot attestation, log forwarding off-box.
+If your posture requirements go beyond this list, that's a real gap in
+this baseline, not a reason to distrust the checks that do exist —
+please open an issue naming what's missing.
+
+## Related
+
+- #1103 — the issue that created this baseline; tracks the two items
+  still open (arming the metadata-block network policy by default, and
+  the blocking-vs-warning product decision).
+- [`SECURITY-FAQ.md`](SECURITY-FAQ.md) — the broader isolation-model
+  answer this baseline is a special case of: "dedicated" is a claim
+  scoped to what we've verified, not what the customer's word says.

--- a/internal/cmd/cloud.go
+++ b/internal/cmd/cloud.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/footprintai/containarium/internal/cloud"
+	"github.com/footprintai/containarium/internal/hostcheck"
 )
 
 // defaultDaemonJWTSecretFile aliases the cloud package's shared default so
@@ -230,6 +231,15 @@ func runCloudEnroll(cmd *cobra.Command, _ []string) error {
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "✓ enrolled host %s with %s\n  config: %s (restart the daemon to start actuating + reporting)\n",
 		hostID, controlPlane, path)
+
+	// Host security posture (#1103). For enterprise BYOC this machine is the
+	// customer's, in their own account, running an image we did not build —
+	// printed loudly HERE, at the moment of enrollment, rather than only
+	// discoverable later via a separate `containarium doctor` run or the
+	// cloud webui's per-host posture badges. Advisory only: it does not
+	// block enrollment (see #1103 for the open product decision on whether
+	// it eventually should).
+	printPosture(hostcheck.RunPosture())
 	return nil
 }
 

--- a/internal/cmd/doctor_windows_stub.go
+++ b/internal/cmd/doctor_windows_stub.go
@@ -1,0 +1,13 @@
+//go:build windows && !containarium_client
+
+package cmd
+
+import "github.com/footprintai/containarium/internal/hostcheck"
+
+// printPosture is a no-op on Windows: doctor.go (where the real
+// implementation lives) is excluded there because the daemon itself doesn't
+// run on Windows and hostcheck.RunPosture's own Windows stub always returns
+// nil anyway. This stub exists only so cross-platform callers like `cloud
+// enroll` (internal/cmd/cloud.go, no !windows tag — it's a valid client-side
+// command on Windows) still link.
+func printPosture(_ []hostcheck.Check) {}

--- a/internal/cmd/pool_join.go
+++ b/internal/cmd/pool_join.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/footprintai/containarium/internal/cloud"
+	"github.com/footprintai/containarium/internal/hostcheck"
 )
 
 // pool join — the turnkey, one-command path that turns a fresh Linux host
@@ -445,6 +446,12 @@ func runPoolJoin(cmd *cobra.Command, args []string) error {
 	if failed := printDoctor(hostDoctorChecks()); failed > 0 {
 		return fmt.Errorf("pool join: %d required capability check(s) FAILED — units were installed but this host is NOT a healthy pool member yet; fix the above and re-run", failed)
 	}
+
+	// Host security posture (#1103) — printed loudly at the moment this host
+	// joins the pool, not just discoverable later via a separate `doctor` run
+	// or the cloud webui. Advisory only, same as `doctor`: it does not block
+	// the join.
+	printPosture(hostcheck.RunPosture())
 
 	// 5b. Verify the tunnel handshake was actually ACCEPTED before claiming
 	// the host joined (#1051). Everything above is host-side: units enabled,


### PR DESCRIPTION
## Summary

Partial fix for #1103. Two of the issue's five proposed fixes (the posture check group in `internal/hostcheck/posture.go`, and surfacing it in `HostCapability` via the status probe) already shipped in #1106 and #1611. This PR closes the remaining *visibility* gap:

- `cloud enroll` and `pool join` never printed posture at all — an operator could enroll a BYOC host and only discover its disk was unencrypted or sshd allowed password auth later, via a separate `containarium doctor` run or the cloud webui's per-host badges.
- Both entry points now print the same advisory "Host security posture" section `doctor` already renders, at the moment the host actually joins.
- Added `docs/security/BYOC-HOST-HARDENING-BASELINE.md` — the customer-facing form of the check table (what each check proves, what a miss means), cross-linked from `SECURITY.md`. It's explicit that this is advisory-only today, not an enforcement gate.

## Why a Windows stub

`internal/cmd/cloud.go` carries no `!windows` build tag (it's a valid client-side command on Windows), but `printPosture` lives in `doctor.go`, which is `!windows`-excluded. Added `internal/cmd/doctor_windows_stub.go` (no-op) following the existing `collaborator_windows_stub.go` pattern rather than restructuring doctor.go's build tags. Verified with `GOOS=windows GOARCH=amd64 go build ./internal/cmd/...`.

## What this does NOT close

#1103 stays open. Two of its five proposed fixes are real open decisions, not code gaps, and I'm not deciding them in this PR:

- **Fix 3** (arm the metadata-block network policy by default at BYOC enrollment): "arming" means turning on the daemon's whole eBPF network-policy stack at the systemd level, not a lightweight per-host toggle — and there's incident history (#654) of that stack causing problems on resource-constrained hosts. Needs either a capacity gate or a narrower alternative (e.g. a plain iptables/nft DROP rule scoped to IMDS) before it's safe to default on.
- **Fix 5** (should a posture miss ever block enrollment, not just warn): currently decided implicitly in a code comment; never an actual recorded product decision.

Raising both as an explicit design question on the issue rather than guessing.

## Test plan

- [x] `go build ./internal/cmd/... ./internal/hostcheck/...`
- [x] `GOOS=windows GOARCH=amd64 go build ./internal/cmd/...`
- [x] `go test ./internal/cmd/... ./internal/hostcheck/...`
- [ ] Manual: run `cloud enroll` / `pool join` against a real host and confirm the posture section prints

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014SxL7T4nzMdwAKqPah2Gw1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added advisory host security posture checks during cloud enrollment and pool joining.
  - Added posture reporting to routine diagnostics, covering encryption, Secure Boot, audit logging, SSH hardening, security updates, metadata endpoint protection, and tunnel token placement.
  - Added guidance for hardening bring-your-own-compute hosts before relying on them as security boundaries.

- **Documentation**
  - Documented that checks are advisory and non-blocking, with details on unmet evidence and controls not yet covered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->