### PR TITLE
feat(hostharden): narrow FORWARD-chain block for the cloud metadata endpoint (#1103)

### DIFF
--- a/internal/cmd/cloud.go
+++ b/internal/cmd/cloud.go
@@ -59,14 +59,15 @@ history. Writes the enrollment to ~/.containarium/cloud.yaml at mode 0600.`,
 }
 
 var (
-	cloudEnrollControlPlane  string
-	cloudEnrollTokenFile     string
-	cloudEnrollInsecure      bool
-	cloudEnrollJWTSecretFile string
-	cloudEnrollBackendID     string
-	cloudEnrollNoDriverToken bool
-	cloudEnrollDriverTTL     time.Duration
-	cloudEnrollAdoptForeign  bool
+	cloudEnrollControlPlane    string
+	cloudEnrollTokenFile       string
+	cloudEnrollInsecure        bool
+	cloudEnrollJWTSecretFile   string
+	cloudEnrollBackendID       string
+	cloudEnrollNoDriverToken   bool
+	cloudEnrollDriverTTL       time.Duration
+	cloudEnrollAdoptForeign    bool
+	cloudEnrollNoBlockMetadata bool
 )
 
 var cloudEnrollCmd = &cobra.Command{
@@ -118,6 +119,7 @@ func init() {
 	cloudEnrollCmd.Flags().BoolVar(&cloudEnrollNoDriverToken, "no-driver-token", false, "enroll without minting a driver token (host registers + heartbeats but the cloud cannot place workloads on it)")
 	cloudEnrollCmd.Flags().DurationVar(&cloudEnrollDriverTTL, "driver-token-ttl", 30*24*time.Hour, "driver token lifetime (capped at the daemon max, 30d); re-run `cloud enroll` before it expires to rotate")
 	cloudEnrollCmd.Flags().BoolVar(&cloudEnrollAdoptForeign, "adopt-foreign", false, "enroll even if this host already runs cloud-managed containers belonging to OTHER organizations (the cloud refuses by default); only use when the co-residency is understood and intended")
+	cloudEnrollCmd.Flags().BoolVar(&cloudEnrollNoBlockMetadata, "no-block-metadata", false, "skip installing the FORWARD-chain iptables rule + reboot unit that blocks tenant containers from reaching the cloud metadata endpoint (#1103); on by default for BYOC")
 	_ = cloudEnrollCmd.MarkFlagRequired("control-plane")
 	_ = cloudEnrollCmd.MarkFlagRequired("token-file")
 }
@@ -240,6 +242,7 @@ func runCloudEnroll(cmd *cobra.Command, _ []string) error {
 	// block enrollment (see #1103 for the open product decision on whether
 	// it eventually should).
 	printPosture(hostcheck.RunPosture())
+	applyMetadataBlock(cmd, "incusbr0", cloudEnrollNoBlockMetadata)
 	return nil
 }
 

--- a/internal/cmd/hostharden.go
+++ b/internal/cmd/hostharden.go
@@ -1,0 +1,55 @@
+//go:build !windows && !containarium_client
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/footprintai/containarium/internal/hostharden"
+)
+
+// hostharden is internal plumbing (#1103 fix 3), not a documented top-level
+// workflow: `cloud enroll` and `pool join` invoke BlockMetadataFromBridge
+// directly, and the persistent systemd unit InstallPersistentUnit writes
+// shells out to THIS subcommand (rather than duplicating the iptables/incus
+// invocation inline) so the unit and the enrollment-time call can never
+// drift apart. Hidden from `containarium --help`; still fully usable if an
+// operator needs to re-run it by hand.
+var hostHardenCmd = &cobra.Command{
+	Use:    "hostharden",
+	Short:  "Narrow host-hardening mutations, applied by cloud enroll / pool join and the reboot unit they install",
+	Hidden: true,
+}
+
+var hostHardenBlockMetadataCmd = &cobra.Command{
+	Use:   "block-metadata <bridge>",
+	Short: "Idempotently drop FORWARDED traffic from <bridge>'s subnet to the cloud metadata endpoint",
+	Long: `Inserts (if not already present) an iptables FORWARD rule dropping traffic
+from <bridge>'s configured subnet to 169.254.169.254 — the cloud metadata
+endpoint every major provider serves at that link-local address. Scoped to
+FORWARDED (container-bridge) traffic only; the host's own OUTPUT-originated
+requests are untouched, so cloud-provider tooling running on the host itself
+keeps working. See internal/hostharden and #1103.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runHostHardenBlockMetadata,
+}
+
+func init() {
+	rootCmd.AddCommand(hostHardenCmd)
+	hostHardenCmd.AddCommand(hostHardenBlockMetadataCmd)
+}
+
+func runHostHardenBlockMetadata(cmd *cobra.Command, args []string) error {
+	applied, detail, err := hostharden.BlockMetadataFromBridge(args[0])
+	if err != nil {
+		return err
+	}
+	mark := "="
+	if applied {
+		mark = "✓"
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "%s %s\n", mark, detail)
+	return nil
+}

--- a/internal/cmd/hostharden_apply.go
+++ b/internal/cmd/hostharden_apply.go
@@ -1,0 +1,52 @@
+//go:build !containarium_client
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/footprintai/containarium/internal/hostharden"
+)
+
+// applyMetadataBlock is the #1103 fix-3 mitigation shared by `cloud enroll`
+// and `pool join`: block the container bridge's FORWARDED traffic to the
+// cloud metadata endpoint, then install a systemd unit so the rule survives
+// a reboot. Every failure here is a printed warning, never a returned
+// error — this narrows a real risk but was never the thing either command
+// exists to do, so it must not turn a successful join/enroll into a
+// reported failure.
+//
+// No !windows tag: this file has the same build constraint as cloud.go (the
+// only caller that also builds on Windows), and on Windows the resulting
+// exec.Command calls simply fail fast (no iptables/incus binaries) and get
+// reported the same non-fatal way.
+func applyMetadataBlock(cmd *cobra.Command, bridge string, skip bool) {
+	if skip {
+		return
+	}
+	bin, err := os.Executable()
+	if err != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "⚠ could not resolve this binary's path (%v); skipping the metadata-endpoint block (#1103)\n", err)
+		return
+	}
+	applied, detail, err := hostharden.BlockMetadataFromBridge(bridge)
+	if err != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(),
+			"⚠ could not block the cloud metadata endpoint from the container bridge (%v)\n"+
+				"  a tenant workload that escapes its container may be able to reach instance credentials via %s\n"+
+				"  pass --no-block-metadata to silence this, or fix and re-run `containarium hostharden block-metadata %s`\n",
+			err, hostharden.MetadataIP, bridge)
+		return
+	}
+	mark := "="
+	if applied {
+		mark = "✓"
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "%s metadata-endpoint block (#1103): %s\n", mark, detail)
+	if err := hostharden.InstallPersistentUnit(bin, bridge); err != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "⚠ metadata block applied but the reboot-persistence unit failed to install (%v)\n  the rule will NOT survive a reboot until this is fixed\n", err)
+	}
+}

--- a/internal/cmd/pool_join.go
+++ b/internal/cmd/pool_join.go
@@ -75,6 +75,7 @@ var (
 	poolJoinCloudControlPlane  string
 	poolJoinCloudInsecure      bool
 	poolJoinSentinelAuthSecret string
+	poolJoinNoBlockMetadata    bool
 )
 
 var poolJoinCmd = &cobra.Command{
@@ -126,6 +127,7 @@ func init() {
 	poolJoinCmd.Flags().StringVar(&poolJoinCloudControlPlane, "cloud-control-plane", "", "Also self-register this host with a cloud control plane (e.g. https://cloud.containarium.dev) using the same --token, right after the tunnel comes up. Optional — omit for a plain OSS pool join with no cloud involvement. A failure here is a warning, not a join failure: the tunnel is joined either way.")
 	poolJoinCmd.Flags().BoolVar(&poolJoinCloudInsecure, "cloud-insecure", false, "Dial --cloud-control-plane without TLS (local dev only; ignored unless --cloud-control-plane is set)")
 	poolJoinCmd.Flags().StringVar(&poolJoinSentinelAuthSecret, "sentinel-auth-secret", os.Getenv("CONTAINARIUM_SENTINEL_AUTH_SECRET"), "Fleet-wide HMAC secret (32+ bytes) matching the sentinel's CONTAINARIUM_SENTINEL_AUTH_SECRET. Without it, the sentinel's keysync/certsync requests to this host's /authorized-keys get rejected with 401 — this host stays joined to the tunnel but never gets an SSH pipe (#687). Defaults to $CONTAINARIUM_SENTINEL_AUTH_SECRET; written to a root-only env file, never into the world-readable drop-in")
+	poolJoinCmd.Flags().BoolVar(&poolJoinNoBlockMetadata, "no-block-metadata", false, "skip installing the FORWARD-chain iptables rule + reboot unit that blocks tenant containers from reaching the cloud metadata endpoint (#1103)")
 }
 
 // tunnelUnitParams are the inputs to the tunnel systemd unit. The token
@@ -452,6 +454,7 @@ func runPoolJoin(cmd *cobra.Command, args []string) error {
 	// or the cloud webui. Advisory only, same as `doctor`: it does not block
 	// the join.
 	printPosture(hostcheck.RunPosture())
+	applyMetadataBlock(cmd, "incusbr0", poolJoinNoBlockMetadata)
 
 	// 5b. Verify the tunnel handshake was actually ACCEPTED before claiming
 	// the host joined (#1051). Everything above is host-side: units enabled,

--- a/internal/hostharden/imds.go
+++ b/internal/hostharden/imds.go
@@ -1,0 +1,103 @@
+// Package hostharden applies narrow, single-purpose host mitigations that
+// don't require the daemon's full eBPF network-policy engine.
+//
+// #1103 fix 3 asked to "arm the network policy (hence IMDS deny) as part of
+// BYOC enrollment rather than leaving it opt-in". The daemon's actual IMDS
+// deny is a PER-TENANT field (network_policies.allow_metadata, default
+// false) enforced by the eBPF engine on a tenant's veth — but that engine is
+// gated behind CONTAINARIUM_NETWORK_POLICY_BPF_OBJECT/_ENFORCE, host-wide
+// systemd config, and has documented incident history (OSS #654) wedging
+// incusd's reconcile loop on a resource-constrained host. Auto-arming that
+// whole stack at BYOC enrollment time, on an arbitrary customer machine,
+// trades one risk for another.
+//
+// This package is the narrower alternative the team chose instead: a single
+// static firewall rule, applied once at enrollment, that blocks the one
+// thing #1103 actually cared about — a workload that escapes its container
+// pivoting through the bridge to instance credentials. It does NOT touch the
+// host's own OUTPUT chain, so cloud-provider tooling running ON the host
+// (guest agent, gcloud, disk-resize scripts) keeps working; only traffic
+// FORWARDED from the container bridge's subnet is blocked.
+package hostharden
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// MetadataIP is the link-local cloud-metadata address common to GCP, AWS,
+// and Azure's IMDS implementations.
+const MetadataIP = "169.254.169.254"
+
+// runner abstracts exec.Command so tests can substitute a fake without
+// actually invoking iptables/incus. Mirrors hostcheck/posture.go's
+// dependency-injection shape for the same reason: a check/mutation that can
+// only be exercised on a correctly-configured real host is one nobody runs
+// in CI.
+type runner func(name string, args ...string) ([]byte, error)
+
+func defaultRunner(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).CombinedOutput() // #nosec G204 -- name/args are package-internal constants ("incus", "iptables") with a caller-supplied bridge name, never raw user input
+}
+
+// BridgeSubnet resolves bridge's configured IPv4 CIDR via the incus CLI
+// (not the Go client library) — this is a narrow, CLI-only feature and
+// deliberately doesn't need an authenticated incus API connection at
+// enrollment time the way the daemon's own network setup does.
+func BridgeSubnet(bridge string) (string, error) {
+	return bridgeSubnet(defaultRunner, bridge)
+}
+
+func bridgeSubnet(run runner, bridge string) (string, error) {
+	out, err := run("incus", "network", "get", bridge, "ipv4.address")
+	if err != nil {
+		return "", fmt.Errorf("incus network get %s ipv4.address: %w: %s", bridge, err, strings.TrimSpace(string(out)))
+	}
+	subnet := strings.TrimSpace(string(out))
+	if subnet == "" || subnet == "none" {
+		return "", fmt.Errorf("bridge %s has no ipv4.address configured", bridge)
+	}
+	return subnet, nil
+}
+
+// BlockMetadataFromBridge inserts an idempotent iptables FORWARD rule
+// dropping traffic from bridge's subnet to MetadataIP. Safe to call on
+// every enrollment: it checks for the exact rule first (`iptables -C`)
+// and only inserts when absent, so re-running `cloud enroll` never
+// duplicates the rule.
+//
+// Scope, precisely: this blocks the container bridge's FORWARDED traffic
+// to the metadata endpoint. It does not block the host's own
+// OUTPUT-originated requests — a deliberate choice (see package doc) — and
+// it does not require or interact with the eBPF network-policy engine.
+//
+// Known gap: this targets `iptables` (works whether the host's real backend
+// is legacy iptables or the nft-via-iptables-shim most modern distros ship),
+// not raw `nft`. A host with nftables ONLY and no iptables shim will fail
+// this step; that failure is surfaced to the caller as an error, not
+// silently swallowed, but it is deliberately non-fatal to enrollment (see
+// cmd/cloud.go) — the fallback is the same "opt-in, documented" state
+// #1103 started from, not a regression.
+func BlockMetadataFromBridge(bridge string) (applied bool, detail string, err error) {
+	return blockMetadataFromBridge(defaultRunner, bridge)
+}
+
+func blockMetadataFromBridge(run runner, bridge string) (bool, string, error) {
+	subnet, err := bridgeSubnet(run, bridge)
+	if err != nil {
+		return false, "", fmt.Errorf("resolve bridge subnet: %w", err)
+	}
+
+	rule := []string{"FORWARD", "-s", subnet, "-d", MetadataIP, "-j", "DROP"}
+
+	if _, err := run("iptables", append([]string{"-C"}, rule...)...); err == nil {
+		return false, fmt.Sprintf("already present: iptables -A %s", strings.Join(rule, " ")), nil
+	}
+
+	insertArgs := append([]string{"-I"}, rule...)
+	if out, err := run("iptables", insertArgs...); err != nil {
+		return false, "", fmt.Errorf("iptables %s: %w: %s", strings.Join(insertArgs, " "), err, strings.TrimSpace(string(out)))
+	}
+	return true, fmt.Sprintf("inserted: iptables -I %s", strings.Join(rule, " ")), nil
+}

--- a/internal/hostharden/imds_test.go
+++ b/internal/hostharden/imds_test.go
@@ -1,0 +1,132 @@
+package hostharden
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+type call struct {
+	name string
+	args []string
+}
+
+func fakeRunner(t *testing.T, calls *[]call, responses map[string]result) runner {
+	t.Helper()
+	return func(name string, args ...string) ([]byte, error) {
+		*calls = append(*calls, call{name, args})
+		key := name + " " + strings.Join(args, " ")
+		for pattern, r := range responses {
+			if strings.HasPrefix(key, pattern) {
+				return []byte(r.out), r.err
+			}
+		}
+		t.Fatalf("unexpected command: %s", key)
+		return nil, nil
+	}
+}
+
+type result struct {
+	out string
+	err error
+}
+
+func TestBridgeSubnet(t *testing.T) {
+	t.Run("resolves the configured address", func(t *testing.T) {
+		var calls []call
+		run := fakeRunner(t, &calls, map[string]result{
+			"incus network get incusbr0 ipv4.address": {out: "10.0.3.1/24\n"},
+		})
+		got, err := bridgeSubnet(run, "incusbr0")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "10.0.3.1/24" {
+			t.Errorf("got %q, want 10.0.3.1/24", got)
+		}
+	})
+
+	t.Run("errors when incus fails", func(t *testing.T) {
+		var calls []call
+		run := fakeRunner(t, &calls, map[string]result{
+			"incus network get incusbr0 ipv4.address": {out: "not found", err: errors.New("exit 1")},
+		})
+		if _, err := bridgeSubnet(run, "incusbr0"); err == nil {
+			t.Fatal("expected an error")
+		}
+	})
+
+	t.Run("errors when the bridge has no address (none)", func(t *testing.T) {
+		var calls []call
+		run := fakeRunner(t, &calls, map[string]result{
+			"incus network get incusbr0 ipv4.address": {out: "none\n"},
+		})
+		if _, err := bridgeSubnet(run, "incusbr0"); err == nil {
+			t.Fatal("expected an error for an unconfigured bridge")
+		}
+	})
+}
+
+func TestBlockMetadataFromBridge(t *testing.T) {
+	t.Run("inserts the rule when absent", func(t *testing.T) {
+		var calls []call
+		run := fakeRunner(t, &calls, map[string]result{
+			"incus network get incusbr0 ipv4.address":                       {out: "10.0.3.1/24\n"},
+			"iptables -C FORWARD -s 10.0.3.1/24 -d 169.254.169.254 -j DROP": {err: errors.New("exit 1: no such rule")},
+			"iptables -I FORWARD -s 10.0.3.1/24 -d 169.254.169.254 -j DROP": {},
+		})
+		applied, detail, err := blockMetadataFromBridge(run, "incusbr0")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !applied {
+			t.Errorf("expected applied=true, detail=%q", detail)
+		}
+		if len(calls) != 3 {
+			t.Fatalf("expected 3 commands (resolve, check, insert), got %d: %+v", len(calls), calls)
+		}
+	})
+
+	t.Run("is idempotent when the rule already exists", func(t *testing.T) {
+		var calls []call
+		run := fakeRunner(t, &calls, map[string]result{
+			"incus network get incusbr0 ipv4.address":                       {out: "10.0.3.1/24\n"},
+			"iptables -C FORWARD -s 10.0.3.1/24 -d 169.254.169.254 -j DROP": {}, // -C succeeds: rule present
+		})
+		applied, detail, err := blockMetadataFromBridge(run, "incusbr0")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if applied {
+			t.Errorf("expected applied=false (already present), detail=%q", detail)
+		}
+		if len(calls) != 2 {
+			t.Fatalf("expected 2 commands (resolve, check — no insert), got %d: %+v", len(calls), calls)
+		}
+	})
+
+	t.Run("propagates a bridge-resolution failure without touching iptables", func(t *testing.T) {
+		var calls []call
+		run := fakeRunner(t, &calls, map[string]result{
+			"incus network get incusbr0 ipv4.address": {err: errors.New("no such network")},
+		})
+		if _, _, err := blockMetadataFromBridge(run, "incusbr0"); err == nil {
+			t.Fatal("expected an error")
+		}
+		if len(calls) != 1 {
+			t.Fatalf("expected exactly 1 command (resolve only), got %d: %+v", len(calls), calls)
+		}
+	})
+
+	t.Run("surfaces an iptables insert failure", func(t *testing.T) {
+		var calls []call
+		run := fakeRunner(t, &calls, map[string]result{
+			"incus network get incusbr0 ipv4.address":                       {out: "10.0.3.1/24\n"},
+			"iptables -C FORWARD -s 10.0.3.1/24 -d 169.254.169.254 -j DROP": {err: errors.New("no such rule")},
+			"iptables -I FORWARD -s 10.0.3.1/24 -d 169.254.169.254 -j DROP": {out: "iptables: command not found", err: errors.New("exit 127")},
+		})
+		if _, _, err := blockMetadataFromBridge(run, "incusbr0"); err == nil {
+			t.Fatal("expected an error")
+		}
+	})
+}

--- a/internal/hostharden/imds_unit.go
+++ b/internal/hostharden/imds_unit.go
@@ -1,0 +1,57 @@
+package hostharden
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// ImdsBlockUnitPath is the systemd unit BlockMetadataFromBridge's rule
+// needs to survive a reboot — `iptables` rules are runtime kernel state,
+// not persisted by the package itself, and this repo doesn't assume any
+// particular distro's persistence mechanism (iptables-persistent,
+// netfilter-persistent, firewalld) is installed. A oneshot unit that
+// re-runs the same idempotent check-then-insert this package already does
+// is simpler than depending on one of those and works everywhere systemd
+// does.
+const ImdsBlockUnitPath = "/etc/systemd/system/containarium-imds-block.service"
+
+// InstallPersistentUnit writes and enables a systemd oneshot unit that
+// re-applies BlockMetadataFromBridge's rule on every boot. Idempotent:
+// re-running (e.g. on a re-enroll) overwrites the same content and
+// `systemctl enable` on an already-enabled unit is a no-op.
+//
+// containariumBin is the path to this binary (os.Executable()) — the unit
+// shells out to `containarium hostharden block-metadata <bridge>` rather
+// than duplicating the iptables/incus invocation inline, so the unit and
+// this package can never drift.
+func InstallPersistentUnit(containariumBin, bridge string) error {
+	return installPersistentUnit(defaultRunner, ImdsBlockUnitPath, containariumBin, bridge)
+}
+
+func installPersistentUnit(run runner, unitPath, containariumBin, bridge string) error {
+	unit := fmt.Sprintf(`[Unit]
+Description=Re-apply the BYOC metadata-endpoint FORWARD block (#1103) after reboot
+After=network-online.target incus.socket
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=%s hostharden block-metadata %s
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+`, containariumBin, bridge)
+
+	if err := os.WriteFile(unitPath, []byte(unit), 0o644); err != nil { // #nosec G306 -- a systemd unit file is meant to be world-readable; it carries no secret (containariumBin/bridge are non-sensitive paths/names)
+		return fmt.Errorf("write %s: %w", unitPath, err)
+	}
+	if out, err := run("systemctl", "daemon-reload"); err != nil {
+		return fmt.Errorf("systemctl daemon-reload: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	if out, err := run("systemctl", "enable", "--now", "containarium-imds-block.service"); err != nil {
+		return fmt.Errorf("systemctl enable --now containarium-imds-block.service: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}

--- a/internal/hostharden/imds_unit_test.go
+++ b/internal/hostharden/imds_unit_test.go
@@ -1,0 +1,54 @@
+package hostharden
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInstallPersistentUnit(t *testing.T) {
+	unitPath := filepath.Join(t.TempDir(), "containarium-imds-block.service")
+
+	var calls []call
+	run := fakeRunner(t, &calls, map[string]result{
+		"systemctl daemon-reload":                                {},
+		"systemctl enable --now containarium-imds-block.service": {},
+	})
+
+	if err := installPersistentUnit(run, unitPath, "/usr/local/bin/containarium", "incusbr0"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(unitPath) // #nosec G304 -- test-owned temp path
+	if err != nil {
+		t.Fatalf("unit file not written: %v", err)
+	}
+	unit := string(data)
+	for _, want := range []string{
+		"ExecStart=/usr/local/bin/containarium hostharden block-metadata incusbr0",
+		"[Install]",
+		"WantedBy=multi-user.target",
+	} {
+		if !strings.Contains(unit, want) {
+			t.Errorf("unit file missing %q:\n%s", want, unit)
+		}
+	}
+
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 systemctl calls, got %d: %+v", len(calls), calls)
+	}
+}
+
+func TestInstallPersistentUnit_DaemonReloadFails(t *testing.T) {
+	unitPath := filepath.Join(t.TempDir(), "containarium-imds-block.service")
+
+	var calls []call
+	run := fakeRunner(t, &calls, map[string]result{
+		"systemctl daemon-reload": {out: "permission denied", err: os.ErrPermission},
+	})
+
+	if err := installPersistentUnit(run, unitPath, "/usr/local/bin/containarium", "incusbr0"); err == nil {
+		t.Fatal("expected an error")
+	}
+}

--- a/internal/hostharden/imds_unit_test.go
+++ b/internal/hostharden/imds_unit_test.go
@@ -16,7 +16,7 @@ func TestInstallPersistentUnit(t *testing.T) {
 		"systemctl enable --now containarium-imds-block.service": {},
 	})
 
-	if err := installPersistentUnit(run, unitPath, "/usr/local/bin/containarium", "incusbr0"); err != nil {
+	if err := installPersistentUnit(run, unitPath, "/usr/local/bin/containariumd", "incusbr0"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -26,7 +26,7 @@ func TestInstallPersistentUnit(t *testing.T) {
 	}
 	unit := string(data)
 	for _, want := range []string{
-		"ExecStart=/usr/local/bin/containarium hostharden block-metadata incusbr0",
+		"ExecStart=/usr/local/bin/containariumd hostharden block-metadata incusbr0",
 		"[Install]",
 		"WantedBy=multi-user.target",
 	} {
@@ -48,7 +48,7 @@ func TestInstallPersistentUnit_DaemonReloadFails(t *testing.T) {
 		"systemctl daemon-reload": {out: "permission denied", err: os.ErrPermission},
 	})
 
-	if err := installPersistentUnit(run, unitPath, "/usr/local/bin/containarium", "incusbr0"); err == nil {
+	if err := installPersistentUnit(run, unitPath, "/usr/local/bin/containariumd", "incusbr0"); err == nil {
 		t.Fatal("expected an error")
 	}
 }


### PR DESCRIPTION
## Summary

Stacked on #1808 — targets that branch, not `main`, so the diff here is only the incremental change. Fix 3 of #1103. Scope decision recorded on the issue (2026-09-13): not the full eBPF network-policy engine (incident history wedging incusd on constrained hosts, #654), but a single-purpose static rule.

## What this does

- `internal/hostharden.BlockMetadataFromBridge(bridge)`: resolves the incus bridge's configured subnet via `incus network get <bridge> ipv4.address`, then inserts an idempotent `iptables -I FORWARD -s <subnet> -d 169.254.169.254 -j DROP` rule (checked with `-C` first, so re-enrollment never duplicates it).
- **Scope, precisely**: FORWARDED (container-bridge) traffic only. The host's own OUTPUT-originated requests are untouched — cloud-provider tooling running on the host itself (guest agent, `gcloud`, disk-resize scripts) keeps working. This is narrower than the per-tenant `allow_metadata` field the eBPF engine enforces, and doesn't require that engine at all.
- `InstallPersistentUnit`: writes + enables a systemd oneshot (`containarium-imds-block.service`) that re-applies the same check-then-insert at boot. It shells out to a new hidden `containarium hostharden block-metadata <bridge>` subcommand rather than duplicating the iptables/incus invocation inline, so the unit and the enrollment-time call can't drift apart.
- Wired into both `cloud enroll` and `pool join` via a shared `applyMetadataBlock` helper, **on by default**, each with a `--no-block-metadata` opt-out.

## Failure handling

Every failure here is a printed warning, never a returned error — this narrows a real risk but was never the thing either command exists to do, and must not turn a successful join/enroll into a reported failure. Concretely: a host with nftables only and no iptables shim will fail this step; that's surfaced to the operator, not silently swallowed, but non-fatal — the fallback is the same "opt-in, documented" state #1103 started from, not a regression.

## Test plan

- [x] `go build` (native) + `GOOS=windows GOARCH=amd64 go build` for `internal/hostharden` and `internal/cmd`
- [x] `go vet`
- [x] `go test ./internal/hostharden/... ./internal/cmd/...`
- [x] `gosec` (clean)
- [x] `golangci-lint run` (0 issues)
- [ ] Manual: run `cloud enroll` on a real host, confirm the rule lands (`iptables -L FORWARD -n`) and the unit re-applies after a reboot

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014SxL7T4nzMdwAKqPah2Gw1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic blocking of container access to the cloud metadata endpoint during enrollment and pool joining.
  * Added persistence so the protection is reapplied after host reboots.
  * Added `--no-block-metadata` options to skip this protection when needed.
  * Added host hardening support for applying and reporting metadata-access rules.

* **Bug Fixes**
  * Hardening failures now produce warnings without causing otherwise successful enrollment or joining operations to fail.

* **Tests**
  * Added coverage for rule application, repeat runs, bridge validation, and persistence setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->